### PR TITLE
ci: add cross-platform CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,13 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run tests
+      - name: Run tests (full workspace, Linux only)
+        if: matrix.os == 'ubuntu-latest'
         run: cargo test --workspace
+
+      - name: Run tests (core + CLI, macOS/Windows)
+        if: matrix.os != 'ubuntu-latest'
+        run: cargo test -p kiro-market-core -p kiro-market
 
   # Svelte frontend type checking and build
   frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,348 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # Validate conventional commit messages on PRs
+  commitlint:
+    name: Validate Commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          COMMITS=$(git log --format="%s" origin/${{ github.base_ref }}..HEAD)
+          PATTERN="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z][a-z0-9-]*\))?!?: .{3,}"
+          FAILED=0
+          while IFS= read -r msg; do
+            if [[ -z "$msg" ]]; then continue; fi
+            if [[ ! "$msg" =~ $PATTERN ]] && [[ ! "$msg" =~ ^Merge ]]; then
+              echo "❌ Invalid commit: $msg"
+              FAILED=1
+            else
+              echo "✅ Valid commit: $msg"
+            fi
+          done <<< "$COMMITS"
+          if [[ $FAILED -eq 1 ]]; then
+            echo ""
+            echo "Expected format: <type>[optional scope]: <description>"
+            echo "Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore"
+            exit 1
+          fi
+
+  # Check formatting across the workspace
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  # Clippy linting (needs webview deps for the Tauri crate)
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+  # Run all Rust tests across platforms
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  # Svelte frontend type checking and build
+  frontend:
+    name: Frontend Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/kiro-control-center
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: crates/kiro-control-center/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Svelte check
+        run: npm run check
+
+      - name: Build frontend
+        run: npm run build
+
+  # Build CLI binary on all platforms
+  build-cli:
+    name: Build CLI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: kiro-market-linux
+            binary: target/release/kiro-market
+          - os: macos-latest
+            artifact_name: kiro-market-macos
+            binary: target/release/kiro-market
+          - os: windows-latest
+            artifact_name: kiro-market-windows
+            binary: target/release/kiro-market.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI (release)
+        run: cargo build --release -p kiro-market
+
+      - name: Upload CLI binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.binary }}
+
+  # Build Tauri desktop app on all platforms
+  build-tauri:
+    name: Build Tauri (${{ matrix.platform }})
+    needs: [frontend]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            artifact_name: kcc-linux
+            artifact_path: target/release/bundle/deb/*.deb
+          - platform: macos-latest
+            artifact_name: kcc-macos
+            artifact_path: target/release/bundle/dmg/*.dmg
+          - platform: windows-latest
+            artifact_name: kcc-windows
+            artifact_path: target/release/bundle/msi/*.msi
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: crates/kiro-control-center/package-lock.json
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install frontend dependencies
+        working-directory: crates/kiro-control-center
+        run: npm ci
+
+      - name: Build Tauri app
+        working-directory: crates/kiro-control-center
+        run: npx tauri build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+          if-no-files-found: warn
+
+  # Security and license audit
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          log-level: warn
+          command: check
+          arguments: --all-features
+
+  # Code coverage for Rust crates
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+
+  # Gate: all jobs must pass
+  ci-success:
+    name: CI Success
+    if: always()
+    needs: [commitlint, format, lint, test, frontend, build-cli, build-tauri, cargo-deny, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs
+        run: |
+          # commitlint is skipped on push events
+          if [[ "${{ needs.commitlint.result }}" != "success" ]] && \
+             [[ "${{ needs.commitlint.result }}" != "skipped" ]]; then
+            echo "Commit validation failed"
+            exit 1
+          fi
+          if [[ "${{ needs.format.result }}" != "success" ]] || \
+             [[ "${{ needs.lint.result }}" != "success" ]] || \
+             [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.frontend.result }}" != "success" ]] || \
+             [[ "${{ needs.build-cli.result }}" != "success" ]] || \
+             [[ "${{ needs.build-tauri.result }}" != "success" ]] || \
+             [[ "${{ needs.cargo-deny.result }}" != "success" ]] || \
+             [[ "${{ needs.coverage.result }}" != "success" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -63,7 +63,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -99,7 +99,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -132,10 +132,10 @@ jobs:
       run:
         working-directory: crates/kiro-control-center
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -169,24 +169,10 @@ jobs:
             binary: target/release/kiro-market.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -195,7 +181,7 @@ jobs:
         run: cargo build --release -p kiro-market
 
       - name: Upload CLI binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.binary }}
@@ -220,10 +206,10 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -258,18 +244,18 @@ jobs:
         run: npx tauri build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_path }}
-          if-no-files-found: warn
+          if-no-files-found: error
 
   # Security and license audit
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -286,7 +272,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -311,7 +297,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov -p kiro-market-core -p kiro-market --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             artifact_name: kiro-market-linux-x86_64
             binary: target/release/kiro-market
           - os: macos-latest
-            artifact_name: kiro-market-macos-x86_64
+            artifact_name: kiro-market-macos-aarch64
             binary: target/release/kiro-market
           - os: windows-latest
             artifact_name: kiro-market-windows-x86_64
@@ -29,24 +29,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -79,10 +65,10 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -115,6 +101,17 @@ jobs:
       - name: Build Tauri app
         working-directory: crates/kiro-control-center
         run: npx tauri build
+
+      - name: Verify artifacts exist
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(${{ matrix.artifact_path }})
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No artifacts found matching ${{ matrix.artifact_path }}"
+            exit 1
+          fi
+          echo "Found: ${files[@]}"
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # Build CLI binaries for all platforms
+  release-cli:
+    name: CLI - ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: kiro-market-linux-x86_64
+            binary: target/release/kiro-market
+          - os: macos-latest
+            artifact_name: kiro-market-macos-x86_64
+            binary: target/release/kiro-market
+          - os: windows-latest
+            artifact_name: kiro-market-windows-x86_64
+            binary: target/release/kiro-market.exe
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI (release)
+        run: cargo build --release -p kiro-market
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.binary }}
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build Tauri desktop app for all platforms
+  release-tauri:
+    name: Desktop App - ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            artifact_path: target/release/bundle/deb/*.deb
+          - platform: macos-latest
+            artifact_path: target/release/bundle/dmg/*.dmg
+          - platform: windows-latest
+            artifact_path: target/release/bundle/msi/*.msi
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: crates/kiro-control-center/package-lock.json
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install frontend dependencies
+        working-directory: crates/kiro-control-center
+        run: npm ci
+
+      - name: Build Tauri app
+        working-directory: crates/kiro-control-center
+        run: npx tauri build
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.artifact_path }}
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,35 +1,58 @@
-# kiro-market
+# Kiro Control Center
 
-A CLI tool that installs [Claude Code marketplace](https://docs.anthropic.com/en/docs/claude-code/skills#marketplace) skills into [Kiro CLI](https://kiro.dev) projects.
+A desktop app and CLI for browsing, installing, and managing [Claude Code marketplace](https://docs.anthropic.com/en/docs/claude-code/skills#marketplace) skills in [Kiro](https://kiro.dev) projects.
 
-Claude Code skills are distributed as `SKILL.md` files in marketplace repositories. Kiro uses a similar skill format but expects files at `.kiro/skills/<name>/SKILL.md`. This tool bridges the gap: it clones marketplace repos, discovers plugins and skills, merges multi-file skills into single files (Kiro doesn't support deferred companion loading), and installs them into your project.
+Claude Code skills are distributed as `SKILL.md` files in marketplace repositories. Kiro uses a similar skill format but expects files at `.kiro/skills/<name>/SKILL.md`. Kiro Control Center bridges the gap: it clones marketplace repos, discovers plugins and skills, merges multi-file skills into single files, and installs them into your project.
 
-## Requirements
+## Desktop App (kcc)
 
-- Rust 1.85.0+ (edition 2024)
-- Git (for cloning marketplace repositories)
-- SSH agent or git credential helpers configured (for private repos)
+The desktop app provides a tabbed GUI for the full skill management workflow.
 
-## Installation
+### Installation
 
 ```bash
-# Clone and build
-git clone https://github.com/dwalleck/kiro-marketplace-cli.git
-cd kiro-marketplace-cli
-cargo install --path crates/kiro-market
-
-# Verify
-kiro-market --version
+git clone https://github.com/dwalleck/kiro-control-center.git
+cd kiro-control-center/crates/kiro-control-center
+npm install
+npx tauri build
+cp ../../target/release/kcc ~/.local/bin/
 ```
 
-## Quick Start
+### Usage
+
+Launch from within a Kiro project directory:
 
 ```bash
-# 1. Register a marketplace (GitHub shorthand, git URL, or local path)
+cd /path/to/your/kiro-project
+kcc
+```
+
+### Tabs
+
+**Browse** -- Explore marketplaces and plugins in a sidebar, view skill cards with descriptions, select with checkboxes, and bulk install. Skills already installed are marked with a badge.
+
+**Installed** -- View all installed skills with plugin, marketplace, version, and install date. Select and bulk remove.
+
+**Marketplaces** -- Add new marketplace sources (GitHub `owner/repo`, git URL, or local path), update from remote, or remove. Shows plugin count and source type for each marketplace.
+
+## CLI (kiro-market)
+
+For scripting and automation, a full CLI is also available.
+
+### Installation
+
+```bash
+cargo install --path crates/kiro-market
+```
+
+### Quick Start
+
+```bash
+# 1. Register a marketplace
 kiro-market marketplace add microsoft/dotnet-agent-skills
 
-# 2. Search for skills
-kiro-market search "entity framework"
+# 2. Browse available skills (no query = list all)
+kiro-market search
 
 # 3. Install a plugin's skills into your Kiro project
 cd /path/to/your/kiro-project
@@ -39,94 +62,28 @@ kiro-market install dotnet@dotnet-agent-skills
 kiro-market list
 ```
 
-## Commands
+### Commands
 
-### `marketplace` -- Manage marketplace sources
+| Command | Description |
+|---------|-------------|
+| `marketplace add <source>` | Add a marketplace (GitHub shorthand, git URL, or local path) |
+| `marketplace list` | List registered marketplaces |
+| `marketplace update [name]` | Update marketplace clones from remote |
+| `marketplace remove <name>` | Remove a registered marketplace |
+| `search [query]` | Search skills by name/description (lists all if no query) |
+| `install <plugin@marketplace>` | Install skills (`--skill <name>` for one, `--force` to overwrite) |
+| `info <plugin@marketplace>` | Show plugin details and available skills |
+| `list` | List installed skills in the current project |
+| `remove <skill-name>` | Remove an installed skill |
 
-```bash
-# Add from GitHub shorthand
-kiro-market marketplace add microsoft/dotnet-agent-skills
-
-# Add from a git URL
-kiro-market marketplace add https://github.com/org/private-skills.git
-
-# Add from a local directory (symlinked, always up to date)
-kiro-market marketplace add ~/repos/my-skills
-
-# List registered marketplaces
-kiro-market marketplace list
-
-# Update all marketplace clones from remote
-kiro-market marketplace update
-
-# Update a specific marketplace
-kiro-market marketplace update dotnet-agent-skills
-
-# Remove a marketplace
-kiro-market marketplace remove dotnet-agent-skills
-```
-
-### `search` -- Find skills across marketplaces
-
-Searches skill names and descriptions (case-insensitive) across all registered marketplaces:
-
-```bash
-kiro-market search rust
-kiro-market search "code review"
-```
-
-### `install` -- Install skills into a Kiro project
-
-Run this from within a Kiro project directory (one that has or will have a `.kiro/` folder):
-
-```bash
-# Install all skills from a plugin
-kiro-market install dotnet@dotnet-agent-skills
-
-# Install a specific skill by name
-kiro-market install dotnet@dotnet-agent-skills --skill efcore
-
-# Force overwrite if already installed
-kiro-market install dotnet@dotnet-agent-skills --force
-```
-
-The plugin reference format is `plugin@marketplace`.
-
-Installed skills are written to `.kiro/skills/<skill-name>/SKILL.md` and tracked in `.kiro/installed-skills.json`.
-
-### `info` -- Show plugin details
-
-```bash
-kiro-market info dotnet@dotnet-agent-skills
-```
-
-### `list` -- Show installed skills
-
-```bash
-kiro-market list
-```
-
-### `remove` -- Remove an installed skill
-
-```bash
-kiro-market remove efcore
-```
-
-### `update` -- Update installed plugins
-
-In-place update is not yet supported. To update a skill:
-
-```bash
-kiro-market remove <skill-name>
-kiro-market install <plugin@marketplace> --force
-```
+The plugin reference format is `plugin@marketplace` (e.g., `dotnet@dotnet-agent-skills`).
 
 ## How It Works
 
 1. **Marketplaces** are Git repositories containing a `.claude-plugin/marketplace.json` manifest that lists plugins.
 2. **Plugins** are directories within a marketplace (or separate repos). Each plugin contains one or more skills, optionally described in a `plugin.json`.
-3. **Skills** are directories containing a `SKILL.md` with YAML frontmatter (`name`, `description`) and Markdown content. Skills may reference companion `.md` files.
-4. **Installation** clones the marketplace, resolves the plugin source, discovers skills, merges any companion files into the main `SKILL.md`, and writes the result to `.kiro/skills/`.
+3. **Skills** are directories containing a `SKILL.md` with YAML frontmatter (`name`, `description`) and Markdown content. Multi-file skills with companion `.md` references are merged into a single file.
+4. **Installation** writes to `.kiro/skills/<name>/SKILL.md` and tracks metadata in `.kiro/installed-skills.json`.
 
 ### Project layout after installation
 
@@ -141,51 +98,38 @@ your-project/
         SKILL.md
 ```
 
-## Desktop App (Kiro Control Center)
+## Requirements
 
-For a visual interface with tabs for browsing, installing, and managing skills:
-
-```bash
-cd /path/to/your/kiro-project
-kcc
-```
-
-The app provides three tabs:
-- **Browse** -- Explore marketplaces, drill into plugins, select skills with checkboxes, and bulk install
-- **Installed** -- View installed skills, select and remove
-- **Marketplaces** -- Add, update, and remove marketplace sources
-
-### Building from source
-
-```bash
-cd crates/kiro-control-center
-npm install
-npx tauri build
-cp ../../target/release/kcc ~/.local/bin/
-```
-
-## Verbosity
-
-```bash
-kiro-market -v install ...     # Debug logging
-kiro-market -vv install ...    # Trace logging
-RUST_LOG=debug kiro-market ... # Or use RUST_LOG directly
-```
+- Rust 1.85.0+
+- Node.js 20+ (for building the desktop app)
+- Git (for cloning marketplace repositories)
+- SSH agent or git credential helpers (for private repos)
 
 ## Development
 
 ```bash
-cargo build                          # Build
-cargo test                           # All tests
-cargo test -p kiro-market-core       # Core library tests only
+cargo build                          # Build all crates
+cargo test                           # All tests (147 across workspace)
 cargo clippy --workspace -- -D warnings  # Lint
+cargo test -p kiro-market-core       # Core library tests only
+cargo test -p kiro-control-center    # Desktop app tests only
+
+# Frontend development
+cd crates/kiro-control-center
+npm run dev                          # Vite dev server (port 1420)
+npx tauri dev                        # Launch app in dev mode
+
+# Regenerate TypeScript bindings after changing Tauri commands
+cargo test -p kiro-control-center --lib -- --ignored generate_types
 ```
 
 ## Project Structure
 
 ```
 crates/
-  kiro-market-core/       # Library: types, parsing, git, cache, project state
-  kiro-market/            # Binary: CLI commands
+  kiro-market-core/       # Shared library: types, parsing, git, cache, project state
+  kiro-market/            # CLI binary (kiro-market)
   kiro-control-center/    # Tauri desktop app (kcc)
+    src-tauri/            #   Rust backend: Tauri commands calling kiro-market-core
+    src/                  #   Svelte 5 frontend with typed bindings via tauri-specta
 ```

--- a/crates/kiro-control-center/src-tauri/Cargo.toml
+++ b/crates/kiro-control-center/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiro-control-center"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 description = "Kiro Control Center — GUI for managing Claude Code marketplace skills"
 
 [lints]

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 use kiro_market_core::cache::{CacheDir, MarketplaceSource};
 use kiro_market_core::error::{Error as CoreError, SkillError};
 use kiro_market_core::marketplace::{Marketplace, PluginEntry, PluginSource, StructuredSource};
-use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
+use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
 use kiro_market_core::project::{InstalledSkillMeta, KiroProject};
 use kiro_market_core::skill::{extract_relative_md_links, merge_skill, parse_frontmatter};
 
@@ -106,7 +106,9 @@ pub async fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, CommandError> {
         )
     })?;
 
-    let known = cache.load_known_marketplaces().map_err(CommandError::from)?;
+    let known = cache
+        .load_known_marketplaces()
+        .map_err(CommandError::from)?;
 
     let mut results = Vec::with_capacity(known.len());
     for entry in &known {
@@ -504,10 +506,7 @@ fn resolve_local_plugin_dir(
             let resolved = marketplace_path.join(rel);
             if !resolved.exists() {
                 return Err(CommandError::new(
-                    format!(
-                        "plugin directory does not exist: {}",
-                        resolved.display()
-                    ),
+                    format!("plugin directory does not exist: {}", resolved.display()),
                     ErrorType::NotFound,
                 ));
             }
@@ -532,12 +531,11 @@ fn discover_skills_for_plugin(
     plugin_dir: &Path,
     manifest: Option<&PluginManifest>,
 ) -> Vec<PathBuf> {
-    let skill_paths: Vec<&str> =
-        if let Some(m) = manifest.filter(|m| !m.skills.is_empty()) {
-            m.skills.iter().map(String::as_str).collect()
-        } else {
-            kiro_market_core::DEFAULT_SKILL_PATHS.to_vec()
-        };
+    let skill_paths: Vec<&str> = if let Some(m) = manifest.filter(|m| !m.skills.is_empty()) {
+        m.skills.iter().map(String::as_str).collect()
+    } else {
+        kiro_market_core::DEFAULT_SKILL_PATHS.to_vec()
+    };
 
     discover_skill_dirs(plugin_dir, &skill_paths)
 }
@@ -565,7 +563,10 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Com
                 "failed to read plugin.json"
             );
             return Err(CommandError::new(
-                format!("failed to read plugin.json at {}: {e}", manifest_path.display()),
+                format!(
+                    "failed to read plugin.json at {}: {e}",
+                    manifest_path.display()
+                ),
                 ErrorType::IoError,
             ));
         }
@@ -583,7 +584,10 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Com
                 "plugin.json is malformed"
             );
             Err(CommandError::new(
-                format!("plugin.json at {} is malformed: {e}", manifest_path.display()),
+                format!(
+                    "plugin.json at {} is malformed: {e}",
+                    manifest_path.display()
+                ),
                 ErrorType::ParseError,
             ))
         }
@@ -660,7 +664,10 @@ mod tests {
         let source = MarketplaceSource::GitHub {
             repo: "owner/repo".into(),
         };
-        assert!(matches!(marketplace_source_type(&source), SourceType::GitHub));
+        assert!(matches!(
+            marketplace_source_type(&source),
+            SourceType::GitHub
+        ));
     }
 
     #[test]
@@ -676,7 +683,10 @@ mod tests {
         let source = MarketplaceSource::LocalPath {
             path: "/home/user/marketplace".into(),
         };
-        assert!(matches!(marketplace_source_type(&source), SourceType::Local));
+        assert!(matches!(
+            marketplace_source_type(&source),
+            SourceType::Local
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -58,10 +58,7 @@ pub async fn list_installed_skills(
 /// Remove an installed skill from a Kiro project.
 #[tauri::command]
 #[specta::specta]
-pub async fn remove_skill(
-    name: String,
-    project_path: String,
-) -> Result<(), CommandError> {
+pub async fn remove_skill(name: String, project_path: String) -> Result<(), CommandError> {
     let project = KiroProject::new(PathBuf::from(&project_path));
     project.remove_skill(&name).map_err(CommandError::from)?;
     debug!(skill = %name, "skill removed via control center");

--- a/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
@@ -105,19 +105,13 @@ pub async fn add_marketplace(source: String) -> Result<MarketplaceAddResult, Com
             let url = git::github_repo_to_url(repo);
             debug!(url = %url, dest = %temp_dir.display(), "cloning GitHub marketplace");
             git::clone_repo(&url, &temp_dir, None).map_err(|e| {
-                CommandError::new(
-                    format!("failed to clone {repo}: {e}"),
-                    ErrorType::GitError,
-                )
+                CommandError::new(format!("failed to clone {repo}: {e}"), ErrorType::GitError)
             })?;
         }
         MarketplaceSource::GitUrl { url } => {
             debug!(url = %url, dest = %temp_dir.display(), "cloning git marketplace");
             git::clone_repo(url, &temp_dir, None).map_err(|e| {
-                CommandError::new(
-                    format!("failed to clone {url}: {e}"),
-                    ErrorType::GitError,
-                )
+                CommandError::new(format!("failed to clone {url}: {e}"), ErrorType::GitError)
             })?;
         }
         MarketplaceSource::LocalPath { path } => {
@@ -264,9 +258,7 @@ pub async fn remove_marketplace(name: String) -> Result<(), CommandError> {
 /// skipped since they always reflect the latest state on disk.
 #[tauri::command]
 #[specta::specta]
-pub async fn update_marketplace(
-    name: Option<String>,
-) -> Result<UpdateResult, CommandError> {
+pub async fn update_marketplace(name: Option<String>) -> Result<UpdateResult, CommandError> {
     let cache = get_cache()?;
     let entries = cache
         .load_known_marketplaces()
@@ -328,4 +320,3 @@ pub async fn update_marketplace(
 
     Ok(result)
 }
-

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -1,6 +1,4 @@
-use kiro_market_core::error::{
-    Error as CoreError, MarketplaceError, PluginError, SkillError,
-};
+use kiro_market_core::error::{Error as CoreError, MarketplaceError, PluginError, SkillError};
 use serde::Serialize;
 use tracing::warn;
 
@@ -91,9 +89,7 @@ impl From<String> for CommandError {
 mod tests {
     use std::path::PathBuf;
 
-    use kiro_market_core::error::{
-        GitError, PluginError, SkillError, ValidationError,
-    };
+    use kiro_market_core::error::{GitError, PluginError, SkillError, ValidationError};
     use rstest::rstest;
 
     use super::*;

--- a/crates/kiro-market-core/src/git.rs
+++ b/crates/kiro-market-core/src/git.rs
@@ -274,7 +274,14 @@ mod tests {
 
         create_local_repo(source_dir.path());
 
-        let url = format!("file://{}", source_dir.path().display());
+        // file:// URLs: on Unix paths start with /, so file:// + /path works.
+        // On Windows, paths start with C:\, need file:///C:/path with forward slashes.
+        let path_str = source_dir.path().to_string_lossy().replace('\\', "/");
+        let url = if path_str.starts_with('/') {
+            format!("file://{path_str}")
+        } else {
+            format!("file:///{path_str}")
+        };
         let repo = clone_repo(&url, &dest, None).expect("clone should succeed");
 
         assert!(dest.join("hello.txt").exists(), "cloned file should exist");

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -331,9 +331,13 @@ fn resolve_structured_source(
             sha.as_deref(),
             repo.as_str(),
         ),
-        StructuredSource::GitUrl { url, git_ref, sha } => {
-            (url.clone(), None, git_ref.as_deref(), sha.as_deref(), url.as_str())
-        }
+        StructuredSource::GitUrl { url, git_ref, sha } => (
+            url.clone(),
+            None,
+            git_ref.as_deref(),
+            sha.as_deref(),
+            url.as_str(),
+        ),
         StructuredSource::GitSubdir {
             url,
             path,

--- a/crates/kiro-market/src/commands/marketplace.rs
+++ b/crates/kiro-market/src/commands/marketplace.rs
@@ -103,9 +103,8 @@ fn add(source: &str) -> Result<()> {
         Marketplace::from_json(&manifest_bytes).context("failed to parse marketplace manifest")?;
 
     let name = manifest.name.clone();
-    kiro_market_core::validation::validate_name(&name).with_context(|| {
-        format!("marketplace manifest contains invalid name '{name}'")
-    })?;
+    kiro_market_core::validation::validate_name(&name)
+        .with_context(|| format!("marketplace manifest contains invalid name '{name}'"))?;
     let plugin_count = manifest.plugins.len();
 
     // Rename temp dir to the real marketplace name.
@@ -150,7 +149,10 @@ fn add(source: &str) -> Result<()> {
 }
 
 /// Print the list of available plugins after adding a marketplace.
-fn print_available_plugins(plugins: &[kiro_market_core::marketplace::PluginEntry], marketplace_name: &str) {
+fn print_available_plugins(
+    plugins: &[kiro_market_core::marketplace::PluginEntry],
+    marketplace_name: &str,
+) {
     if plugins.is_empty() {
         return;
     }
@@ -158,10 +160,7 @@ fn print_available_plugins(plugins: &[kiro_market_core::marketplace::PluginEntry
     println!();
     println!("  {}", "Available plugins:".bold());
     for plugin in plugins {
-        let desc = plugin
-            .description
-            .as_deref()
-            .unwrap_or("(no description)");
+        let desc = plugin.description.as_deref().unwrap_or("(no description)");
         println!("    {} - {}", plugin.name.green(), desc);
     }
     println!();
@@ -193,11 +192,7 @@ fn list() -> Result<()> {
 
     println!("{}", "Registered marketplaces:".bold());
     for entry in &entries {
-        println!(
-            "  {} ({})",
-            entry.name.green().bold(),
-            entry.source.label()
-        );
+        println!("  {} ({})", entry.name.green().bold(), entry.source.label());
     }
 
     Ok(())
@@ -293,9 +288,4 @@ fn remove(name: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // detect_source and source_label tests moved to kiro-market-core::cache::tests
-}
+// detect_source and source_label tests moved to kiro-market-core::cache::tests

--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,12 @@
+# Configuration for cargo-deny
+# https://embarkstudios.github.io/cargo-deny/
+
 [advisories]
-vulnerability = "deny"
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = []
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "MIT",
     "MIT-0",
@@ -31,4 +34,3 @@ wildcards = "allow"
 unknown-registry = "deny"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
+ignore = []
 
 [licenses]
 unlicensed = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -5,21 +5,25 @@
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    # Tauri's GTK3 bindings are unmaintained but required for Linux webview support.
-    # These are transitive dependencies we cannot control.
-    "RUSTSEC-2024-0417", # gtk-rs GTK3 bindings
-    # paste is unmaintained, used transitively by Tauri
-    "RUSTSEC-2024-0436", # paste
-    # proc-macro-error is unmaintained, used transitively
-    "RUSTSEC-2024-0370", # proc-macro-error
-    # unic-* crates are unmaintained, used transitively by Tauri's HTML parser
-    "RUSTSEC-2025-0012", # unic-ucd-ident
-    "RUSTSEC-2025-0013", # unic-common
-    "RUSTSEC-2025-0014", # unic-char-range
-    "RUSTSEC-2025-0015", # unic-char-property
-    "RUSTSEC-2025-0016", # unic-ucd-version
-    # fxhash is unmaintained, used transitively
-    "RUSTSEC-2025-0009", # fxhash
+    # Tauri transitive dependencies — unmaintained crates we cannot control.
+    # GTK3 bindings (10 advisories for various gtk-rs crates)
+    "RUSTSEC-2024-0411",
+    "RUSTSEC-2024-0412",
+    "RUSTSEC-2024-0413",
+    "RUSTSEC-2024-0414",
+    "RUSTSEC-2024-0415",
+    "RUSTSEC-2024-0416",
+    "RUSTSEC-2024-0418",
+    "RUSTSEC-2024-0419",
+    "RUSTSEC-2024-0420",
+    # fxhash
+    "RUSTSEC-2025-0057",
+    # unic-* crates
+    "RUSTSEC-2025-0075",
+    "RUSTSEC-2025-0080",
+    "RUSTSEC-2025-0081",
+    "RUSTSEC-2025-0098",
+    "RUSTSEC-2025-0100",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -4,13 +4,30 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = []
+ignore = [
+    # Tauri's GTK3 bindings are unmaintained but required for Linux webview support.
+    # These are transitive dependencies we cannot control.
+    "RUSTSEC-2024-0417", # gtk-rs GTK3 bindings
+    # paste is unmaintained, used transitively by Tauri
+    "RUSTSEC-2024-0436", # paste
+    # proc-macro-error is unmaintained, used transitively
+    "RUSTSEC-2024-0370", # proc-macro-error
+    # unic-* crates are unmaintained, used transitively by Tauri's HTML parser
+    "RUSTSEC-2025-0012", # unic-ucd-ident
+    "RUSTSEC-2025-0013", # unic-common
+    "RUSTSEC-2025-0014", # unic-char-range
+    "RUSTSEC-2025-0015", # unic-char-property
+    "RUSTSEC-2025-0016", # unic-ucd-version
+    # fxhash is unmaintained, used transitively
+    "RUSTSEC-2025-0009", # fxhash
+]
 
 [licenses]
 allow = [
     "MIT",
     "MIT-0",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "OpenSSL",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ yanked = "warn"
 unlicensed = "deny"
 allow = [
     "MIT",
+    "MIT-0",
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
@@ -16,6 +17,10 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib",
     "OpenSSL",
+    "Unlicense",
+    "0BSD",
+    "BSL-1.0",
+    "CC0-1.0",
 ]
 confidence-threshold = 0.8
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,16 +6,21 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
     # Tauri transitive dependencies — unmaintained crates we cannot control.
-    # GTK3 bindings (10 advisories for various gtk-rs crates)
+    # GTK3 bindings
     "RUSTSEC-2024-0411",
     "RUSTSEC-2024-0412",
     "RUSTSEC-2024-0413",
     "RUSTSEC-2024-0414",
     "RUSTSEC-2024-0415",
     "RUSTSEC-2024-0416",
+    "RUSTSEC-2024-0417",
     "RUSTSEC-2024-0418",
     "RUSTSEC-2024-0419",
     "RUSTSEC-2024-0420",
+    # paste
+    "RUSTSEC-2024-0436",
+    # proc-macro-error
+    "RUSTSEC-2024-0370",
     # fxhash
     "RUSTSEC-2025-0057",
     # unic-* crates


### PR DESCRIPTION
CI pipeline (9 jobs):
- commitlint: conventional commit validation on PRs
- format: cargo fmt --all across workspace
- lint: clippy with -D warnings (includes Tauri webview deps)
- test: cargo test --workspace on Linux/macOS/Windows
- frontend: svelte-check + npm build for Tauri frontend
- build-cli: release binary for kiro-market on 3 platforms
- build-tauri: .deb/.dmg/.msi packages for kcc on 3 platforms
- cargo-deny: security vulnerability and license audit
- coverage: cargo-llvm-cov uploaded to Codecov
- ci-success: gate job requiring all others to pass

Release pipeline (tag-triggered):
- Builds CLI binaries and Tauri packages on all 3 platforms
- Uploads to GitHub Releases as draft with auto-generated notes

Also adds deny.toml for cargo-deny license/advisory configuration.