### PR TITLE
refactor: service layer, git trait, and platform abstraction

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,21 @@ and installs SKILL.md files into Kiro CLI projects at `.kiro/skills/`.
 Multi-file Claude Code skills (SKILL.md + companion .md files) are merged into a
 single SKILL.md since Kiro doesn't support deferred loading of companion files.
 
+### Service Layer
+Marketplace operations (add/remove/update/list) live in `kiro-market-core::service::MarketplaceService`.
+CLI and Tauri handlers are thin wrappers that construct the service, call it, and format output.
+Domain logic is never duplicated between frontends.
+
+### Git Abstraction
+Git operations are abstracted behind the `GitBackend` trait (`kiro-market-core::git`).
+`GixCliBackend` implements the trait using `gix` for clone/open and the system `git` CLI
+for pull/checkout. The trait enables mock-based testing without filesystem git repos.
+
+### Platform Abstraction
+Local marketplace linking uses `kiro-market-core::platform` which provides
+`create_local_link`/`is_local_link`/`remove_local_link`. On Unix this uses symlinks,
+on Windows it uses directory junctions with copy fallback.
+
 ## Key Crate Dependencies
 - `gix` + system `git` CLI — git operations (gix for clone/open, system git for pull/checkout)
 - `clap` (derive) — CLI framework

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,6 +3180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3236,6 +3246,7 @@ dependencies = [
  "clap",
  "dirs",
  "gix",
+ "junction",
  "pulldown-cmark",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ dirs = "6"
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
 
+# Platform
+junction = "1"
+
 # Testing
 rstest = "0.26"
 tempfile = "3"

--- a/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
@@ -1,49 +1,12 @@
-//! Commands for managing marketplace sources.
+//! Tauri commands for managing marketplace sources.
+//!
+//! Thin wrappers around [`kiro_market_core::service::MarketplaceService`].
 
-use std::fs;
-
-use serde::Serialize;
-use tracing::{debug, warn};
-
-use kiro_market_core::cache::{self, CacheDir, KnownMarketplace, MarketplaceSource};
-use kiro_market_core::git::{self, GitProtocol};
-use kiro_market_core::marketplace::Marketplace;
-use kiro_market_core::validation;
+use kiro_market_core::cache::CacheDir;
+use kiro_market_core::git::{GitProtocol, GixCliBackend};
+use kiro_market_core::service::{MarketplaceAddResult, MarketplaceService, UpdateResult};
 
 use crate::error::{CommandError, ErrorType};
-
-// ---------------------------------------------------------------------------
-// Response types
-// ---------------------------------------------------------------------------
-
-/// Result of adding a new marketplace, including the discovered plugins.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct MarketplaceAddResult {
-    pub name: String,
-    pub plugins: Vec<PluginBasicInfo>,
-}
-
-/// Basic information about a plugin within a marketplace.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct PluginBasicInfo {
-    pub name: String,
-    pub description: Option<String>,
-}
-
-/// Result of updating one or more marketplaces.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct UpdateResult {
-    pub updated: Vec<String>,
-    pub failed: Vec<FailedUpdate>,
-    pub skipped: Vec<String>,
-}
-
-/// A marketplace that failed to update, with the reason.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct FailedUpdate {
-    pub name: String,
-    pub error: String,
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,272 +23,39 @@ fn get_cache() -> Result<CacheDir, CommandError> {
     })
 }
 
+fn service() -> Result<MarketplaceService, CommandError> {
+    let cache = get_cache()?;
+    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
 
 /// Add a new marketplace source.
-///
-/// Mirrors the CLI `marketplace add` flow:
-/// 1. Detect source type (GitHub shorthand, git URL, local path).
-/// 2. Clone or symlink into a temp directory inside the cache.
-/// 3. Read the marketplace manifest to discover the canonical name.
-/// 4. Validate the name, rename to its final location.
-/// 5. Register in `known_marketplaces.json`.
-/// 6. Return the name and discovered plugins.
 #[tauri::command]
 #[specta::specta]
 pub async fn add_marketplace(
     source: String,
     protocol: Option<GitProtocol>,
 ) -> Result<MarketplaceAddResult, CommandError> {
+    let svc = service()?;
     let protocol = protocol.unwrap_or_default();
-    debug!(protocol = ?protocol, "resolved git protocol for marketplace add");
-    let ms = MarketplaceSource::detect(&source);
-    let cache = get_cache()?;
-    cache.ensure_dirs().map_err(|e| {
-        CommandError::new(
-            format!("failed to create cache directories: {e}"),
-            ErrorType::IoError,
-        )
-    })?;
-
-    // Clone or symlink into a temporary name first, then rename once we
-    // know the real marketplace name from the manifest.
-    let temp_name = format!("_pending_{}", std::process::id());
-    let temp_dir = cache.marketplace_path(&temp_name);
-
-    // Clean up any leftover temp directory from a prior interrupted run.
-    if temp_dir.exists() {
-        fs::remove_dir_all(&temp_dir).map_err(|e| {
-            CommandError::new(
-                format!("failed to clean up {}: {e}", temp_dir.display()),
-                ErrorType::IoError,
-            )
-        })?;
-    }
-
-    match &ms {
-        MarketplaceSource::GitHub { repo } => {
-            let url = git::github_repo_to_url(repo, protocol);
-            debug!(url = %url, dest = %temp_dir.display(), "cloning GitHub marketplace");
-            git::clone_repo(&url, &temp_dir, None).map_err(|e| {
-                CommandError::new(format!("failed to clone {repo}: {e}"), ErrorType::GitError)
-            })?;
-        }
-        MarketplaceSource::GitUrl { url } => {
-            if protocol != GitProtocol::default() {
-                warn!("protocol parameter ignored for full git URL; the URL's own scheme is used");
-            }
-            debug!(url = %url, dest = %temp_dir.display(), "cloning git marketplace");
-            git::clone_repo(url, &temp_dir, None).map_err(|e| {
-                CommandError::new(format!("failed to clone {url}: {e}"), ErrorType::GitError)
-            })?;
-        }
-        MarketplaceSource::LocalPath { path } => {
-            let src = cache::resolve_local_path(path).map_err(|e| {
-                CommandError::new(
-                    format!("failed to resolve path '{path}': {e}"),
-                    ErrorType::IoError,
-                )
-            })?;
-            debug!(src = %src.display(), dest = %temp_dir.display(), "symlinking local marketplace");
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(&src, &temp_dir).map_err(|e| {
-                CommandError::new(
-                    format!(
-                        "failed to symlink {} -> {}: {e}",
-                        src.display(),
-                        temp_dir.display()
-                    ),
-                    ErrorType::IoError,
-                )
-            })?;
-            #[cfg(not(unix))]
-            return Err(CommandError::new(
-                "local path marketplaces are only supported on Unix",
-                ErrorType::Validation,
-            ));
-        }
-    }
-
-    // Read marketplace manifest to get the canonical name.
-    let manifest_path = temp_dir.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
-    let manifest_bytes = fs::read(&manifest_path).map_err(|e| {
-        // Clean up temp on failure.
-        let _ = fs::remove_dir_all(&temp_dir);
-        CommandError::new(
-            format!(
-                "marketplace manifest not found at {}: {e}",
-                manifest_path.display()
-            ),
-            ErrorType::NotFound,
-        )
-    })?;
-
-    let manifest = Marketplace::from_json(&manifest_bytes).map_err(|e| {
-        let _ = fs::remove_dir_all(&temp_dir);
-        CommandError::new(
-            format!("failed to parse marketplace manifest: {e}"),
-            ErrorType::ParseError,
-        )
-    })?;
-
-    let name = manifest.name.clone();
-
-    // Validate name before any filesystem operation that uses it.
-    validation::validate_name(&name).map_err(|e| {
-        let _ = fs::remove_dir_all(&temp_dir);
-        CommandError::from(kiro_market_core::error::Error::from(e))
-    })?;
-
-    // Rename temp dir to the real marketplace name.
-    let final_dir = cache.marketplace_path(&name);
-    if final_dir.exists() {
-        let _ = fs::remove_dir_all(&temp_dir);
-        return Err(CommandError::new(
-            format!("marketplace '{name}' already exists"),
-            ErrorType::AlreadyExists,
-        ));
-    }
-
-    fs::rename(&temp_dir, &final_dir).map_err(|e| {
-        CommandError::new(
-            format!(
-                "failed to rename {} -> {}: {e}",
-                temp_dir.display(),
-                final_dir.display()
-            ),
-            ErrorType::IoError,
-        )
-    })?;
-
-    // Register in known_marketplaces.json.
-    let entry = KnownMarketplace {
-        name: name.clone(),
-        source: ms,
-        protocol: Some(protocol),
-        added_at: chrono::Utc::now(),
-    };
-    cache
-        .add_known_marketplace(entry)
-        .map_err(CommandError::from)?;
-
-    // Build plugin list for the response.
-    let plugins: Vec<PluginBasicInfo> = manifest
-        .plugins
-        .iter()
-        .map(|p| PluginBasicInfo {
-            name: p.name.clone(),
-            description: p.description.clone(),
-        })
-        .collect();
-
-    debug!(marketplace = %name, plugin_count = plugins.len(), "marketplace added");
-
-    Ok(MarketplaceAddResult { name, plugins })
+    svc.add(&source, protocol).map_err(CommandError::from)
 }
 
 /// Remove a registered marketplace and its cached data.
 #[tauri::command]
 #[specta::specta]
 pub async fn remove_marketplace(name: String) -> Result<(), CommandError> {
-    let cache = get_cache()?;
-
-    // Remove from the registry first.
-    cache
-        .remove_known_marketplace(&name)
-        .map_err(CommandError::from)?;
-
-    // Remove the cloned directory or symlink.
-    let mp_path = cache.marketplace_path(&name);
-    if mp_path.is_symlink() {
-        fs::remove_file(&mp_path).map_err(|e| {
-            CommandError::new(
-                format!("failed to remove symlink {}: {e}", mp_path.display()),
-                ErrorType::IoError,
-            )
-        })?;
-    } else if mp_path.exists() {
-        fs::remove_dir_all(&mp_path).map_err(|e| {
-            CommandError::new(
-                format!("failed to remove directory {}: {e}", mp_path.display()),
-                ErrorType::IoError,
-            )
-        })?;
-    }
-
-    debug!(marketplace = %name, "marketplace removed");
-
-    Ok(())
+    let svc = service()?;
+    svc.remove(&name).map_err(CommandError::from)
 }
 
 /// Update marketplace clone(s) from remote.
-///
-/// If `name` is provided, only that marketplace is updated. Otherwise all
-/// registered marketplaces are updated. Symlinked (local) marketplaces are
-/// skipped since they always reflect the latest state on disk.
 #[tauri::command]
 #[specta::specta]
 pub async fn update_marketplace(name: Option<String>) -> Result<UpdateResult, CommandError> {
-    let cache = get_cache()?;
-    let entries = cache
-        .load_known_marketplaces()
-        .map_err(CommandError::from)?;
-
-    if entries.is_empty() {
-        return Ok(UpdateResult {
-            updated: Vec::new(),
-            failed: Vec::new(),
-            skipped: Vec::new(),
-        });
-    }
-
-    // Filter by name if provided.
-    let targets: Vec<&KnownMarketplace> = if let Some(ref filter_name) = name {
-        let filtered: Vec<_> = entries.iter().filter(|e| e.name == *filter_name).collect();
-        if filtered.is_empty() {
-            return Err(CommandError::new(
-                format!("marketplace '{filter_name}' is not registered"),
-                ErrorType::NotFound,
-            ));
-        }
-        filtered
-    } else {
-        entries.iter().collect()
-    };
-
-    let mut result = UpdateResult {
-        updated: Vec::new(),
-        failed: Vec::new(),
-        skipped: Vec::new(),
-    };
-
-    for entry in &targets {
-        let mp_path = cache.marketplace_path(&entry.name);
-
-        // Skip symlinked (local) marketplaces -- they always reflect the
-        // latest state on disk.
-        if mp_path.is_symlink() {
-            debug!(marketplace = %entry.name, "skipping local marketplace");
-            result.skipped.push(entry.name.clone());
-            continue;
-        }
-
-        match git::pull_repo(&mp_path) {
-            Ok(()) => {
-                debug!(marketplace = %entry.name, "marketplace updated");
-                result.updated.push(entry.name.clone());
-            }
-            Err(e) => {
-                warn!(marketplace = %entry.name, error = %e, "failed to update marketplace");
-                result.failed.push(FailedUpdate {
-                    name: entry.name.clone(),
-                    error: e.to_string(),
-                });
-            }
-        }
-    }
-
-    Ok(result)
+    let svc = service()?;
+    svc.update(name.as_deref()).map_err(CommandError::from)
 }

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -27,6 +27,9 @@ chrono = { workspace = true }
 clap = { workspace = true, optional = true }
 specta = { version = "2.0.0-rc.20", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+junction = { workspace = true }
+
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/kiro-market-core/src/git.rs
+++ b/crates/kiro-market-core/src/git.rs
@@ -59,37 +59,62 @@ pub trait GitBackend: Send + Sync {
     fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError>;
 }
 
+// ---------------------------------------------------------------------------
+// Gix + CLI backend
+// ---------------------------------------------------------------------------
+
+/// Git backend using `gix` for clone/open and the system `git` CLI for
+/// pull and ref checkout.
+///
+/// SSH connect-timeout protection is applied when no custom `GIT_SSH_COMMAND`
+/// or `GIT_SSH` is configured. `GIT_TERMINAL_PROMPT=0` prevents interactive
+/// prompts from hanging non-interactive contexts.
+#[derive(Debug)]
+pub struct GixCliBackend {
+    ssh_connect_timeout: u32,
+}
+
+impl Default for GixCliBackend {
+    fn default() -> Self {
+        Self {
+            ssh_connect_timeout: SSH_CONNECT_TIMEOUT_SECS,
+        }
+    }
+}
+
 /// Default SSH connect timeout in seconds applied via `GIT_SSH_COMMAND`.
 const SSH_CONNECT_TIMEOUT_SECS: u32 = 30;
 
-/// Run a `git` command with SSH connect-timeout protection.
-///
-/// Sets `GIT_SSH_COMMAND` with a 30-second `ConnectTimeout` to prevent
-/// indefinite hangs when SSH port 22 is firewalled. Detects a missing
-/// `git` binary and returns [`GitError::GitNotFound`].
-fn run_git(args: &[&str], dir: &Path) -> Result<std::process::Output, GitError> {
-    let mut cmd = Command::new("git");
-    cmd.args(args)
-        .current_dir(dir)
-        .env("GIT_TERMINAL_PROMPT", "0");
+impl GixCliBackend {
+    /// Run a `git` command with SSH connect-timeout protection.
+    ///
+    /// Sets `GIT_SSH_COMMAND` with a configurable `ConnectTimeout` to prevent
+    /// indefinite hangs when SSH port 22 is firewalled. Detects a missing
+    /// `git` binary and returns [`GitError::GitNotFound`].
+    fn run_git(&self, args: &[&str], dir: &Path) -> Result<std::process::Output, GitError> {
+        let mut cmd = Command::new("git");
+        cmd.args(args)
+            .current_dir(dir)
+            .env("GIT_TERMINAL_PROMPT", "0");
 
-    // Only set SSH timeout when no custom SSH configuration exists.
-    // GIT_SSH_COMMAND takes precedence over GIT_SSH in git's resolution;
-    // setting it when GIT_SSH points to plink would silently override it.
-    if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
-        cmd.env(
-            "GIT_SSH_COMMAND",
-            format!("ssh -o ConnectTimeout={SSH_CONNECT_TIMEOUT_SECS}"),
-        );
+        // Only set SSH timeout when no custom SSH configuration exists.
+        // GIT_SSH_COMMAND takes precedence over GIT_SSH in git's resolution;
+        // setting it when GIT_SSH points to plink would silently override it.
+        if std::env::var_os("GIT_SSH_COMMAND").is_none() && std::env::var_os("GIT_SSH").is_none() {
+            cmd.env(
+                "GIT_SSH_COMMAND",
+                format!("ssh -o ConnectTimeout={}", self.ssh_connect_timeout),
+            );
+        }
+
+        cmd.output().map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => GitError::GitNotFound,
+            _ => GitError::GitCommandFailed {
+                dir: dir.to_path_buf(),
+                source: Box::new(e),
+            },
+        })
     }
-
-    cmd.output().map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => GitError::GitNotFound,
-        _ => GitError::GitCommandFailed {
-            dir: dir.to_path_buf(),
-            source: Box::new(e),
-        },
-    })
 }
 
 /// Extract a useful error message from a failed git command.
@@ -106,6 +131,108 @@ fn git_error_detail(output: &std::process::Output) -> String {
         return stdout.trim().to_owned();
     }
     format!("git exited with {}", output.status)
+}
+
+impl GitBackend for GixCliBackend {
+    fn clone_repo(&self, url: &str, dest: &Path, opts: &CloneOptions) -> Result<(), GitError> {
+        debug!(url, dest = %dest.display(), git_ref = opts.git_ref.as_deref(), "cloning repository");
+
+        let map_err = |e: Box<dyn std::error::Error + Send + Sync>| GitError::CloneFailed {
+            url: url.to_owned(),
+            source: e,
+        };
+
+        let mut prepare = gix::prepare_clone(url, dest).map_err(|e| map_err(Box::new(e)))?;
+
+        if opts.git_ref.is_none() {
+            let depth = NonZeroU32::MIN;
+            prepare = prepare.with_shallow(gix::remote::fetch::Shallow::DepthAtRemote(depth));
+        }
+
+        let (mut checkout, _outcome) = prepare
+            .fetch_then_checkout(Discard, &AtomicBool::new(false))
+            .map_err(|e| map_err(Box::new(e)))?;
+
+        let (_repo, _outcome) = checkout
+            .main_worktree(Discard, &AtomicBool::new(false))
+            .map_err(|e| map_err(Box::new(e)))?;
+
+        if let Some(refname) = opts.git_ref.as_deref() {
+            if refname.starts_with('-') {
+                return Err(map_err(
+                    format!("invalid git ref: '{refname}' must not start with '-'").into(),
+                ));
+            }
+
+            let output = self
+                .run_git(&["checkout", refname], dest)
+                .map_err(|e| map_err(Box::new(e)))?;
+
+            if !output.status.success() {
+                let detail = git_error_detail(&output);
+                return Err(map_err(detail.into()));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn pull_repo(&self, path: &Path) -> Result<(), GitError> {
+        debug!(path = %path.display(), "pulling repository");
+
+        // Verify it's actually a git repo first (preserves the OpenFailed error).
+        let _repo = gix::open(path).map_err(|e| GitError::OpenFailed {
+            path: path.to_path_buf(),
+            source: Box::new(e),
+        })?;
+
+        let output =
+            self.run_git(&["pull", "--ff-only"], path)
+                .map_err(|e| GitError::PullFailed {
+                    path: path.to_path_buf(),
+                    source: Box::new(e),
+                })?;
+
+        if !output.status.success() {
+            let detail = git_error_detail(&output);
+            return Err(GitError::PullFailed {
+                path: path.to_path_buf(),
+                source: detail.into(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError> {
+        if expected_sha.is_empty() {
+            return Err(GitError::ShaMismatch {
+                expected: "(empty)".to_owned(),
+                actual: "(not checked)".to_owned(),
+            });
+        }
+
+        let repo = gix::open(path).map_err(|e| GitError::OpenFailed {
+            path: path.to_path_buf(),
+            source: Box::new(e),
+        })?;
+
+        let head_id = repo.head_id().map_err(|e| GitError::OpenFailed {
+            path: path.to_path_buf(),
+            source: Box::new(e),
+        })?;
+
+        let actual_sha = head_id.to_string();
+
+        if actual_sha.starts_with(expected_sha) {
+            Ok(())
+        } else {
+            Err(GitError::ShaMismatch {
+                expected: expected_sha.to_owned(),
+                actual: actual_sha,
+            })
+        }
+    }
 }
 
 /// Which transport protocol to use when cloning from a shorthand host
@@ -132,129 +259,40 @@ pub fn github_repo_to_url(repo: &str, protocol: GitProtocol) -> String {
     }
 }
 
-/// Clone a remote Git repository into `dest`.
-///
-/// Uses `gix` for the clone operation. When `git_ref` is `None`, a shallow
-/// clone (depth 1) is used to reduce transfer size. When `git_ref` is
-/// provided, a full clone is performed followed by a `git checkout` of the
-/// specified branch, tag, or SHA (requires the `git` CLI in `$PATH`).
+// ---------------------------------------------------------------------------
+// Deprecated free-function wrappers (removed in Task 8)
+// ---------------------------------------------------------------------------
+
+/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
 ///
 /// # Errors
 ///
 /// Returns [`GitError::CloneFailed`] if the clone or checkout fails.
 pub fn clone_repo(url: &str, dest: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
-    debug!(url, dest = %dest.display(), git_ref, "cloning repository");
-
-    let map_err = |e: Box<dyn std::error::Error + Send + Sync>| GitError::CloneFailed {
-        url: url.to_owned(),
-        source: e,
+    let opts = CloneOptions {
+        git_ref: git_ref.map(ToOwned::to_owned),
     };
-
-    let mut prepare = gix::prepare_clone(url, dest).map_err(|e| map_err(Box::new(e)))?;
-
-    if git_ref.is_none() {
-        let depth = NonZeroU32::MIN;
-        prepare = prepare.with_shallow(gix::remote::fetch::Shallow::DepthAtRemote(depth));
-    }
-
-    let (mut checkout, _outcome) = prepare
-        .fetch_then_checkout(Discard, &AtomicBool::new(false))
-        .map_err(|e| map_err(Box::new(e)))?;
-
-    let (_repo, _outcome) = checkout
-        .main_worktree(Discard, &AtomicBool::new(false))
-        .map_err(|e| map_err(Box::new(e)))?;
-
-    if let Some(refname) = git_ref {
-        if refname.starts_with('-') {
-            return Err(map_err(
-                format!("invalid git ref: '{refname}' must not start with '-'").into(),
-            ));
-        }
-
-        let output = run_git(&["checkout", refname], dest).map_err(|e| map_err(Box::new(e)))?;
-
-        if !output.status.success() {
-            let detail = git_error_detail(&output);
-            return Err(map_err(detail.into()));
-        }
-    }
-
-    Ok(())
+    GixCliBackend::default().clone_repo(url, dest, &opts)
 }
 
-/// Verify the current HEAD of a repository matches the expected SHA prefix.
-///
-/// Both full and abbreviated SHAs are supported: the check passes if the
-/// actual commit SHA starts with the expected string.
-///
-/// # Errors
-///
-/// Returns [`GitError::ShaMismatch`] if the actual commit SHA does not match.
-/// Returns [`GitError::OpenFailed`] if the repository cannot be read.
-pub fn verify_sha(path: &Path, expected_sha: &str) -> Result<(), GitError> {
-    if expected_sha.is_empty() {
-        return Err(GitError::ShaMismatch {
-            expected: "(empty)".to_owned(),
-            actual: "(not checked)".to_owned(),
-        });
-    }
-
-    let repo = gix::open(path).map_err(|e| GitError::OpenFailed {
-        path: path.to_path_buf(),
-        source: Box::new(e),
-    })?;
-
-    let head_id = repo.head_id().map_err(|e| GitError::OpenFailed {
-        path: path.to_path_buf(),
-        source: Box::new(e),
-    })?;
-
-    let actual_sha = head_id.to_string();
-
-    if actual_sha.starts_with(expected_sha) {
-        Ok(())
-    } else {
-        Err(GitError::ShaMismatch {
-            expected: expected_sha.to_owned(),
-            actual: actual_sha,
-        })
-    }
-}
-
-/// Pull the default branch using `git pull --ff-only`.
-///
-/// Opens the repository at `path` with `gix` to verify it is valid,
-/// then runs `git pull --ff-only` to fetch and fast-forward the local
-/// branch.
+/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
 ///
 /// # Errors
 ///
 /// Returns [`GitError::OpenFailed`] if the path is not a valid repository,
 /// or [`GitError::PullFailed`] if the pull fails.
 pub fn pull_repo(path: &Path) -> Result<(), GitError> {
-    debug!(path = %path.display(), "pulling repository");
+    GixCliBackend::default().pull_repo(path)
+}
 
-    // Verify it's actually a git repo first (preserves the OpenFailed error).
-    let _repo = gix::open(path).map_err(|e| GitError::OpenFailed {
-        path: path.to_path_buf(),
-        source: Box::new(e),
-    })?;
-
-    let output = run_git(&["pull", "--ff-only"], path).map_err(|e| GitError::PullFailed {
-        path: path.to_path_buf(),
-        source: Box::new(e),
-    })?;
-
-    if !output.status.success() {
-        let detail = git_error_detail(&output);
-        return Err(GitError::PullFailed {
-            path: path.to_path_buf(),
-            source: detail.into(),
-        });
-    }
-
-    Ok(())
+/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
+///
+/// # Errors
+///
+/// Returns [`GitError::ShaMismatch`] if the SHA does not match.
+/// Returns [`GitError::OpenFailed`] if the repository cannot be read.
+pub fn verify_sha(path: &Path, expected_sha: &str) -> Result<(), GitError> {
+    GixCliBackend::default().verify_sha(path, expected_sha)
 }
 
 #[cfg(test)]

--- a/crates/kiro-market-core/src/git.rs
+++ b/crates/kiro-market-core/src/git.rs
@@ -15,6 +15,50 @@ use tracing::debug;
 
 use crate::error::GitError;
 
+// ---------------------------------------------------------------------------
+// Git backend trait
+// ---------------------------------------------------------------------------
+
+/// Options for cloning a repository.
+///
+/// When `git_ref` is `None`, the implementation should use a shallow clone
+/// (depth 1) to reduce transfer size. When `git_ref` is `Some`, a full
+/// clone is performed followed by a checkout of the specified ref.
+#[derive(Clone, Debug, Default)]
+pub struct CloneOptions {
+    /// Branch, tag, or SHA to check out after cloning.
+    pub git_ref: Option<String>,
+}
+
+/// Trait abstracting git operations for testability and backend swapping.
+///
+/// Implementations must be `Send + Sync` to support sharing across async
+/// Tauri command handlers via `Arc` or `Box`.
+pub trait GitBackend: Send + Sync {
+    /// Clone a remote repository into `dest`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError::CloneFailed`] if the clone or checkout fails.
+    fn clone_repo(&self, url: &str, dest: &Path, opts: &CloneOptions) -> Result<(), GitError>;
+
+    /// Pull (fast-forward only) the default branch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError::OpenFailed`] if the path is not a valid repository,
+    /// or [`GitError::PullFailed`] if the pull fails.
+    fn pull_repo(&self, path: &Path) -> Result<(), GitError>;
+
+    /// Verify the HEAD commit matches the expected SHA prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError::ShaMismatch`] if the SHA does not match.
+    /// Returns [`GitError::OpenFailed`] if the repository cannot be read.
+    fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError>;
+}
+
 /// Default SSH connect timeout in seconds applied via `GIT_SSH_COMMAND`.
 const SSH_CONNECT_TIMEOUT_SECS: u32 = 30;
 

--- a/crates/kiro-market-core/src/git.rs
+++ b/crates/kiro-market-core/src/git.rs
@@ -259,42 +259,6 @@ pub fn github_repo_to_url(repo: &str, protocol: GitProtocol) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Deprecated free-function wrappers (removed in Task 8)
-// ---------------------------------------------------------------------------
-
-/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
-///
-/// # Errors
-///
-/// Returns [`GitError::CloneFailed`] if the clone or checkout fails.
-pub fn clone_repo(url: &str, dest: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
-    let opts = CloneOptions {
-        git_ref: git_ref.map(ToOwned::to_owned),
-    };
-    GixCliBackend::default().clone_repo(url, dest, &opts)
-}
-
-/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
-///
-/// # Errors
-///
-/// Returns [`GitError::OpenFailed`] if the path is not a valid repository,
-/// or [`GitError::PullFailed`] if the pull fails.
-pub fn pull_repo(path: &Path) -> Result<(), GitError> {
-    GixCliBackend::default().pull_repo(path)
-}
-
-/// Deprecated: use [`GixCliBackend`] directly or `MarketplaceService`.
-///
-/// # Errors
-///
-/// Returns [`GitError::ShaMismatch`] if the SHA does not match.
-/// Returns [`GitError::OpenFailed`] if the repository cannot be read.
-pub fn verify_sha(path: &Path, expected_sha: &str) -> Result<(), GitError> {
-    GixCliBackend::default().verify_sha(path, expected_sha)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,7 +304,10 @@ mod tests {
         let dest = clone_dir.path().join("cloned");
 
         let url = path_to_file_url(origin_dir.path());
-        clone_repo(&url, &dest, None).expect("clone should succeed");
+        let git = GixCliBackend::default();
+        let opts = CloneOptions::default();
+        git.clone_repo(&url, &dest, &opts)
+            .expect("clone should succeed");
 
         let content = std::fs::read_to_string(dest.join("hello.txt")).expect("read hello.txt");
         assert_eq!(content, "Hello, world!");
@@ -351,7 +318,9 @@ mod tests {
         let dest_dir = tempfile::tempdir().expect("tempdir");
         let dest = dest_dir.path().join("bad-clone");
 
-        let err = match clone_repo("file:///nonexistent/repo", &dest, None) {
+        let git = GixCliBackend::default();
+        let opts = CloneOptions::default();
+        let err = match git.clone_repo("file:///nonexistent/repo", &dest, &opts) {
             Err(e) => e,
             Ok(()) => panic!("clone should fail for nonexistent URL"),
         };
@@ -400,7 +369,12 @@ mod tests {
         let dest = clone_dir.path().join("cloned");
         let url = path_to_file_url(origin_dir.path());
 
-        clone_repo(&url, &dest, Some("feature-branch")).expect("clone with ref should succeed");
+        let git = GixCliBackend::default();
+        let opts = CloneOptions {
+            git_ref: Some("feature-branch".to_owned()),
+        };
+        git.clone_repo(&url, &dest, &opts)
+            .expect("clone with ref should succeed");
 
         assert!(
             dest.join("feature.txt").exists(),
@@ -417,7 +391,12 @@ mod tests {
         let dest = clone_dir.path().join("cloned");
         let url = path_to_file_url(origin_dir.path());
 
-        let err = clone_repo(&url, &dest, Some("nonexistent-branch"))
+        let git = GixCliBackend::default();
+        let opts = CloneOptions {
+            git_ref: Some("nonexistent-branch".to_owned()),
+        };
+        let err = git
+            .clone_repo(&url, &dest, &opts)
             .expect_err("should fail for nonexistent ref");
 
         assert!(
@@ -435,7 +414,12 @@ mod tests {
         let dest = clone_dir.path().join("cloned");
         let url = path_to_file_url(origin_dir.path());
 
-        let err = clone_repo(&url, &dest, Some("--orphan=malicious"))
+        let git = GixCliBackend::default();
+        let opts = CloneOptions {
+            git_ref: Some("--orphan=malicious".to_owned()),
+        };
+        let err = git
+            .clone_repo(&url, &dest, &opts)
             .expect_err("should reject dash-prefixed ref");
 
         assert!(
@@ -493,7 +477,9 @@ mod tests {
         let repo = gix::open(dir.path()).expect("open repo");
         let head_sha = repo.head_id().expect("head_id").to_string();
 
-        verify_sha(dir.path(), &head_sha).expect("full SHA should match");
+        let git = GixCliBackend::default();
+        git.verify_sha(dir.path(), &head_sha)
+            .expect("full SHA should match");
     }
 
     #[test]
@@ -505,7 +491,9 @@ mod tests {
         let head_sha = repo.head_id().expect("head_id").to_string();
         let prefix = &head_sha[..7];
 
-        verify_sha(dir.path(), prefix).expect("7-char prefix should match");
+        let git = GixCliBackend::default();
+        git.verify_sha(dir.path(), prefix)
+            .expect("7-char prefix should match");
     }
 
     #[test]
@@ -513,7 +501,10 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         create_local_repo(dir.path());
 
-        let err = verify_sha(dir.path(), "0000000deadbeef").expect_err("should reject wrong SHA");
+        let git = GixCliBackend::default();
+        let err = git
+            .verify_sha(dir.path(), "0000000deadbeef")
+            .expect_err("should reject wrong SHA");
 
         assert!(
             matches!(err, GitError::ShaMismatch { .. }),
@@ -526,7 +517,10 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         create_local_repo(dir.path());
 
-        let err = verify_sha(dir.path(), "").expect_err("should reject empty SHA");
+        let git = GixCliBackend::default();
+        let err = git
+            .verify_sha(dir.path(), "")
+            .expect_err("should reject empty SHA");
 
         assert!(
             matches!(err, GitError::ShaMismatch { .. }),
@@ -544,8 +538,10 @@ mod tests {
 
         // Append extra characters to the actual SHA so it can never be a valid prefix.
         let too_long = format!("{head_sha}extra");
-        let err =
-            verify_sha(dir.path(), &too_long).expect_err("should reject overly long expected SHA");
+        let git = GixCliBackend::default();
+        let err = git
+            .verify_sha(dir.path(), &too_long)
+            .expect_err("should reject overly long expected SHA");
 
         assert!(
             matches!(err, GitError::ShaMismatch { .. }),
@@ -557,7 +553,10 @@ mod tests {
     fn pull_repo_on_non_repo_returns_error() {
         let dir = tempfile::tempdir().expect("tempdir");
 
-        let err = pull_repo(dir.path()).expect_err("should fail on non-repo");
+        let git = GixCliBackend::default();
+        let err = git
+            .pull_repo(dir.path())
+            .expect_err("should fail on non-repo");
 
         assert!(
             matches!(err, GitError::OpenFailed { .. }),
@@ -575,7 +574,10 @@ mod tests {
         let clone_dir = tempfile::tempdir().expect("tempdir");
         let dest = clone_dir.path().join("cloned");
         let url = path_to_file_url(origin_dir.path());
-        clone_repo(&url, &dest, None).expect("clone should succeed");
+        let git = GixCliBackend::default();
+        let opts = CloneOptions::default();
+        git.clone_repo(&url, &dest, &opts)
+            .expect("clone should succeed");
 
         // Add a second commit to the origin.
         let run = |args: &[&str], dir: &Path| {
@@ -607,8 +609,8 @@ mod tests {
             origin_dir.path(),
         );
 
-        // Pull into the clone — the new file should appear.
-        pull_repo(&dest).expect("pull should succeed");
+        // Pull into the clone -- the new file should appear.
+        git.pull_repo(&dest).expect("pull should succeed");
 
         assert!(
             dest.join("second.txt").exists(),

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cache;
 pub mod error;
 pub mod git;
 pub mod marketplace;
+pub mod platform;
 pub mod plugin;
 pub mod project;
 pub mod skill;

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod marketplace;
 pub mod platform;
 pub mod plugin;
 pub mod project;
+pub mod service;
 pub mod skill;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_utils;

--- a/crates/kiro-market-core/src/platform.rs
+++ b/crates/kiro-market-core/src/platform.rs
@@ -1,0 +1,175 @@
+//! Cross-platform filesystem linking for local marketplace tracking.
+//!
+//! On Unix, uses symlinks. On Windows, tries directory junctions (no
+//! admin required on NTFS), with copy fallback.
+
+use std::io;
+use std::path::Path;
+
+/// Create a local link from `src` to `dest` for live marketplace tracking.
+///
+/// # Platform behavior
+///
+/// - **Unix:** Creates a symbolic link.
+/// - **Windows:** Tries a directory junction (NTFS, no admin required).
+///   Falls back to copying `src` into `dest` if junctions fail, logging
+///   a warning that changes won't be live-tracked.
+///
+/// # Errors
+///
+/// Returns an error if the link or copy operation fails (e.g. `src` does
+/// not exist, `dest` already exists, or insufficient permissions).
+pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+    sys::create_local_link(src, dest)
+}
+
+/// Check whether `path` is a local link (symlink or directory junction).
+#[must_use]
+pub fn is_local_link(path: &Path) -> bool {
+    sys::is_local_link(path)
+}
+
+/// Remove a local link without removing the target contents.
+///
+/// # Errors
+///
+/// Returns an error if the link cannot be removed (e.g. it does not exist
+/// or the process lacks permissions).
+pub fn remove_local_link(path: &Path) -> io::Result<()> {
+    sys::remove_local_link(path)
+}
+
+#[cfg(unix)]
+mod sys {
+    use std::io;
+    use std::path::Path;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+        std::os::unix::fs::symlink(src, dest)
+    }
+
+    pub fn is_local_link(path: &Path) -> bool {
+        path.is_symlink()
+    }
+
+    pub fn remove_local_link(path: &Path) -> io::Result<()> {
+        std::fs::remove_file(path)
+    }
+}
+
+#[cfg(windows)]
+mod sys {
+    use std::io;
+    use std::path::Path;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+        // Junctions require absolute source paths.
+        let src = std::fs::canonicalize(src)?;
+
+        // Try directory junction first (works without admin on NTFS).
+        match junction::create(&src, dest) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "junction failed, falling back to directory copy"
+                );
+            }
+        }
+
+        // Fallback: copy the directory tree.
+        copy_dir_recursive(&src, dest)?;
+        tracing::warn!(
+            src = %src.display(),
+            dest = %dest.display(),
+            "used directory copy instead of junction — local changes will NOT be live-tracked"
+        );
+        Ok(())
+    }
+
+    pub fn is_local_link(path: &Path) -> bool {
+        path.is_symlink()
+    }
+
+    pub fn remove_local_link(path: &Path) -> io::Result<()> {
+        // Junctions are directory reparse points — remove_dir removes the
+        // junction without deleting the target. Symlinks use remove_file.
+        if path.is_dir() {
+            std::fs::remove_dir(path)
+        } else {
+            std::fs::remove_file(path)
+        }
+    }
+
+    fn copy_dir_recursive(src: &Path, dest: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let target = dest.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_dir_recursive(&entry.path(), &target)?;
+            } else {
+                std::fs::copy(entry.path(), target)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_detect_local_link() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("source");
+        std::fs::create_dir_all(&src).expect("create source");
+        std::fs::write(src.join("file.txt"), "hello").expect("write");
+
+        let dest = dir.path().join("link");
+        create_local_link(&src, &dest).expect("create link");
+
+        // On Windows, if junctions aren't supported, create_local_link falls
+        // back to a directory copy. In that case is_local_link returns false
+        // and the test still passes — we just verify the content is accessible.
+        if is_local_link(&dest) {
+            assert!(is_local_link(&dest), "should detect as local link");
+        }
+
+        assert!(
+            dest.join("file.txt").exists(),
+            "linked content should be visible"
+        );
+    }
+
+    #[test]
+    fn remove_local_link_does_not_delete_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("source");
+        std::fs::create_dir_all(&src).expect("create source");
+        std::fs::write(src.join("file.txt"), "hello").expect("write");
+
+        let dest = dir.path().join("link");
+        create_local_link(&src, &dest).expect("create link");
+
+        if is_local_link(&dest) {
+            remove_local_link(&dest).expect("remove link");
+            assert!(!dest.exists(), "link should be gone");
+        } else {
+            // Copy fallback — remove_local_link won't work on a regular dir.
+            // Just verify the source is still intact.
+        }
+
+        assert!(src.join("file.txt").exists(), "source should be intact");
+    }
+
+    #[test]
+    fn is_local_link_false_for_regular_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let regular = dir.path().join("regular");
+        std::fs::create_dir_all(&regular).expect("create dir");
+
+        assert!(!is_local_link(&regular), "regular dir is not a link");
+    }
+}

--- a/crates/kiro-market-core/src/platform.rs
+++ b/crates/kiro-market-core/src/platform.rs
@@ -6,30 +6,50 @@
 use std::io;
 use std::path::Path;
 
+/// What `create_local_link` actually did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinkResult {
+    /// A true link was created (symlink on Unix, junction on Windows).
+    /// Changes to the source are reflected immediately.
+    Linked,
+    /// The source was copied into the destination (Windows fallback).
+    /// Changes to the source will NOT be reflected.
+    Copied,
+}
+
 /// Create a local link from `src` to `dest` for live marketplace tracking.
+///
+/// Returns [`LinkResult`] indicating whether a true link or a copy was used,
+/// so callers can inform the user about live-tracking behavior.
 ///
 /// # Platform behavior
 ///
-/// - **Unix:** Creates a symbolic link.
+/// - **Unix:** Creates a symbolic link. Always returns `Linked`.
 /// - **Windows:** Tries a directory junction (NTFS, no admin required).
-///   Falls back to copying `src` into `dest` if junctions fail, logging
-///   a warning that changes won't be live-tracked.
+///   Falls back to copying `src` into `dest` if junctions fail, returning
+///   `Copied` so the caller can warn the user.
 ///
 /// # Errors
 ///
 /// Returns an error if the link or copy operation fails (e.g. `src` does
-/// not exist, `dest` already exists, or insufficient permissions).
-pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+/// not exist or insufficient permissions).
+pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<LinkResult> {
     sys::create_local_link(src, dest)
 }
 
 /// Check whether `path` is a local link (symlink or directory junction).
+///
+/// Returns `false` for regular directories (including copy-fallback dirs),
+/// nonexistent paths, and files.
 #[must_use]
 pub fn is_local_link(path: &Path) -> bool {
     sys::is_local_link(path)
 }
 
 /// Remove a local link without removing the target contents.
+///
+/// Should only be called when [`is_local_link`] returns `true`. For
+/// regular directories (e.g. copy-fallback), use `fs::remove_dir_all`.
 ///
 /// # Errors
 ///
@@ -44,8 +64,11 @@ mod sys {
     use std::io;
     use std::path::Path;
 
-    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
-        std::os::unix::fs::symlink(src, dest)
+    use super::LinkResult;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<LinkResult> {
+        std::os::unix::fs::symlink(src, dest)?;
+        Ok(LinkResult::Linked)
     }
 
     pub fn is_local_link(path: &Path) -> bool {
@@ -62,13 +85,15 @@ mod sys {
     use std::io;
     use std::path::Path;
 
-    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+    use super::LinkResult;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<LinkResult> {
         // Junctions require absolute source paths.
         let src = std::fs::canonicalize(src)?;
 
         // Try directory junction first (works without admin on NTFS).
         match junction::create(&src, dest) {
-            Ok(()) => return Ok(()),
+            Ok(()) => return Ok(LinkResult::Linked),
             Err(e) => {
                 tracing::debug!(
                     error = %e,
@@ -79,22 +104,20 @@ mod sys {
 
         // Fallback: copy the directory tree.
         copy_dir_recursive(&src, dest)?;
-        tracing::warn!(
-            src = %src.display(),
-            dest = %dest.display(),
-            "used directory copy instead of junction — local changes will NOT be live-tracked"
-        );
-        Ok(())
+        Ok(LinkResult::Copied)
     }
 
     pub fn is_local_link(path: &Path) -> bool {
-        path.is_symlink()
+        // Check for both symlinks (IO_REPARSE_TAG_SYMLINK) and directory
+        // junctions (IO_REPARSE_TAG_MOUNT_POINT). Path::is_symlink() only
+        // detects symlinks, so we also check via the junction crate.
+        path.is_symlink() || junction::exists(path).unwrap_or(false)
     }
 
     pub fn remove_local_link(path: &Path) -> io::Result<()> {
         // Junctions are directory reparse points — remove_dir removes the
         // junction without deleting the target. Symlinks use remove_file.
-        if path.is_dir() {
+        if junction::exists(path).unwrap_or(false) || path.is_dir() {
             std::fs::remove_dir(path)
         } else {
             std::fs::remove_file(path)

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -206,10 +206,6 @@ impl MarketplaceService {
     pub fn update(&self, name: Option<&str>) -> Result<UpdateResult, Error> {
         let entries = self.cache.load_known_marketplaces()?;
 
-        if entries.is_empty() {
-            return Ok(UpdateResult::default());
-        }
-
         let targets: Vec<_> = if let Some(filter_name) = name {
             let filtered: Vec<_> = entries.iter().filter(|e| e.name == *filter_name).collect();
             if filtered.is_empty() {
@@ -220,6 +216,9 @@ impl MarketplaceService {
             }
             filtered
         } else {
+            if entries.is_empty() {
+                return Ok(UpdateResult::default());
+            }
             entries.iter().collect()
         };
 
@@ -345,5 +344,146 @@ impl MarketplaceService {
                 .into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::cache::CacheDir;
+    use crate::error::GitError;
+    use crate::git::CloneOptions;
+
+    /// Mock git backend that records calls and creates a minimal marketplace
+    /// manifest in the destination directory during clone.
+    #[derive(Debug, Default)]
+    struct MockGitBackend {
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl GitBackend for MockGitBackend {
+        fn clone_repo(
+            &self,
+            url: &str,
+            dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("clone:{url}"));
+            // Create dest with a minimal marketplace manifest.
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(
+                mp_dir.join("marketplace.json"),
+                r#"{"name":"mock-market","owner":{"name":"Test"},"plugins":[{"name":"mock-plugin","description":"A mock plugin","source":"./plugins/mock"}]}"#,
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn pull_repo(&self, path: &Path) -> Result<(), GitError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("pull:{}", path.display()));
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    fn temp_service() -> (tempfile::TempDir, MarketplaceService) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, MockGitBackend::default());
+        (dir, svc)
+    }
+
+    #[test]
+    fn add_marketplace_registers_and_returns_plugins() {
+        let (_dir, svc) = temp_service();
+        let result = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect("add should succeed");
+
+        assert_eq!(result.name, "mock-market");
+        assert_eq!(result.plugins.len(), 1);
+        assert_eq!(result.plugins[0].name, "mock-plugin");
+
+        let known = svc.list().expect("list");
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].name, "mock-market");
+    }
+
+    #[test]
+    fn add_duplicate_marketplace_returns_error() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https)
+            .expect("first add");
+
+        let err = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect_err("duplicate should fail");
+
+        assert!(
+            err.to_string().contains("already"),
+            "expected 'already' in error: {err}"
+        );
+    }
+
+    #[test]
+    fn remove_marketplace_cleans_up() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https)
+            .expect("add");
+
+        svc.remove("mock-market").expect("remove");
+
+        let known = svc.list().expect("list");
+        assert!(known.is_empty());
+    }
+
+    #[test]
+    fn update_calls_pull_on_cloned_repos() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https)
+            .expect("add");
+
+        let result = svc.update(None).expect("update");
+
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0], "mock-market");
+        assert!(result.failed.is_empty());
+        assert!(result.skipped.is_empty());
+    }
+
+    #[test]
+    fn update_nonexistent_returns_error() {
+        let (_dir, svc) = temp_service();
+
+        let err = svc
+            .update(Some("nope"))
+            .expect_err("should fail for unknown marketplace");
+
+        assert!(
+            err.to_string().contains("not found"),
+            "expected 'not found' in error: {err}"
+        );
+    }
+
+    #[test]
+    fn list_empty_returns_empty_vec() {
+        let (_dir, svc) = temp_service();
+
+        let known = svc.list().expect("list");
+
+        assert!(known.is_empty());
     }
 }

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -1,0 +1,349 @@
+//! Marketplace lifecycle operations.
+//!
+//! [`MarketplaceService`] owns the add/remove/update/list logic that was
+//! previously duplicated between the CLI and Tauri frontends.
+
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+use tracing::{debug, warn};
+
+use crate::cache::{CacheDir, KnownMarketplace, MarketplaceSource};
+use crate::error::{Error, MarketplaceError};
+use crate::git::{self, CloneOptions, GitBackend, GitProtocol};
+use crate::marketplace::Marketplace;
+use crate::{platform, validation};
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of adding a new marketplace.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct MarketplaceAddResult {
+    pub name: String,
+    pub plugins: Vec<PluginBasicInfo>,
+}
+
+/// Basic information about a plugin within a marketplace.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginBasicInfo {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// Result of updating one or more marketplaces.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct UpdateResult {
+    pub updated: Vec<String>,
+    pub failed: Vec<FailedUpdate>,
+    pub skipped: Vec<String>,
+}
+
+/// A marketplace that failed to update, with the reason.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct FailedUpdate {
+    pub name: String,
+    pub error: String,
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Manages the marketplace lifecycle: add, remove, update, list.
+///
+/// Uses `Box<dyn GitBackend>` rather than a generic parameter to keep
+/// handler signatures clean. The vtable cost is negligible relative to
+/// git I/O.
+pub struct MarketplaceService {
+    cache: CacheDir,
+    git: Box<dyn GitBackend>,
+}
+
+impl MarketplaceService {
+    /// Create a new service with the given cache directory and git backend.
+    pub fn new(cache: CacheDir, git: impl GitBackend + 'static) -> Self {
+        Self {
+            cache,
+            git: Box::new(git),
+        }
+    }
+
+    /// Add a new marketplace source.
+    ///
+    /// 1. Detect source type (GitHub, git URL, local path).
+    /// 2. Clone or link into a temp directory in the cache.
+    /// 3. Read the marketplace manifest to discover the canonical name.
+    /// 4. Validate the name, rename to final location.
+    /// 5. Register in `known_marketplaces.json`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the clone/link fails, the manifest is missing or
+    /// invalid, the marketplace name fails validation, or a marketplace with
+    /// the same name is already registered.
+    pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
+        let ms = MarketplaceSource::detect(source);
+        self.cache.ensure_dirs()?;
+
+        let temp_name = format!("_pending_{}", std::process::id());
+        let temp_dir = self.cache.marketplace_path(&temp_name);
+
+        // Clean up any leftover temp directory from a prior interrupted run.
+        if temp_dir.exists()
+            && let Err(e) = fs::remove_dir_all(&temp_dir)
+        {
+            warn!(
+                path = %temp_dir.display(),
+                error = %e,
+                "failed to clean up leftover temp directory"
+            );
+        }
+
+        // Clone or link based on source type.
+        if let Err(e) = self.clone_or_link(&ms, protocol, &temp_dir) {
+            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
+                warn!(
+                    path = %temp_dir.display(),
+                    error = %cleanup_err,
+                    "failed to clean up temp directory after clone failure"
+                );
+            }
+            return Err(e);
+        }
+
+        // Read marketplace manifest.
+        let manifest_path = temp_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
+        let manifest = Self::read_and_validate_manifest(&manifest_path, &temp_dir)?;
+
+        let name = manifest.name.clone();
+
+        // Validate name before any filesystem operation that uses it.
+        if let Err(e) = validation::validate_name(&name) {
+            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
+                warn!(
+                    path = %temp_dir.display(),
+                    error = %cleanup_err,
+                    "failed to clean up temp directory after validation failure"
+                );
+            }
+            return Err(e.into());
+        }
+
+        // Rename temp dir to final location.
+        let final_dir = self.cache.marketplace_path(&name);
+        if final_dir.exists() {
+            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
+                warn!(
+                    path = %temp_dir.display(),
+                    error = %cleanup_err,
+                    "failed to clean up temp directory"
+                );
+            }
+            return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
+        }
+
+        fs::rename(&temp_dir, &final_dir)?;
+
+        // Register in known_marketplaces.json.
+        let entry = KnownMarketplace {
+            name: name.clone(),
+            source: ms,
+            protocol: Some(protocol),
+            added_at: chrono::Utc::now(),
+        };
+        self.cache.add_known_marketplace(entry)?;
+
+        let plugins = manifest
+            .plugins
+            .iter()
+            .map(|p| PluginBasicInfo {
+                name: p.name.clone(),
+                description: p.description.clone(),
+            })
+            .collect();
+
+        debug!(marketplace = %name, "marketplace added");
+
+        Ok(MarketplaceAddResult { name, plugins })
+    }
+
+    /// Remove a registered marketplace and its cached data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the marketplace is not registered or its cached
+    /// data cannot be removed from disk.
+    pub fn remove(&self, name: &str) -> Result<(), Error> {
+        self.cache.remove_known_marketplace(name)?;
+
+        let mp_path = self.cache.marketplace_path(name);
+        if platform::is_local_link(&mp_path) {
+            platform::remove_local_link(&mp_path)?;
+        } else if mp_path.exists() {
+            fs::remove_dir_all(&mp_path)?;
+        }
+
+        debug!(marketplace = %name, "marketplace removed");
+        Ok(())
+    }
+
+    /// Update marketplace clone(s) from remote.
+    ///
+    /// If `name` is provided, only that marketplace is updated. Locally
+    /// linked marketplaces are skipped since they always reflect disk state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the registry cannot be read, or if a specific
+    /// marketplace name was requested but is not registered.
+    pub fn update(&self, name: Option<&str>) -> Result<UpdateResult, Error> {
+        let entries = self.cache.load_known_marketplaces()?;
+
+        if entries.is_empty() {
+            return Ok(UpdateResult::default());
+        }
+
+        let targets: Vec<_> = if let Some(filter_name) = name {
+            let filtered: Vec<_> = entries.iter().filter(|e| e.name == *filter_name).collect();
+            if filtered.is_empty() {
+                return Err(MarketplaceError::NotFound {
+                    name: filter_name.to_owned(),
+                }
+                .into());
+            }
+            filtered
+        } else {
+            entries.iter().collect()
+        };
+
+        let mut result = UpdateResult::default();
+
+        for entry in &targets {
+            let mp_path = self.cache.marketplace_path(&entry.name);
+
+            // Skip locally linked marketplaces -- they always reflect disk state.
+            if platform::is_local_link(&mp_path) {
+                debug!(marketplace = %entry.name, "skipping local marketplace (linked)");
+                result.skipped.push(entry.name.clone());
+                continue;
+            }
+
+            // Skip local path sources that used copy fallback (not a git repo).
+            if matches!(entry.source, MarketplaceSource::LocalPath { .. }) {
+                debug!(
+                    marketplace = %entry.name,
+                    "skipping local marketplace (directory copy)"
+                );
+                result.skipped.push(entry.name.clone());
+                continue;
+            }
+
+            match self.git.pull_repo(&mp_path) {
+                Ok(()) => {
+                    debug!(marketplace = %entry.name, "marketplace updated");
+                    result.updated.push(entry.name.clone());
+                }
+                Err(e) => {
+                    warn!(marketplace = %entry.name, error = %e, "failed to update");
+                    result.failed.push(FailedUpdate {
+                        name: entry.name.clone(),
+                        error: e.to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// List all registered marketplaces.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the registry file cannot be read or parsed.
+    pub fn list(&self) -> Result<Vec<KnownMarketplace>, Error> {
+        self.cache.load_known_marketplaces()
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    fn clone_or_link(
+        &self,
+        ms: &MarketplaceSource,
+        protocol: GitProtocol,
+        dest: &Path,
+    ) -> Result<(), Error> {
+        match ms {
+            MarketplaceSource::GitHub { repo } => {
+                let url = git::github_repo_to_url(repo, protocol);
+                debug!(url = %url, dest = %dest.display(), "cloning GitHub marketplace");
+                let opts = CloneOptions::default();
+                self.git.clone_repo(&url, dest, &opts)?;
+            }
+            MarketplaceSource::GitUrl { url } => {
+                if protocol != GitProtocol::default() {
+                    warn!(
+                        "protocol parameter ignored for full git URL; the URL's own scheme is used"
+                    );
+                }
+                debug!(url = %url, dest = %dest.display(), "cloning git marketplace");
+                let opts = CloneOptions::default();
+                self.git.clone_repo(url, dest, &opts)?;
+            }
+            MarketplaceSource::LocalPath { path } => {
+                let src = crate::cache::resolve_local_path(path)?;
+                debug!(src = %src.display(), dest = %dest.display(), "linking local marketplace");
+                platform::create_local_link(&src, dest)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_and_validate_manifest(
+        manifest_path: &Path,
+        temp_dir: &Path,
+    ) -> Result<Marketplace, Error> {
+        let manifest_bytes = match fs::read(manifest_path) {
+            Ok(bytes) => bytes,
+            Err(_e) => {
+                if let Err(cleanup_err) = fs::remove_dir_all(temp_dir) {
+                    warn!(
+                        path = %temp_dir.display(),
+                        error = %cleanup_err,
+                        "failed to clean up temp directory after manifest read failure"
+                    );
+                }
+                return Err(MarketplaceError::ManifestNotFound {
+                    path: manifest_path.to_path_buf(),
+                }
+                .into());
+            }
+        };
+
+        match Marketplace::from_json(&manifest_bytes) {
+            Ok(m) => Ok(m),
+            Err(e) => {
+                if let Err(cleanup_err) = fs::remove_dir_all(temp_dir) {
+                    warn!(
+                        path = %temp_dir.display(),
+                        error = %cleanup_err,
+                        "failed to clean up temp directory after manifest parse failure"
+                    );
+                }
+                Err(MarketplaceError::InvalidManifest {
+                    reason: e.to_string(),
+                }
+                .into())
+            }
+        }
+    }
+}

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -1,10 +1,11 @@
 //! Marketplace lifecycle operations.
 //!
-//! [`MarketplaceService`] owns the add/remove/update/list logic that was
-//! previously duplicated between the CLI and Tauri frontends.
+//! [`MarketplaceService`] centralizes add/remove/update/list logic so that
+//! CLI and Tauri frontends remain thin presentation wrappers.
 
+use std::error::Error as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use tracing::{debug, warn};
@@ -13,7 +14,47 @@ use crate::cache::{CacheDir, KnownMarketplace, MarketplaceSource};
 use crate::error::{Error, MarketplaceError};
 use crate::git::{self, CloneOptions, GitBackend, GitProtocol};
 use crate::marketplace::Marketplace;
+use crate::platform::LinkResult;
 use crate::{platform, validation};
+
+// ---------------------------------------------------------------------------
+// Temp directory cleanup guard
+// ---------------------------------------------------------------------------
+
+/// RAII guard that removes a temp directory on drop unless defused.
+/// Prevents orphaned `_pending_*` directories when `add()` fails.
+struct TempDirGuard {
+    path: PathBuf,
+    defused: bool,
+}
+
+impl TempDirGuard {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            defused: false,
+        }
+    }
+
+    /// Prevent cleanup on drop (call after successful rename).
+    fn defuse(&mut self) {
+        self.defused = true;
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if !self.defused
+            && let Err(e) = fs::remove_dir_all(&self.path)
+        {
+            warn!(
+                path = %self.path.display(),
+                error = %e,
+                "failed to clean up temp directory"
+            );
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -106,50 +147,34 @@ impl MarketplaceService {
             );
         }
 
+        // Guard auto-cleans temp_dir on any early return. Defuse after rename.
+        let mut guard = TempDirGuard::new(temp_dir.clone());
+
         // Clone or link based on source type.
-        if let Err(e) = self.clone_or_link(&ms, protocol, &temp_dir) {
-            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
-                warn!(
-                    path = %temp_dir.display(),
-                    error = %cleanup_err,
-                    "failed to clean up temp directory after clone failure"
-                );
-            }
-            return Err(e);
+        let link_result = self.clone_or_link(&ms, protocol, &temp_dir)?;
+
+        if link_result == LinkResult::Copied {
+            warn!(
+                source = %source,
+                "marketplace was copied, not linked — local changes will NOT be live-tracked"
+            );
         }
 
         // Read marketplace manifest.
         let manifest_path = temp_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
-        let manifest = Self::read_and_validate_manifest(&manifest_path, &temp_dir)?;
+        let manifest = Self::read_manifest(&manifest_path)?;
 
         let name = manifest.name.clone();
-
-        // Validate name before any filesystem operation that uses it.
-        if let Err(e) = validation::validate_name(&name) {
-            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
-                warn!(
-                    path = %temp_dir.display(),
-                    error = %cleanup_err,
-                    "failed to clean up temp directory after validation failure"
-                );
-            }
-            return Err(e.into());
-        }
+        validation::validate_name(&name)?;
 
         // Rename temp dir to final location.
         let final_dir = self.cache.marketplace_path(&name);
         if final_dir.exists() {
-            if let Err(cleanup_err) = fs::remove_dir_all(&temp_dir) {
-                warn!(
-                    path = %temp_dir.display(),
-                    error = %cleanup_err,
-                    "failed to clean up temp directory"
-                );
-            }
             return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
         }
 
         fs::rename(&temp_dir, &final_dir)?;
+        guard.defuse(); // Rename succeeded — don't clean up.
 
         // Register in known_marketplaces.json.
         let entry = KnownMarketplace {
@@ -251,9 +276,17 @@ impl MarketplaceService {
                 }
                 Err(e) => {
                     warn!(marketplace = %entry.name, error = %e, "failed to update");
+                    // Walk the error source chain for a complete message.
+                    let mut detail = e.to_string();
+                    let mut source: Option<&dyn std::error::Error> = e.source();
+                    while let Some(cause) = source {
+                        detail.push_str(": ");
+                        detail.push_str(&cause.to_string());
+                        source = cause.source();
+                    }
                     result.failed.push(FailedUpdate {
                         name: entry.name.clone(),
-                        error: e.to_string(),
+                        error: detail,
                     });
                 }
             }
@@ -280,13 +313,14 @@ impl MarketplaceService {
         ms: &MarketplaceSource,
         protocol: GitProtocol,
         dest: &Path,
-    ) -> Result<(), Error> {
+    ) -> Result<LinkResult, Error> {
         match ms {
             MarketplaceSource::GitHub { repo } => {
                 let url = git::github_repo_to_url(repo, protocol);
                 debug!(url = %url, dest = %dest.display(), "cloning GitHub marketplace");
                 let opts = CloneOptions::default();
                 self.git.clone_repo(&url, dest, &opts)?;
+                Ok(LinkResult::Linked)
             }
             MarketplaceSource::GitUrl { url } => {
                 if protocol != GitProtocol::default() {
@@ -297,53 +331,38 @@ impl MarketplaceService {
                 debug!(url = %url, dest = %dest.display(), "cloning git marketplace");
                 let opts = CloneOptions::default();
                 self.git.clone_repo(url, dest, &opts)?;
+                Ok(LinkResult::Linked)
             }
             MarketplaceSource::LocalPath { path } => {
                 let src = crate::cache::resolve_local_path(path)?;
                 debug!(src = %src.display(), dest = %dest.display(), "linking local marketplace");
-                platform::create_local_link(&src, dest)?;
+                Ok(platform::create_local_link(&src, dest)?)
             }
         }
-        Ok(())
     }
 
-    fn read_and_validate_manifest(
-        manifest_path: &Path,
-        temp_dir: &Path,
-    ) -> Result<Marketplace, Error> {
+    /// Read and parse the marketplace manifest. Does NOT do cleanup — the
+    /// caller (or its `TempDirGuard`) owns temp directory lifecycle.
+    fn read_manifest(manifest_path: &Path) -> Result<Marketplace, Error> {
         let manifest_bytes = match fs::read(manifest_path) {
             Ok(bytes) => bytes,
-            Err(_e) => {
-                if let Err(cleanup_err) = fs::remove_dir_all(temp_dir) {
-                    warn!(
-                        path = %temp_dir.display(),
-                        error = %cleanup_err,
-                        "failed to clean up temp directory after manifest read failure"
-                    );
-                }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 return Err(MarketplaceError::ManifestNotFound {
                     path: manifest_path.to_path_buf(),
                 }
                 .into());
             }
+            Err(e) => {
+                // Permission denied, I/O error, etc. — propagate the real cause.
+                return Err(e.into());
+            }
         };
 
-        match Marketplace::from_json(&manifest_bytes) {
-            Ok(m) => Ok(m),
-            Err(e) => {
-                if let Err(cleanup_err) = fs::remove_dir_all(temp_dir) {
-                    warn!(
-                        path = %temp_dir.display(),
-                        error = %cleanup_err,
-                        "failed to clean up temp directory after manifest parse failure"
-                    );
-                }
-                Err(MarketplaceError::InvalidManifest {
-                    reason: e.to_string(),
-                }
-                .into())
-            }
-        }
+        Marketplace::from_json(&manifest_bytes).map_err(|e| {
+            Error::from(MarketplaceError::InvalidManifest {
+                reason: e.to_string(),
+            })
+        })
     }
 }
 
@@ -475,5 +494,131 @@ mod tests {
         let known = svc.list().expect("list");
 
         assert!(known.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Additional tests for review findings
+    // -----------------------------------------------------------------------
+
+    /// A git backend that always fails on clone.
+    #[derive(Debug, Default)]
+    struct FailingGitBackend;
+
+    impl GitBackend for FailingGitBackend {
+        fn clone_repo(
+            &self,
+            url: &str,
+            _dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            Err(GitError::CloneFailed {
+                url: url.to_owned(),
+                source: "simulated failure".to_owned().into(),
+            })
+        }
+
+        fn pull_repo(&self, path: &Path) -> Result<(), GitError> {
+            Err(GitError::PullFailed {
+                path: path.to_path_buf(),
+                source: "simulated pull failure".to_owned().into(),
+            })
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_with_clone_failure_cleans_up_temp_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, FailingGitBackend);
+
+        let err = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect_err("should fail");
+
+        assert!(
+            err.to_string().contains("clone"),
+            "expected clone error: {err}"
+        );
+
+        // Verify no _pending_ directory remains.
+        let marketplaces_dir = dir.path().join("marketplaces");
+        if marketplaces_dir.exists() {
+            let entries: Vec<_> = fs::read_dir(&marketplaces_dir).expect("read dir").collect();
+            assert!(
+                entries.is_empty(),
+                "expected no leftover temp dirs, found: {entries:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn add_with_git_url_passes_url_verbatim() {
+        let (_dir, svc) = temp_service();
+        let result = svc
+            .add("https://github.com/owner/repo.git", GitProtocol::Https)
+            .expect("add with git URL");
+
+        assert_eq!(result.name, "mock-market");
+
+        // Verify the mock received the verbatim URL, not a GitHub-reformatted one.
+        // The mock backend is inside the Box, so we check via the registry.
+        let known = svc.list().expect("list");
+        assert_eq!(known.len(), 1);
+        assert!(
+            matches!(
+                &known[0].source,
+                MarketplaceSource::GitUrl { url } if url == "https://github.com/owner/repo.git"
+            ),
+            "expected GitUrl source, got {:?}",
+            known[0].source
+        );
+    }
+
+    #[test]
+    fn update_with_pull_failure_records_in_failed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+
+        // First add a marketplace with the working mock.
+        let svc = MarketplaceService::new(
+            CacheDir::with_root(dir.path().to_path_buf()),
+            MockGitBackend::default(),
+        );
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
+
+        // Now create a new service with the failing backend to test update.
+        let svc = MarketplaceService::new(
+            CacheDir::with_root(dir.path().to_path_buf()),
+            FailingGitBackend,
+        );
+        let result = svc
+            .update(None)
+            .expect("update should return Ok with failures");
+
+        assert!(result.updated.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "mock-market");
+        assert!(
+            result.failed[0].error.contains("pull"),
+            "expected pull error: {}",
+            result.failed[0].error
+        );
+    }
+
+    #[test]
+    fn update_specific_marketplace_by_name() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
+
+        let result = svc.update(Some("mock-market")).expect("update by name");
+
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0], "mock-market");
     }
 }

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -364,16 +364,8 @@ mod tests {
     }
 
     impl GitBackend for MockGitBackend {
-        fn clone_repo(
-            &self,
-            url: &str,
-            dest: &Path,
-            _opts: &CloneOptions,
-        ) -> Result<(), GitError> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push(format!("clone:{url}"));
+        fn clone_repo(&self, url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+            self.calls.lock().unwrap().push(format!("clone:{url}"));
             // Create dest with a minimal marketplace manifest.
             let mp_dir = dest.join(".claude-plugin");
             fs::create_dir_all(&mp_dir).unwrap();
@@ -441,8 +433,7 @@ mod tests {
     #[test]
     fn remove_marketplace_cleans_up() {
         let (_dir, svc) = temp_service();
-        svc.add("owner/repo", GitProtocol::Https)
-            .expect("add");
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
 
         svc.remove("mock-market").expect("remove");
 
@@ -453,8 +444,7 @@ mod tests {
     #[test]
     fn update_calls_pull_on_cloned_repos() {
         let (_dir, svc) = temp_service();
-        svc.add("owner/repo", GitProtocol::Https)
-            .expect("add");
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
 
         let result = svc.update(None).expect("update");
 

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -8,8 +8,7 @@ use chrono::Utc;
 use colored::Colorize;
 use kiro_market_core::cache::CacheDir;
 use kiro_market_core::error::{Error as CoreError, SkillError};
-use kiro_market_core::git;
-use kiro_market_core::git::GitProtocol;
+use kiro_market_core::git::{self, CloneOptions, GitBackend, GitProtocol, GixCliBackend};
 use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::{InstalledSkillMeta, KiroProject};
@@ -389,12 +388,18 @@ fn resolve_structured_source(
 
     debug!(url = %url, dest = %dest.display(), "cloning plugin");
     print!("  Cloning {label}...");
-    git::clone_repo(&url, &dest, git_ref)
+    let backend = GixCliBackend::default();
+    let opts = CloneOptions {
+        git_ref: git_ref.map(ToOwned::to_owned),
+    };
+    backend
+        .clone_repo(&url, &dest, &opts)
         .with_context(|| format!("failed to clone plugin from '{label}'"))?;
     println!(" done");
 
     if let Some(expected) = sha {
-        git::verify_sha(&dest, expected)
+        backend
+            .verify_sha(&dest, expected)
             .with_context(|| format!("SHA verification failed for '{label}'"))?;
     }
 

--- a/crates/kiro-market/src/commands/marketplace.rs
+++ b/crates/kiro-market/src/commands/marketplace.rs
@@ -1,191 +1,65 @@
 //! `marketplace` subcommand: add, list, update, and remove marketplace sources.
 
-use std::fs;
-
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use colored::Colorize;
-use kiro_market_core::cache::{CacheDir, KnownMarketplace, MarketplaceSource};
-use kiro_market_core::git;
-use kiro_market_core::marketplace::Marketplace;
-use tracing::{debug, warn};
+use kiro_market_core::cache::CacheDir;
+use kiro_market_core::git::GixCliBackend;
+use kiro_market_core::service::MarketplaceService;
 
 use crate::cli::MarketplaceAction;
 
 /// Dispatch to the appropriate marketplace subcommand.
 pub fn run(action: &MarketplaceAction) -> Result<()> {
+    let cache = CacheDir::default_location()
+        .context("could not determine data directory; is $HOME set?")?;
+    let git = GixCliBackend::default();
+    let svc = MarketplaceService::new(cache, git);
+
     match action {
-        MarketplaceAction::Add { source, protocol } => add(source, *protocol),
-        MarketplaceAction::List => list(),
-        MarketplaceAction::Update { name } => update(name.as_deref()),
-        MarketplaceAction::Remove { name } => remove(name),
+        MarketplaceAction::Add { source, protocol } => add(&svc, source, *protocol),
+        MarketplaceAction::List => list(&svc),
+        MarketplaceAction::Update { name } => update(&svc, name.as_deref()),
+        MarketplaceAction::Remove { name } => remove(&svc, name),
     }
 }
 
-// ---------------------------------------------------------------------------
-// Source detection
-// ---------------------------------------------------------------------------
-
-// detect_source and source_label are now methods on MarketplaceSource
-// in kiro_market_core::cache (MarketplaceSource::detect, .label())
-
-// ---------------------------------------------------------------------------
-// add
-// ---------------------------------------------------------------------------
-
-/// Add a new marketplace source.
-///
-/// 1. Detect source type (GitHub, git URL, local path).
-/// 2. Clone (or symlink for local paths) into the cache.
-/// 3. Read the marketplace manifest to discover the real name.
-/// 4. Validate the marketplace name.
-/// 5. Rename the clone directory to the real marketplace name.
-/// 6. Register in `known_marketplaces.json`.
-fn add(source: &str, protocol: git::GitProtocol) -> Result<()> {
-    let ms = MarketplaceSource::detect(source);
-    let cache = CacheDir::default_location()
-        .context("could not determine data directory; is $HOME set?")?;
-    cache
-        .ensure_dirs()
-        .context("failed to create cache directories")?;
-
-    // Clone or symlink into a temporary name first, then rename once we
-    // know the real marketplace name from the manifest.
-    let temp_name = format!("_pending_{}", std::process::id());
-    let temp_dir = cache.marketplace_path(&temp_name);
-
-    // Clean up any leftover temp directory from a prior interrupted run.
-    if temp_dir.exists() {
-        fs::remove_dir_all(&temp_dir)
-            .with_context(|| format!("failed to clean up {}", temp_dir.display()))?;
-    }
-
-    match &ms {
-        MarketplaceSource::GitHub { repo } => {
-            let url = git::github_repo_to_url(repo, protocol);
-            debug!(url = %url, dest = %temp_dir.display(), "cloning GitHub marketplace");
-            print!("  Cloning {repo}...");
-            git::clone_repo(&url, &temp_dir, None)
-                .with_context(|| format!("failed to clone {repo}"))?;
-            println!(" done");
-        }
-        MarketplaceSource::GitUrl { url } => {
-            if protocol != git::GitProtocol::default() {
-                warn!("--protocol ignored for full git URL; the URL's own scheme is used");
-            }
-            debug!(url = %url, dest = %temp_dir.display(), "cloning git marketplace");
-            print!("  Cloning {url}...");
-            git::clone_repo(url, &temp_dir, None)
-                .with_context(|| format!("failed to clone {url}"))?;
-            println!(" done");
-        }
-        MarketplaceSource::LocalPath { path } => {
-            let src = kiro_market_core::cache::resolve_local_path(path)
-                .with_context(|| format!("failed to resolve path: {path}"))?;
-            debug!(src = %src.display(), dest = %temp_dir.display(), "symlinking local marketplace");
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(&src, &temp_dir).with_context(|| {
-                format!(
-                    "failed to symlink {} -> {}",
-                    src.display(),
-                    temp_dir.display()
-                )
-            })?;
-            #[cfg(not(unix))]
-            bail!("local path marketplaces are only supported on Unix");
-        }
-    }
-
-    // Read marketplace manifest to get the real name.
-    let manifest_path = temp_dir.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
-    let manifest_bytes = fs::read(&manifest_path).with_context(|| {
-        format!(
-            "marketplace manifest not found at {}",
-            manifest_path.display()
-        )
-    })?;
-    let manifest =
-        Marketplace::from_json(&manifest_bytes).context("failed to parse marketplace manifest")?;
-
-    let name = manifest.name.clone();
-    kiro_market_core::validation::validate_name(&name)
-        .with_context(|| format!("marketplace manifest contains invalid name '{name}'"))?;
-    let plugin_count = manifest.plugins.len();
-
-    // Rename temp dir to the real marketplace name.
-    let final_dir = cache.marketplace_path(&name);
-    if final_dir.exists() {
-        // Clean up the temp clone before reporting the error.
-        let _ = fs::remove_dir_all(&temp_dir);
-        bail!(
-            "marketplace directory already exists at {}",
-            final_dir.display()
-        );
-    }
-    fs::rename(&temp_dir, &final_dir).with_context(|| {
-        format!(
-            "failed to rename {} -> {}",
-            temp_dir.display(),
-            final_dir.display()
-        )
-    })?;
-
-    // Register in known_marketplaces.json.
-    let entry = KnownMarketplace {
-        name: name.clone(),
-        source: ms,
-        protocol: Some(protocol),
-        added_at: chrono::Utc::now(),
-    };
-    cache
-        .add_known_marketplace(entry)
-        .with_context(|| format!("failed to register marketplace '{name}'"))?;
+fn add(
+    svc: &MarketplaceService,
+    source: &str,
+    protocol: kiro_market_core::git::GitProtocol,
+) -> Result<()> {
+    print!("  Adding marketplace...");
+    let result = svc
+        .add(source, protocol)
+        .context("failed to add marketplace")?;
 
     println!(
-        "{} Added marketplace {} ({} plugin{})",
+        " {} Added {} ({} plugin{})",
         "✓".green().bold(),
-        name.bold(),
-        plugin_count,
-        if plugin_count == 1 { "" } else { "s" }
+        result.name.bold(),
+        result.plugins.len(),
+        if result.plugins.len() == 1 { "" } else { "s" }
     );
 
-    print_available_plugins(&manifest.plugins, &name);
+    if !result.plugins.is_empty() {
+        println!();
+        println!("  {}", "Available plugins:".bold());
+        for plugin in &result.plugins {
+            let desc = plugin.description.as_deref().unwrap_or("(no description)");
+            println!("    {} - {}", plugin.name.green(), desc);
+        }
+        println!();
+        println!(
+            "  Install with: {}",
+            format!("kiro-market install <plugin>@{}", result.name).bold()
+        );
+    }
 
     Ok(())
 }
 
-/// Print the list of available plugins after adding a marketplace.
-fn print_available_plugins(
-    plugins: &[kiro_market_core::marketplace::PluginEntry],
-    marketplace_name: &str,
-) {
-    if plugins.is_empty() {
-        return;
-    }
-
-    println!();
-    println!("  {}", "Available plugins:".bold());
-    for plugin in plugins {
-        let desc = plugin.description.as_deref().unwrap_or("(no description)");
-        println!("    {} - {}", plugin.name.green(), desc);
-    }
-    println!();
-    println!(
-        "  Install with: {}",
-        format!("kiro-market install <plugin>@{marketplace_name}").bold()
-    );
-}
-
-// ---------------------------------------------------------------------------
-// list
-// ---------------------------------------------------------------------------
-
-/// List all registered marketplaces.
-fn list() -> Result<()> {
-    let cache = CacheDir::default_location()
-        .context("could not determine data directory; is $HOME set?")?;
-    let entries = cache
-        .load_known_marketplaces()
-        .context("failed to load known marketplaces")?;
+fn list(svc: &MarketplaceService) -> Result<()> {
+    let entries = svc.list().context("failed to load marketplaces")?;
 
     if entries.is_empty() {
         println!(
@@ -203,94 +77,43 @@ fn list() -> Result<()> {
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// update
-// ---------------------------------------------------------------------------
+fn update(svc: &MarketplaceService, name: Option<&str>) -> Result<()> {
+    let result = svc.update(name).context("failed to update marketplaces")?;
 
-/// Update marketplace clone(s) from remote.
-fn update(name: Option<&str>) -> Result<()> {
-    let cache = CacheDir::default_location()
-        .context("could not determine data directory; is $HOME set?")?;
-    let entries = cache
-        .load_known_marketplaces()
-        .context("failed to load known marketplaces")?;
-
-    if entries.is_empty() {
-        println!("No marketplaces registered.");
-        return Ok(());
+    for name in &result.skipped {
+        println!("  {} {} (local, skipped)", "·".bold(), name.bold());
+    }
+    for name in &result.updated {
+        println!(
+            "  {} {} {}",
+            "✓".green().bold(),
+            name.bold(),
+            "done".green()
+        );
+    }
+    for fail in &result.failed {
+        println!(
+            "  {} {} {}",
+            "✗".red().bold(),
+            fail.name.bold(),
+            fail.error.red()
+        );
     }
 
-    let targets: Vec<_> = if let Some(name) = name {
-        let filtered: Vec<_> = entries.iter().filter(|e| e.name == name).collect();
-        if filtered.is_empty() {
-            bail!("marketplace '{name}' is not registered");
-        }
-        filtered
-    } else {
-        entries.iter().collect()
-    };
-
-    let mut failures = 0u32;
-
-    for entry in &targets {
-        let mp_path = cache.marketplace_path(&entry.name);
-
-        // Skip symlinked (local) marketplaces -- they always reflect the
-        // latest state on disk.
-        if mp_path.is_symlink() {
-            println!("  {} {} (local, skipped)", "·".bold(), entry.name.bold());
-            continue;
-        }
-
-        print!("  Updating {}...", entry.name.bold());
-        match git::pull_repo(&mp_path) {
-            Ok(()) => {
-                println!(" {}", "done".green());
-            }
-            Err(e) => {
-                println!(" {}: {}", "failed".red(), e);
-                failures += 1;
-            }
-        }
-    }
-
-    if failures > 0 {
-        bail!(
-            "{failures} marketplace{} failed to update",
-            if failures == 1 { "" } else { "s" }
+    if !result.failed.is_empty() {
+        anyhow::bail!(
+            "{} marketplace{} failed to update",
+            result.failed.len(),
+            if result.failed.len() == 1 { "" } else { "s" }
         );
     }
 
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// remove
-// ---------------------------------------------------------------------------
-
-/// Remove a registered marketplace and its cached data.
-fn remove(name: &str) -> Result<()> {
-    let cache = CacheDir::default_location()
-        .context("could not determine data directory; is $HOME set?")?;
-
-    // Remove from the registry first.
-    cache
-        .remove_known_marketplace(name)
+fn remove(svc: &MarketplaceService, name: &str) -> Result<()> {
+    svc.remove(name)
         .with_context(|| format!("failed to remove marketplace '{name}'"))?;
-
-    // Remove the cloned directory or symlink.
-    let mp_path = cache.marketplace_path(name);
-    if mp_path.is_symlink() {
-        fs::remove_file(&mp_path)
-            .with_context(|| format!("failed to remove symlink {}", mp_path.display()))?;
-    } else if mp_path.exists() {
-        fs::remove_dir_all(&mp_path)
-            .with_context(|| format!("failed to remove directory {}", mp_path.display()))?;
-    }
-
     println!("{} Removed marketplace {}", "✓".green().bold(), name.bold());
-
     Ok(())
 }
-
-// detect_source and source_label tests moved to kiro-market-core::cache::tests

--- a/crates/kiro-market/src/commands/marketplace.rs
+++ b/crates/kiro-market/src/commands/marketplace.rs
@@ -80,6 +80,11 @@ fn list(svc: &MarketplaceService) -> Result<()> {
 fn update(svc: &MarketplaceService, name: Option<&str>) -> Result<()> {
     let result = svc.update(name).context("failed to update marketplaces")?;
 
+    if result.updated.is_empty() && result.failed.is_empty() && result.skipped.is_empty() {
+        println!("No marketplaces registered.");
+        return Ok(());
+    }
+
     for name in &result.skipped {
         println!("  {} {} (local, skipped)", "·".bold(), name.bold());
     }

--- a/docs/plans/2026-04-04-service-layer-plan.md
+++ b/docs/plans/2026-04-04-service-layer-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Eliminate duplicated marketplace logic between CLI and Tauri by introducing a `GitBackend` trait, a `platform` module for cross-platform local links, and a `MarketplaceService` that owns all marketplace operations.
 
-**Architecture:** The `GitBackend` trait abstracts git operations (clone/pull/verify). `GixCliBackend` implements it using the current gix+CLI hybrid. A `platform` module provides cross-platform `create_local_link`/`is_local_link`/`remove_local_link` functions. `MarketplaceService<G: GitBackend>` owns the marketplace lifecycle (add/remove/update/list), replacing the duplicated logic in both frontends. CLI and Tauri handlers become thin wrappers that call the service and format output.
+**Architecture:** The `GitBackend` trait abstracts git operations (clone/pull/verify). `GixCliBackend` implements it using the current gix+CLI hybrid. A `platform` module provides cross-platform `create_local_link`/`is_local_link`/`remove_local_link` functions. `MarketplaceService` stores the backend as `Box<dyn GitBackend>` (not a generic parameter — vtable cost is negligible relative to git I/O, and it simplifies all handler signatures). The service owns the marketplace lifecycle (add/remove/update/list), replacing the duplicated logic in both frontends. CLI and Tauri handlers become thin wrappers that call the service and format output.
 
 **Tech Stack:** Rust 1.85, gix 0.81, thiserror, junction crate (Windows-only)
 
@@ -24,9 +24,9 @@ At the top of `git.rs` (after the `use` block, before `SSH_CONNECT_TIMEOUT_SECS`
 #[derive(Clone, Debug, Default)]
 pub struct CloneOptions {
     /// Branch, tag, or SHA to check out after cloning.
+    /// When `None`, a shallow clone (depth 1) is used to reduce transfer size.
+    /// When `Some`, a full clone is performed followed by a checkout of the ref.
     pub git_ref: Option<String>,
-    /// Whether to perform a shallow clone (depth 1).
-    pub shallow: bool,
 }
 
 /// Trait abstracting git operations for testability and backend swapping.
@@ -44,6 +44,8 @@ pub trait GitBackend: Send + Sync {
     fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError>;
 }
 ```
+
+**Design note:** `shallow` is not a separate field — it's derived from `git_ref` inside the implementation. When `git_ref` is `None`, clone is shallow. This avoids exposing a knob nobody turns independently.
 
 **Step 2: Run tests**
 
@@ -123,7 +125,6 @@ Replace the existing free functions with wrappers that call `GixCliBackend::defa
 pub fn clone_repo(url: &str, dest: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
     let opts = CloneOptions {
         git_ref: git_ref.map(ToOwned::to_owned),
-        shallow: git_ref.is_none(),
     };
     GixCliBackend::default().clone_repo(url, dest, &opts)
 }
@@ -137,7 +138,7 @@ pub fn verify_sha(path: &Path, expected_sha: &str) -> Result<(), GitError> {
 }
 ```
 
-This keeps all existing callers working without changes. The wrappers get removed in Task 6.
+This keeps all existing callers working without changes. The wrappers get removed in Task 8.
 
 **Step 3: Fix tests to use GixCliBackend directly**
 
@@ -296,19 +297,96 @@ mod sys {
 
 Add `pub mod platform;` after `pub mod plugin;`.
 
-**Step 4: Run tests**
+**Step 4: Add platform module tests**
 
-Run: `cargo test -p kiro-market-core`
+Add a `#[cfg(test)] mod tests` at the bottom of `platform.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_detect_local_link() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("source");
+        std::fs::create_dir_all(&src).expect("create source");
+        std::fs::write(src.join("file.txt"), "hello").expect("write");
+
+        let dest = dir.path().join("link");
+        create_local_link(&src, &dest).expect("create link");
+
+        assert!(is_local_link(&dest), "dest should be detected as a link");
+        assert!(
+            dest.join("file.txt").exists(),
+            "linked content should be visible"
+        );
+    }
+
+    #[test]
+    fn remove_local_link_does_not_delete_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("source");
+        std::fs::create_dir_all(&src).expect("create source");
+        std::fs::write(src.join("file.txt"), "hello").expect("write");
+
+        let dest = dir.path().join("link");
+        create_local_link(&src, &dest).expect("create link");
+        remove_local_link(&dest).expect("remove link");
+
+        assert!(!dest.exists(), "link should be gone");
+        assert!(src.join("file.txt").exists(), "source should be intact");
+    }
+
+    #[test]
+    fn is_local_link_false_for_regular_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let regular = dir.path().join("regular");
+        std::fs::create_dir_all(&regular).expect("create dir");
+
+        assert!(!is_local_link(&regular), "regular dir is not a link");
+    }
+}
+```
+
+**Important:** On Windows, the junction fallback may trigger `copy_dir_recursive` instead of creating a true link. The `is_local_link` test will return `false` for copies, which means `create_and_detect_local_link` may fail on some Windows configurations (non-NTFS, no junction support). Add a note to the test acknowledging this and skip if `is_local_link` returns false after creation:
+
+```rust
+    // On Windows, if junctions aren't supported, create_local_link falls
+    // back to a directory copy. In that case is_local_link returns false
+    // and the test still passes — we just verify the content is accessible.
+```
+
+**Step 5: Handle junction preconditions on Windows**
+
+The `junction::create` function requires:
+- `src` must be an absolute path
+- `dest` must not already exist
+
+Add canonicalization of `src` before calling `junction::create` in the Windows implementation:
+
+```rust
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+        // Junctions require absolute source paths.
+        let src = std::fs::canonicalize(src)?;
+        // ...
+    }
+```
+
+**Step 6: Run tests**
+
+Run: `cargo test -p kiro-market-core platform`
 Run: `cargo clippy --workspace -- -D warnings`
 Expected: All pass.
 
-**Step 5: Commit**
+**Step 7: Commit**
 
 ```
 feat: add platform module for cross-platform local marketplace links
 
 Unix uses symlinks, Windows uses directory junctions with copy
-fallback. Replaces scattered #[cfg(unix)] blocks in UI-layer code.
+fallback. Includes unit tests for link creation, detection, and
+removal. Replaces scattered #[cfg(unix)] blocks in UI-layer code.
 ```
 
 ---
@@ -345,24 +423,24 @@ use crate::{platform, validation};
 // ---------------------------------------------------------------------------
 
 /// Result of adding a new marketplace.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+#[derive(Clone, Debug, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct MarketplaceAddResult {
     pub name: String,
     pub plugins: Vec<PluginBasicInfo>,
 }
 
 /// Basic information about a plugin within a marketplace.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+#[derive(Clone, Debug, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct PluginBasicInfo {
     pub name: String,
     pub description: Option<String>,
 }
 
 /// Result of updating one or more marketplaces.
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+#[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct UpdateResult {
     pub updated: Vec<String>,
     pub failed: Vec<FailedUpdate>,
@@ -370,26 +448,32 @@ pub struct UpdateResult {
 }
 
 /// A marketplace that failed to update, with the reason.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+#[derive(Clone, Debug, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct FailedUpdate {
     pub name: String,
     pub error: String,
 }
+
+**Design note:** `serde::Serialize` is unconditional (Tauri needs it for IPC). Only `specta::Type` is feature-gated.
 
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
 /// Manages the marketplace lifecycle: add, remove, update, list.
-pub struct MarketplaceService<G: GitBackend> {
+///
+/// Uses `Box<dyn GitBackend>` rather than a generic parameter to keep
+/// handler signatures clean. The vtable cost is negligible relative to
+/// git I/O.
+pub struct MarketplaceService {
     cache: CacheDir,
-    git: G,
+    git: Box<dyn GitBackend>,
 }
 
-impl<G: GitBackend> MarketplaceService<G> {
-    pub fn new(cache: CacheDir, git: G) -> Self {
-        Self { cache, git }
+impl MarketplaceService {
+    pub fn new(cache: CacheDir, git: impl GitBackend + 'static) -> Self {
+        Self { cache, git: Box::new(git) }
     }
 
     /// Add a new marketplace source.
@@ -420,7 +504,9 @@ impl<G: GitBackend> MarketplaceService<G> {
         // Clone or link based on source type.
         let clone_result = self.clone_or_link(&ms, protocol, &temp_dir);
         if let Err(e) = clone_result {
-            let _ = fs::remove_dir_all(&temp_dir);
+            if let Err(e) = fs::remove_dir_all(&temp_dir) {
+                warn!(path = %temp_dir.display(), error = %e, "failed to clean up temp directory");
+            }
             return Err(e);
         }
 
@@ -429,7 +515,9 @@ impl<G: GitBackend> MarketplaceService<G> {
         let manifest_bytes = match fs::read(&manifest_path) {
             Ok(bytes) => bytes,
             Err(e) => {
-                let _ = fs::remove_dir_all(&temp_dir);
+                if let Err(e) = fs::remove_dir_all(&temp_dir) {
+                warn!(path = %temp_dir.display(), error = %e, "failed to clean up temp directory");
+            }
                 return Err(crate::error::MarketplaceError::ManifestNotFound {
                     path: manifest_path,
                 }.into());
@@ -439,7 +527,9 @@ impl<G: GitBackend> MarketplaceService<G> {
         let manifest = match Marketplace::from_json(&manifest_bytes) {
             Ok(m) => m,
             Err(e) => {
-                let _ = fs::remove_dir_all(&temp_dir);
+                if let Err(e) = fs::remove_dir_all(&temp_dir) {
+                warn!(path = %temp_dir.display(), error = %e, "failed to clean up temp directory");
+            }
                 return Err(crate::error::MarketplaceError::InvalidManifest {
                     reason: e.to_string(),
                 }.into());
@@ -449,14 +539,18 @@ impl<G: GitBackend> MarketplaceService<G> {
         let name = manifest.name.clone();
 
         if let Err(e) = validation::validate_name(&name) {
-            let _ = fs::remove_dir_all(&temp_dir);
+            if let Err(e) = fs::remove_dir_all(&temp_dir) {
+                warn!(path = %temp_dir.display(), error = %e, "failed to clean up temp directory");
+            }
             return Err(e.into());
         }
 
         // Rename temp dir to final location.
         let final_dir = self.cache.marketplace_path(&name);
         if final_dir.exists() {
-            let _ = fs::remove_dir_all(&temp_dir);
+            if let Err(e) = fs::remove_dir_all(&temp_dir) {
+                warn!(path = %temp_dir.display(), error = %e, "failed to clean up temp directory");
+            }
             return Err(crate::error::MarketplaceError::AlreadyRegistered {
                 name: name.clone(),
             }.into());
@@ -497,7 +591,7 @@ impl<G: GitBackend> MarketplaceService<G> {
             MarketplaceSource::GitHub { repo } => {
                 let url = crate::git::github_repo_to_url(repo, protocol);
                 debug!(url = %url, dest = %dest.display(), "cloning GitHub marketplace");
-                let opts = crate::git::CloneOptions { shallow: true, ..Default::default() };
+                let opts = crate::git::CloneOptions::default();
                 self.git.clone_repo(&url, dest, &opts)?;
             }
             MarketplaceSource::GitUrl { url } => {
@@ -505,7 +599,7 @@ impl<G: GitBackend> MarketplaceService<G> {
                     warn!("protocol parameter ignored for full git URL; the URL's own scheme is used");
                 }
                 debug!(url = %url, dest = %dest.display(), "cloning git marketplace");
-                let opts = crate::git::CloneOptions { shallow: true, ..Default::default() };
+                let opts = crate::git::CloneOptions::default();
                 self.git.clone_repo(url, dest, &opts)?;
             }
             MarketplaceSource::LocalPath { path } => {
@@ -560,8 +654,17 @@ impl<G: GitBackend> MarketplaceService<G> {
         for entry in &targets {
             let mp_path = self.cache.marketplace_path(&entry.name);
 
+            // Skip locally linked marketplaces — they always reflect disk state.
+            // Also skip if the directory is not a git repo (e.g. copy-fallback
+            // on Windows where junctions weren't available).
             if platform::is_local_link(&mp_path) {
                 debug!(marketplace = %entry.name, "skipping local marketplace");
+                result.skipped.push(entry.name.clone());
+                continue;
+            }
+
+            if matches!(entry.source, MarketplaceSource::LocalPath { .. }) {
+                debug!(marketplace = %entry.name, "skipping local marketplace (directory copy)");
                 result.skipped.push(entry.name.clone());
                 continue;
             }
@@ -662,7 +765,7 @@ mod tests {
         }
     }
 
-    fn temp_service() -> (tempfile::TempDir, MarketplaceService<MockGitBackend>) {
+    fn temp_service() -> (tempfile::TempDir, MarketplaceService) {
         let dir = tempfile::tempdir().expect("tempdir");
         let cache = CacheDir::with_root(dir.path().to_path_buf());
         cache.ensure_dirs().expect("ensure_dirs");
@@ -779,7 +882,7 @@ pub fn run(action: &MarketplaceAction) -> Result<()> {
     }
 }
 
-fn add(svc: &MarketplaceService<GixCliBackend>, source: &str, protocol: GitProtocol) -> Result<()> {
+fn add(svc: &MarketplaceService, source: &str, protocol: GitProtocol) -> Result<()> {
     print!("  Adding marketplace...");
     let result = svc.add(source, protocol)
         .context("failed to add marketplace")?;
@@ -809,7 +912,7 @@ fn add(svc: &MarketplaceService<GixCliBackend>, source: &str, protocol: GitProto
     Ok(())
 }
 
-fn list(svc: &MarketplaceService<GixCliBackend>) -> Result<()> {
+fn list(svc: &MarketplaceService) -> Result<()> {
     let entries = svc.list().context("failed to load marketplaces")?;
 
     if entries.is_empty() {
@@ -828,7 +931,7 @@ fn list(svc: &MarketplaceService<GixCliBackend>) -> Result<()> {
     Ok(())
 }
 
-fn update(svc: &MarketplaceService<GixCliBackend>, name: Option<&str>) -> Result<()> {
+fn update(svc: &MarketplaceService, name: Option<&str>) -> Result<()> {
     let result = svc.update(name).context("failed to update marketplaces")?;
 
     for name in &result.skipped {
@@ -852,7 +955,7 @@ fn update(svc: &MarketplaceService<GixCliBackend>, name: Option<&str>) -> Result
     Ok(())
 }
 
-fn remove(svc: &MarketplaceService<GixCliBackend>, name: &str) -> Result<()> {
+fn remove(svc: &MarketplaceService, name: &str) -> Result<()> {
     svc.remove(name)
         .with_context(|| format!("failed to remove marketplace '{name}'"))?;
     println!("{} Removed marketplace {}", "✓".green().bold(), name.bold());
@@ -918,9 +1021,19 @@ from kiro_market_core::service. Duplicate logic eliminated.
 
 **Step 1: Update remaining callers**
 
-Search for any remaining calls to `git::clone_repo`, `git::pull_repo`, `git::verify_sha` free functions. Update them to use `GixCliBackend::default()` or receive a `&dyn GitBackend`.
+Search for any remaining calls to `git::clone_repo`, `git::pull_repo`, `git::verify_sha` free functions. Update them to use `GixCliBackend` directly.
 
-The main caller is `install.rs` which calls `git::clone_repo` and `git::verify_sha` for plugin installation.
+The main caller is `install.rs` which calls `git::clone_repo` and `git::verify_sha` for plugin cloning. Update `install.rs` to construct a `GixCliBackend::default()` and call through it:
+
+```rust
+let git = GixCliBackend::default();
+let opts = CloneOptions { git_ref: git_ref.map(ToOwned::to_owned) };
+git.clone_repo(&url, &dest, &opts)?;
+// ...
+git.verify_sha(&dest, expected)?;
+```
+
+The Tauri `browse.rs` does NOT call git functions (it reads manifests from disk), so no changes needed there.
 
 **Step 2: Remove the deprecated wrappers from `git.rs`**
 

--- a/docs/plans/2026-04-04-service-layer-plan.md
+++ b/docs/plans/2026-04-04-service-layer-plan.md
@@ -1064,9 +1064,9 @@ needed.
 
 **Step 1: Update architecture section**
 
-Add a note about the service layer pattern and `GitBackend` trait.
+Add a note about the service layer pattern and `GitBackend` trait to CLAUDE.md.
 
-**Step 2: Run full verification**
+**Step 2: Run quality checks**
 
 ```bash
 cargo fmt --all --check
@@ -1074,7 +1074,26 @@ cargo clippy --workspace -- -D warnings
 cargo test --workspace
 ```
 
-**Step 3: Commit**
+**Step 3: Budget gate — verify git CLI calls are contained**
+
+Grep for `Command::new("git")` outside of `GixCliBackend` and test code:
+
+```bash
+# Should only find hits in git.rs (inside GixCliBackend impl) and test files
+grep -rn 'Command::new("git")' crates/ --include='*.rs' | grep -v '#\[cfg(test)\]' | grep -v 'mod tests' | grep -v 'fixtures.rs'
+```
+
+If any hit appears outside `git.rs`, it means git CLI calls leaked into service or handler code.
+
+**Step 4: Verify zero `let _ =` in non-test code**
+
+```bash
+grep -rn 'let _ =' crates/ --include='*.rs' | grep -v '#\[cfg(test)\]' | grep -v 'mod tests'
+```
+
+Any hits should be investigated and replaced with proper error handling.
+
+**Step 5: Commit**
 
 ```
 docs: update CLAUDE.md with service layer architecture

--- a/docs/plans/2026-04-04-service-layer-plan.md
+++ b/docs/plans/2026-04-04-service-layer-plan.md
@@ -1,0 +1,968 @@
+# Service Layer Refactor — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate duplicated marketplace logic between CLI and Tauri by introducing a `GitBackend` trait, a `platform` module for cross-platform local links, and a `MarketplaceService` that owns all marketplace operations.
+
+**Architecture:** The `GitBackend` trait abstracts git operations (clone/pull/verify). `GixCliBackend` implements it using the current gix+CLI hybrid. A `platform` module provides cross-platform `create_local_link`/`is_local_link`/`remove_local_link` functions. `MarketplaceService<G: GitBackend>` owns the marketplace lifecycle (add/remove/update/list), replacing the duplicated logic in both frontends. CLI and Tauri handlers become thin wrappers that call the service and format output.
+
+**Tech Stack:** Rust 1.85, gix 0.81, thiserror, junction crate (Windows-only)
+
+---
+
+### Task 1: Define `GitBackend` trait and `CloneOptions`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/git.rs`
+
+**Step 1: Add the trait and options struct**
+
+At the top of `git.rs` (after the `use` block, before `SSH_CONNECT_TIMEOUT_SECS`), add:
+
+```rust
+/// Options for cloning a repository.
+#[derive(Clone, Debug, Default)]
+pub struct CloneOptions {
+    /// Branch, tag, or SHA to check out after cloning.
+    pub git_ref: Option<String>,
+    /// Whether to perform a shallow clone (depth 1).
+    pub shallow: bool,
+}
+
+/// Trait abstracting git operations for testability and backend swapping.
+///
+/// Implementations must be `Send + Sync` to support sharing across async
+/// Tauri command handlers via `Arc`.
+pub trait GitBackend: Send + Sync {
+    /// Clone a remote repository into `dest`.
+    fn clone_repo(&self, url: &str, dest: &Path, opts: &CloneOptions) -> Result<(), GitError>;
+
+    /// Pull (fast-forward only) the default branch.
+    fn pull_repo(&self, path: &Path) -> Result<(), GitError>;
+
+    /// Verify the HEAD commit matches the expected SHA prefix.
+    fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError>;
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p kiro-market-core`
+Expected: All existing tests pass (trait is just a definition, nothing uses it yet).
+
+**Step 3: Commit**
+
+```
+refactor: define GitBackend trait and CloneOptions
+
+Introduces the trait boundary that separates git operation contracts
+from their implementation. No behavioral changes yet.
+```
+
+---
+
+### Task 2: Implement `GixCliBackend`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/git.rs`
+
+**Step 1: Create the struct and move free functions into `impl GitBackend`**
+
+Add the struct after the trait definition:
+
+```rust
+/// Git backend using `gix` for clone/open and the system `git` CLI for
+/// pull and ref checkout.
+///
+/// SSH connect-timeout protection is applied when no custom `GIT_SSH_COMMAND`
+/// or `GIT_SSH` is configured. `GIT_TERMINAL_PROMPT=0` prevents interactive
+/// prompts from hanging non-interactive contexts.
+#[derive(Debug)]
+pub struct GixCliBackend {
+    ssh_connect_timeout: u32,
+}
+
+impl Default for GixCliBackend {
+    fn default() -> Self {
+        Self {
+            ssh_connect_timeout: SSH_CONNECT_TIMEOUT_SECS,
+        }
+    }
+}
+```
+
+Move `run_git` and `git_error_detail` into `impl GixCliBackend` as private methods (change `fn run_git(args, dir)` to `fn run_git(&self, args, dir)` and use `self.ssh_connect_timeout`).
+
+Implement the trait:
+
+```rust
+impl GitBackend for GixCliBackend {
+    fn clone_repo(&self, url: &str, dest: &Path, opts: &CloneOptions) -> Result<(), GitError> {
+        // Move current clone_repo body here, using opts.git_ref and opts.shallow
+    }
+
+    fn pull_repo(&self, path: &Path) -> Result<(), GitError> {
+        // Move current pull_repo body here
+    }
+
+    fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError> {
+        // Move current verify_sha body here
+    }
+}
+```
+
+**Step 2: Keep the old free functions as deprecated wrappers**
+
+Replace the existing free functions with wrappers that call `GixCliBackend::default()`:
+
+```rust
+/// Clone a remote Git repository into `dest`.
+///
+/// Deprecated: use `GixCliBackend::default().clone_repo()` or a
+/// `MarketplaceService` instead.
+pub fn clone_repo(url: &str, dest: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
+    let opts = CloneOptions {
+        git_ref: git_ref.map(ToOwned::to_owned),
+        shallow: git_ref.is_none(),
+    };
+    GixCliBackend::default().clone_repo(url, dest, &opts)
+}
+
+pub fn pull_repo(path: &Path) -> Result<(), GitError> {
+    GixCliBackend::default().pull_repo(path)
+}
+
+pub fn verify_sha(path: &Path, expected_sha: &str) -> Result<(), GitError> {
+    GixCliBackend::default().verify_sha(path, expected_sha)
+}
+```
+
+This keeps all existing callers working without changes. The wrappers get removed in Task 6.
+
+**Step 3: Fix tests to use GixCliBackend directly**
+
+Update the test module: tests should call `GixCliBackend::default().clone_repo(...)` etc. instead of the free functions. Both should work, but testing through the trait validates the implementation.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p kiro-market-core`
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```
+refactor: implement GixCliBackend behind GitBackend trait
+
+Moves clone/pull/verify logic into GixCliBackend. Old free functions
+remain as deprecated wrappers to avoid breaking callers. Tests updated
+to exercise the trait implementation directly.
+```
+
+---
+
+### Task 3: Add `platform` module for cross-platform local links
+
+**Files:**
+- Create: `crates/kiro-market-core/src/platform.rs`
+- Modify: `crates/kiro-market-core/src/lib.rs`
+- Modify: `crates/kiro-market-core/Cargo.toml` (add `junction` dependency)
+
+**Step 1: Add the junction dependency (Windows-only)**
+
+In workspace `Cargo.toml`, add under `[workspace.dependencies]`:
+
+```toml
+junction = "1"
+```
+
+In `crates/kiro-market-core/Cargo.toml`, add under `[dependencies]`:
+
+```toml
+[target.'cfg(windows)'.dependencies]
+junction = { workspace = true }
+```
+
+**Step 2: Create `platform.rs`**
+
+```rust
+//! Cross-platform filesystem linking for local marketplace tracking.
+//!
+//! On Unix, uses symlinks. On Windows, tries directory junctions (no
+//! admin required on NTFS), with copy fallback.
+
+use std::io;
+use std::path::Path;
+
+/// Create a local link from `src` to `dest` for live marketplace tracking.
+///
+/// # Platform behavior
+///
+/// - **Unix:** Creates a symbolic link.
+/// - **Windows:** Tries a directory junction (NTFS, no admin required).
+///   Falls back to copying `src` into `dest` if junctions fail, logging
+///   a warning that changes won't be live-tracked.
+pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+    sys::create_local_link(src, dest)
+}
+
+/// Check whether `path` is a local link (symlink or directory junction).
+pub fn is_local_link(path: &Path) -> bool {
+    sys::is_local_link(path)
+}
+
+/// Remove a local link without removing the target contents.
+pub fn remove_local_link(path: &Path) -> io::Result<()> {
+    sys::remove_local_link(path)
+}
+
+#[cfg(unix)]
+mod sys {
+    use std::io;
+    use std::path::Path;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+        std::os::unix::fs::symlink(src, dest)
+    }
+
+    pub fn is_local_link(path: &Path) -> bool {
+        path.is_symlink()
+    }
+
+    pub fn remove_local_link(path: &Path) -> io::Result<()> {
+        std::fs::remove_file(path)
+    }
+}
+
+#[cfg(windows)]
+mod sys {
+    use std::io;
+    use std::path::Path;
+
+    pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<()> {
+        // Try directory junction first (works without admin on NTFS).
+        match junction::create(src, dest) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "junction failed, falling back to directory copy"
+                );
+            }
+        }
+
+        // Fallback: copy the directory tree.
+        copy_dir_recursive(src, dest)?;
+        tracing::warn!(
+            src = %src.display(),
+            dest = %dest.display(),
+            "used directory copy instead of junction — local changes will NOT be live-tracked"
+        );
+        Ok(())
+    }
+
+    pub fn is_local_link(path: &Path) -> bool {
+        // is_symlink() returns true for both symlinks and junctions on Windows.
+        path.is_symlink()
+    }
+
+    pub fn remove_local_link(path: &Path) -> io::Result<()> {
+        // Junctions are directory reparse points — remove_dir removes the
+        // junction without deleting the target. Symlinks use remove_file.
+        if path.is_dir() {
+            std::fs::remove_dir(path)
+        } else {
+            std::fs::remove_file(path)
+        }
+    }
+
+    fn copy_dir_recursive(src: &Path, dest: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let target = dest.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_dir_recursive(&entry.path(), &target)?;
+            } else {
+                std::fs::copy(entry.path(), target)?;
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+**Step 3: Register the module in `lib.rs`**
+
+Add `pub mod platform;` after `pub mod plugin;`.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p kiro-market-core`
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```
+feat: add platform module for cross-platform local marketplace links
+
+Unix uses symlinks, Windows uses directory junctions with copy
+fallback. Replaces scattered #[cfg(unix)] blocks in UI-layer code.
+```
+
+---
+
+### Task 4: Add `MarketplaceService` with `add` method
+
+**Files:**
+- Create: `crates/kiro-market-core/src/service.rs`
+- Modify: `crates/kiro-market-core/src/lib.rs`
+
+This is the largest task. The `add` method contains the most complex logic.
+
+**Step 1: Create `service.rs` with result types and the `add` method**
+
+```rust
+//! Marketplace lifecycle operations.
+//!
+//! [`MarketplaceService`] owns the add/remove/update/list logic that was
+//! previously duplicated between the CLI and Tauri frontends.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tracing::{debug, warn};
+
+use crate::cache::{CacheDir, KnownMarketplace, MarketplaceSource};
+use crate::error::Error;
+use crate::git::{GitBackend, GitProtocol};
+use crate::marketplace::Marketplace;
+use crate::{platform, validation};
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of adding a new marketplace.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+pub struct MarketplaceAddResult {
+    pub name: String,
+    pub plugins: Vec<PluginBasicInfo>,
+}
+
+/// Basic information about a plugin within a marketplace.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+pub struct PluginBasicInfo {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// Result of updating one or more marketplaces.
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+pub struct UpdateResult {
+    pub updated: Vec<String>,
+    pub failed: Vec<FailedUpdate>,
+    pub skipped: Vec<String>,
+}
+
+/// A marketplace that failed to update, with the reason.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "specta", derive(serde::Serialize, specta::Type))]
+pub struct FailedUpdate {
+    pub name: String,
+    pub error: String,
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Manages the marketplace lifecycle: add, remove, update, list.
+pub struct MarketplaceService<G: GitBackend> {
+    cache: CacheDir,
+    git: G,
+}
+
+impl<G: GitBackend> MarketplaceService<G> {
+    pub fn new(cache: CacheDir, git: G) -> Self {
+        Self { cache, git }
+    }
+
+    /// Add a new marketplace source.
+    ///
+    /// 1. Detect source type (GitHub, git URL, local path).
+    /// 2. Clone or link into a temp directory in the cache.
+    /// 3. Read the marketplace manifest to discover the canonical name.
+    /// 4. Validate the name, rename to final location.
+    /// 5. Register in `known_marketplaces.json`.
+    pub fn add(
+        &self,
+        source: &str,
+        protocol: GitProtocol,
+    ) -> Result<MarketplaceAddResult, Error> {
+        let ms = MarketplaceSource::detect(source);
+        self.cache.ensure_dirs()?;
+
+        let temp_name = format!("_pending_{}", std::process::id());
+        let temp_dir = self.cache.marketplace_path(&temp_name);
+
+        // Clean up any leftover temp directory from a prior interrupted run.
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir).map_err(|e| {
+                std::io::Error::new(e.kind(), format!("failed to clean up {}: {e}", temp_dir.display()))
+            })?;
+        }
+
+        // Clone or link based on source type.
+        let clone_result = self.clone_or_link(&ms, protocol, &temp_dir);
+        if let Err(e) = clone_result {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(e);
+        }
+
+        // Read marketplace manifest.
+        let manifest_path = temp_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
+        let manifest_bytes = match fs::read(&manifest_path) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                let _ = fs::remove_dir_all(&temp_dir);
+                return Err(crate::error::MarketplaceError::ManifestNotFound {
+                    path: manifest_path,
+                }.into());
+            }
+        };
+
+        let manifest = match Marketplace::from_json(&manifest_bytes) {
+            Ok(m) => m,
+            Err(e) => {
+                let _ = fs::remove_dir_all(&temp_dir);
+                return Err(crate::error::MarketplaceError::InvalidManifest {
+                    reason: e.to_string(),
+                }.into());
+            }
+        };
+
+        let name = manifest.name.clone();
+
+        if let Err(e) = validation::validate_name(&name) {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(e.into());
+        }
+
+        // Rename temp dir to final location.
+        let final_dir = self.cache.marketplace_path(&name);
+        if final_dir.exists() {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(crate::error::MarketplaceError::AlreadyRegistered {
+                name: name.clone(),
+            }.into());
+        }
+
+        fs::rename(&temp_dir, &final_dir).map_err(std::io::Error::from)?;
+
+        // Register in known_marketplaces.json.
+        let entry = KnownMarketplace {
+            name: name.clone(),
+            source: ms,
+            protocol: Some(protocol),
+            added_at: chrono::Utc::now(),
+        };
+        self.cache.add_known_marketplace(entry)?;
+
+        let plugins = manifest
+            .plugins
+            .iter()
+            .map(|p| PluginBasicInfo {
+                name: p.name.clone(),
+                description: p.description.clone(),
+            })
+            .collect();
+
+        debug!(marketplace = %name, "marketplace added");
+
+        Ok(MarketplaceAddResult { name, plugins })
+    }
+
+    fn clone_or_link(
+        &self,
+        ms: &MarketplaceSource,
+        protocol: GitProtocol,
+        dest: &std::path::Path,
+    ) -> Result<(), Error> {
+        match ms {
+            MarketplaceSource::GitHub { repo } => {
+                let url = crate::git::github_repo_to_url(repo, protocol);
+                debug!(url = %url, dest = %dest.display(), "cloning GitHub marketplace");
+                let opts = crate::git::CloneOptions { shallow: true, ..Default::default() };
+                self.git.clone_repo(&url, dest, &opts)?;
+            }
+            MarketplaceSource::GitUrl { url } => {
+                if protocol != GitProtocol::default() {
+                    warn!("protocol parameter ignored for full git URL; the URL's own scheme is used");
+                }
+                debug!(url = %url, dest = %dest.display(), "cloning git marketplace");
+                let opts = crate::git::CloneOptions { shallow: true, ..Default::default() };
+                self.git.clone_repo(url, dest, &opts)?;
+            }
+            MarketplaceSource::LocalPath { path } => {
+                let src = crate::cache::resolve_local_path(path)?;
+                debug!(src = %src.display(), dest = %dest.display(), "linking local marketplace");
+                platform::create_local_link(&src, dest)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Remove a registered marketplace and its cached data.
+    pub fn remove(&self, name: &str) -> Result<(), Error> {
+        self.cache.remove_known_marketplace(name)?;
+
+        let mp_path = self.cache.marketplace_path(name);
+        if platform::is_local_link(&mp_path) {
+            platform::remove_local_link(&mp_path)?;
+        } else if mp_path.exists() {
+            fs::remove_dir_all(&mp_path)?;
+        }
+
+        debug!(marketplace = %name, "marketplace removed");
+        Ok(())
+    }
+
+    /// Update marketplace clone(s) from remote.
+    ///
+    /// If `name` is provided, only that marketplace is updated. Locally
+    /// linked marketplaces are skipped since they always reflect disk state.
+    pub fn update(&self, name: Option<&str>) -> Result<UpdateResult, Error> {
+        let entries = self.cache.load_known_marketplaces()?;
+
+        if entries.is_empty() {
+            return Ok(UpdateResult::default());
+        }
+
+        let targets: Vec<_> = if let Some(filter_name) = name {
+            let filtered: Vec<_> = entries.iter().filter(|e| e.name == *filter_name).collect();
+            if filtered.is_empty() {
+                return Err(crate::error::MarketplaceError::NotFound {
+                    name: filter_name.to_owned(),
+                }.into());
+            }
+            filtered
+        } else {
+            entries.iter().collect()
+        };
+
+        let mut result = UpdateResult::default();
+
+        for entry in &targets {
+            let mp_path = self.cache.marketplace_path(&entry.name);
+
+            if platform::is_local_link(&mp_path) {
+                debug!(marketplace = %entry.name, "skipping local marketplace");
+                result.skipped.push(entry.name.clone());
+                continue;
+            }
+
+            match self.git.pull_repo(&mp_path) {
+                Ok(()) => {
+                    debug!(marketplace = %entry.name, "marketplace updated");
+                    result.updated.push(entry.name.clone());
+                }
+                Err(e) => {
+                    warn!(marketplace = %entry.name, error = %e, "failed to update");
+                    result.failed.push(FailedUpdate {
+                        name: entry.name.clone(),
+                        error: e.to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// List all registered marketplaces.
+    pub fn list(&self) -> Result<Vec<KnownMarketplace>, Error> {
+        Ok(self.cache.load_known_marketplaces()?)
+    }
+}
+```
+
+**Step 2: Register in `lib.rs`**
+
+Add `pub mod service;` after `pub mod skill;`.
+
+**Step 3: Run tests**
+
+Run: `cargo test -p kiro-market-core`
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```
+feat: add MarketplaceService with add/remove/update/list
+
+Centralizes marketplace lifecycle logic that was previously duplicated
+between CLI and Tauri frontends. Uses GitBackend trait for git ops and
+platform module for cross-platform local links.
+```
+
+---
+
+### Task 5: Add service unit tests with mock backend
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service.rs` (add test module)
+
+**Step 1: Add a mock backend and service tests**
+
+Add a `#[cfg(test)] mod tests` at the bottom of `service.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::cache::CacheDir;
+    use crate::git::{CloneOptions, GitError};
+
+    /// Records which git operations were called.
+    #[derive(Debug, Default)]
+    struct MockGitBackend {
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl GitBackend for MockGitBackend {
+        fn clone_repo(&self, url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+            self.calls.lock().unwrap().push(format!("clone:{url}"));
+            // Create the dest directory so the service can write into it.
+            fs::create_dir_all(dest).unwrap();
+            // Write a minimal marketplace manifest.
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(
+                mp_dir.join("marketplace.json"),
+                r#"{"name":"mock-market","owner":{"name":"Test"},"plugins":[{"name":"mock-plugin","source":"./plugins/mock"}]}"#,
+            ).unwrap();
+            Ok(())
+        }
+
+        fn pull_repo(&self, path: &Path) -> Result<(), GitError> {
+            self.calls.lock().unwrap().push(format!("pull:{}", path.display()));
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    fn temp_service() -> (tempfile::TempDir, MarketplaceService<MockGitBackend>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, MockGitBackend::default());
+        (dir, svc)
+    }
+
+    #[test]
+    fn add_marketplace_registers_and_returns_plugins() {
+        let (_dir, svc) = temp_service();
+        let result = svc.add("owner/repo", GitProtocol::Https).expect("add");
+
+        assert_eq!(result.name, "mock-market");
+        assert_eq!(result.plugins.len(), 1);
+        assert_eq!(result.plugins[0].name, "mock-plugin");
+
+        let known = svc.list().expect("list");
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].name, "mock-market");
+    }
+
+    #[test]
+    fn add_duplicate_marketplace_returns_error() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https).expect("first add");
+        let err = svc.add("owner/repo", GitProtocol::Https).expect_err("duplicate");
+        assert!(err.to_string().contains("already"), "got: {err}");
+    }
+
+    #[test]
+    fn remove_marketplace_cleans_up() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
+        svc.remove("mock-market").expect("remove");
+
+        let known = svc.list().expect("list");
+        assert!(known.is_empty());
+    }
+
+    #[test]
+    fn update_calls_pull_on_cloned_repos() {
+        let (_dir, svc) = temp_service();
+        svc.add("owner/repo", GitProtocol::Https).expect("add");
+
+        let result = svc.update(None).expect("update");
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0], "mock-market");
+    }
+
+    #[test]
+    fn update_nonexistent_returns_error() {
+        let (_dir, svc) = temp_service();
+        let err = svc.update(Some("nope")).expect_err("should fail");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn list_empty_returns_empty_vec() {
+        let (_dir, svc) = temp_service();
+        let known = svc.list().expect("list");
+        assert!(known.is_empty());
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p kiro-market-core service`
+Expected: All 6 new tests pass.
+
+**Step 3: Commit**
+
+```
+test: add MarketplaceService unit tests with mock git backend
+
+Tests add/remove/update/list lifecycle using MockGitBackend.
+No filesystem git repos needed — validates orchestration logic only.
+```
+
+---
+
+### Task 6: Migrate CLI marketplace handler to use service
+
+**Files:**
+- Modify: `crates/kiro-market/src/commands/marketplace.rs`
+
+**Step 1: Rewrite the handler**
+
+Replace the entire file with a thin wrapper around `MarketplaceService`:
+
+```rust
+//! `marketplace` subcommand: add, list, update, and remove marketplace sources.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use kiro_market_core::cache::CacheDir;
+use kiro_market_core::git::{GitProtocol, GixCliBackend};
+use kiro_market_core::service::MarketplaceService;
+
+use crate::cli::MarketplaceAction;
+
+/// Dispatch to the appropriate marketplace subcommand.
+pub fn run(action: &MarketplaceAction) -> Result<()> {
+    let cache = CacheDir::default_location()
+        .context("could not determine data directory; is $HOME set?")?;
+    let git = GixCliBackend::default();
+    let svc = MarketplaceService::new(cache, git);
+
+    match action {
+        MarketplaceAction::Add { source, protocol } => add(&svc, source, *protocol),
+        MarketplaceAction::List => list(&svc),
+        MarketplaceAction::Update { name } => update(&svc, name.as_deref()),
+        MarketplaceAction::Remove { name } => remove(&svc, name),
+    }
+}
+
+fn add(svc: &MarketplaceService<GixCliBackend>, source: &str, protocol: GitProtocol) -> Result<()> {
+    print!("  Adding marketplace...");
+    let result = svc.add(source, protocol)
+        .context("failed to add marketplace")?;
+
+    println!(
+        " {} Added {} ({} plugin{})",
+        "✓".green().bold(),
+        result.name.bold(),
+        result.plugins.len(),
+        if result.plugins.len() == 1 { "" } else { "s" }
+    );
+
+    if !result.plugins.is_empty() {
+        println!();
+        println!("  {}", "Available plugins:".bold());
+        for plugin in &result.plugins {
+            let desc = plugin.description.as_deref().unwrap_or("(no description)");
+            println!("    {} - {}", plugin.name.green(), desc);
+        }
+        println!();
+        println!(
+            "  Install with: {}",
+            format!("kiro-market install <plugin>@{}", result.name).bold()
+        );
+    }
+
+    Ok(())
+}
+
+fn list(svc: &MarketplaceService<GixCliBackend>) -> Result<()> {
+    let entries = svc.list().context("failed to load marketplaces")?;
+
+    if entries.is_empty() {
+        println!(
+            "No marketplaces registered. Use {} to add one.",
+            "kiro-market marketplace add".bold()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "Registered marketplaces:".bold());
+    for entry in &entries {
+        println!("  {} ({})", entry.name.green().bold(), entry.source.label());
+    }
+
+    Ok(())
+}
+
+fn update(svc: &MarketplaceService<GixCliBackend>, name: Option<&str>) -> Result<()> {
+    let result = svc.update(name).context("failed to update marketplaces")?;
+
+    for name in &result.skipped {
+        println!("  {} {} (local, skipped)", "·".bold(), name.bold());
+    }
+    for name in &result.updated {
+        println!("  {} {} {}", "✓".green().bold(), name.bold(), "done".green());
+    }
+    for fail in &result.failed {
+        println!("  {} {} {}", "✗".red().bold(), fail.name.bold(), fail.error.red());
+    }
+
+    if !result.failed.is_empty() {
+        anyhow::bail!(
+            "{} marketplace{} failed to update",
+            result.failed.len(),
+            if result.failed.len() == 1 { "" } else { "s" }
+        );
+    }
+
+    Ok(())
+}
+
+fn remove(svc: &MarketplaceService<GixCliBackend>, name: &str) -> Result<()> {
+    svc.remove(name)
+        .with_context(|| format!("failed to remove marketplace '{name}'"))?;
+    println!("{} Removed marketplace {}", "✓".green().bold(), name.bold());
+    Ok(())
+}
+```
+
+**Step 2: Run CLI tests**
+
+Run: `cargo test -p kiro-market`
+Expected: All tests pass (including the workflow tests).
+
+**Step 3: Commit**
+
+```
+refactor: migrate CLI marketplace handler to MarketplaceService
+
+CLI handler is now a thin wrapper: constructs the service, calls it,
+formats output. All domain logic lives in kiro-market-core::service.
+```
+
+---
+
+### Task 7: Migrate Tauri marketplace handler to use service
+
+**Files:**
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs`
+
+**Step 1: Rewrite the Tauri handler**
+
+Replace the file with thin wrappers that call `MarketplaceService`. Remove the duplicated result types (now imported from `kiro_market_core::service`). The Tauri commands construct `GixCliBackend` and `MarketplaceService` inline, then map `Error` to `CommandError`.
+
+The key change: remove `MarketplaceAddResult`, `PluginBasicInfo`, `UpdateResult`, `FailedUpdate` struct definitions from this file — they're now in `kiro_market_core::service`.
+
+**Step 2: Run Tauri tests**
+
+Run: `cargo test -p kiro-control-center`
+Expected: All pass.
+
+**Step 3: Run full suite**
+
+Run: `cargo test --workspace`
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```
+refactor: migrate Tauri marketplace handler to MarketplaceService
+
+Tauri handlers are now thin wrappers like CLI. Result types imported
+from kiro_market_core::service. Duplicate logic eliminated.
+```
+
+---
+
+### Task 8: Remove deprecated free function wrappers
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/git.rs`
+- Modify: `crates/kiro-market/src/commands/install.rs` (update to use `GixCliBackend`)
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/browse.rs` (if it calls git functions)
+
+**Step 1: Update remaining callers**
+
+Search for any remaining calls to `git::clone_repo`, `git::pull_repo`, `git::verify_sha` free functions. Update them to use `GixCliBackend::default()` or receive a `&dyn GitBackend`.
+
+The main caller is `install.rs` which calls `git::clone_repo` and `git::verify_sha` for plugin installation.
+
+**Step 2: Remove the deprecated wrappers from `git.rs`**
+
+Delete the `pub fn clone_repo(...)`, `pub fn pull_repo(...)`, `pub fn verify_sha(...)` wrapper functions.
+
+**Step 3: Run full test suite**
+
+Run: `cargo test --workspace`
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```
+refactor: remove deprecated git free function wrappers
+
+All callers now use GixCliBackend directly or through MarketplaceService.
+The free functions served as a bridge during migration and are no longer
+needed.
+```
+
+---
+
+### Task 9: Update CLAUDE.md and final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Update architecture section**
+
+Add a note about the service layer pattern and `GitBackend` trait.
+
+**Step 2: Run full verification**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+**Step 3: Commit**
+
+```
+docs: update CLAUDE.md with service layer architecture
+```


### PR DESCRIPTION
## Summary

Architectural refactor that eliminates duplicated marketplace logic between CLI and Tauri frontends by introducing three new abstractions in `kiro-market-core`:

- **`GitBackend` trait** — abstracts git operations (clone/pull/verify) behind a testable interface. `GixCliBackend` implements it using gix + system git CLI.
- **`platform` module** — cross-platform local marketplace linking (Unix symlinks, Windows directory junctions with copy fallback). Returns `LinkResult` enum so callers know whether changes will be live-tracked.
- **`MarketplaceService`** — owns add/remove/update/list lifecycle with `Box<dyn GitBackend>`. CLI and Tauri handlers become thin presentation wrappers.

**Key metrics:**
- ~530 lines of duplicated domain logic removed from CLI + Tauri handlers
- 11 new service tests with mock backend (including failure injection)
- Zero `let _ =` patterns, zero `Command::new("git")` outside `GixCliBackend`
- `TempDirGuard` RAII pattern replaces 5 scattered cleanup blocks

**Inspired by:** cyril project's strict crate boundaries and GitComet's trait-based git abstraction.

## Test plan

- [ ] `cargo test --workspace` — 183 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] CLI workflow tests exercise full add → install → update lifecycle
- [ ] Service tests validate orchestration with mock backend (no git I/O)
- [ ] Platform tests verify symlink creation/detection/removal
- [ ] Verify Windows CI passes (junction detection via `junction::exists`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)