### PR TITLE
refactor: copy skill directories instead of merging companion files

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           show_full_output: true
-          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,10 @@ cargo clippy --workspace -- -D warnings
 
 ## Architecture
 The tool reads Claude Code `marketplace.json` catalogs, discovers plugins and skills,
-and installs SKILL.md files into Kiro CLI projects at `.kiro/skills/`.
+and installs them into Kiro CLI projects at `.kiro/skills/`.
 
-Multi-file Claude Code skills (SKILL.md + companion .md files) are merged into a
-single SKILL.md since Kiro doesn't support deferred loading of companion files.
+Skill directories are copied wholesale (SKILL.md + `references/` companion files)
+so that Kiro's native lazy loading can resolve companion files on demand.
 
 ### Service Layer
 Marketplace operations (add/remove/update/list) live in `kiro-market-core::service::MarketplaceService`.
@@ -54,7 +54,6 @@ on Windows it uses directory junctions with copy fallback.
 ## Key Crate Dependencies
 - `gix` + system `git` CLI — git operations (gix for clone/open, system git for pull/checkout)
 - `clap` (derive) — CLI framework
-- `pulldown-cmark` — markdown parsing for skill merging
 - `serde` / `serde_json` / `serde_yaml` — JSON and YAML parsing
 - `colored` — terminal output
 - `dirs` — XDG path resolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,6 @@ clap = { version = "4", features = ["derive"] }
 # Git
 gix = { version = "0.81", default-features = true, features = ["blocking-network-client", "blocking-http-transport-curl"] }
 
-# Markdown
-pulldown-cmark = { version = "0.13", default-features = false }
-
 # Console
 colored = "3"
 

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -12,7 +12,7 @@ use kiro_market_core::error::{Error as CoreError, SkillError};
 use kiro_market_core::marketplace::{Marketplace, PluginEntry, PluginSource, StructuredSource};
 use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
 use kiro_market_core::project::{InstalledSkillMeta, KiroProject};
-use kiro_market_core::skill::{extract_relative_md_links, merge_skill, parse_frontmatter};
+use kiro_market_core::skill::parse_frontmatter;
 
 use crate::error::{CommandError, ErrorType};
 
@@ -299,7 +299,7 @@ pub async fn install_skills(
             }
         };
 
-        let (frontmatter, body_offset) = match parse_frontmatter(&content) {
+        let (frontmatter, _body_offset) = match parse_frontmatter(&content) {
             Ok(r) => r,
             Err(e) => {
                 warn!(
@@ -317,17 +317,6 @@ pub async fn install_skills(
 
         processed_skills.insert(frontmatter.name.clone());
 
-        let merged_content = match prepare_merged_content(&content, body_offset, skill_dir) {
-            Ok(c) => c,
-            Err(e) => {
-                result.failed.push(FailedSkill {
-                    name: frontmatter.name,
-                    error: e,
-                });
-                continue;
-            }
-        };
-
         let meta = InstalledSkillMeta {
             marketplace: marketplace.clone(),
             plugin: plugin.clone(),
@@ -336,9 +325,9 @@ pub async fn install_skills(
         };
 
         let install_outcome = if force {
-            project.install_skill_force(&frontmatter.name, &merged_content, meta)
+            project.install_skill_from_dir_force(&frontmatter.name, skill_dir, meta)
         } else {
-            project.install_skill(&frontmatter.name, &merged_content, meta)
+            project.install_skill_from_dir(&frontmatter.name, skill_dir, meta)
         };
 
         match install_outcome {
@@ -606,42 +595,6 @@ fn count_plugin_skills(entry: &PluginEntry, marketplace_path: &Path) -> usize {
         }
         PluginSource::Structured(_) => 0,
     }
-}
-
-/// Read companion files and merge them into a single SKILL.md document.
-///
-/// Kiro doesn't support deferred loading of companion markdown files, so
-/// multi-file Claude Code skills must be merged into one file before
-/// installation. Returns an error string on failure.
-fn prepare_merged_content(
-    skill_content: &str,
-    body_offset: usize,
-    skill_dir: &Path,
-) -> Result<String, String> {
-    let body = &skill_content[body_offset..];
-    let relative_links = extract_relative_md_links(body);
-
-    let mut companions: Vec<(String, String)> = Vec::new();
-    for link in &relative_links {
-        let companion_path = skill_dir.join(link);
-        match fs::read_to_string(&companion_path) {
-            Ok(content) => companions.push((link.clone(), content)),
-            Err(e) => {
-                return Err(format!(
-                    "companion file '{}' referenced by SKILL.md could not be read: {e}",
-                    companion_path.display()
-                ));
-            }
-        }
-    }
-
-    let companion_refs: Vec<(&str, &str)> = companions
-        .iter()
-        .map(|(path, content)| (path.as_str(), content.as_str()))
-        .collect();
-
-    merge_skill(skill_content, &companion_refs)
-        .map_err(|e| format!("failed to merge skill content: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -82,9 +82,15 @@ mod tests {
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
         };
+        let skill_src = tempfile::tempdir().expect("skill src");
+        std::fs::write(
+            skill_src.path().join("SKILL.md"),
+            "# Test Skill\nBody content",
+        )
+        .expect("write SKILL.md");
         project
-            .install_skill(name, "# Test Skill\nBody content", meta)
-            .expect("install_skill");
+            .install_skill_from_dir(name, skill_src.path(), meta)
+            .expect("install_skill_from_dir");
         let path = dir.path().to_str().expect("valid utf-8").to_owned();
         (dir, path)
     }
@@ -102,9 +108,12 @@ mod tests {
                 version: Some("1.0.0".into()),
                 installed_at: Utc::now(),
             };
+            let skill_src = tempfile::tempdir().expect("skill src");
+            std::fs::write(skill_src.path().join("SKILL.md"), "# Skill\nBody")
+                .expect("write SKILL.md");
             project
-                .install_skill(name, "# Skill\nBody", meta)
-                .expect("install_skill");
+                .install_skill_from_dir(name, skill_src.path(), meta)
+                .expect("install_skill_from_dir");
         }
 
         let result = list_installed_skills(path).await.expect("should succeed");

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -49,7 +49,6 @@ impl From<CoreError> for CommandError {
             CoreError::Skill(SkillError::AlreadyInstalled { .. }) => ErrorType::AlreadyExists,
             CoreError::Skill(SkillError::NotInstalled { .. }) => ErrorType::NotFound,
             CoreError::Skill(SkillError::SkillMdNotFound { .. }) => ErrorType::NotFound,
-            CoreError::Skill(SkillError::MergeFailed { .. }) => ErrorType::IoError,
             CoreError::Skill(_) => ErrorType::Unknown,
             CoreError::Validation(_) => ErrorType::Validation,
             CoreError::Git(_) => ErrorType::GitError,
@@ -126,14 +125,6 @@ mod tests {
     #[case::skill_md_not_found(
         CoreError::Skill(SkillError::SkillMdNotFound { path: PathBuf::from("skills/SKILL.md") }),
         ErrorType::NotFound
-    )]
-    #[case::skill_merge_failed(
-        CoreError::Skill(SkillError::MergeFailed {
-            skill: "go-lint".into(),
-            path: PathBuf::from(".kiro/skills"),
-            reason: "conflict".into(),
-        }),
-        ErrorType::IoError
     )]
     #[case::validation_invalid_name(
         CoreError::Validation(ValidationError::InvalidName {

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -19,7 +19,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 gix = { workspace = true }
-pulldown-cmark = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -77,14 +77,6 @@ pub enum SkillError {
     /// No `SKILL.md` was found for the skill.
     #[error("SKILL.md not found at {path}")]
     SkillMdNotFound { path: PathBuf },
-
-    /// Merging the skill into the target project failed.
-    #[error("failed to merge skill `{skill}` into {path}: {reason}")]
-    MergeFailed {
-        skill: String,
-        path: PathBuf,
-        reason: String,
-    },
 }
 
 // ---------------------------------------------------------------------------
@@ -255,14 +247,6 @@ mod tests {
     #[case::skill_md_not_found(
         SkillError::SkillMdNotFound { path: PathBuf::from("skills/rust/SKILL.md") },
         "SKILL.md not found at skills/rust/SKILL.md"
-    )]
-    #[case::skill_merge_failed(
-        SkillError::MergeFailed {
-            skill: "go-lint".into(),
-            path: PathBuf::from(".kiro/skills"),
-            reason: "conflict".into(),
-        },
-        "failed to merge skill `go-lint` into .kiro/skills: conflict"
     )]
     fn skill_error_display(#[case] err: SkillError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -46,9 +46,6 @@ pub struct InstalledSkills {
 /// Name of the tracking file inside `.kiro/`.
 const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
 
-/// Name of the skill definition file inside each skill directory.
-const SKILL_MD: &str = "SKILL.md";
-
 /// Recursively copy a directory tree from `src` to `dest`.
 ///
 /// Creates `dest` and all intermediate directories. Files are copied
@@ -158,57 +155,6 @@ impl KiroProject {
         }
     }
 
-    /// Install a skill into the project.
-    ///
-    /// Creates `.kiro/skills/<name>/SKILL.md` with the provided `content`
-    /// and records the installation in the tracking file.
-    ///
-    /// # Errors
-    ///
-    /// - [`SkillError::AlreadyInstalled`] if a skill with this name already
-    ///   exists.
-    /// - I/O or JSON serialisation errors.
-    pub fn install_skill(
-        &self,
-        name: &str,
-        content: &str,
-        meta: InstalledSkillMeta,
-    ) -> crate::error::Result<()> {
-        validation::validate_name(name)?;
-        let dir = self.skill_dir(name);
-
-        if dir.exists() {
-            return Err(SkillError::AlreadyInstalled {
-                name: name.to_owned(),
-            }
-            .into());
-        }
-
-        self.write_skill(name, content, meta)
-    }
-
-    /// Install a skill, overwriting any existing installation.
-    ///
-    /// # Errors
-    ///
-    /// I/O or JSON serialisation errors.
-    pub fn install_skill_force(
-        &self,
-        name: &str,
-        content: &str,
-        meta: InstalledSkillMeta,
-    ) -> crate::error::Result<()> {
-        validation::validate_name(name)?;
-        let dir = self.skill_dir(name);
-
-        if dir.exists() {
-            debug!(name, "removing existing skill directory for force install");
-            fs::remove_dir_all(&dir)?;
-        }
-
-        self.write_skill(name, content, meta)
-    }
-
     /// Remove an installed skill.
     ///
     /// Deletes the skill directory and removes the entry from the tracking
@@ -288,25 +234,6 @@ impl KiroProject {
     }
 
     // -- internal helpers --------------------------------------------------
-
-    /// Write SKILL.md and update tracking for a skill installation.
-    fn write_skill(
-        &self,
-        name: &str,
-        content: &str,
-        meta: InstalledSkillMeta,
-    ) -> crate::error::Result<()> {
-        let dir = self.skill_dir(name);
-        fs::create_dir_all(&dir)?;
-        crate::cache::atomic_write(&dir.join(SKILL_MD), content.as_bytes())?;
-
-        let mut installed = self.load_installed()?;
-        installed.skills.insert(name.to_owned(), meta);
-        self.write_tracking(&installed)?;
-
-        debug!(name, "skill installed");
-        Ok(())
-    }
 
     /// Copy a source skill directory atomically and update tracking.
     ///
@@ -392,71 +319,17 @@ mod tests {
     }
 
     #[test]
-    fn install_skill_creates_directory_and_file() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: rust-check\ndescription: Rust checks\n---\nBody.\n";
-
-        project
-            .install_skill("rust-check", content, sample_meta())
-            .expect("install should succeed");
-
-        let skill_md = project.skill_dir("rust-check").join("SKILL.md");
-        assert!(skill_md.exists(), "SKILL.md should exist");
-
-        let written = fs::read_to_string(&skill_md).expect("read SKILL.md");
-        assert_eq!(written, content);
-
-        let installed = project.load_installed().expect("load");
-        assert!(installed.skills.contains_key("rust-check"));
-        assert_eq!(installed.skills["rust-check"].plugin, "test-plugin");
-    }
-
-    #[test]
-    fn install_skill_rejects_duplicate_without_force() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: dup\ndescription: Dup\n---\n";
-
-        project
-            .install_skill("dup", content, sample_meta())
-            .expect("first install should succeed");
-
-        let err = project
-            .install_skill("dup", content, sample_meta())
-            .expect_err("second install should fail");
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("already installed"),
-            "expected 'already installed', got: {msg}"
-        );
-    }
-
-    #[test]
-    fn install_skill_force_overwrites_existing() {
-        let (_dir, project) = temp_project();
-        let original = "---\nname: skill\ndescription: v1\n---\nOriginal.\n";
-        let updated = "---\nname: skill\ndescription: v2\n---\nUpdated.\n";
-
-        project
-            .install_skill("skill", original, sample_meta())
-            .expect("first install");
-
-        project
-            .install_skill_force("skill", updated, sample_meta())
-            .expect("force install should succeed");
-
-        let written =
-            fs::read_to_string(project.skill_dir("skill").join("SKILL.md")).expect("read");
-        assert_eq!(written, updated);
-    }
-
-    #[test]
     fn remove_skill_deletes_directory_and_tracking() {
         let (_dir, project) = temp_project();
-        let content = "---\nname: removable\ndescription: Goes away\n---\n";
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: removable\ndescription: Goes away\n---\n",
+        )
+        .expect("write");
 
         project
-            .install_skill("removable", content, sample_meta())
+            .install_skill_from_dir("removable", src.path(), sample_meta())
             .expect("install");
 
         project
@@ -497,51 +370,6 @@ mod tests {
     }
 
     #[test]
-    fn install_skill_rejects_path_traversal() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: evil\ndescription: Evil\n---\n";
-
-        let err = project
-            .install_skill("../escape", content, sample_meta())
-            .expect_err("should reject path traversal");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid name"),
-            "expected 'invalid name', got: {msg}"
-        );
-    }
-
-    #[test]
-    fn install_skill_rejects_slash_in_name() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: evil\ndescription: Evil\n---\n";
-
-        let err = project
-            .install_skill("sub/dir", content, sample_meta())
-            .expect_err("should reject path separator");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("path separator"),
-            "expected 'path separator', got: {msg}"
-        );
-    }
-
-    #[test]
-    fn install_skill_force_rejects_path_traversal() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: evil\ndescription: Evil\n---\n";
-
-        let err = project
-            .install_skill_force("../escape", content, sample_meta())
-            .expect_err("should reject path traversal");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid name"),
-            "expected 'invalid name', got: {msg}"
-        );
-    }
-
-    #[test]
     fn remove_skill_rejects_path_traversal() {
         let (_dir, project) = temp_project();
 
@@ -558,10 +386,15 @@ mod tests {
     #[test]
     fn load_installed_returns_installed_skills() {
         let (_dir, project) = temp_project();
-        let content = "---\nname: listed\ndescription: Listed\n---\n";
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: listed\ndescription: Listed\n---\n",
+        )
+        .expect("write");
 
         project
-            .install_skill("listed", content, sample_meta())
+            .install_skill_from_dir("listed", src.path(), sample_meta())
             .expect("install");
 
         let installed = project.load_installed().expect("load");
@@ -571,10 +404,15 @@ mod tests {
     #[test]
     fn tracking_file_contains_valid_json_after_install() {
         let (_dir, project) = temp_project();
-        let content = "---\nname: atomic-check\ndescription: Checks atomic\n---\n";
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: atomic-check\ndescription: Checks atomic\n---\n",
+        )
+        .expect("write");
 
         project
-            .install_skill("atomic-check", content, sample_meta())
+            .install_skill_from_dir("atomic-check", src.path(), sample_meta())
             .expect("install");
 
         let raw = fs::read(project.tracking_path()).expect("read tracking file");
@@ -582,32 +420,9 @@ mod tests {
             serde_json::from_slice(&raw).expect("tracking file should be valid JSON");
         assert!(parsed.skills.contains_key("atomic-check"));
 
-        // The temp file should not remain.
         assert!(
             !project.tracking_path().with_extension("tmp").exists(),
             ".tmp file should be gone after atomic rename"
-        );
-    }
-
-    #[test]
-    fn skill_md_written_atomically_no_tmp_leftover() {
-        let (_dir, project) = temp_project();
-        let content = "---\nname: atomic-skill\ndescription: Atomic write\n---\nBody.\n";
-
-        project
-            .install_skill("atomic-skill", content, sample_meta())
-            .expect("install");
-
-        let skill_md = project.skill_dir("atomic-skill").join("SKILL.md");
-        assert!(skill_md.exists(), "SKILL.md should exist");
-
-        let written = fs::read_to_string(&skill_md).expect("read SKILL.md");
-        assert_eq!(written, content, "content should match exactly");
-
-        // The atomic write temp file should not remain.
-        assert!(
-            !skill_md.with_extension("tmp").exists(),
-            "SKILL.md.tmp should be gone after atomic rename"
         );
     }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -49,8 +49,9 @@ const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
 /// Recursively copy a directory tree from `src` to `dest`.
 ///
 /// Creates `dest` and all intermediate directories. Files are copied
-/// preserving the relative directory structure. Symlinks are followed
-/// (the target content is copied, not the link itself).
+/// preserving the relative directory structure. **Symlinks are skipped**
+/// to prevent path traversal attacks where a malicious skill package
+/// could include symlinks pointing to sensitive host files.
 ///
 /// # Errors
 ///
@@ -61,14 +62,22 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let target = dest.join(entry.file_name());
-        // Use fs::metadata (follows symlinks) so that symlinks are
-        // transparently treated as the file/directory they point to.
-        let metadata = fs::metadata(entry.path()).map_err(|e| {
+        // Use symlink_metadata (does NOT follow symlinks) so we can
+        // detect and skip symlinks. Skill source directories are
+        // untrusted input — a symlink could point to sensitive files.
+        let metadata = fs::symlink_metadata(entry.path()).map_err(|e| {
             std::io::Error::new(
                 e.kind(),
                 format!("failed to read metadata for {}: {e}", entry.path().display()),
             )
         })?;
+        if metadata.is_symlink() {
+            debug!(
+                path = %entry.path().display(),
+                "skipping symlink in skill directory"
+            );
+            continue;
+        }
         if metadata.is_dir() {
             copy_dir_recursive(&entry.path(), &target)?;
         } else {
@@ -754,5 +763,29 @@ mod tests {
 
         let err = copy_dir_recursive(&fake_src, &dest_path).expect_err("should fail");
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_dir_recursive_skips_symlinks() {
+        use std::os::unix::fs as unix_fs;
+
+        let src = tempfile::tempdir().expect("tempdir");
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().join("output");
+
+        fs::write(src.path().join("SKILL.md"), "skill content").expect("write");
+        // Create a symlink that points to a sensitive file.
+        unix_fs::symlink("/etc/passwd", src.path().join("evil-link")).expect("symlink");
+
+        copy_dir_recursive(src.path(), &dest_path).expect("copy should succeed");
+
+        // The regular file should be copied.
+        assert!(dest_path.join("SKILL.md").exists());
+        // The symlink should NOT be copied.
+        assert!(
+            !dest_path.join("evil-link").exists(),
+            "symlinks should be skipped during copy"
+        );
     }
 }

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -75,7 +75,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
         if metadata.is_dir() {
             copy_dir_recursive(&entry.path(), &target)?;
         } else {
-            fs::copy(&entry.path(), &target).map_err(|e| {
+            fs::copy(entry.path(), &target).map_err(|e| {
                 std::io::Error::new(
                     e.kind(),
                     format!(

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -48,6 +48,47 @@ const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
 
 /// Name of the skill definition file inside each skill directory.
 const SKILL_MD: &str = "SKILL.md";
+
+/// Recursively copy a directory tree from `src` to `dest`.
+///
+/// Creates `dest` and all intermediate directories. Files are copied
+/// preserving the relative directory structure. Symlinks are followed
+/// (the target content is copied, not the link itself).
+///
+/// # Errors
+///
+/// Returns an I/O error if any directory creation or file copy fails.
+/// The error includes the path that caused the failure.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let target = dest.join(entry.file_name());
+        // Use fs::metadata (follows symlinks) instead of entry.file_type()
+        // (which does not follow symlinks on all platforms).
+        let metadata = fs::metadata(entry.path()).map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!("failed to read metadata for {}: {e}", entry.path().display()),
+            )
+        })?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(&entry.path(), &target).map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to copy {} to {}: {e}",
+                        entry.path().display(),
+                        target.display()
+                    ),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
 
 /// Manages skill installation within a Kiro project directory.
 ///
@@ -198,6 +239,54 @@ impl KiroProject {
         Ok(())
     }
 
+    /// Install a skill by copying an entire source directory into the project.
+    ///
+    /// Recursively copies `source_dir` to `.kiro/skills/<name>/`, preserving
+    /// companion files (e.g. `references/`) for Kiro's lazy loading. The copy
+    /// is atomic: files are staged in a temp directory, then renamed into place
+    /// so a crash cannot leave a partially installed skill.
+    ///
+    /// # Errors
+    ///
+    /// - [`SkillError::AlreadyInstalled`] if a skill with this name already exists.
+    /// - I/O or JSON serialisation errors.
+    pub fn install_skill_from_dir(
+        &self,
+        name: &str,
+        source_dir: &Path,
+        meta: InstalledSkillMeta,
+    ) -> crate::error::Result<()> {
+        validation::validate_name(name)?;
+        let dir = self.skill_dir(name);
+
+        if dir.exists() {
+            return Err(SkillError::AlreadyInstalled {
+                name: name.to_owned(),
+            }
+            .into());
+        }
+
+        self.write_skill_dir(name, source_dir, meta)
+    }
+
+    /// Install a skill by copying a source directory, overwriting any existing installation.
+    ///
+    /// The copy is atomic: new content is staged in a temp directory first, then
+    /// the old directory is removed and the temp is renamed into place.
+    ///
+    /// # Errors
+    ///
+    /// I/O or JSON serialisation errors.
+    pub fn install_skill_from_dir_force(
+        &self,
+        name: &str,
+        source_dir: &Path,
+        meta: InstalledSkillMeta,
+    ) -> crate::error::Result<()> {
+        validation::validate_name(name)?;
+        self.write_skill_dir(name, source_dir, meta)
+    }
+
     // -- internal helpers --------------------------------------------------
 
     /// Write SKILL.md and update tracking for a skill installation.
@@ -216,6 +305,53 @@ impl KiroProject {
         self.write_tracking(&installed)?;
 
         debug!(name, "skill installed");
+        Ok(())
+    }
+
+    /// Copy a source skill directory atomically and update tracking.
+    ///
+    /// Copies to a staging directory (`_installing-<name>`) first, then
+    /// renames into the final location. For force installs, the old directory
+    /// is removed after the staging copy succeeds but before the rename.
+    fn write_skill_dir(
+        &self,
+        name: &str,
+        source_dir: &Path,
+        meta: InstalledSkillMeta,
+    ) -> crate::error::Result<()> {
+        let dir = self.skill_dir(name);
+        let staging_dir = self.skills_dir().join(format!("_installing-{name}"));
+
+        // Clean up any leftover staging dir from a previous crash.
+        if staging_dir.exists() {
+            debug!(
+                path = %staging_dir.display(),
+                "removing leftover staging directory"
+            );
+            fs::remove_dir_all(&staging_dir)?;
+        }
+
+        // Ensure the skills parent directory exists.
+        fs::create_dir_all(self.skills_dir())?;
+
+        // Stage the copy into the temp directory.
+        copy_dir_recursive(source_dir, &staging_dir)?;
+
+        // For force installs, remove the old directory now that the new
+        // content is safely staged.
+        if dir.exists() {
+            debug!(name, "removing existing skill directory for force install");
+            fs::remove_dir_all(&dir)?;
+        }
+
+        // Atomic rename from staging to final location.
+        fs::rename(&staging_dir, &dir)?;
+
+        let mut installed = self.load_installed()?;
+        installed.skills.insert(name.to_owned(), meta);
+        self.write_tracking(&installed)?;
+
+        debug!(name, "skill installed from directory");
         Ok(())
     }
 
@@ -473,5 +609,212 @@ mod tests {
             !skill_md.with_extension("tmp").exists(),
             "SKILL.md.tmp should be gone after atomic rename"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // install_skill_from_dir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_skill_from_dir_copies_skill_and_references() {
+        let (_dir, project) = temp_project();
+        let src = tempfile::tempdir().expect("tempdir");
+
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: with-refs\ndescription: Has references\n---\nSee `references/api.md`.\n",
+        )
+        .expect("write");
+        fs::create_dir_all(src.path().join("references")).expect("mkdir");
+        fs::write(
+            src.path().join("references").join("api.md"),
+            "# API Reference\nDetails here.",
+        )
+        .expect("write");
+
+        project
+            .install_skill_from_dir("with-refs", src.path(), sample_meta())
+            .expect("install should succeed");
+
+        let skill_md = project.skill_dir("with-refs").join("SKILL.md");
+        let content = fs::read_to_string(&skill_md).expect("read");
+        assert!(content.contains("See `references/api.md`."));
+
+        let ref_file = project
+            .skill_dir("with-refs")
+            .join("references")
+            .join("api.md");
+        assert!(ref_file.exists(), "reference file should be copied");
+        let ref_content = fs::read_to_string(&ref_file).expect("read");
+        assert_eq!(ref_content, "# API Reference\nDetails here.");
+
+        let installed = project.load_installed().expect("load");
+        assert!(installed.skills.contains_key("with-refs"));
+
+        // No temp dir should remain.
+        let skills_dir = project.skills_dir();
+        let leftover: Vec<_> = fs::read_dir(&skills_dir)
+            .expect("read skills dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("_installing-")
+            })
+            .collect();
+        assert!(leftover.is_empty(), "temp dir should be cleaned up");
+    }
+
+    #[test]
+    fn install_skill_from_dir_rejects_duplicate() {
+        let (_dir, project) = temp_project();
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: dup\ndescription: Dup\n---\n",
+        )
+        .expect("write");
+
+        project
+            .install_skill_from_dir("dup", src.path(), sample_meta())
+            .expect("first install");
+
+        let err = project
+            .install_skill_from_dir("dup", src.path(), sample_meta())
+            .expect_err("second install should fail");
+        assert!(err.to_string().contains("already installed"));
+    }
+
+    #[test]
+    fn install_skill_from_dir_force_overwrites() {
+        let (_dir, project) = temp_project();
+        let src1 = tempfile::tempdir().expect("tempdir");
+        let src2 = tempfile::tempdir().expect("tempdir");
+
+        fs::write(
+            src1.path().join("SKILL.md"),
+            "---\nname: s\ndescription: v1\n---\nOriginal.\n",
+        )
+        .expect("write");
+        fs::write(
+            src2.path().join("SKILL.md"),
+            "---\nname: s\ndescription: v2\n---\nUpdated.\n",
+        )
+        .expect("write");
+        fs::create_dir_all(src2.path().join("references")).expect("mkdir");
+        fs::write(src2.path().join("references").join("new.md"), "new ref").expect("write");
+
+        project
+            .install_skill_from_dir("s", src1.path(), sample_meta())
+            .expect("first install");
+
+        project
+            .install_skill_from_dir_force("s", src2.path(), sample_meta())
+            .expect("force install");
+
+        let content =
+            fs::read_to_string(project.skill_dir("s").join("SKILL.md")).expect("read");
+        assert!(content.contains("Updated."));
+
+        assert!(project
+            .skill_dir("s")
+            .join("references")
+            .join("new.md")
+            .exists());
+    }
+
+    #[test]
+    fn install_skill_from_dir_rejects_path_traversal() {
+        let (_dir, project) = temp_project();
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: evil\ndescription: Evil\n---\n",
+        )
+        .expect("write");
+
+        let err = project
+            .install_skill_from_dir("../escape", src.path(), sample_meta())
+            .expect_err("should reject path traversal");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid name"),
+            "expected 'invalid name', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn install_skill_from_dir_works_with_skill_only_no_references() {
+        let (_dir, project) = temp_project();
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: simple\ndescription: Simple\n---\nBody.\n",
+        )
+        .expect("write");
+
+        project
+            .install_skill_from_dir("simple", src.path(), sample_meta())
+            .expect("install should succeed");
+
+        let skill_md = project.skill_dir("simple").join("SKILL.md");
+        assert!(skill_md.exists());
+        assert!(!project.skill_dir("simple").join("references").exists());
+    }
+
+    // -----------------------------------------------------------------------
+    // copy_dir_recursive
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_structure() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().join("output");
+
+        fs::write(src.path().join("SKILL.md"), "skill content").expect("write");
+        fs::create_dir_all(src.path().join("references")).expect("mkdir");
+        fs::write(
+            src.path().join("references").join("guide.md"),
+            "guide content",
+        )
+        .expect("write");
+
+        copy_dir_recursive(src.path(), &dest_path).expect("copy should succeed");
+
+        assert_eq!(
+            fs::read_to_string(dest_path.join("SKILL.md")).expect("read"),
+            "skill content"
+        );
+        assert_eq!(
+            fs::read_to_string(dest_path.join("references").join("guide.md")).expect("read"),
+            "guide content"
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_handles_empty_directory() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().join("output");
+
+        fs::write(src.path().join("SKILL.md"), "just skill").expect("write");
+
+        copy_dir_recursive(src.path(), &dest_path).expect("copy should succeed");
+
+        assert_eq!(
+            fs::read_to_string(dest_path.join("SKILL.md")).expect("read"),
+            "just skill"
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_errors_on_nonexistent_source() {
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().join("output");
+        let fake_src = dest.path().join("does-not-exist");
+
+        let err = copy_dir_recursive(&fake_src, &dest_path).expect_err("should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -61,8 +61,8 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let target = dest.join(entry.file_name());
-        // Use fs::metadata (follows symlinks) instead of entry.file_type()
-        // (which does not follow symlinks on all platforms).
+        // Use fs::metadata (follows symlinks) so that symlinks are
+        // transparently treated as the file/directory they point to.
         let metadata = fs::metadata(entry.path()).map_err(|e| {
             std::io::Error::new(
                 e.kind(),
@@ -98,6 +98,8 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
 ///     skills/
 ///       <skill-name>/
 ///         SKILL.md
+///         references/    (optional companion files)
+///           *.md
 /// ```
 #[derive(Debug, Clone)]
 pub struct KiroProject {
@@ -188,9 +190,10 @@ impl KiroProject {
     /// Install a skill by copying an entire source directory into the project.
     ///
     /// Recursively copies `source_dir` to `.kiro/skills/<name>/`, preserving
-    /// companion files (e.g. `references/`) for Kiro's lazy loading. The copy
-    /// is atomic: files are staged in a temp directory, then renamed into place
-    /// so a crash cannot leave a partially installed skill.
+    /// companion files (e.g. `references/`) for Kiro's lazy loading. Files
+    /// are staged in a temp directory, then renamed into place so a crash
+    /// during the copy phase cannot leave a partially installed skill
+    /// directory. The tracking file is updated separately after the rename.
     ///
     /// # Errors
     ///
@@ -217,8 +220,9 @@ impl KiroProject {
 
     /// Install a skill by copying a source directory, overwriting any existing installation.
     ///
-    /// The copy is atomic: new content is staged in a temp directory first, then
-    /// the old directory is removed and the temp is renamed into place.
+    /// New content is staged in a temp directory first, then the old directory
+    /// is removed and the temp is renamed into place. The tracking file is
+    /// updated separately after the rename.
     ///
     /// # Errors
     ///
@@ -235,11 +239,14 @@ impl KiroProject {
 
     // -- internal helpers --------------------------------------------------
 
-    /// Copy a source skill directory atomically and update tracking.
+    /// Copy a source skill directory and update tracking.
     ///
     /// Copies to a staging directory (`_installing-<name>`) first, then
-    /// renames into the final location. For force installs, the old directory
-    /// is removed after the staging copy succeeds but before the rename.
+    /// renames into the final location so a crash during the copy phase
+    /// cannot leave a partially installed skill directory. The tracking
+    /// file is updated separately after the rename. For force installs,
+    /// the old directory is removed after staging succeeds but before
+    /// the rename.
     fn write_skill_dir(
         &self,
         name: &str,
@@ -262,7 +269,17 @@ impl KiroProject {
         fs::create_dir_all(self.skills_dir())?;
 
         // Stage the copy into the temp directory.
-        copy_dir_recursive(source_dir, &staging_dir)?;
+        if let Err(e) = copy_dir_recursive(source_dir, &staging_dir) {
+            // Clean up the partial staging directory.
+            if let Err(cleanup_err) = fs::remove_dir_all(&staging_dir) {
+                debug!(
+                    path = %staging_dir.display(),
+                    error = %cleanup_err,
+                    "failed to clean up partial staging directory"
+                );
+            }
+            return Err(e.into());
+        }
 
         // For force installs, remove the old directory now that the new
         // content is safely staged.
@@ -271,12 +288,33 @@ impl KiroProject {
             fs::remove_dir_all(&dir)?;
         }
 
-        // Atomic rename from staging to final location.
+        // Rename staging to final location.
         fs::rename(&staging_dir, &dir)?;
 
-        let mut installed = self.load_installed()?;
-        installed.skills.insert(name.to_owned(), meta);
-        self.write_tracking(&installed)?;
+        // Update the tracking file. If this fails, roll back the rename
+        // to keep the filesystem and tracking file consistent.
+        let tracking_result = self
+            .load_installed()
+            .and_then(|mut installed| {
+                installed.skills.insert(name.to_owned(), meta);
+                self.write_tracking(&installed)
+            });
+
+        if let Err(e) = tracking_result {
+            debug!(
+                name,
+                error = %e,
+                "tracking update failed after rename, rolling back"
+            );
+            if let Err(rollback_err) = fs::remove_dir_all(&dir) {
+                debug!(
+                    path = %dir.display(),
+                    error = %rollback_err,
+                    "failed to roll back skill directory after tracking failure"
+                );
+            }
+            return Err(e);
+        }
 
         debug!(name, "skill installed from directory");
         Ok(())
@@ -575,6 +613,91 @@ mod tests {
         let skill_md = project.skill_dir("simple").join("SKILL.md");
         assert!(skill_md.exists());
         assert!(!project.skill_dir("simple").join("references").exists());
+    }
+
+    #[test]
+    fn install_skill_from_dir_force_rejects_path_traversal() {
+        let (_dir, project) = temp_project();
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: evil\ndescription: Evil\n---\n",
+        )
+        .expect("write");
+
+        let err = project
+            .install_skill_from_dir_force("../escape", src.path(), sample_meta())
+            .expect_err("should reject path traversal");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid name"),
+            "expected 'invalid name', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn install_skill_from_dir_recovers_from_leftover_staging_dir() {
+        let (_dir, project) = temp_project();
+
+        // Simulate a previous crash that left a staging directory behind.
+        let staging_dir = project.skills_dir().join("_installing-recovered");
+        fs::create_dir_all(&staging_dir).expect("create staging dir");
+        fs::write(staging_dir.join("SKILL.md"), "stale content").expect("write stale");
+
+        // A fresh install of the same skill should clean up and succeed.
+        let src = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: recovered\ndescription: Fresh\n---\nFresh content.\n",
+        )
+        .expect("write");
+
+        project
+            .install_skill_from_dir("recovered", src.path(), sample_meta())
+            .expect("install should succeed despite leftover staging dir");
+
+        let content =
+            fs::read_to_string(project.skill_dir("recovered").join("SKILL.md")).expect("read");
+        assert!(content.contains("Fresh content."));
+        assert!(!staging_dir.exists(), "staging dir should be cleaned up");
+    }
+
+    #[test]
+    fn install_skill_from_dir_force_removes_stale_files_from_old_version() {
+        let (_dir, project) = temp_project();
+        let src1 = tempfile::tempdir().expect("tempdir");
+        let src2 = tempfile::tempdir().expect("tempdir");
+
+        // v1: SKILL.md + references/old.md
+        fs::write(
+            src1.path().join("SKILL.md"),
+            "---\nname: s\ndescription: v1\n---\n",
+        )
+        .expect("write");
+        fs::create_dir_all(src1.path().join("references")).expect("mkdir");
+        fs::write(src1.path().join("references").join("old.md"), "old ref").expect("write");
+
+        project
+            .install_skill_from_dir("s", src1.path(), sample_meta())
+            .expect("first install");
+        assert!(project.skill_dir("s").join("references").join("old.md").exists());
+
+        // v2: SKILL.md only, no references/
+        fs::write(
+            src2.path().join("SKILL.md"),
+            "---\nname: s\ndescription: v2\n---\n",
+        )
+        .expect("write");
+
+        project
+            .install_skill_from_dir_force("s", src2.path(), sample_meta())
+            .expect("force install");
+
+        // Old reference file should be gone — full directory replacement.
+        assert!(
+            !project.skill_dir("s").join("references").exists(),
+            "stale references/ dir from v1 should be gone after force install"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kiro-market-core/src/skill.rs
+++ b/crates/kiro-market-core/src/skill.rs
@@ -1,13 +1,9 @@
-//! Parsing and merging of `SKILL.md` files.
+//! Parsing of `SKILL.md` files.
 //!
 //! A skill file uses YAML frontmatter delimited by `---` fences, followed by
 //! free-form Markdown content. This module extracts and validates the
-//! frontmatter, records where the body begins, and supports merging companion
-//! `.md` files into a single output.
+//! frontmatter and records where the body begins.
 
-use std::path::Path;
-
-use pulldown_cmark::{Event, Parser, Tag};
 use serde::Deserialize;
 use thiserror::Error;
 
@@ -90,76 +86,6 @@ pub fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, usize), Par
     Ok((frontmatter, body_offset))
 }
 
-/// Extract relative `.md` link destinations from Markdown content.
-///
-/// Only links whose `dest_url`:
-/// - ends with `.md`
-/// - does **not** start with `http://`, `https://`, or `/`
-///
-/// are returned. This identifies companion files that live alongside a
-/// `SKILL.md` and can be merged into it.
-#[must_use]
-pub fn extract_relative_md_links(markdown: &str) -> Vec<String> {
-    let parser = Parser::new(markdown);
-    let mut links = Vec::new();
-
-    for event in parser {
-        if let Event::Start(Tag::Link { dest_url, .. }) = event {
-            let url: &str = &dest_url;
-            let has_md_ext = Path::new(url)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
-
-            if has_md_ext
-                && !url.starts_with("http://")
-                && !url.starts_with("https://")
-                && !url.starts_with('/')
-                && !url.contains("..")
-            {
-                links.push(url.to_owned());
-            }
-        }
-    }
-
-    links
-}
-
-/// Merge companion files into a `SKILL.md` document.
-///
-/// For each relative `.md` link found in `skill_content` that has a matching
-/// entry in `companions` (keyed by relative path), the companion file content
-/// is appended after a separator comment.
-///
-/// If `companions` is empty the original content is returned unchanged.
-///
-/// # Errors
-///
-/// Returns [`ParseError`] if the frontmatter in `skill_content` is invalid.
-pub fn merge_skill(skill_content: &str, companions: &[(&str, &str)]) -> Result<String, ParseError> {
-    if companions.is_empty() {
-        return Ok(skill_content.to_owned());
-    }
-
-    // Validate frontmatter so we fail fast on malformed input.
-    let (_fm, body_offset) = parse_frontmatter(skill_content)?;
-    let body = &skill_content[body_offset..];
-
-    let referenced_links = extract_relative_md_links(body);
-
-    let mut merged = skill_content.to_owned();
-
-    for link in &referenced_links {
-        if let Some(&(_path, content)) = companions.iter().find(|(p, _)| *p == link.as_str()) {
-            merged.push_str("\n\n---\n<!-- Merged from ");
-            merged.push_str(link);
-            merged.push_str(" -->\n");
-            merged.push_str(content);
-        }
-    }
-
-    Ok(merged)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,108 +145,4 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // extract_relative_md_links
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn extract_relative_md_links_from_mixed_content() {
-        let markdown = r"
-Check [external](https://example.com/docs.md) and [image](logo.png).
-Also see [type mapping](references/type-mapping.md) and
-[error guide](references/error-guide.md).
-And a [root link](/absolute/path.md).
-";
-        let links = extract_relative_md_links(markdown);
-        assert_eq!(
-            links,
-            vec!["references/type-mapping.md", "references/error-guide.md",]
-        );
-    }
-
-    #[test]
-    fn extract_relative_md_links_rejects_parent_traversal() {
-        let markdown = r"
-See [escape](../secret.md) and [nested](sub/../../other.md).
-But [safe](companion.md) is fine.
-";
-        let links = extract_relative_md_links(markdown);
-        assert_eq!(links, vec!["companion.md"]);
-    }
-
-    #[test]
-    fn extract_relative_md_links_returns_empty_for_plain_text() {
-        let markdown = "No links here, just plain text with a .md mention.";
-        let links = extract_relative_md_links(markdown);
-        assert!(links.is_empty());
-    }
-
-    // -----------------------------------------------------------------------
-    // merge_skill
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn merge_skill_with_one_companion() {
-        let skill = "\
----
-name: test-skill
-description: A test
----
-See [ref](companion.md) for details.
-";
-        let companion_content = "# Companion\nExtra details here.";
-        let companions = [("companion.md", companion_content)];
-
-        let merged = merge_skill(skill, &companions).expect("should merge");
-
-        assert!(merged.starts_with(skill));
-        assert!(merged.contains("<!-- Merged from companion.md -->"));
-        assert!(merged.contains(companion_content));
-    }
-
-    #[test]
-    fn merge_skill_with_no_companions_returns_original() {
-        let skill = "\
----
-name: standalone
-description: No companions
----
-Just the body.
-";
-        let merged = merge_skill(skill, &[]).expect("should succeed");
-        assert_eq!(merged, skill);
-    }
-
-    #[test]
-    fn merge_skill_with_multiple_companions() {
-        let skill = "\
----
-name: multi
-description: Multiple refs
----
-Read [types](references/types.md) and [errors](references/errors.md).
-";
-        let companions = [
-            ("references/types.md", "# Types\nType info."),
-            ("references/errors.md", "# Errors\nError info."),
-        ];
-
-        let merged = merge_skill(skill, &companions).expect("should merge");
-
-        assert!(merged.contains("<!-- Merged from references/types.md -->"));
-        assert!(merged.contains("# Types\nType info."));
-        assert!(merged.contains("<!-- Merged from references/errors.md -->"));
-        assert!(merged.contains("# Errors\nError info."));
-
-        let types_pos = merged
-            .find("<!-- Merged from references/types.md -->")
-            .expect("types marker");
-        let errors_pos = merged
-            .find("<!-- Merged from references/errors.md -->")
-            .expect("errors marker");
-        assert!(
-            types_pos < errors_pos,
-            "types should appear before errors (document order)"
-        );
-    }
 }

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -1,7 +1,7 @@
 //! Path and name validation utilities.
 //!
 //! These functions guard against path traversal attacks where untrusted input
-//! (marketplace manifests, plugin.json, SKILL.md frontmatter, companion links)
+//! (marketplace manifests, plugin.json, SKILL.md frontmatter)
 //! could escape intended directories via `..` segments or path separators.
 
 use std::path::Path;

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -12,7 +12,7 @@ use kiro_market_core::git::{self, CloneOptions, GitBackend, GitProtocol, GixCliB
 use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::{InstalledSkillMeta, KiroProject};
-use kiro_market_core::skill::{extract_relative_md_links, merge_skill, parse_frontmatter};
+use kiro_market_core::skill::parse_frontmatter;
 use tracing::{debug, warn};
 
 use crate::cli;
@@ -26,8 +26,8 @@ struct InstallStats {
 
 /// Run the install command.
 ///
-/// Resolves `plugin_ref` to a plugin, discovers skills, merges companions,
-/// and installs into the current Kiro project.
+/// Resolves `plugin_ref` to a plugin, discovers skills, copies skill
+/// directories, and installs into the current Kiro project.
 pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<()> {
     let (plugin_name, marketplace_name) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
         format!("invalid plugin reference '{plugin_ref}': expected plugin@marketplace")
@@ -187,7 +187,7 @@ fn process_skill(
         }
     };
 
-    let (frontmatter, body_offset) = match parse_frontmatter(&skill_content) {
+    let (frontmatter, _body_offset) = match parse_frontmatter(&skill_content) {
         Ok(result) => result,
         Err(e) => {
             eprintln!(
@@ -208,38 +208,6 @@ fn process_skill(
         return SkillResult::Filtered;
     }
 
-    // Extract relative md links and read companion files.
-    let body = &skill_content[body_offset..];
-    let relative_links = extract_relative_md_links(body);
-
-    let companions: Vec<(String, String)> = relative_links
-        .iter()
-        .filter_map(|link| {
-            let companion_path = skill_dir.join(link);
-            match fs::read_to_string(&companion_path) {
-                Ok(content) => Some((link.clone(), content)),
-                Err(e) => {
-                    debug!(link, error = %e, "companion file not found, skipping");
-                    None
-                }
-            }
-        })
-        .collect();
-
-    let companion_refs: Vec<(&str, &str)> = companions
-        .iter()
-        .map(|(path, content)| (path.as_str(), content.as_str()))
-        .collect();
-
-    let Ok(merged_content) = merge_skill(&skill_content, &companion_refs) else {
-        eprintln!(
-            "  {} Failed to merge skill '{}'",
-            "✗".red().bold(),
-            frontmatter.name
-        );
-        return SkillResult::Failed;
-    };
-
     let meta = InstalledSkillMeta {
         marketplace: marketplace_name.to_owned(),
         plugin: plugin_name.to_owned(),
@@ -248,9 +216,9 @@ fn process_skill(
     };
 
     let install_result = if force {
-        project.install_skill_force(&frontmatter.name, &merged_content, meta)
+        project.install_skill_from_dir_force(&frontmatter.name, skill_dir, meta)
     } else {
-        project.install_skill(&frontmatter.name, &merged_content, meta)
+        project.install_skill_from_dir(&frontmatter.name, skill_dir, meta)
     };
 
     match install_result {


### PR DESCRIPTION
## Summary
- Replace skill merging (where companion .md files were concatenated into a monolithic SKILL.md) with directory copying that preserves the original file structure for Kiro's native lazy loading
- Skill installation is now atomic: files are staged in a temp directory, then renamed into place. If the copy fails mid-way, the staging dir is cleaned up. If the tracking file update fails after rename, the directory is rolled back
- Remove `merge_skill`, `extract_relative_md_links`, `pulldown-cmark` dependency, and `MergeFailed` error variant — all dead code after the refactor

## Motivation
Kiro CLI supports deferred/lazy loading of companion files from a `references/` directory alongside SKILL.md. The old merge approach defeated this by inlining all companion content into a single file, bloating every skill load.

## Installed layout change
Before:
```
.kiro/skills/<name>/
└── SKILL.md          # merged monolith with <!-- Merged from ... --> markers
```

After:
```
.kiro/skills/<name>/
├── SKILL.md          # original, unmodified
└── references/       # copied as-is
    ├── guide.md
    └── troubleshooting.md
```

## Test plan
- [ ] `cargo test --workspace` — 131 core + 9 CLI + 42 Tauri tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] New tests cover: directory copy with references, empty source, nonexistent source, duplicate rejection, force overwrite, path traversal (both normal and force), staging dir crash recovery, stale file removal on force install
- [ ] Manual: `kiro-market install dotnet@dotnet-agent-skills --skill mcp-csharp-create` installs with `references/` directory intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)