### PR TITLE
feat(control-center): expand/collapse long skill descriptions

### DIFF
--- a/crates/kiro-control-center/src/lib/components/SkillCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/SkillCard.svelte
@@ -6,6 +6,16 @@
     selected: boolean;
     onToggle: () => void;
   } = $props();
+
+  let expanded = $state(false);
+  let overflows = $state(false);
+  let descEl: HTMLParagraphElement | undefined = $state();
+
+  $effect(() => {
+    if (descEl) {
+      overflows = descEl.scrollHeight > descEl.clientHeight;
+    }
+  });
 </script>
 
 <button
@@ -35,6 +45,23 @@
         </span>
       {/if}
     </div>
-    <p class="mt-1 text-sm text-kiro-text-secondary truncate">{skill.description}</p>
+    <p
+      bind:this={descEl}
+      class="mt-1 text-sm text-kiro-text-secondary"
+      class:line-clamp-3={!expanded}
+    >
+      {skill.description}
+    </p>
+    {#if overflows || expanded}
+      <span
+        role="button"
+        tabindex="0"
+        class="mt-1 inline-block text-xs text-kiro-accent-400 hover:text-kiro-accent-300 cursor-pointer"
+        onclick={(e) => { e.stopPropagation(); expanded = !expanded; }}
+        onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); e.preventDefault(); expanded = !expanded; } }}
+      >
+        {expanded ? "Show less" : "Show more"}
+      </span>
+    {/if}
   </div>
 </button>

--- a/docs/plans/2026-04-06-skill-card-description-design.md
+++ b/docs/plans/2026-04-06-skill-card-description-design.md
@@ -1,0 +1,37 @@
+# Skill Card Description Expansion
+
+## Problem
+
+`SkillCard.svelte` uses CSS `truncate` (single-line ellipsis) on skill descriptions.
+Long descriptions are cut off with no way to read the full text in the Control Center GUI.
+
+## Solution
+
+Replace single-line truncation with a 3-line clamp and an expand-in-place toggle.
+
+## Design
+
+### Behavior
+
+- **Default:** description shows up to 3 lines via `line-clamp-3`. If the text fits,
+  no toggle appears.
+- **Overflow detected:** a "Show more" text button appears below the description.
+- **Expanded:** clamp is removed, full description visible, button reads "Show less".
+- **Collapsed:** returns to 3-line clamp.
+
+### Overflow detection
+
+Use a Svelte `$effect` that compares `scrollHeight > clientHeight` on the description
+`<p>` element after mount and on content changes. This conditionally shows the toggle
+button only when the text actually overflows the clamp.
+
+### Scope
+
+- **Modified:** `crates/kiro-control-center/src/lib/components/SkillCard.svelte`
+- **No backend changes** — `SkillInfo.description` already carries the full text.
+- **No new components** — the toggle lives inside the existing card.
+
+### Alternatives considered
+
+- **Detail panel/sidebar:** More room for metadata but heavier lift; can be added later.
+- **Tooltip on hover:** Doesn't work on touch, hard to read long text in a popover.

--- a/docs/plans/2026-04-06-skill-card-description-plan.md
+++ b/docs/plans/2026-04-06-skill-card-description-plan.md
@@ -1,0 +1,83 @@
+# Skill Card Description Expansion — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow users to see full skill descriptions in the Control Center's browse view instead of truncating to one line.
+
+**Architecture:** Replace single-line CSS `truncate` with `line-clamp-3` and add a reactive expand/collapse toggle. Overflow detection uses `scrollHeight > clientHeight` comparison in a Svelte `$effect`.
+
+**Tech Stack:** Svelte 5 (runes), Tailwind CSS v4
+
+---
+
+### Task 1: Update SkillCard with line-clamp and expand toggle
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/SkillCard.svelte`
+
+**Step 1: Add reactive state and element binding**
+
+Add to the `<script>` block:
+
+```svelte
+let expanded = $state(false);
+let overflows = $state(false);
+let descEl: HTMLParagraphElement | undefined = $state();
+
+$effect(() => {
+  if (descEl) {
+    overflows = descEl.scrollHeight > descEl.clientHeight;
+  }
+});
+```
+
+**Step 2: Replace the description paragraph**
+
+Change line 38 from:
+
+```svelte
+<p class="mt-1 text-sm text-kiro-text-secondary truncate">{skill.description}</p>
+```
+
+To:
+
+```svelte
+<p
+  bind:this={descEl}
+  class="mt-1 text-sm text-kiro-text-secondary"
+  class:line-clamp-3={!expanded}
+>
+  {skill.description}
+</p>
+{#if overflows || expanded}
+  <button
+    type="button"
+    class="mt-1 text-xs text-kiro-accent-400 hover:text-kiro-accent-300 focus:outline-none"
+    onclick={(e) => { e.stopPropagation(); expanded = !expanded; }}
+  >
+    {expanded ? "Show less" : "Show more"}
+  </button>
+{/if}
+```
+
+**Step 3: Build and verify**
+
+Run: `cd crates/kiro-control-center && npm run build`
+Expected: clean build, no errors.
+
+**Step 4: Manual test**
+
+Run: `cd crates/kiro-control-center/src-tauri && cargo tauri dev`
+- Browse to a plugin with long skill descriptions
+- Verify: short descriptions show fully with no "Show more" button
+- Verify: long descriptions clamp at 3 lines with "Show more"
+- Click "Show more" — full text visible, button says "Show less"
+- Click "Show less" — collapses back
+- Verify: clicking "Show more" does NOT toggle the checkbox
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/SkillCard.svelte
+git commit -m "feat(control-center): expand/collapse long skill descriptions in SkillCard"
+```


### PR DESCRIPTION
## Summary
- Replace single-line `truncate` on `SkillCard` descriptions with `line-clamp-3` and an expand/collapse toggle
- Short descriptions display fully with no toggle; long descriptions clamp at 3 lines with "Show more"
- Uses `<span role="button">` instead of nested `<button>` to avoid invalid HTML

## Test plan
- [ ] `npm run build` in `crates/kiro-control-center/` passes cleanly
- [ ] Browse a plugin with short descriptions — no "Show more" button appears
- [ ] Browse a plugin with long descriptions — text clamps at 3 lines, "Show more" visible
- [ ] Click "Show more" — full description expands, button changes to "Show less"
- [ ] Click "Show less" — collapses back to 3 lines
- [ ] Clicking "Show more/less" does NOT toggle the skill's checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)