### PR TITLE
feat(control-center): Kiro IDE color theme

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           show_full_output: true
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/crates/kiro-control-center/src-tauri/src/commands/settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/settings.rs
@@ -36,21 +36,17 @@ pub struct DiscoveredProject {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Path to the settings file.
+/// Resolve the platform config directory for kiro-market settings.
 ///
-/// Respects `KIRO_MARKET_CONFIG_DIR` env var for test isolation.
-fn settings_path() -> Option<PathBuf> {
-    if let Ok(dir) = std::env::var("KIRO_MARKET_CONFIG_DIR") {
-        return Some(PathBuf::from(dir).join("settings.json"));
-    }
-    dirs::config_dir().map(|d| d.join("kiro-market").join("settings.json"))
+/// Returns `None` only when the OS has no config directory (rare).
+fn default_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("kiro-market"))
 }
 
-/// Load settings from disk, returning defaults if the file doesn't exist.
-fn load_settings() -> Settings {
-    let Some(path) = settings_path() else {
-        return Settings::default();
-    };
+/// Load settings from `config_dir/settings.json`, returning defaults if
+/// the file doesn't exist or is corrupt.
+fn load_settings_from(config_dir: &Path) -> Settings {
+    let path = config_dir.join("settings.json");
     match fs::read(&path) {
         Ok(bytes) => match serde_json::from_slice(&bytes) {
             Ok(settings) => settings,
@@ -71,22 +67,15 @@ fn load_settings() -> Settings {
     }
 }
 
-/// Save settings to disk.
-fn save_settings(settings: &Settings) -> Result<(), CommandError> {
-    let path = settings_path().ok_or_else(|| {
+/// Save settings to `config_dir/settings.json`.
+fn save_settings_to(config_dir: &Path, settings: &Settings) -> Result<(), CommandError> {
+    let path = config_dir.join("settings.json");
+    fs::create_dir_all(config_dir).map_err(|e| {
         CommandError::new(
-            "could not determine config directory",
+            format!("failed to create config directory: {e}"),
             crate::error::ErrorType::IoError,
         )
     })?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| {
-            CommandError::new(
-                format!("failed to create config directory: {e}"),
-                crate::error::ErrorType::IoError,
-            )
-        })?;
-    }
     let json = serde_json::to_string_pretty(settings).map_err(|e| {
         CommandError::new(
             format!("failed to serialize settings: {e}"),
@@ -101,6 +90,25 @@ fn save_settings(settings: &Settings) -> Result<(), CommandError> {
     })?;
     debug!(path = %path.display(), "settings saved");
     Ok(())
+}
+
+/// Convenience: load from the default config directory.
+fn load_settings() -> Settings {
+    let Some(dir) = default_config_dir() else {
+        return Settings::default();
+    };
+    load_settings_from(&dir)
+}
+
+/// Convenience: save to the default config directory.
+fn save_settings(settings: &Settings) -> Result<(), CommandError> {
+    let dir = default_config_dir().ok_or_else(|| {
+        CommandError::new(
+            "could not determine config directory",
+            crate::error::ErrorType::IoError,
+        )
+    })?;
+    save_settings_to(&dir, settings)
 }
 
 // ---------------------------------------------------------------------------
@@ -250,46 +258,25 @@ fn scan_for_projects(
 mod tests {
     use super::*;
 
-    /// Set `KIRO_MARKET_CONFIG_DIR` to a temp directory for isolated tests.
-    ///
-    /// **Not thread-safe**: env var mutation is process-global. Tests that
-    /// use this helper must run with `--test-threads=1` to avoid races.
-    /// Each test uses its own `TempDir` so values don't collide in the
-    /// filesystem, but concurrent `set_var` + `load_settings` calls can
-    /// interleave. The CI workflow should use `--test-threads=1` for this
-    /// crate.
-    ///
-    /// In edition 2024 `set_var`/`remove_var` are unsafe; this crate is
-    /// edition 2021 so the calls compile without `unsafe`.
-    fn with_temp_config<F: FnOnce()>(dir: &tempfile::TempDir, f: F) {
-        std::env::set_var("KIRO_MARKET_CONFIG_DIR", dir.path());
-        f();
-        std::env::remove_var("KIRO_MARKET_CONFIG_DIR");
-    }
-
     #[test]
     fn load_settings_returns_defaults_when_no_file() {
         let dir = tempfile::tempdir().expect("tempdir");
-        with_temp_config(&dir, || {
-            let settings = load_settings();
-            assert!(settings.scan_roots.is_empty());
-            assert!(settings.last_project.is_none());
-        });
+        let settings = load_settings_from(dir.path());
+        assert!(settings.scan_roots.is_empty());
+        assert!(settings.last_project.is_none());
     }
 
     #[test]
     fn save_and_load_settings_roundtrip() {
         let dir = tempfile::tempdir().expect("tempdir");
-        with_temp_config(&dir, || {
-            let mut settings = Settings::default();
-            settings.scan_roots = vec!["~/repos".into(), "~/work".into()];
-            settings.last_project = Some("/home/user/project".into());
-            save_settings(&settings).expect("save");
+        let mut settings = Settings::default();
+        settings.scan_roots = vec!["~/repos".into(), "~/work".into()];
+        settings.last_project = Some("/home/user/project".into());
+        save_settings_to(dir.path(), &settings).expect("save");
 
-            let loaded = load_settings();
-            assert_eq!(loaded.scan_roots, vec!["~/repos", "~/work"]);
-            assert_eq!(loaded.last_project.as_deref(), Some("/home/user/project"));
-        });
+        let loaded = load_settings_from(dir.path());
+        assert_eq!(loaded.scan_roots, vec!["~/repos", "~/work"]);
+        assert_eq!(loaded.last_project.as_deref(), Some("/home/user/project"));
     }
 
     #[test]
@@ -369,47 +356,40 @@ mod tests {
     #[test]
     fn load_settings_returns_defaults_on_corrupt_json() {
         let dir = tempfile::tempdir().expect("tempdir");
-        with_temp_config(&dir, || {
-            // Write garbage to the settings file.
-            let path = settings_path().expect("settings path");
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).expect("create dir");
-            }
-            std::fs::write(&path, "not valid json {{{").expect("write garbage");
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "not valid json {{{").expect("write garbage");
 
-            let settings = load_settings();
-            assert!(
-                settings.scan_roots.is_empty(),
-                "corrupt file should fall back to defaults"
-            );
-            assert!(settings.last_project.is_none());
-        });
+        let settings = load_settings_from(dir.path());
+        assert!(
+            settings.scan_roots.is_empty(),
+            "corrupt file should fall back to defaults"
+        );
+        assert!(settings.last_project.is_none());
     }
 
     #[test]
     fn save_scan_roots_preserves_last_project() {
         let dir = tempfile::tempdir().expect("tempdir");
-        with_temp_config(&dir, || {
-            // Save settings with both fields populated.
-            let mut settings = Settings::default();
-            settings.scan_roots = vec!["~/old-root".into()];
-            settings.last_project = Some("/home/user/my-project".into());
-            save_settings(&settings).expect("save initial");
 
-            // Now update only scan_roots (simulating save_scan_roots).
-            let mut loaded = load_settings();
-            loaded.scan_roots = vec!["~/new-root".into()];
-            save_settings(&loaded).expect("save updated roots");
+        // Save settings with both fields populated.
+        let mut settings = Settings::default();
+        settings.scan_roots = vec!["~/old-root".into()];
+        settings.last_project = Some("/home/user/my-project".into());
+        save_settings_to(dir.path(), &settings).expect("save initial");
 
-            // Verify last_project survived the update.
-            let final_settings = load_settings();
-            assert_eq!(final_settings.scan_roots, vec!["~/new-root"]);
-            assert_eq!(
-                final_settings.last_project.as_deref(),
-                Some("/home/user/my-project"),
-                "last_project should survive scan_roots update"
-            );
-        });
+        // Now update only scan_roots (simulating save_scan_roots).
+        let mut loaded = load_settings_from(dir.path());
+        loaded.scan_roots = vec!["~/new-root".into()];
+        save_settings_to(dir.path(), &loaded).expect("save updated roots");
+
+        // Verify last_project survived the update.
+        let final_settings = load_settings_from(dir.path());
+        assert_eq!(final_settings.scan_roots, vec!["~/new-root"]);
+        assert_eq!(
+            final_settings.last_project.as_deref(),
+            Some("/home/user/my-project"),
+            "last_project should survive scan_roots update"
+        );
     }
 
     #[test]

--- a/crates/kiro-control-center/src/app.css
+++ b/crates/kiro-control-center/src/app.css
@@ -68,7 +68,7 @@
     --kiro-muted: oklch(82.82% 0.0115 302.85);
     --kiro-subtle: oklch(75.35% 0.0159 298.34);
     --kiro-text: oklch(31.73% 0.0259 304.41);
-    --kiro-text-secondary: oklch(65.73% 0.0182 300.94);
+    --kiro-text-secondary: oklch(45% 0.0182 300.94);
     --kiro-success: oklch(52.97% 0.0963 155.38);
     --kiro-error: oklch(47.08% 0.1367 23.99);
     --kiro-error-hover: oklch(41.46% 0.1191 23.89);

--- a/crates/kiro-control-center/src/app.css
+++ b/crates/kiro-control-center/src/app.css
@@ -1,5 +1,82 @@
 @import "tailwindcss";
 
+/*
+ * CRITICAL: @theme inline is required for var() references.
+ * Without it, Tailwind generates utility classes referencing --color-kiro-*,
+ * which then resolve var(--kiro-*) at the wrong cascade level.
+ * With inline, utilities embed var(--kiro-*) directly.
+ *
+ * All color values use OKLCH for native compatibility with
+ * Tailwind v4's opacity modifier system (e.g., bg-kiro-error/10).
+ */
+
+/* Surface, text, and semantic colors — auto-swap via CSS custom properties */
+@theme inline {
+  --color-kiro-base: var(--kiro-base);
+  --color-kiro-surface: var(--kiro-surface);
+  --color-kiro-overlay: var(--kiro-overlay);
+  --color-kiro-muted: var(--kiro-muted);
+  --color-kiro-subtle: var(--kiro-subtle);
+  --color-kiro-text: var(--kiro-text);
+  --color-kiro-text-secondary: var(--kiro-text-secondary);
+  --color-kiro-success: var(--kiro-success);
+  --color-kiro-error: var(--kiro-error);
+  --color-kiro-error-hover: var(--kiro-error-hover);
+  --color-kiro-warning: var(--kiro-warning);
+  --color-kiro-info: var(--kiro-info);
+}
+
+/* Accent scale — static purple, same in both modes. No var() references,
+   so a regular @theme block is correct here. */
+@theme {
+  --color-kiro-accent-50: oklch(96.33% 0.0206 301.01);
+  --color-kiro-accent-100: oklch(90.91% 0.0536 303.22);
+  --color-kiro-accent-200: oklch(83.09% 0.1019 302.28);
+  --color-kiro-accent-300: oklch(70.14% 0.1831 299.07);
+  --color-kiro-accent-400: oklch(62.76% 0.2304 297.02);
+  --color-kiro-accent-500: oklch(58.87% 0.2534 294.98);
+  --color-kiro-accent-600: oklch(49.95% 0.2130 295.09);
+  --color-kiro-accent-700: oklch(42.40% 0.1802 295.51);
+  --color-kiro-accent-800: oklch(34.63% 0.1446 296.00);
+  --color-kiro-accent-900: oklch(26.77% 0.1065 297.06);
+}
+
+/* Dark-first: dark values are the default */
+:root {
+  color-scheme: dark;
+  --kiro-base: oklch(20.69% 0.0144 304.56);
+  --kiro-surface: oklch(23.88% 0.0162 307.66);
+  --kiro-overlay: oklch(26.90% 0.0191 303.28);
+  --kiro-muted: oklch(32.22% 0.0291 301.89);
+  --kiro-subtle: oklch(39.82% 0.0360 300.00);
+  --kiro-text: oklch(100% 0 0);
+  --kiro-text-secondary: oklch(65.73% 0.0182 300.94);
+  --kiro-success: oklch(90.81% 0.1542 156.00);
+  --kiro-error: oklch(74.45% 0.1550 21.49);
+  --kiro-error-hover: oklch(67.41% 0.1547 22.08);
+  --kiro-warning: oklch(88.39% 0.0880 69.59);
+  --kiro-info: oklch(81.12% 0.0948 245.43);
+}
+
+/* Light mode override */
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --kiro-base: oklch(95.98% 0.0042 300.72);
+    --kiro-surface: oklch(93.40% 0.0071 303.81);
+    --kiro-overlay: oklch(89.14% 0.0071 303.83);
+    --kiro-muted: oklch(82.82% 0.0115 302.85);
+    --kiro-subtle: oklch(75.35% 0.0159 298.34);
+    --kiro-text: oklch(31.73% 0.0259 304.41);
+    --kiro-text-secondary: oklch(65.73% 0.0182 300.94);
+    --kiro-success: oklch(52.97% 0.0963 155.38);
+    --kiro-error: oklch(47.08% 0.1367 23.99);
+    --kiro-error-hover: oklch(41.46% 0.1191 23.89);
+    --kiro-warning: oklch(67.07% 0.1392 63.52);
+    --kiro-info: oklch(50.99% 0.1053 247.85);
+  }
+}
+
 html,
 body {
   height: 100%;
@@ -8,10 +85,4 @@ body {
   font-family: Inter, system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -132,47 +132,47 @@
 
 <div class="flex h-full">
   <!-- Sidebar -->
-  <div class="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 overflow-y-auto">
+  <div class="w-64 flex-shrink-0 border-r border-kiro-muted bg-kiro-surface overflow-y-auto">
     <div class="p-3">
-      <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+      <h3 class="text-xs font-semibold text-kiro-subtle uppercase tracking-wider mb-2">
         Marketplaces
       </h3>
       {#if loadingMarketplaces}
-        <p class="text-sm text-gray-400 dark:text-gray-500 px-2">Loading...</p>
+        <p class="text-sm text-kiro-subtle px-2">Loading...</p>
       {:else if marketplaces.length === 0}
-        <p class="text-sm text-gray-400 dark:text-gray-500 px-2">No marketplaces found</p>
+        <p class="text-sm text-kiro-subtle px-2">No marketplaces found</p>
       {:else}
         {#each marketplaces as mp (mp.name)}
           <div class="mb-1">
             <button
               class="w-full text-left px-3 py-2 text-sm rounded-md transition-colors duration-100
                 {expandedMarketplace === mp.name
-                  ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}"
+                  ? 'bg-kiro-muted text-kiro-text'
+                  : 'text-kiro-text-secondary hover:bg-kiro-overlay'}"
               onclick={() => toggleMarketplace(mp.name)}
             >
               <span class="flex items-center justify-between">
                 <span class="truncate font-medium">{mp.name}</span>
-                <span class="text-xs text-gray-400">{mp.plugin_count}</span>
+                <span class="text-xs text-kiro-subtle">{mp.plugin_count}</span>
               </span>
             </button>
 
             {#if expandedMarketplace === mp.name}
               <div class="ml-3 mt-1 space-y-0.5">
                 {#if loadingPlugins === mp.name}
-                  <p class="text-xs text-gray-400 px-3 py-1">Loading plugins...</p>
+                  <p class="text-xs text-kiro-subtle px-3 py-1">Loading plugins...</p>
                 {:else if pluginsByMarketplace[mp.name]}
                   {#each pluginsByMarketplace[mp.name] as plugin (plugin.name)}
                     <button
                       class="w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors duration-100
                         {selectedMarketplace === mp.name && selectedPlugin === plugin.name
-                          ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-                          : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
+                          ? 'bg-kiro-accent-900/30 text-kiro-accent-300'
+                          : 'text-kiro-text-secondary hover:bg-kiro-overlay'}"
                       onclick={() => selectPlugin(mp.name, plugin.name)}
                     >
                       <span class="flex items-center justify-between">
                         <span class="truncate">{plugin.name}</span>
-                        <span class="text-xs text-gray-400">{plugin.skill_count}</span>
+                        <span class="text-xs text-kiro-subtle">{plugin.skill_count}</span>
                       </span>
                     </button>
                   {/each}
@@ -188,41 +188,41 @@
   <!-- Main area -->
   <div class="flex-1 flex flex-col min-w-0">
     <!-- Search bar -->
-    <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+    <div class="p-4 border-b border-kiro-muted">
       <input
         type="text"
         placeholder="Filter skills by name or description..."
         bind:value={filterText}
-        class="w-full px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        class="w-full px-3 py-2 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       />
     </div>
 
     <!-- Error display -->
     {#if error}
-      <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-        <p class="text-sm text-red-700 dark:text-red-400">{error}</p>
+      <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+        <p class="text-sm text-kiro-error">{error}</p>
       </div>
     {/if}
 
     <!-- Install success message -->
     {#if installMessage}
-      <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-        <p class="text-sm text-green-700 dark:text-green-400">{installMessage}</p>
+      <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
+        <p class="text-sm text-kiro-success">{installMessage}</p>
       </div>
     {/if}
 
     <!-- Skills content -->
     <div class="flex-1 overflow-y-auto p-4">
       {#if !selectedPlugin}
-        <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+        <div class="flex items-center justify-center h-full text-kiro-subtle">
           <p class="text-sm">Select a plugin from the sidebar to browse skills</p>
         </div>
       {:else if loadingSkills}
-        <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+        <div class="flex items-center justify-center h-full text-kiro-subtle">
           <p class="text-sm">Loading skills...</p>
         </div>
       {:else if filteredSkills.length === 0}
-        <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+        <div class="flex items-center justify-center h-full text-kiro-subtle">
           <p class="text-sm">
             {filterText ? "No skills match the filter" : "No skills available"}
           </p>
@@ -242,20 +242,20 @@
 
     <!-- Bottom bar -->
     {#if selectedPlugin}
-      <div class="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex items-center justify-between">
-        <label class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+      <div class="p-4 border-t border-kiro-muted bg-kiro-surface flex items-center justify-between">
+        <label class="flex items-center gap-2 text-sm text-kiro-text-secondary">
           <input
             type="checkbox"
             bind:checked={forceInstall}
-            class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            class="h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
           />
           Force reinstall
         </label>
         <button
           class="px-4 py-2 text-sm font-medium rounded-md text-white transition-colors duration-150
             {selectedCount > 0 && !installing
-              ? 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600'
-              : 'bg-gray-300 dark:bg-gray-700 cursor-not-allowed'}"
+              ? 'bg-kiro-accent-600 hover:bg-kiro-accent-700'
+              : 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'}"
           disabled={selectedCount === 0 || installing}
           onclick={installSelected}
         >

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -108,51 +108,51 @@
 
 <div class="flex flex-col h-full">
   <!-- Search bar -->
-  <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+  <div class="p-4 border-b border-kiro-muted">
     <input
       type="text"
       placeholder="Filter by name, plugin, or marketplace..."
       bind:value={filterText}
-      class="w-full px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      class="w-full px-3 py-2 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
     />
   </div>
 
   <!-- Error display -->
   {#if error}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-      <p class="text-sm text-red-700 dark:text-red-400">{error}</p>
+    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+      <p class="text-sm text-kiro-error">{error}</p>
     </div>
   {/if}
 
   <!-- Success message -->
   {#if successMessage}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-      <p class="text-sm text-green-700 dark:text-green-400">{successMessage}</p>
+    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
+      <p class="text-sm text-kiro-success">{successMessage}</p>
     </div>
   {/if}
 
   <!-- Table -->
   <div class="flex-1 overflow-y-auto">
     {#if loading}
-      <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+      <div class="flex items-center justify-center h-full text-kiro-subtle">
         <p class="text-sm">Loading installed skills...</p>
       </div>
     {:else if filteredSkills.length === 0}
-      <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+      <div class="flex items-center justify-center h-full text-kiro-subtle">
         <p class="text-sm">
           {filterText ? "No installed skills match the filter" : "No skills installed"}
         </p>
       </div>
     {:else}
       <table class="w-full text-sm text-left">
-        <thead class="text-xs text-gray-500 dark:text-gray-400 uppercase bg-gray-50 dark:bg-gray-900 sticky top-0">
+        <thead class="text-xs text-kiro-subtle uppercase bg-kiro-surface sticky top-0">
           <tr>
             <th class="px-4 py-3 w-10">
               <input
                 type="checkbox"
                 checked={selectedSkills.size === filteredSkills.length && filteredSkills.length > 0}
                 onchange={toggleAll}
-                class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                class="h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
               />
             </th>
             <th class="px-4 py-3">Name</th>
@@ -165,22 +165,22 @@
         <tbody>
           {#each filteredSkills as skill (skill.name)}
             <tr
-              class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors duration-100
-                {selectedSkills.has(skill.name) ? 'bg-blue-50 dark:bg-blue-900/10' : ''}"
+              class="border-b border-kiro-muted/50 hover:bg-kiro-overlay transition-colors duration-100
+                {selectedSkills.has(skill.name) ? 'bg-kiro-accent-900/10' : ''}"
             >
               <td class="px-4 py-3">
                 <input
                   type="checkbox"
                   checked={selectedSkills.has(skill.name)}
                   onchange={() => toggleSkill(skill.name)}
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  class="h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
                 />
               </td>
-              <td class="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{skill.name}</td>
-              <td class="px-4 py-3 text-gray-600 dark:text-gray-400">{skill.plugin}</td>
-              <td class="px-4 py-3 text-gray-600 dark:text-gray-400">{skill.marketplace}</td>
-              <td class="px-4 py-3 text-gray-600 dark:text-gray-400">{skill.version ?? "---"}</td>
-              <td class="px-4 py-3 text-gray-600 dark:text-gray-400">{formatDate(skill.installed_at)}</td>
+              <td class="px-4 py-3 font-medium text-kiro-text">{skill.name}</td>
+              <td class="px-4 py-3 text-kiro-text-secondary">{skill.plugin}</td>
+              <td class="px-4 py-3 text-kiro-text-secondary">{skill.marketplace}</td>
+              <td class="px-4 py-3 text-kiro-text-secondary">{skill.version ?? "---"}</td>
+              <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(skill.installed_at)}</td>
             </tr>
           {/each}
         </tbody>
@@ -189,15 +189,15 @@
   </div>
 
   <!-- Bottom bar -->
-  <div class="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex items-center justify-between">
-    <span class="text-sm text-gray-500 dark:text-gray-400">
+  <div class="p-4 border-t border-kiro-muted bg-kiro-surface flex items-center justify-between">
+    <span class="text-sm text-kiro-subtle">
       {skills.length} skill{skills.length === 1 ? "" : "s"} installed
     </span>
     <button
       class="px-4 py-2 text-sm font-medium rounded-md text-white transition-colors duration-150
         {selectedCount > 0 && !removing
-          ? 'bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'
-          : 'bg-gray-300 dark:bg-gray-700 cursor-not-allowed'}"
+          ? 'bg-kiro-error hover:bg-kiro-error-hover'
+          : 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'}"
       disabled={selectedCount === 0 || removing}
       onclick={removeSelected}
     >

--- a/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
@@ -184,7 +184,7 @@
                 class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150
                   {updatingName === mp.name
                     ? 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'
-                    : 'bg-kiro-muted text-kiro-text-secondary hover:bg-kiro-muted'}"
+                    : 'bg-kiro-muted text-kiro-text-secondary hover:bg-kiro-subtle'}"
                 disabled={updatingName === mp.name}
                 onclick={() => updateMarketplace(mp.name)}
               >

--- a/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
@@ -87,13 +87,13 @@
   function sourceTypeBadgeClass(sourceType: string): string {
     switch (sourceType) {
       case "github":
-        return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400";
+        return "bg-kiro-info/15 text-kiro-info";
       case "git":
-        return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400";
+        return "bg-kiro-accent-900/30 text-kiro-accent-300";
       case "local":
-        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400";
+        return "bg-kiro-warning/15 text-kiro-warning";
       default:
-        return "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300";
+        return "bg-kiro-muted text-kiro-text-secondary";
     }
   }
 
@@ -104,8 +104,8 @@
 
 <div class="flex flex-col h-full">
   <!-- Add marketplace section -->
-  <div class="p-4 border-b border-gray-200 dark:border-gray-700">
-    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Add marketplace</h3>
+  <div class="p-4 border-b border-kiro-muted">
+    <h3 class="text-sm font-medium text-kiro-text-secondary mb-2">Add marketplace</h3>
     <form
       class="flex gap-2"
       onsubmit={(e: Event) => { e.preventDefault(); addMarketplace(); }}
@@ -115,12 +115,12 @@
         placeholder="owner/repo, git URL, or local path"
         bind:value={newSource}
         disabled={adding}
-        class="flex-1 px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+        class="flex-1 px-3 py-2 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent disabled:opacity-50"
       />
       <select
         bind:value={protocol}
         disabled={adding}
-        class="px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+        class="px-3 py-2 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent disabled:opacity-50"
       >
         <option value="https">HTTPS</option>
         <option value="ssh">SSH</option>
@@ -130,8 +130,8 @@
         disabled={adding || !newSource.trim()}
         class="px-4 py-2 text-sm font-medium rounded-md text-white transition-colors duration-150
           {!adding && newSource.trim()
-            ? 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600'
-            : 'bg-gray-300 dark:bg-gray-700 cursor-not-allowed'}"
+            ? 'bg-kiro-accent-600 hover:bg-kiro-accent-700'
+            : 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'}"
       >
         {adding ? "Adding..." : "Add"}
       </button>
@@ -140,41 +140,41 @@
 
   <!-- Error display -->
   {#if error}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-      <p class="text-sm text-red-700 dark:text-red-400">{error}</p>
+    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+      <p class="text-sm text-kiro-error">{error}</p>
     </div>
   {/if}
 
   <!-- Success message -->
   {#if successMessage}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-      <p class="text-sm text-green-700 dark:text-green-400">{successMessage}</p>
+    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
+      <p class="text-sm text-kiro-success">{successMessage}</p>
     </div>
   {/if}
 
   <!-- Marketplace list -->
   <div class="flex-1 overflow-y-auto p-4">
     {#if loading}
-      <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+      <div class="flex items-center justify-center h-full text-kiro-subtle">
         <p class="text-sm">Loading marketplaces...</p>
       </div>
     {:else if marketplaces.length === 0}
-      <div class="flex items-center justify-center h-full text-gray-400 dark:text-gray-500">
+      <div class="flex items-center justify-center h-full text-kiro-subtle">
         <p class="text-sm">No marketplaces registered. Add one above to get started.</p>
       </div>
     {:else}
       <div class="space-y-3">
         {#each marketplaces as mp (mp.name)}
-          <div class="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div class="flex items-center justify-between p-4 rounded-lg border border-kiro-muted bg-kiro-overlay">
             <div class="flex items-center gap-3 min-w-0">
               <div class="min-w-0">
                 <div class="flex items-center gap-2">
-                  <span class="font-semibold text-gray-900 dark:text-gray-100 truncate">{mp.name}</span>
+                  <span class="font-semibold text-kiro-text truncate">{mp.name}</span>
                   <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full {sourceTypeBadgeClass(mp.source_type)}">
                     {mp.source_type}
                   </span>
                 </div>
-                <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+                <p class="mt-0.5 text-sm text-kiro-subtle">
                   {mp.plugin_count} plugin{mp.plugin_count === 1 ? "" : "s"}
                 </p>
               </div>
@@ -183,8 +183,8 @@
               <button
                 class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150
                   {updatingName === mp.name
-                    ? 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
+                    ? 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'
+                    : 'bg-kiro-muted text-kiro-text-secondary hover:bg-kiro-muted'}"
                 disabled={updatingName === mp.name}
                 onclick={() => updateMarketplace(mp.name)}
               >
@@ -193,8 +193,8 @@
               <button
                 class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150
                   {removingName === mp.name
-                    ? 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                    : 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40'}"
+                    ? 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'
+                    : 'bg-kiro-error/10 text-kiro-error hover:bg-kiro-error/20'}"
                 disabled={removingName === mp.name}
                 onclick={() => removeMarketplace(mp.name)}
               >

--- a/crates/kiro-control-center/src/lib/components/ProjectDropdown.svelte
+++ b/crates/kiro-control-center/src/lib/components/ProjectDropdown.svelte
@@ -38,7 +38,7 @@
 
 <div class="relative">
   <button
-    class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+    class="flex items-center gap-2 text-sm text-kiro-text-secondary hover:text-kiro-text transition-colors"
     onclick={toggle}
   >
     <span class="truncate max-w-xs font-medium">
@@ -50,31 +50,31 @@
   </button>
 
   {#if isOpen}
-    <div class="absolute right-0 top-full mt-1 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50 overflow-hidden">
+    <div class="absolute right-0 top-full mt-1 w-80 bg-kiro-overlay rounded-lg shadow-lg border border-kiro-muted z-50 overflow-hidden">
       {#if store.discoveredProjects.length > 0}
         <div class="max-h-64 overflow-y-auto py-1">
           {#each store.discoveredProjects as project (project.path)}
             <button
-              class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors
-                {project.path === store.projectPath ? 'bg-blue-50 dark:bg-blue-900/20' : ''}"
+              class="w-full text-left px-4 py-2 hover:bg-kiro-muted transition-colors
+                {project.path === store.projectPath ? 'bg-kiro-accent-900/20' : ''}"
               onclick={() => handleSelectProject(project.path)}
             >
-              <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{project.name}</div>
-              <div class="text-xs text-gray-500 dark:text-gray-400 truncate">{project.path}</div>
+              <div class="text-sm font-medium text-kiro-text">{project.name}</div>
+              <div class="text-xs text-kiro-subtle truncate">{project.path}</div>
             </button>
           {/each}
         </div>
       {/if}
 
-      <div class="border-t border-gray-200 dark:border-gray-700 py-1">
+      <div class="border-t border-kiro-muted py-1">
         <button
-          class="w-full text-left px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+          class="w-full text-left px-4 py-2 text-sm text-kiro-text-secondary hover:bg-kiro-muted"
           onclick={handleOpenOther}
         >
           Open Other...
         </button>
         <button
-          class="w-full text-left px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+          class="w-full text-left px-4 py-2 text-sm text-kiro-text-secondary hover:bg-kiro-muted"
           onclick={handleManageRoots}
         >
           Manage Directories...

--- a/crates/kiro-control-center/src/lib/components/ProjectPicker.svelte
+++ b/crates/kiro-control-center/src/lib/components/ProjectPicker.svelte
@@ -15,36 +15,36 @@
   }
 </script>
 
-<div class="flex items-center justify-center h-full bg-gray-100 dark:bg-gray-950">
+<div class="flex items-center justify-center h-full bg-kiro-base">
   <div class="max-w-2xl w-full mx-auto p-8">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Kiro Control Center</h1>
-    <p class="text-gray-500 dark:text-gray-400 mb-8">Select a project to manage its skills.</p>
+    <h1 class="text-2xl font-bold text-kiro-text mb-2">Kiro Control Center</h1>
+    <p class="text-kiro-subtle mb-8">Select a project to manage its skills.</p>
 
     {#if store.discoveredProjects.length > 0}
       <div class="space-y-2 mb-6">
         {#each store.discoveredProjects as project (project.path)}
           <button
-            class="w-full text-left px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 hover:border-blue-400 dark:hover:border-blue-500 transition-colors"
+            class="w-full text-left px-4 py-3 rounded-lg border border-kiro-muted bg-kiro-surface hover:border-kiro-accent-400 transition-colors"
             onclick={() => selectProject(project.path)}
           >
-            <div class="font-medium text-gray-900 dark:text-gray-100">{project.name}</div>
-            <div class="text-sm text-gray-500 dark:text-gray-400 truncate">{project.path}</div>
+            <div class="font-medium text-kiro-text">{project.name}</div>
+            <div class="text-sm text-kiro-subtle truncate">{project.path}</div>
           </button>
         {/each}
       </div>
     {:else if (store.settings.scan_roots ?? []).length > 0}
-      <p class="text-gray-500 dark:text-gray-400 mb-6">No projects found in your configured directories.</p>
+      <p class="text-kiro-subtle mb-6">No projects found in your configured directories.</p>
     {/if}
 
     <div class="flex gap-3">
       <button
-        class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors text-sm font-medium"
+        class="px-4 py-2 rounded-lg bg-kiro-accent-600 text-white hover:bg-kiro-accent-700 transition-colors text-sm font-medium"
         onclick={handleAddDirectory}
       >
         Add Directory to Scan
       </button>
       <button
-        class="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-sm font-medium"
+        class="px-4 py-2 rounded-lg border border-kiro-muted text-kiro-text-secondary hover:bg-kiro-overlay transition-colors text-sm font-medium"
         onclick={handleOpenOther}
       >
         Open Other...
@@ -52,7 +52,7 @@
     </div>
 
     {#if (store.settings.scan_roots ?? []).length > 0}
-      <div class="mt-8 text-xs text-gray-400 dark:text-gray-500">
+      <div class="mt-8 text-xs text-kiro-subtle">
         Scanning: {(store.settings.scan_roots ?? []).join(", ")}
       </div>
     {/if}

--- a/crates/kiro-control-center/src/lib/components/ScanRootsPanel.svelte
+++ b/crates/kiro-control-center/src/lib/components/ScanRootsPanel.svelte
@@ -13,17 +13,17 @@
 
 <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onclick={onClose} role="none">
   <div
-    class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden"
+    class="bg-kiro-overlay rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden"
     onclick={(e) => e.stopPropagation()}
     onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}
     role="dialog"
     aria-label="Manage scan directories"
     tabindex="0"
   >
-    <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-      <h2 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Scan Directories</h2>
+    <div class="flex items-center justify-between px-4 py-3 border-b border-kiro-muted">
+      <h2 class="text-sm font-semibold text-kiro-text">Scan Directories</h2>
       <button
-        class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+        class="text-kiro-subtle hover:text-kiro-text-secondary"
         onclick={onClose}
         aria-label="Close dialog"
       >
@@ -37,10 +37,10 @@
       {#if (store.settings.scan_roots ?? []).length > 0}
         <ul class="space-y-2 mb-4">
           {#each store.settings.scan_roots ?? [] as root (root)}
-            <li class="flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-700/50 rounded text-sm">
-              <span class="truncate text-gray-700 dark:text-gray-300">{root}</span>
+            <li class="flex items-center justify-between px-3 py-2 bg-kiro-overlay rounded text-sm">
+              <span class="truncate text-kiro-text-secondary">{root}</span>
               <button
-                class="ml-2 text-gray-400 hover:text-red-500 flex-shrink-0"
+                class="ml-2 text-kiro-subtle hover:text-kiro-error flex-shrink-0"
                 onclick={() => removeScanRoot(root)}
                 aria-label="Remove {root}"
               >
@@ -52,13 +52,13 @@
           {/each}
         </ul>
       {:else}
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        <p class="text-sm text-kiro-subtle mb-4">
           No directories configured. Add a directory to discover Kiro projects.
         </p>
       {/if}
 
       <button
-        class="w-full px-4 py-2 rounded-lg border border-dashed border-gray-300 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-400 hover:border-blue-400 hover:text-blue-500 transition-colors"
+        class="w-full px-4 py-2 rounded-lg border border-dashed border-kiro-muted text-sm text-kiro-text-secondary hover:border-kiro-accent-400 hover:text-kiro-accent-400 transition-colors"
         onclick={handleAddRoot}
       >
         + Add Directory

--- a/crates/kiro-control-center/src/lib/components/SkillCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/SkillCard.svelte
@@ -12,8 +12,8 @@
   type="button"
   class="flex items-start gap-3 w-full text-left p-4 rounded-lg border transition-colors duration-150
     {selected
-      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400'
-      : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600'}
+      ? 'border-kiro-accent-500 bg-kiro-accent-900/20'
+      : 'border-kiro-muted bg-kiro-overlay hover:border-kiro-subtle'}
     {skill.installed ? 'opacity-60' : ''}"
   onclick={onToggle}
   disabled={skill.installed}
@@ -22,19 +22,19 @@
     type="checkbox"
     checked={selected}
     disabled={skill.installed}
-    class="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+    class="mt-1 h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
     onclick={(e: MouseEvent) => e.stopPropagation()}
     onchange={onToggle}
   />
   <div class="flex-1 min-w-0">
     <div class="flex items-center gap-2">
-      <span class="font-semibold text-gray-900 dark:text-gray-100">{skill.name}</span>
+      <span class="font-semibold text-kiro-text">{skill.name}</span>
       {#if skill.installed}
-        <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
+        <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-kiro-success/15 text-kiro-success">
           Installed
         </span>
       {/if}
     </div>
-    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">{skill.description}</p>
+    <p class="mt-1 text-sm text-kiro-text-secondary truncate">{skill.description}</p>
   </div>
 </button>

--- a/crates/kiro-control-center/src/lib/components/TabBar.svelte
+++ b/crates/kiro-control-center/src/lib/components/TabBar.svelte
@@ -6,13 +6,13 @@
   } = $props();
 </script>
 
-<nav class="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+<nav class="flex border-b border-kiro-muted bg-kiro-surface">
   {#each tabs as tab (tab)}
     <button
       class="px-6 py-3 text-sm font-medium transition-colors duration-150 focus:outline-none
         {activeTab === tab
-          ? 'text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400'
-          : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-b-2 hover:border-gray-300 dark:hover:border-gray-600'}"
+          ? 'text-kiro-accent-400 border-b-2 border-kiro-accent-400'
+          : 'text-kiro-subtle hover:text-kiro-text-secondary hover:border-b-2 hover:border-kiro-subtle'}"
       onclick={() => onTabChange(tab)}
     >
       {tab}

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -25,12 +25,12 @@
 </script>
 
 {#if store.loading}
-  <div class="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-950">
-    <p class="text-gray-500 dark:text-gray-400">Loading...</p>
+  <div class="flex items-center justify-center h-screen bg-kiro-base">
+    <p class="text-kiro-subtle">Loading...</p>
   </div>
 {:else if store.projectPath}
-  <div class="flex flex-col h-screen bg-gray-100 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
-    <header class="flex items-center justify-between px-6 py-3 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
+  <div class="flex flex-col h-screen bg-kiro-base text-kiro-text">
+    <header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
       <h1 class="text-lg font-semibold">Kiro Control Center</h1>
       <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
     </header>
@@ -52,10 +52,10 @@
 {/if}
 
 {#if store.projectError}
-  <div class="fixed bottom-4 right-4 z-50 max-w-md px-4 py-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 shadow-lg">
-    <p class="text-sm text-red-700 dark:text-red-400">{store.projectError}</p>
+  <div class="fixed bottom-4 right-4 z-50 max-w-md px-4 py-3 rounded-lg bg-kiro-error/10 border border-kiro-error/30 shadow-lg">
+    <p class="text-sm text-kiro-error">{store.projectError}</p>
     <button
-      class="mt-1 text-xs text-red-500 hover:text-red-700 dark:hover:text-red-300"
+      class="mt-1 text-xs text-kiro-error/70 hover:text-kiro-error"
       onclick={() => (store.projectError = null)}
     >
       Dismiss


### PR DESCRIPTION
## Summary

- Restyle kiro-control-center to match the Kiro IDE purple-tinted color palette
- Add custom Tailwind v4 theme with `@theme inline` for CSS-variable-based surface/semantic colors and a static purple accent scale
- All colors use OKLCH format for native opacity modifier support
- Dark-first with light mode fallback via `prefers-color-scheme`
- Replace all Tailwind `gray-*`/`blue-*`/`red-*`/`green-*` classes with `kiro-*` semantic tokens across 10 components
- Eliminates all `dark:` prefixes — auto-swapping CSS custom properties handle both modes

## Color palette source

Derived from the [Kiro VS Code Theme](https://marketplace.visualstudio.com/items?itemName=MohdZaid.kiro-theme) (forked from the official Kiro IDE).

## Key design decisions

- **`@theme inline`** for `var()` references — required by Tailwind v4 to avoid CSS cascade resolution bugs
- **Separate `@theme`** for static accent scale — no `var()` references, so standard block is correct
- **OKLCH color values** — native to Tailwind v4's opacity modifier system (`bg-kiro-error/10`)
- **Semantic tokens** (`kiro-base`, `kiro-surface`, `kiro-overlay`, `kiro-muted`, `kiro-subtle`) — map to UI depth levels, not arbitrary shades

## Test plan

- [x] `npm run build` passes
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] Visual verification with `cargo tauri dev`
- [x] Grep confirms zero remaining `dark:`, `bg-white`, `gray-*`, `blue-*`, `red-*`, `green-*` color classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)