### PR TITLE
feat: add settings view, file locking, and skill card improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,6 +5051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccbb212565d2dc177bc15ecb7b039d66c4490da892436a4eee5b394d620c9bc"
 dependencies = [
  "paste",
+ "serde_json",
  "specta-macros",
  "thiserror 1.0.69",
 ]

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -47,6 +47,10 @@ pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError>
 #[allow(clippy::unused_async)]
 pub async fn set_kiro_setting(key: String, value: JsonValue) -> Result<SettingEntry, CommandError>
 {
+    if key.is_empty() {
+        return Err(CommandError::new("setting key must not be empty", ErrorType::Validation));
+    }
+
     let reg = registry();
     if !reg.iter().any(|def| def.key == key)
     {

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -113,9 +113,11 @@ pub async fn set_kiro_setting(
     let dir = kiro_dir()?;
 
     // Serialize load-modify-save to prevent lost updates from rapid changes.
-    let _guard = SETTINGS_WRITE_LOCK
-        .lock()
-        .expect("settings write lock poisoned");
+    let _guard = SETTINGS_WRITE_LOCK.lock().unwrap_or_else(|poisoned| {
+        // A prior panic poisoned the lock. Recover rather than cascade panics —
+        // a lost-update is preferable to permanently bricking settings writes.
+        poisoned.into_inner()
+    });
 
     let mut json = load_settings(&dir)?;
     set_nested(&mut json, &key, value);
@@ -141,9 +143,11 @@ pub async fn reset_kiro_setting(key: String) -> Result<(), CommandError> {
     let dir = kiro_dir()?;
 
     // Serialize load-modify-save to prevent lost updates from rapid changes.
-    let _guard = SETTINGS_WRITE_LOCK
-        .lock()
-        .expect("settings write lock poisoned");
+    let _guard = SETTINGS_WRITE_LOCK.lock().unwrap_or_else(|poisoned| {
+        // A prior panic poisoned the lock. Recover rather than cascade panics —
+        // a lost-update is preferable to permanently bricking settings writes.
+        poisoned.into_inner()
+    });
 
     let mut json = load_settings(&dir)?;
     remove_nested(&mut json, &key);

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -1,29 +1,74 @@
 //! Tauri commands for reading and writing Kiro CLI settings.
 
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use kiro_market_core::kiro_settings::{
     default_kiro_dir, load_kiro_settings_from, registry, remove_nested, resolve_settings,
-    save_kiro_settings_to, set_nested, SettingEntry,
+    save_kiro_settings_to, set_nested, LoadSettingsError, SettingEntry,
 };
 use serde_json::Value as JsonValue;
 
 use crate::error::{CommandError, ErrorType};
 
 // ---------------------------------------------------------------------------
-// Helper
+// Helpers
 // ---------------------------------------------------------------------------
+
+/// Serialize settings writes to prevent lost-update races from rapid UI
+/// interactions (e.g. toggling multiple booleans quickly).
+static SETTINGS_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Resolve the Kiro home directory (`~/.kiro`), returning a [`CommandError`]
 /// if the home directory cannot be determined.
-fn kiro_dir() -> Result<PathBuf, CommandError>
-{
+fn kiro_dir() -> Result<PathBuf, CommandError> {
     default_kiro_dir().ok_or_else(|| {
         CommandError::new(
             "could not determine Kiro home directory",
             ErrorType::IoError,
         )
     })
+}
+
+/// Load the settings JSON, treating a missing file as empty defaults but
+/// propagating corrupt-file and I/O errors to the caller.
+fn load_settings(dir: &std::path::Path) -> Result<JsonValue, CommandError> {
+    match load_kiro_settings_from(dir) {
+        Ok(json) => Ok(json),
+        Err(LoadSettingsError::NotFound) => Ok(serde_json::json!({})),
+        Err(LoadSettingsError::InvalidJson(e)) => Err(CommandError::new(
+            format!(
+                "settings file contains invalid JSON and cannot be safely updated: {e}. \
+                 Back up or delete ~/.kiro/settings/cli.json and try again."
+            ),
+            ErrorType::ParseError,
+        )),
+        Err(LoadSettingsError::Io(e)) => Err(CommandError::new(
+            format!("could not read settings file: {e}"),
+            ErrorType::IoError,
+        )),
+    }
+}
+
+/// Validate that a setting key is non-empty and exists in the registry.
+/// Returns the index into the registry for the matched definition.
+fn validate_key(key: &str) -> Result<usize, CommandError> {
+    if key.is_empty() {
+        return Err(CommandError::new(
+            "setting key must not be empty",
+            ErrorType::Validation,
+        ));
+    }
+
+    let reg = registry();
+    reg.iter()
+        .position(|def| def.key == key)
+        .ok_or_else(|| {
+            CommandError::new(
+                format!("unknown setting key: {key}"),
+                ErrorType::Validation,
+            )
+        })
 }
 
 // ---------------------------------------------------------------------------
@@ -34,10 +79,9 @@ fn kiro_dir() -> Result<PathBuf, CommandError>
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::unused_async)]
-pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError>
-{
+pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError> {
     let dir = kiro_dir()?;
-    let json = load_kiro_settings_from(&dir);
+    let json = load_settings(&dir)?;
     Ok(resolve_settings(&json))
 }
 
@@ -45,23 +89,35 @@ pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError>
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::unused_async)]
-pub async fn set_kiro_setting(key: String, value: JsonValue) -> Result<SettingEntry, CommandError>
-{
-    if key.is_empty() {
-        return Err(CommandError::new("setting key must not be empty", ErrorType::Validation));
-    }
+pub async fn set_kiro_setting(
+    key: String,
+    value: JsonValue,
+) -> Result<SettingEntry, CommandError> {
+    let reg_idx = validate_key(&key)?;
 
+    // Validate that the value matches the setting's declared type.
     let reg = registry();
-    if !reg.iter().any(|def| def.key == key)
-    {
+    let def = &reg[reg_idx];
+    if !def.value_type.is_compatible_value(&value) {
         return Err(CommandError::new(
-            format!("unknown setting key: {key}"),
+            format!(
+                "invalid value for '{}': expected {}, got {}",
+                key,
+                def.value_type.type_name(),
+                value_type_label(&value),
+            ),
             ErrorType::Validation,
         ));
     }
 
     let dir = kiro_dir()?;
-    let mut json = load_kiro_settings_from(&dir);
+
+    // Serialize load-modify-save to prevent lost updates from rapid changes.
+    let _guard = SETTINGS_WRITE_LOCK
+        .lock()
+        .expect("settings write lock poisoned");
+
+    let mut json = load_settings(&dir)?;
     set_nested(&mut json, &key, value);
     save_kiro_settings_to(&dir, &json).map_err(|e| {
         CommandError::new(format!("failed to save settings: {e}"), ErrorType::IoError)
@@ -79,23 +135,37 @@ pub async fn set_kiro_setting(key: String, value: JsonValue) -> Result<SettingEn
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::unused_async)]
-pub async fn reset_kiro_setting(key: String) -> Result<(), CommandError>
-{
-    let reg = registry();
-    if !reg.iter().any(|def| def.key == key)
-    {
-        return Err(CommandError::new(
-            format!("unknown setting key: {key}"),
-            ErrorType::Validation,
-        ));
-    }
+pub async fn reset_kiro_setting(key: String) -> Result<(), CommandError> {
+    validate_key(&key)?;
 
     let dir = kiro_dir()?;
-    let mut json = load_kiro_settings_from(&dir);
+
+    // Serialize load-modify-save to prevent lost updates from rapid changes.
+    let _guard = SETTINGS_WRITE_LOCK
+        .lock()
+        .expect("settings write lock poisoned");
+
+    let mut json = load_settings(&dir)?;
     remove_nested(&mut json, &key);
     save_kiro_settings_to(&dir, &json).map_err(|e| {
         CommandError::new(format!("failed to save settings: {e}"), ErrorType::IoError)
     })?;
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/// Human-readable label for a JSON value's type, used in validation errors.
+fn value_type_label(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "boolean",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "array",
+        JsonValue::Object(_) => "object",
+    }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -1,0 +1,97 @@
+//! Tauri commands for reading and writing Kiro CLI settings.
+
+use std::path::PathBuf;
+
+use kiro_market_core::kiro_settings::{
+    default_kiro_dir, load_kiro_settings_from, registry, remove_nested, resolve_settings,
+    save_kiro_settings_to, set_nested, SettingEntry,
+};
+use serde_json::Value as JsonValue;
+
+use crate::error::{CommandError, ErrorType};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Resolve the Kiro home directory (`~/.kiro`), returning a [`CommandError`]
+/// if the home directory cannot be determined.
+fn kiro_dir() -> Result<PathBuf, CommandError>
+{
+    default_kiro_dir().ok_or_else(|| {
+        CommandError::new(
+            "could not determine Kiro home directory",
+            ErrorType::IoError,
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/// Load all Kiro CLI settings, merging the stored JSON with the registry defaults.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError>
+{
+    let dir = kiro_dir()?;
+    let json = load_kiro_settings_from(&dir);
+    Ok(resolve_settings(&json))
+}
+
+/// Update a single Kiro CLI setting by key and return the updated entry.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn set_kiro_setting(key: String, value: JsonValue) -> Result<SettingEntry, CommandError>
+{
+    let reg = registry();
+    if !reg.iter().any(|def| def.key == key)
+    {
+        return Err(CommandError::new(
+            format!("unknown setting key: {key}"),
+            ErrorType::Validation,
+        ));
+    }
+
+    let dir = kiro_dir()?;
+    let mut json = load_kiro_settings_from(&dir);
+    set_nested(&mut json, &key, value);
+    save_kiro_settings_to(&dir, &json).map_err(|e| {
+        CommandError::new(format!("failed to save settings: {e}"), ErrorType::IoError)
+    })?;
+
+    let entry = resolve_settings(&json)
+        .into_iter()
+        .find(|e| e.key == key)
+        .expect("key was validated against registry above");
+
+    Ok(entry)
+}
+
+/// Remove a single Kiro CLI setting by key, reverting it to its default.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn reset_kiro_setting(key: String) -> Result<(), CommandError>
+{
+    let reg = registry();
+    if !reg.iter().any(|def| def.key == key)
+    {
+        return Err(CommandError::new(
+            format!("unknown setting key: {key}"),
+            ErrorType::Validation,
+        ));
+    }
+
+    let dir = kiro_dir()?;
+    let mut json = load_kiro_settings_from(&dir);
+    remove_nested(&mut json, &key);
+    save_kiro_settings_to(&dir, &json).map_err(|e| {
+        CommandError::new(format!("failed to save settings: {e}"), ErrorType::IoError)
+    })?;
+
+    Ok(())
+}

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod browse;
 pub mod installed;
+pub mod kiro_settings;
 pub mod marketplaces;
 pub mod settings;

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -110,10 +110,6 @@ mod tests {
         CoreError::Marketplace(MarketplaceError::InvalidManifest { reason: "bad json".into() }),
         ErrorType::ParseError
     )]
-    #[case::marketplace_manifest_not_found(
-        CoreError::Marketplace(MarketplaceError::ManifestNotFound { path: PathBuf::from("/tmp/mp.json") }),
-        ErrorType::ParseError
-    )]
     #[case::skill_already_installed(
         CoreError::Skill(SkillError::AlreadyInstalled { name: "rust-check".into() }),
         ErrorType::AlreadyExists

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -29,6 +29,9 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::settings::save_scan_roots,
         commands::settings::discover_projects,
         commands::settings::set_active_project,
+        commands::kiro_settings::get_kiro_settings,
+        commands::kiro_settings::set_kiro_setting,
+        commands::kiro_settings::reset_kiro_setting,
     ])
 }
 

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -292,6 +292,10 @@ export type PluginInfo = { name: string; description: string | null; skill_count
  */
 export type ProjectInfo = { path: string; kiro_initialized: boolean; installed_skill_count: number }
 /**
+ * Top-level category for a Kiro CLI setting.
+ */
+export type SettingCategory = "telemetry" | "chat" | "knowledge" | "key_bindings" | "features" | "api" | "mcp" | "environment"
+/**
  * A fully-resolved setting entry suitable for serialisation to a frontend.
  */
 export type SettingEntry = { 
@@ -308,21 +312,17 @@ label: string;
  */
 description: string; 
 /**
- * Machine-readable category identifier (serialized `snake_case` string).
+ * Typed category identifier.
  */
-category: string; 
+category: SettingCategory; 
 /**
  * Human-readable category label.
  */
 category_label: string; 
 /**
- * Wire-format type name (`"bool"`, `"string"`, `"enum"`, …).
+ * Value type and type-specific metadata (discriminated union on the frontend).
  */
-value_type: string; 
-/**
- * For `Enum` settings: the allowed values. Empty vec for all other types.
- */
-enum_options: string[]; 
+value_type: SettingValueInfo; 
 /**
  * Default value as a JSON value. `None` when no default is known.
  */
@@ -331,6 +331,13 @@ default_value: JsonValue | null;
  * Current value from the user's settings file. `None` means key absent (using default).
  */
 current_value: JsonValue | null }
+/**
+ * Describes the value type and any type-specific metadata for a setting entry.
+ * 
+ * Serialized as an internally-tagged enum so the frontend can use a
+ * discriminated union: `entry.value_type.kind === "bool"`.
+ */
+export type SettingValueInfo = { kind: "bool" } | { kind: "string" } | { kind: "number" } | { kind: "char" } | { kind: "string_array" } | { kind: "enum"; options: string[] }
 /**
  * Persisted application settings.
  */

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -160,6 +160,39 @@ async setActiveProject(path: string) : Promise<Result<ProjectInfo, CommandError>
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Load all Kiro CLI settings, merging the stored JSON with the registry defaults.
+ */
+async getKiroSettings() : Promise<Result<SettingEntry[], CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_kiro_settings") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Update a single Kiro CLI setting by key and return the updated entry.
+ */
+async setKiroSetting(key: string, value: JsonValue) : Promise<Result<SettingEntry, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_kiro_setting", { key, value }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Remove a single Kiro CLI setting by key, reverting it to its default.
+ */
+async resetKiroSetting(key: string) : Promise<Result<null, CommandError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reset_kiro_setting", { key }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -232,6 +265,7 @@ export type InstalledSkillInfo = { name: string; marketplace: string; plugin: st
  * ISO 8601 timestamp of when the skill was installed.
  */
 installed_at: string }
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }
 /**
  * Result of adding a new marketplace.
  */
@@ -257,6 +291,50 @@ export type PluginInfo = { name: string; description: string | null; skill_count
  * Summary information about a Kiro project directory.
  */
 export type ProjectInfo = { path: string; kiro_initialized: boolean; installed_skill_count: number }
+/**
+ * Top-level category for a Kiro CLI setting.
+ */
+export type SettingCategory = "telemetry" | "chat" | "knowledge" | "key_bindings" | "features" | "api" | "mcp" | "environment"
+/**
+ * A fully-resolved setting entry suitable for serialisation to a frontend.
+ */
+export type SettingEntry = { 
+/**
+ * Dotted JSON key path.
+ */
+key: string; 
+/**
+ * Short human-readable label.
+ */
+label: string; 
+/**
+ * Longer description.
+ */
+description: string; 
+/**
+ * Machine-readable category identifier.
+ */
+category: SettingCategory; 
+/**
+ * Human-readable category label.
+ */
+category_label: string; 
+/**
+ * Wire-format type name (`"bool"`, `"string"`, `"enum"`, …).
+ */
+value_type: string; 
+/**
+ * For `Enum` settings: the allowed values.  `None` for all other types.
+ */
+enum_options: string[] | null; 
+/**
+ * Default value as a JSON value.
+ */
+default_value: JsonValue; 
+/**
+ * Current value as stored in the user's settings file.
+ */
+current_value: JsonValue }
 /**
  * Persisted application settings.
  */

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -292,10 +292,6 @@ export type PluginInfo = { name: string; description: string | null; skill_count
  */
 export type ProjectInfo = { path: string; kiro_initialized: boolean; installed_skill_count: number }
 /**
- * Top-level category for a Kiro CLI setting.
- */
-export type SettingCategory = "telemetry" | "chat" | "knowledge" | "key_bindings" | "features" | "api" | "mcp" | "environment"
-/**
  * A fully-resolved setting entry suitable for serialisation to a frontend.
  */
 export type SettingEntry = { 
@@ -312,9 +308,9 @@ label: string;
  */
 description: string; 
 /**
- * Machine-readable category identifier.
+ * Machine-readable category identifier (serialized `snake_case` string).
  */
-category: SettingCategory; 
+category: string; 
 /**
  * Human-readable category label.
  */
@@ -324,17 +320,17 @@ category_label: string;
  */
 value_type: string; 
 /**
- * For `Enum` settings: the allowed values.  `None` for all other types.
+ * For `Enum` settings: the allowed values. Empty vec for all other types.
  */
-enum_options: string[] | null; 
+enum_options: string[]; 
 /**
- * Default value as a JSON value.
+ * Default value as a JSON value. `None` when no default is known.
  */
-default_value: JsonValue; 
+default_value: JsonValue | null; 
 /**
- * Current value as stored in the user's settings file.
+ * Current value from the user's settings file. `None` means key absent (using default).
  */
-current_value: JsonValue }
+current_value: JsonValue | null }
 /**
  * Persisted application settings.
  */

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -138,7 +138,7 @@
         Marketplaces
       </h3>
       {#if loadingMarketplaces}
-        <p class="text-sm text-kiro-subtle px-2">Loading...</p>
+        <p class="text-sm text-kiro-subtle px-2 animate-pulse">Loading...</p>
       {:else if marketplaces.length === 0}
         <p class="text-sm text-kiro-subtle px-2">No marketplaces found</p>
       {:else}
@@ -152,7 +152,14 @@
               onclick={() => toggleMarketplace(mp.name)}
             >
               <span class="flex items-center justify-between">
-                <span class="truncate font-medium">{mp.name}</span>
+                <span class="flex items-center gap-2 truncate">
+                  <span class="w-2 h-2 rounded-full flex-shrink-0 {
+                    mp.source_type === 'github' ? 'bg-kiro-info' :
+                    mp.source_type === 'local' ? 'bg-kiro-warning' :
+                    'bg-kiro-accent-400'
+                  }"></span>
+                  <span class="truncate font-medium">{mp.name}</span>
+                </span>
                 <span class="text-xs text-kiro-subtle">{mp.plugin_count}</span>
               </span>
             </button>
@@ -214,15 +221,27 @@
     <!-- Skills content -->
     <div class="flex-1 overflow-y-auto p-4">
       {#if !selectedPlugin}
-        <div class="flex items-center justify-center h-full text-kiro-subtle">
+        <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+          <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+              d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+          </svg>
           <p class="text-sm">Select a plugin from the sidebar to browse skills</p>
         </div>
       {:else if loadingSkills}
-        <div class="flex items-center justify-center h-full text-kiro-subtle">
+        <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+          <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
           <p class="text-sm">Loading skills...</p>
         </div>
       {:else if filteredSkills.length === 0}
-        <div class="flex items-center justify-center h-full text-kiro-subtle">
+        <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+          <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
           <p class="text-sm">
             {filterText ? "No skills match the filter" : "No skills available"}
           </p>

--- a/crates/kiro-control-center/src/lib/components/CategoryList.svelte
+++ b/crates/kiro-control-center/src/lib/components/CategoryList.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  let {
+    categories,
+    activeCategory,
+    onSelect,
+    matchCounts,
+  }: {
+    categories: { key: string; label: string; count: number }[];
+    activeCategory: string;
+    onSelect: (key: string) => void;
+    matchCounts: Record<string, number> | null;
+  } = $props();
+</script>
+
+<nav class="flex flex-col gap-0.5 p-2">
+  {#each categories as cat (cat.key)}
+    {@const count = matchCounts !== null ? (matchCounts[cat.key] ?? 0) : cat.count}
+    {@const dimmed = matchCounts !== null && count === 0}
+    <button
+      type="button"
+      class="w-full text-left px-3 py-2 text-sm rounded-md transition-colors duration-100 flex items-center justify-between
+        {activeCategory === cat.key
+          ? 'bg-kiro-muted text-kiro-text font-medium'
+          : dimmed
+            ? 'text-kiro-subtle/40 cursor-not-allowed'
+            : 'text-kiro-text-secondary hover:bg-kiro-overlay'}"
+      disabled={dimmed}
+      onclick={() => !dimmed && onSelect(cat.key)}
+    >
+      <span class="truncate">{cat.label}</span>
+      <span class="ml-2 text-xs {activeCategory === cat.key ? 'text-kiro-text-secondary' : 'text-kiro-subtle'} flex-shrink-0">
+        {count}
+      </span>
+    </button>
+  {/each}
+</nav>

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -134,11 +134,19 @@
   <!-- Table -->
   <div class="flex-1 overflow-y-auto">
     {#if loading}
-      <div class="flex items-center justify-center h-full text-kiro-subtle">
+      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+        <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
         <p class="text-sm">Loading installed skills...</p>
       </div>
     {:else if filteredSkills.length === 0}
-      <div class="flex items-center justify-center h-full text-kiro-subtle">
+      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+        <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+        </svg>
         <p class="text-sm">
           {filterText ? "No installed skills match the filter" : "No skills installed"}
         </p>

--- a/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
@@ -155,17 +155,25 @@
   <!-- Marketplace list -->
   <div class="flex-1 overflow-y-auto p-4">
     {#if loading}
-      <div class="flex items-center justify-center h-full text-kiro-subtle">
+      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+        <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
         <p class="text-sm">Loading marketplaces...</p>
       </div>
     {:else if marketplaces.length === 0}
-      <div class="flex items-center justify-center h-full text-kiro-subtle">
+      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+        <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+        </svg>
         <p class="text-sm">No marketplaces registered. Add one above to get started.</p>
       </div>
     {:else}
       <div class="space-y-3">
         {#each marketplaces as mp (mp.name)}
-          <div class="flex items-center justify-between p-4 rounded-lg border border-kiro-muted bg-kiro-overlay">
+          <div class="flex items-center justify-between p-4 rounded-lg border border-kiro-muted border-l-2 border-l-kiro-accent-800 bg-kiro-overlay">
             <div class="flex items-center gap-3 min-w-0">
               <div class="min-w-0">
                 <div class="flex items-center gap-2">

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -201,19 +201,21 @@
       <span class="text-sm text-kiro-subtle italic">Unsupported type: {entry.value_type}</span>
     {/if}
 
-    <!-- Reset button -->
-    {#if isModified}
-      <button
-        type="button"
-        title="Reset to default"
-        aria-label="Reset {entry.label} to default"
-        onclick={handleReset}
-        class="p-1.5 rounded-md text-kiro-subtle hover:text-kiro-text-secondary hover:bg-kiro-overlay transition-colors"
-      >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-      </button>
-    {/if}
+    <!-- Reset button (always rendered to reserve space, invisible when unmodified) -->
+    <button
+      type="button"
+      title="Reset to default"
+      aria-label="Reset {entry.label} to default"
+      onclick={handleReset}
+      disabled={!isModified}
+      class="p-1.5 rounded-md transition-colors
+        {isModified
+          ? 'text-kiro-subtle hover:text-kiro-text-secondary hover:bg-kiro-overlay'
+          : 'invisible'}"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+    </button>
   </div>
 </div>

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -15,27 +15,43 @@
   let error: string | null = $state(null);
 
   async function handleSet(value: JsonValue) {
+    if (saving) return;
     saving = true;
     error = null;
-    const result = await commands.setKiroSetting(entry.key, value);
-    if (result.status === "ok") {
-      onUpdate(result.data);
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.setKiroSetting(entry.key, value);
+      if (result.status === "ok") {
+        onUpdate(result.data);
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      error = e instanceof Error
+        ? `Failed to save: ${e.message}`
+        : "Failed to save setting.";
+    } finally {
+      saving = false;
     }
-    saving = false;
   }
 
   async function handleReset() {
+    if (saving) return;
     saving = true;
     error = null;
-    const result = await commands.resetKiroSetting(entry.key);
-    if (result.status === "ok") {
-      onUpdate({ ...entry, current_value: null });
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.resetKiroSetting(entry.key);
+      if (result.status === "ok") {
+        onUpdate({ ...entry, current_value: null });
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      error = e instanceof Error
+        ? `Failed to reset: ${e.message}`
+        : "Failed to reset setting.";
+    } finally {
+      saving = false;
     }
-    saving = false;
   }
 
   function handleStringChange(e: Event) {
@@ -45,10 +61,16 @@
 
   function handleNumberChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    const num = Number(target.value);
-    if (!Number.isNaN(num) && target.value !== "") {
-      handleSet(num);
+    if (target.value === "") {
+      handleReset();
+      return;
     }
+    const num = Number(target.value);
+    if (Number.isNaN(num)) {
+      error = "Invalid number";
+      return;
+    }
+    handleSet(num);
   }
 
   function handleCharChange(e: Event) {
@@ -130,7 +152,8 @@
     {:else if entry.value_type === "number"}
       <input
         type="number"
-        value={typeof displayValue === "number" ? displayValue : 0}
+        value={typeof displayValue === "number" ? displayValue : ""}
+        placeholder={entry.default_value !== null ? String(entry.default_value) : "not set"}
         onchange={handleNumberChange}
         class="w-24 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       />

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -124,7 +124,7 @@
 
   <!-- Right: editor + reset -->
   <div class="flex items-center gap-2 flex-shrink-0">
-    {#if entry.value_type === "bool"}
+    {#if entry.value_type.kind === "bool"}
       <!-- Toggle switch -->
       <button
         type="button"
@@ -141,7 +141,7 @@
         ></span>
       </button>
 
-    {:else if entry.value_type === "string"}
+    {:else if entry.value_type.kind === "string"}
       <input
         type="text"
         value={typeof displayValue === "string" ? displayValue : ""}
@@ -149,7 +149,7 @@
         class="w-48 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       />
 
-    {:else if entry.value_type === "number"}
+    {:else if entry.value_type.kind === "number"}
       <input
         type="number"
         value={typeof displayValue === "number" ? displayValue : ""}
@@ -158,7 +158,7 @@
         class="w-24 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       />
 
-    {:else if entry.value_type === "char"}
+    {:else if entry.value_type.kind === "char"}
       <input
         type="text"
         maxlength={1}
@@ -167,7 +167,7 @@
         class="w-12 px-2.5 py-1.5 text-sm text-center rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       />
 
-    {:else if entry.value_type === "string_array"}
+    {:else if entry.value_type.kind === "string_array"}
       <div class="flex flex-col gap-2 w-64">
         <!-- Chips -->
         {#if Array.isArray(displayValue) && displayValue.length > 0}
@@ -209,19 +209,19 @@
         </div>
       </div>
 
-    {:else if entry.value_type === "enum"}
+    {:else if entry.value_type.kind === "enum"}
       <select
         value={typeof displayValue === "string" ? displayValue : ""}
         onchange={handleSelectChange}
         class="w-40 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
       >
-        {#each entry.enum_options as option (option)}
+        {#each entry.value_type.options as option (option)}
           <option value={option}>{option}</option>
         {/each}
       </select>
 
     {:else}
-      <span class="text-sm text-kiro-subtle italic">Unsupported type: {entry.value_type}</span>
+      <span class="text-sm text-kiro-subtle italic">Unsupported type</span>
     {/if}
 
     <!-- Reset button (always rendered to reserve space, invisible when unmodified) -->

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  import { commands } from "$lib/bindings";
+  import type { SettingEntry, JsonValue } from "$lib/bindings";
+
+  let { entry, onUpdate }: {
+    entry: SettingEntry;
+    onUpdate: (updated: SettingEntry) => void;
+  } = $props();
+
+  let displayValue = $derived(entry.current_value ?? entry.default_value);
+  let isModified = $derived(entry.current_value !== null);
+
+  let chipInput = $state("");
+
+  async function handleSet(value: JsonValue) {
+    const result = await commands.setKiroSetting(entry.key, value);
+    if (result.status === "ok") {
+      onUpdate(result.data);
+    }
+  }
+
+  async function handleReset() {
+    const result = await commands.resetKiroSetting(entry.key);
+    if (result.status === "ok") {
+      onUpdate({ ...entry, current_value: null });
+    }
+  }
+
+  function handleStringChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    handleSet(target.value);
+  }
+
+  function handleNumberChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    handleSet(Number(target.value));
+  }
+
+  function handleCharChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    handleSet(target.value.slice(0, 1));
+  }
+
+  function handleSelectChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    handleSet(target.value);
+  }
+
+  function handleAddChip() {
+    const trimmed = chipInput.trim();
+    if (!trimmed) return;
+    const current = Array.isArray(displayValue) ? (displayValue as string[]) : [];
+    handleSet([...current, trimmed]);
+    chipInput = "";
+  }
+
+  function handleChipKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddChip();
+    }
+  }
+
+  function handleRemoveChip(index: number) {
+    const current = Array.isArray(displayValue) ? (displayValue as string[]) : [];
+    handleSet(current.filter((_, i) => i !== index));
+  }
+</script>
+
+<div class="flex items-start justify-between gap-6 py-4 border-b border-kiro-muted last:border-b-0">
+  <!-- Left: label, description, key -->
+  <div class="flex-1 min-w-0">
+    <div class="flex items-center gap-2">
+      <span class="font-semibold text-sm text-kiro-text">{entry.label}</span>
+      {#if isModified}
+        <span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-kiro-accent-900/30 text-kiro-accent-400">
+          Modified
+        </span>
+      {/if}
+    </div>
+    <p class="mt-0.5 text-sm text-kiro-text-secondary">{entry.description}</p>
+    <p class="mt-0.5 font-mono text-[10px] text-kiro-subtle">{entry.key}</p>
+  </div>
+
+  <!-- Right: editor + reset -->
+  <div class="flex items-center gap-2 flex-shrink-0">
+    {#if entry.value_type === "bool"}
+      <!-- Toggle switch -->
+      <button
+        type="button"
+        role="switch"
+        aria-checked={displayValue === true}
+        aria-label="Toggle {entry.label}"
+        class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:ring-offset-2 focus:ring-offset-kiro-base
+          {displayValue === true ? 'bg-kiro-accent-600' : 'bg-kiro-muted'}"
+        onclick={() => handleSet(displayValue !== true)}
+      >
+        <span
+          class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200
+            {displayValue === true ? 'translate-x-6' : 'translate-x-1'}"
+        ></span>
+      </button>
+
+    {:else if entry.value_type === "string"}
+      <input
+        type="text"
+        value={typeof displayValue === "string" ? displayValue : ""}
+        onchange={handleStringChange}
+        class="w-48 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+      />
+
+    {:else if entry.value_type === "number"}
+      <input
+        type="number"
+        value={typeof displayValue === "number" ? displayValue : 0}
+        onchange={handleNumberChange}
+        class="w-24 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+      />
+
+    {:else if entry.value_type === "char"}
+      <input
+        type="text"
+        maxlength={1}
+        value={typeof displayValue === "string" ? displayValue : ""}
+        onchange={handleCharChange}
+        class="w-12 px-2.5 py-1.5 text-sm text-center rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+      />
+
+    {:else if entry.value_type === "string_array"}
+      <div class="flex flex-col gap-2 w-64">
+        <!-- Chips -->
+        {#if Array.isArray(displayValue) && displayValue.length > 0}
+          <div class="flex flex-wrap gap-1">
+            {#each displayValue as chip, i (i)}
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-kiro-overlay border border-kiro-muted text-kiro-text-secondary">
+                {chip}
+                <button
+                  type="button"
+                  aria-label="Remove {chip}"
+                  class="text-kiro-subtle hover:text-kiro-error transition-colors"
+                  onclick={() => handleRemoveChip(i)}
+                >
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </span>
+            {/each}
+          </div>
+        {/if}
+        <!-- Add input -->
+        <div class="flex gap-1">
+          <input
+            type="text"
+            placeholder="Add item..."
+            bind:value={chipInput}
+            onkeydown={handleChipKeydown}
+            class="flex-1 px-2 py-1 text-xs rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-1 focus:ring-kiro-accent-500 focus:border-transparent"
+          />
+          <button
+            type="button"
+            onclick={handleAddChip}
+            class="px-2 py-1 text-xs rounded-md bg-kiro-overlay border border-kiro-muted text-kiro-text-secondary hover:bg-kiro-muted transition-colors"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+    {:else if entry.value_type === "enum"}
+      <select
+        value={typeof displayValue === "string" ? displayValue : ""}
+        onchange={handleSelectChange}
+        class="w-40 px-2.5 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+      >
+        {#each entry.enum_options as option (option)}
+          <option value={option}>{option}</option>
+        {/each}
+      </select>
+
+    {:else}
+      <span class="text-sm text-kiro-subtle italic">Unsupported type: {entry.value_type}</span>
+    {/if}
+
+    <!-- Reset button -->
+    {#if isModified}
+      <button
+        type="button"
+        title="Reset to default"
+        aria-label="Reset {entry.label} to default"
+        onclick={handleReset}
+        class="p-1.5 rounded-md text-kiro-subtle hover:text-kiro-text-secondary hover:bg-kiro-overlay transition-colors"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+      </button>
+    {/if}
+  </div>
+</div>

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -75,7 +75,12 @@
 
   function handleCharChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    handleSet(target.value.slice(0, 1));
+    const char = target.value.slice(0, 1);
+    if (char === "") {
+      handleReset();
+      return;
+    }
+    handleSet(char);
   }
 
   function handleSelectChange(e: Event) {

--- a/crates/kiro-control-center/src/lib/components/SettingControl.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingControl.svelte
@@ -11,19 +11,31 @@
   let isModified = $derived(entry.current_value !== null);
 
   let chipInput = $state("");
+  let saving = $state(false);
+  let error: string | null = $state(null);
 
   async function handleSet(value: JsonValue) {
+    saving = true;
+    error = null;
     const result = await commands.setKiroSetting(entry.key, value);
     if (result.status === "ok") {
       onUpdate(result.data);
+    } else {
+      error = result.error.message;
     }
+    saving = false;
   }
 
   async function handleReset() {
+    saving = true;
+    error = null;
     const result = await commands.resetKiroSetting(entry.key);
     if (result.status === "ok") {
       onUpdate({ ...entry, current_value: null });
+    } else {
+      error = result.error.message;
     }
+    saving = false;
   }
 
   function handleStringChange(e: Event) {
@@ -33,7 +45,10 @@
 
   function handleNumberChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    handleSet(Number(target.value));
+    const num = Number(target.value);
+    if (!Number.isNaN(num) && target.value !== "") {
+      handleSet(num);
+    }
   }
 
   function handleCharChange(e: Event) {
@@ -80,6 +95,9 @@
     </div>
     <p class="mt-0.5 text-sm text-kiro-text-secondary">{entry.description}</p>
     <p class="mt-0.5 font-mono text-[10px] text-kiro-subtle">{entry.key}</p>
+    {#if error}
+      <p class="mt-1 text-xs text-kiro-error">{error}</p>
+    {/if}
   </div>
 
   <!-- Right: editor + reset -->
@@ -160,6 +178,7 @@
           <button
             type="button"
             onclick={handleAddChip}
+            aria-label="Add item to {entry.label}"
             class="px-2 py-1 text-xs rounded-md bg-kiro-overlay border border-kiro-muted text-kiro-text-secondary hover:bg-kiro-muted transition-colors"
           >
             +

--- a/crates/kiro-control-center/src/lib/components/SettingsPanel.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingsPanel.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { SvelteMap } from "svelte/reactivity";
+  import type { SettingEntry } from "$lib/bindings";
+  import SettingControl from "./SettingControl.svelte";
+
+  let {
+    entries,
+    showCategoryHeaders,
+    onUpdate,
+  }: {
+    entries: SettingEntry[];
+    showCategoryHeaders: boolean;
+    onUpdate: (updated: SettingEntry) => void;
+  } = $props();
+
+  let grouped = $derived.by(() => {
+    if (!showCategoryHeaders) return null;
+    const map = new SvelteMap<string, SettingEntry[]>();
+    for (const entry of entries) {
+      const existing = map.get(entry.category_label);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        map.set(entry.category_label, [entry]);
+      }
+    }
+    return map;
+  });
+</script>
+
+<div class="flex-1 overflow-y-auto p-6">
+  {#if entries.length === 0}
+    <div class="flex items-center justify-center h-32 text-kiro-subtle">
+      <p class="text-sm">No settings match the search</p>
+    </div>
+  {:else if showCategoryHeaders && grouped !== null}
+    {#each grouped as [label, group] (label)}
+      <section class="mb-8">
+        <h2 class="text-xs font-semibold text-kiro-subtle uppercase tracking-wider mb-3">{label}</h2>
+        <div class="rounded-lg border border-kiro-muted bg-kiro-surface px-4">
+          {#each group as entry (entry.key)}
+            <SettingControl {entry} {onUpdate} />
+          {/each}
+        </div>
+      </section>
+    {/each}
+  {:else}
+    <div class="rounded-lg border border-kiro-muted bg-kiro-surface px-4">
+      {#each entries as entry (entry.key)}
+        <SettingControl {entry} {onUpdate} />
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/crates/kiro-control-center/src/lib/components/SettingsView.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingsView.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { SvelteMap } from "svelte/reactivity";
+  import { commands } from "$lib/bindings";
+  import type { SettingEntry } from "$lib/bindings";
+  import CategoryList from "./CategoryList.svelte";
+  import SettingsPanel from "./SettingsPanel.svelte";
+
+  let { onClose }: { onClose: () => void } = $props();
+
+  let allEntries: SettingEntry[] = $state([]);
+  let loading: boolean = $state(true);
+  let loadError: string | null = $state(null);
+  let searchQuery: string = $state("");
+  let _activeCategoryOverride: string | null = $state(null);
+
+  let categories = $derived.by(() => {
+    const seen = new SvelteMap<string, { key: string; label: string; count: number }>();
+    for (const entry of allEntries) {
+      const existing = seen.get(entry.category);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        seen.set(entry.category, { key: entry.category, label: entry.category_label, count: 1 });
+      }
+    }
+    return Array.from(seen.values());
+  });
+
+  // Derive the active category: use the user's choice if set, otherwise default to first category
+  let activeCategory = $derived(
+    _activeCategoryOverride !== null ? _activeCategoryOverride : (categories[0]?.key ?? "")
+  );
+
+  function setActiveCategory(key: string) {
+    _activeCategoryOverride = key;
+  }
+
+  let filteredEntries = $derived.by(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return allEntries.filter(
+      (e) =>
+        e.label.toLowerCase().includes(q) ||
+        e.description.toLowerCase().includes(q) ||
+        e.key.toLowerCase().includes(q)
+    );
+  });
+
+  let matchCounts = $derived.by((): Record<string, number> | null => {
+    if (!searchQuery.trim()) return null;
+    const counts: Record<string, number> = {};
+    for (const entry of filteredEntries) {
+      counts[entry.category] = (counts[entry.category] ?? 0) + 1;
+    }
+    return counts;
+  });
+
+  let displayEntries = $derived.by(() => {
+    if (searchQuery.trim()) return filteredEntries;
+    return allEntries.filter((e) => e.category === activeCategory);
+  });
+
+  let showCategoryHeaders = $derived(searchQuery.trim().length > 0);
+
+  function handleUpdate(updated: SettingEntry) {
+    allEntries = allEntries.map((e) => (e.key === updated.key ? updated : e));
+  }
+
+  onMount(async () => {
+    const result = await commands.getKiroSettings();
+    if (result.status === "ok") {
+      allEntries = result.data;
+    } else {
+      loadError = result.error.message;
+    }
+    loading = false;
+  });
+</script>
+
+<div class="flex flex-col h-full bg-kiro-base text-kiro-text">
+  <!-- Top bar -->
+  <div class="flex items-center gap-4 px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
+    <button
+      type="button"
+      onclick={onClose}
+      class="flex items-center gap-1.5 text-sm text-kiro-text-secondary hover:text-kiro-text transition-colors"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+      Back
+    </button>
+
+    <h1 class="text-sm font-semibold text-kiro-text">Kiro Settings</h1>
+
+    <div class="flex-1 max-w-sm ml-auto">
+      <input
+        type="search"
+        placeholder="Search settings..."
+        bind:value={searchQuery}
+        class="w-full px-3 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+      />
+    </div>
+  </div>
+
+  <!-- Body -->
+  {#if loading}
+    <div class="flex items-center justify-center flex-1 text-kiro-subtle">
+      <p class="text-sm">Loading settings...</p>
+    </div>
+  {:else if loadError}
+    <div class="flex items-center justify-center flex-1">
+      <div class="px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+        <p class="text-sm text-kiro-error">{loadError}</p>
+      </div>
+    </div>
+  {:else}
+    <div class="flex flex-1 overflow-hidden">
+      <!-- Sidebar -->
+      <div class="w-56 flex-shrink-0 border-r border-kiro-muted bg-kiro-surface overflow-y-auto">
+        <CategoryList
+          {categories}
+          {activeCategory}
+          onSelect={setActiveCategory}
+          {matchCounts}
+        />
+      </div>
+
+      <!-- Main panel -->
+      <SettingsPanel
+        entries={displayEntries}
+        {showCategoryHeaders}
+        onUpdate={handleUpdate}
+      />
+    </div>
+  {/if}
+</div>

--- a/crates/kiro-control-center/src/lib/components/SettingsView.svelte
+++ b/crates/kiro-control-center/src/lib/components/SettingsView.svelte
@@ -68,13 +68,20 @@
   }
 
   onMount(async () => {
-    const result = await commands.getKiroSettings();
-    if (result.status === "ok") {
-      allEntries = result.data;
-    } else {
-      loadError = result.error.message;
+    try {
+      const result = await commands.getKiroSettings();
+      if (result.status === "ok") {
+        allEntries = result.data;
+      } else {
+        loadError = result.error.message;
+      }
+    } catch (e) {
+      loadError = e instanceof Error
+        ? `Failed to load settings: ${e.message}`
+        : "Failed to load settings due to an unexpected error.";
+    } finally {
+      loading = false;
     }
-    loading = false;
   });
 </script>
 

--- a/crates/kiro-control-center/src/lib/components/SkillCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/SkillCard.svelte
@@ -22,8 +22,8 @@
   type="button"
   class="flex items-start gap-3 w-full text-left p-4 rounded-lg border transition-colors duration-150
     {selected
-      ? 'border-kiro-accent-500 bg-kiro-accent-900/20'
-      : 'border-kiro-muted bg-kiro-overlay hover:border-kiro-subtle'}
+      ? 'border-kiro-accent-500 border-l-kiro-accent-400 bg-kiro-accent-900/20'
+      : 'border-kiro-muted border-l-2 border-l-kiro-accent-800 bg-kiro-overlay hover:border-l-kiro-accent-500 hover:bg-kiro-accent-900/5'}
     {skill.installed ? 'opacity-60' : ''}"
   onclick={onToggle}
   disabled={skill.installed}
@@ -44,6 +44,9 @@
           Installed
         </span>
       {/if}
+      <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-kiro-info/15 text-kiro-info">
+        {skill.plugin}
+      </span>
     </div>
     <p
       bind:this={descEl}

--- a/crates/kiro-control-center/src/lib/components/TabBar.svelte
+++ b/crates/kiro-control-center/src/lib/components/TabBar.svelte
@@ -11,7 +11,7 @@
     <button
       class="px-6 py-3 text-sm font-medium transition-colors duration-150 focus:outline-none
         {activeTab === tab
-          ? 'text-kiro-accent-400 border-b-2 border-kiro-accent-400'
+          ? 'text-kiro-accent-300 border-b-2 border-kiro-accent-400 bg-kiro-accent-900/10'
           : 'text-kiro-subtle hover:text-kiro-text-secondary hover:border-b-2 hover:border-kiro-subtle'}"
       onclick={() => onTabChange(tab)}
     >

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -32,7 +32,7 @@
   </div>
 {:else if store.projectPath}
   <div class="flex flex-col h-screen bg-kiro-base text-kiro-text">
-    <header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
+    <header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b-2 border-kiro-accent-700 shadow-sm">
       <div class="flex items-center gap-3">
         <h1 class="text-lg font-semibold">Kiro Control Center</h1>
         <button

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -8,10 +8,12 @@
   import ProjectPicker from "$lib/components/ProjectPicker.svelte";
   import ProjectDropdown from "$lib/components/ProjectDropdown.svelte";
   import ScanRootsPanel from "$lib/components/ScanRootsPanel.svelte";
+  import SettingsView from "$lib/components/SettingsView.svelte";
 
   const tabs = ["Browse", "Installed", "Marketplaces"];
   let activeTab: string = $state("Browse");
   let showManageRoots = $state(false);
+  let showSettings = $state(false);
 
   // Initialize once on mount. Uses onMount (not $effect) because initialize()
   // is a one-shot async function that should not re-trigger on state changes.
@@ -31,21 +33,38 @@
 {:else if store.projectPath}
   <div class="flex flex-col h-screen bg-kiro-base text-kiro-text">
     <header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
-      <h1 class="text-lg font-semibold">Kiro Control Center</h1>
+      <div class="flex items-center gap-3">
+        <h1 class="text-lg font-semibold">Kiro Control Center</h1>
+        <button
+          type="button"
+          aria-label="Open settings"
+          onclick={() => (showSettings = true)}
+          class="p-1.5 rounded-md text-kiro-subtle hover:text-kiro-text-secondary hover:bg-kiro-overlay transition-colors"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+      </div>
       <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
     </header>
 
-    <TabBar {tabs} {activeTab} onTabChange={(tab) => (activeTab = tab)} />
+    {#if showSettings}
+      <SettingsView onClose={() => (showSettings = false)} />
+    {:else}
+      <TabBar {tabs} {activeTab} onTabChange={(tab) => (activeTab = tab)} />
 
-    <main class="flex-1 overflow-hidden">
-      {#if activeTab === "Browse"}
-        <BrowseTab projectPath={store.projectPath} />
-      {:else if activeTab === "Installed"}
-        <InstalledTab projectPath={store.projectPath} />
-      {:else if activeTab === "Marketplaces"}
-        <MarketplacesTab />
-      {/if}
-    </main>
+      <main class="flex-1 overflow-hidden">
+        {#if activeTab === "Browse"}
+          <BrowseTab projectPath={store.projectPath} />
+        {:else if activeTab === "Installed"}
+          <InstalledTab projectPath={store.projectPath} />
+        {:else if activeTab === "Marketplaces"}
+          <MarketplacesTab />
+        {/if}
+      </main>
+    {/if}
   </div>
 {:else}
   <ProjectPicker />

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -47,7 +47,9 @@
           </svg>
         </button>
       </div>
-      <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
+      {#if !showSettings}
+        <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
+      {/if}
     </header>
 
     {#if showSettings}

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -25,7 +25,7 @@ dirs = { workspace = true }
 chrono = { workspace = true }
 fs4 = { workspace = true }
 clap = { workspace = true, optional = true }
-specta = { version = "2.0.0-rc.20", optional = true }
+specta = { version = "2.0.0-rc.20", optional = true, features = ["derive", "serde_json"] }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/kiro-market-core/src/cache.rs
+++ b/crates/kiro-market-core/src/cache.rs
@@ -77,6 +77,33 @@ impl MarketplaceSource {
             Self::LocalPath { .. } => "local",
         }
     }
+
+    /// Derive a marketplace name from the source when no manifest provides one.
+    ///
+    /// Extracts the last path/URL segment, strips a `.git` suffix if present,
+    /// and validates the result. Returns `None` if the derived name fails
+    /// validation.
+    #[must_use]
+    pub fn fallback_name(&self) -> Option<String> {
+        let raw = match self {
+            Self::GitHub { repo } => repo.rsplit('/').next(),
+            Self::GitUrl { url } => url.rsplit('/').next().or_else(|| url.rsplit(':').next()),
+            Self::LocalPath { path } => {
+                let trimmed = path.trim_end_matches(['/', '\\']);
+                trimmed.rsplit(['/', '\\']).next()
+            }
+        };
+
+        let segment = raw?;
+        let name = segment.strip_suffix(".git").unwrap_or(segment);
+
+        if name.is_empty() {
+            return None;
+        }
+
+        validation::validate_name(name).ok()?;
+        Some(name.to_owned())
+    }
 }
 
 /// Resolve a local path string to an absolute path.
@@ -316,6 +343,8 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn temp_cache() -> (tempfile::TempDir, CacheDir) {
@@ -681,6 +710,40 @@ mod tests {
             }
             .label(),
             "local"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // MarketplaceSource::fallback_name
+    // -----------------------------------------------------------------------
+
+    #[rstest]
+    #[case::github("owner/skills", "skills")]
+    #[case::github_nested("org/sub-repo", "sub-repo")]
+    #[case::git_url_https("https://github.com/dotnet/skills.git", "skills")]
+    #[case::git_url_no_suffix("https://github.com/dotnet/skills", "skills")]
+    #[case::git_ssh("git@github.com:owner/repo.git", "repo")]
+    #[case::local_path("/home/user/my-plugins", "my-plugins")]
+    #[case::local_tilde("~/marketplaces/mine", "mine")]
+    #[case::local_relative("./my-market", "my-market")]
+    fn fallback_name_derives_from_source(#[case] source_str: &str, #[case] expected: &str) {
+        let source = MarketplaceSource::detect(source_str);
+        let name = source.fallback_name();
+        assert_eq!(
+            name.as_deref(),
+            Some(expected),
+            "fallback name for '{source_str}'"
+        );
+    }
+
+    #[test]
+    fn fallback_name_returns_none_for_invalid_name() {
+        let source = MarketplaceSource::LocalPath {
+            path: "/home/user/..".into(),
+        };
+        assert!(
+            source.fallback_name().is_none(),
+            "should return None for invalid name"
         );
     }
 }

--- a/crates/kiro-market-core/src/cache.rs
+++ b/crates/kiro-market-core/src/cache.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use tracing::debug;
+
 use crate::error::MarketplaceError;
 use crate::git::GitProtocol;
 use crate::validation;
@@ -101,7 +103,14 @@ impl MarketplaceSource {
             return None;
         }
 
-        validation::validate_name(name).ok()?;
+        if let Err(e) = validation::validate_name(name) {
+            debug!(
+                name = name,
+                error = %e,
+                "derived marketplace name fails validation"
+            );
+            return None;
+        }
         Some(name.to_owned())
     }
 }

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -31,6 +31,10 @@ pub enum MarketplaceError {
     /// No `marketplace.json` exists at the expected location.
     #[error("marketplace manifest not found at {path}")]
     ManifestNotFound { path: PathBuf },
+
+    /// No `marketplace.json` and no `plugin.json` files found via scan.
+    #[error("no plugins found in {path}")]
+    NoPluginsFound { path: PathBuf },
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +213,10 @@ mod tests {
     #[case::marketplace_manifest_not_found(
         MarketplaceError::ManifestNotFound { path: PathBuf::from("/tmp/mp.json") },
         "marketplace manifest not found at /tmp/mp.json"
+    )]
+    #[case::no_plugins_found(
+        MarketplaceError::NoPluginsFound { path: PathBuf::from("/tmp/repo") },
+        "no plugins found in /tmp/repo"
     )]
     fn marketplace_error_display(#[case] err: MarketplaceError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -28,10 +28,6 @@ pub enum MarketplaceError {
     #[error("invalid marketplace manifest: {reason}")]
     InvalidManifest { reason: String },
 
-    /// No `marketplace.json` exists at the expected location.
-    #[error("marketplace manifest not found at {path}")]
-    ManifestNotFound { path: PathBuf },
-
     /// No `marketplace.json` and no `plugin.json` files found via scan.
     #[error("no plugins found in {path}")]
     NoPluginsFound { path: PathBuf },
@@ -209,10 +205,6 @@ mod tests {
     #[case::marketplace_invalid_manifest(
         MarketplaceError::InvalidManifest { reason: "bad json".into() },
         "invalid marketplace manifest: bad json"
-    )]
-    #[case::marketplace_manifest_not_found(
-        MarketplaceError::ManifestNotFound { path: PathBuf::from("/tmp/mp.json") },
-        "marketplace manifest not found at /tmp/mp.json"
     )]
     #[case::no_plugins_found(
         MarketplaceError::NoPluginsFound { path: PathBuf::from("/tmp/repo") },

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -59,7 +59,7 @@ pub enum SettingType {
 }
 
 impl SettingType {
-    /// Returns the wire-format type name used in [`SettingEntry::value_type`].
+    /// Returns the wire-format type name used in error messages.
     #[must_use]
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -69,14 +69,6 @@ impl SettingType {
             Self::Char => "char",
             Self::StringArray => "string_array",
             Self::Enum(_) => "enum",
-        }
-    }
-
-    /// Returns enum options if this is an `Enum` variant, otherwise an empty vec.
-    fn enum_options(&self) -> Vec<std::string::String> {
-        match self {
-            Self::Enum(opts) => opts.iter().map(|s| (*s).to_owned()).collect(),
-            _ => vec![],
         }
     }
 
@@ -93,6 +85,26 @@ impl SettingType {
             Self::Enum(opts) => value.as_str().is_some_and(|s| opts.contains(&s)),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Setting value info (frontend-facing discriminated union)
+// ---------------------------------------------------------------------------
+
+/// Describes the value type and any type-specific metadata for a setting entry.
+///
+/// Serialized as an internally-tagged enum so the frontend can use a
+/// discriminated union: `entry.value_type.kind === "bool"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SettingValueInfo {
+    Bool,
+    String,
+    Number,
+    Char,
+    StringArray,
+    Enum { options: Vec<std::string::String> },
 }
 
 // ---------------------------------------------------------------------------
@@ -129,14 +141,12 @@ pub struct SettingEntry {
     pub label: std::string::String,
     /// Longer description.
     pub description: std::string::String,
-    /// Machine-readable category identifier (serialized `snake_case` string).
-    pub category: std::string::String,
+    /// Typed category identifier.
+    pub category: SettingCategory,
     /// Human-readable category label.
     pub category_label: std::string::String,
-    /// Wire-format type name (`"bool"`, `"string"`, `"enum"`, …).
-    pub value_type: std::string::String,
-    /// For `Enum` settings: the allowed values. Empty vec for all other types.
-    pub enum_options: Vec<std::string::String>,
+    /// Value type and type-specific metadata (discriminated union on the frontend).
+    pub value_type: SettingValueInfo,
     /// Default value as a JSON value. `None` when no default is known.
     pub default_value: Option<JsonValue>,
     /// Current value from the user's settings file. `None` means key absent (using default).
@@ -589,12 +599,6 @@ fn remove_nested_impl(value: &mut JsonValue, segments: &[&str]) -> bool {
 /// `current_value` is `None` when the key is absent from `json` (meaning the
 /// setting is at its default). `default_value` is `None` when no default is
 /// known for that setting.
-///
-/// # Panics
-///
-/// Cannot panic in practice: `SettingCategory` derives `Serialize` and always
-/// serializes to a `snake_case` JSON string, so both `expect` calls on the
-/// serialization result are unreachable.
 #[must_use]
 pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
     registry()
@@ -602,20 +606,24 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
         .map(|def| {
             let current_value = get_nested(json, def.key).cloned();
 
-            let category_str = serde_json::to_value(def.category)
-                .expect("SettingCategory serialization is infallible")
-                .as_str()
-                .expect("SettingCategory serializes to a JSON string")
-                .to_owned();
+            let value_type = match &def.value_type {
+                SettingType::Bool => SettingValueInfo::Bool,
+                SettingType::String => SettingValueInfo::String,
+                SettingType::Number => SettingValueInfo::Number,
+                SettingType::Char => SettingValueInfo::Char,
+                SettingType::StringArray => SettingValueInfo::StringArray,
+                SettingType::Enum(opts) => SettingValueInfo::Enum {
+                    options: opts.iter().map(|&s| s.to_owned()).collect(),
+                },
+            };
 
             SettingEntry {
                 key: def.key.to_owned(),
                 label: def.label.to_owned(),
                 description: def.description.to_owned(),
-                category: category_str,
+                category: def.category,
                 category_label: def.category.label().to_owned(),
-                value_type: def.value_type.type_name().to_owned(),
-                enum_options: def.value_type.enum_options(),
+                value_type,
                 default_value: def.default,
                 current_value,
             }
@@ -631,24 +639,17 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
 const SETTINGS_FILE: &str = "settings/cli.json";
 
 /// Errors from loading the Kiro CLI settings file.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LoadSettingsError {
     /// The file does not exist — use empty defaults.
+    #[error("settings file not found")]
     NotFound,
     /// An I/O error occurred reading the file.
-    Io(std::io::Error),
+    #[error("failed to read settings file: {0}")]
+    Io(#[from] std::io::Error),
     /// The file exists but contains invalid JSON.
-    InvalidJson(serde_json::Error),
-}
-
-impl std::fmt::Display for LoadSettingsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound => write!(f, "settings file not found"),
-            Self::Io(e) => write!(f, "failed to read settings file: {e}"),
-            Self::InvalidJson(e) => write!(f, "settings file contains invalid JSON: {e}"),
-        }
-    }
+    #[error("settings file contains invalid JSON: {0}")]
+    InvalidJson(#[from] serde_json::Error),
 }
 
 /// Load `settings/cli.json` from the given Kiro home directory.
@@ -1016,10 +1017,10 @@ mod tests {
             "expected 'Telemetry & Privacy' category label to appear in resolved entries"
         );
 
-        let mut labels_by_category: HashMap<String, String> = HashMap::new();
+        let mut labels_by_category: HashMap<SettingCategory, String> = HashMap::new();
         for entry in &entries {
             labels_by_category
-                .entry(entry.category.clone())
+                .entry(entry.category)
                 .or_insert_with(|| entry.category_label.clone());
         }
         for label in labels_by_category.values() {

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -1,7 +1,11 @@
-//! Kiro CLI settings registry types and definitions.
+//! Kiro CLI settings registry, JSON path helpers, and file I/O.
+
+use std::io;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use tracing::{debug, warn};
 
 // ---------------------------------------------------------------------------
 // Setting category
@@ -607,12 +611,87 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
 }
 
 // ---------------------------------------------------------------------------
+// Kiro settings file I/O
+// ---------------------------------------------------------------------------
+
+/// Path to the CLI settings file relative to the Kiro home directory.
+const SETTINGS_FILE: &str = "settings/cli.json";
+
+/// Load `settings/cli.json` from the given Kiro home directory.
+///
+/// Returns an empty JSON object (`{}`) if the file does not exist or if its
+/// contents cannot be parsed as JSON.
+#[must_use]
+pub fn load_kiro_settings_from(kiro_dir: &Path) -> JsonValue {
+    let path = kiro_dir.join(SETTINGS_FILE);
+    debug!(path = %path.display(), "loading Kiro settings");
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => match serde_json::from_str::<JsonValue>(&contents) {
+            Ok(json) => json,
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "settings file contains invalid JSON, using empty config"
+                );
+                serde_json::json!({})
+            }
+        },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            debug!(path = %path.display(), "settings file not found, using empty config");
+            serde_json::json!({})
+        }
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "could not read settings file, using empty config"
+            );
+            serde_json::json!({})
+        }
+    }
+}
+
+/// Save a JSON value to `settings/cli.json` inside the given Kiro home directory.
+///
+/// Creates the `settings/` subdirectory if it does not already exist.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if directory creation or file write fails.
+pub fn save_kiro_settings_to(kiro_dir: &Path, json: &JsonValue) -> io::Result<()> {
+    let path = kiro_dir.join(SETTINGS_FILE);
+    debug!(path = %path.display(), "saving Kiro settings");
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let contents = serde_json::to_string_pretty(json)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    std::fs::write(&path, contents)?;
+    Ok(())
+}
+
+/// Resolve the default Kiro home directory (`~/.kiro`).
+///
+/// Returns `None` if the home directory cannot be determined.
+#[must_use]
+pub fn default_kiro_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".kiro"))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -853,5 +932,77 @@ mod tests {
         for label in labels_by_category.values() {
             assert!(!label.is_empty(), "category_label must not be empty");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 3 — Kiro settings file I/O
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn load_kiro_settings_returns_empty_when_no_file() {
+        let dir = TempDir::new().unwrap();
+        let result = load_kiro_settings_from(dir.path());
+        assert_eq!(result, serde_json::json!({}));
+    }
+
+    #[test]
+    fn save_and_load_kiro_settings_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let settings = serde_json::json!({
+            "chat": {
+                "defaultModel": "claude-opus-4",
+                "temperature": 0.5
+            }
+        });
+
+        save_kiro_settings_to(dir.path(), &settings).expect("save should succeed");
+
+        let loaded = load_kiro_settings_from(dir.path());
+        assert_eq!(loaded, settings);
+    }
+
+    #[test]
+    fn save_kiro_settings_creates_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        // The settings subdirectory does not exist yet.
+        let nested = dir.path().join("does_not_exist_yet");
+        let settings = serde_json::json!({"key": "value"});
+
+        save_kiro_settings_to(&nested, &settings).expect("save should create parent dirs");
+
+        let loaded = load_kiro_settings_from(&nested);
+        assert_eq!(loaded, settings);
+    }
+
+    #[test]
+    fn load_kiro_settings_returns_empty_on_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let settings_dir = dir.path().join("settings");
+        std::fs::create_dir_all(&settings_dir).unwrap();
+        std::fs::write(settings_dir.join("cli.json"), b"{ this is not valid json }").unwrap();
+
+        let result = load_kiro_settings_from(dir.path());
+        assert_eq!(result, serde_json::json!({}));
+    }
+
+    #[test]
+    fn save_kiro_settings_preserves_unknown_keys() {
+        let dir = TempDir::new().unwrap();
+        let settings = serde_json::json!({
+            "chat": {"defaultModel": "claude-sonnet-4-5"},
+            "unknownFutureKey": {"nestedValue": true}
+        });
+
+        save_kiro_settings_to(dir.path(), &settings).unwrap();
+        let loaded = load_kiro_settings_from(dir.path());
+
+        assert_eq!(
+            loaded["unknownFutureKey"]["nestedValue"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            loaded["chat"]["defaultModel"],
+            serde_json::json!("claude-sonnet-4-5")
+        );
     }
 }

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -56,7 +56,6 @@ pub enum SettingType {
 
 impl SettingType {
     /// Returns the wire-format type name used in [`SettingEntry::value_type`].
-    #[allow(dead_code)]
     fn type_name(&self) -> &'static str {
         match self {
             Self::Bool => "bool",
@@ -69,7 +68,6 @@ impl SettingType {
     }
 
     /// Returns enum options if this is an `Enum` variant, otherwise `None`.
-    #[allow(dead_code)]
     fn enum_options(&self) -> Option<Vec<String>> {
         match self {
             Self::Enum(opts) => Some(opts.iter().map(|s| (*s).to_owned()).collect()),
@@ -489,12 +487,132 @@ pub fn registry() -> Vec<SettingDef> {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — Task 1
+// JSON path helpers
+// ---------------------------------------------------------------------------
+
+/// Traverse a nested JSON object following a dotted key path.
+///
+/// Returns `None` if any segment of the path is absent or if an intermediate
+/// value is not an object.
+///
+/// # Examples
+/// ```
+/// # use serde_json::json;
+/// # use kiro_market_core::kiro_settings::get_nested;
+/// let v = json!({"chat": {"defaultModel": "claude-sonnet-4-5"}});
+/// assert_eq!(get_nested(&v, "chat.defaultModel"), Some(&json!("claude-sonnet-4-5")));
+/// assert_eq!(get_nested(&v, "chat.missing"), None);
+/// ```
+#[must_use]
+pub fn get_nested<'a>(value: &'a JsonValue, path: &str) -> Option<&'a JsonValue> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.as_object()?.get(segment)?;
+    }
+    Some(current)
+}
+
+/// Write a value at a dotted key path, creating intermediate objects as needed.
+///
+/// If any intermediate node already exists but is not an object it is replaced
+/// with an empty object before descending.
+///
+/// # Panics
+///
+/// Panics if `path` is an empty string (i.e. contains no `.`-separated segments).
+pub fn set_nested(value: &mut JsonValue, path: &str, val: JsonValue) {
+    let segments: Vec<&str> = path.split('.').collect();
+    let (last, parents) = segments.split_last().expect("path must not be empty");
+
+    let mut current = value;
+    for &segment in parents {
+        if !current.is_object() {
+            *current = serde_json::json!({});
+        }
+        let obj = current.as_object_mut().expect("ensured above");
+        if !obj.contains_key(segment) {
+            obj.insert(segment.to_owned(), serde_json::json!({}));
+        }
+        current = obj.get_mut(segment).expect("just inserted");
+    }
+
+    if !current.is_object() {
+        *current = serde_json::json!({});
+    }
+    current
+        .as_object_mut()
+        .expect("ensured above")
+        .insert((*last).to_owned(), val);
+}
+
+/// Remove the value at a dotted key path, cleaning up empty parent objects.
+///
+/// If the path does not exist this is a no-op.
+pub fn remove_nested(value: &mut JsonValue, path: &str) {
+    let segments: Vec<&str> = path.split('.').collect();
+    remove_nested_impl(value, &segments);
+}
+
+/// Recursive implementation for [`remove_nested`].
+///
+/// Returns `true` if the caller should remove the current object from its
+/// parent (i.e., the object became empty after the removal).
+fn remove_nested_impl(value: &mut JsonValue, segments: &[&str]) -> bool {
+    let Some((&first, rest)) = segments.split_first() else {
+        return false;
+    };
+
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+
+    if rest.is_empty() {
+        obj.remove(first);
+    } else if let Some(child) = obj.get_mut(first) {
+        let should_remove = remove_nested_impl(child, rest);
+        if should_remove {
+            obj.remove(first);
+        }
+    }
+
+    obj.is_empty()
+}
+
+/// Resolve all registry settings against a loaded JSON config, returning a
+/// [`SettingEntry`] for each definition.
+///
+/// Settings absent from `json` fall back to their `default` values.
+#[must_use]
+pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
+    registry()
+        .into_iter()
+        .map(|def| {
+            let current_value = get_nested(json, def.key)
+                .cloned()
+                .unwrap_or_else(|| def.default.clone());
+
+            SettingEntry {
+                key: def.key.to_owned(),
+                label: def.label.to_owned(),
+                description: def.description.to_owned(),
+                category: def.category,
+                category_label: def.category.label().to_owned(),
+                value_type: def.value_type.type_name().to_owned(),
+                enum_options: def.value_type.enum_options(),
+                default_value: def.default,
+                current_value,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use super::*;
 
@@ -605,6 +723,135 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 2 — JSON path helpers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_nested_finds_top_level_key() {
+        let v = serde_json::json!({"foo": 42});
+        assert_eq!(get_nested(&v, "foo"), Some(&serde_json::json!(42)));
+    }
+
+    #[test]
+    fn get_nested_finds_dotted_path() {
+        let v = serde_json::json!({"chat": {"defaultModel": "claude-sonnet-4-5"}});
+        assert_eq!(
+            get_nested(&v, "chat.defaultModel"),
+            Some(&serde_json::json!("claude-sonnet-4-5"))
+        );
+    }
+
+    #[test]
+    fn get_nested_returns_none_for_missing() {
+        let v = serde_json::json!({"chat": {}});
+        assert_eq!(get_nested(&v, "chat.defaultModel"), None);
+        assert_eq!(get_nested(&v, "nonexistent"), None);
+    }
+
+    #[test]
+    fn set_nested_creates_intermediate_objects() {
+        let mut v = serde_json::json!({});
+        set_nested(
+            &mut v,
+            "chat.defaultModel",
+            serde_json::json!("claude-opus-4"),
+        );
+        assert_eq!(
+            get_nested(&v, "chat.defaultModel"),
+            Some(&serde_json::json!("claude-opus-4"))
+        );
+    }
+
+    #[test]
+    fn set_nested_overwrites_existing() {
+        let mut v = serde_json::json!({"chat": {"defaultModel": "old"}});
+        set_nested(&mut v, "chat.defaultModel", serde_json::json!("new"));
+        assert_eq!(
+            get_nested(&v, "chat.defaultModel"),
+            Some(&serde_json::json!("new"))
+        );
+    }
+
+    #[test]
+    fn remove_nested_deletes_key() {
+        let mut v =
+            serde_json::json!({"chat": {"defaultModel": "claude-sonnet-4-5", "temperature": 0.7}});
+        remove_nested(&mut v, "chat.defaultModel");
+        assert_eq!(get_nested(&v, "chat.defaultModel"), None);
+        // sibling should still exist
+        assert_eq!(
+            get_nested(&v, "chat.temperature"),
+            Some(&serde_json::json!(0.7))
+        );
+    }
+
+    #[test]
+    fn remove_nested_cleans_empty_parents() {
+        let mut v = serde_json::json!({"chat": {"defaultModel": "claude-sonnet-4-5"}});
+        remove_nested(&mut v, "chat.defaultModel");
+        // chat object should have been pruned since it became empty
+        assert_eq!(get_nested(&v, "chat"), None);
+    }
+
+    #[test]
+    fn remove_nested_noop_for_missing() {
+        let mut v = serde_json::json!({"chat": {}});
+        // should not panic
+        remove_nested(&mut v, "chat.doesNotExist");
+        remove_nested(&mut v, "completely.missing.path");
+    }
+
+    #[test]
+    fn resolve_settings_uses_defaults_when_no_file() {
+        let empty = serde_json::json!({});
+        let entries = resolve_settings(&empty);
+
+        assert!(!entries.is_empty());
+
+        for entry in &entries {
+            assert_eq!(
+                entry.current_value, entry.default_value,
+                "key '{}' should use default when config is empty",
+                entry.key
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_settings_picks_up_user_values() {
+        let config = serde_json::json!({
+            "chat": {
+                "defaultModel": "claude-opus-4"
+            }
+        });
+        let entries = resolve_settings(&config);
+
+        let model_entry = entries
+            .iter()
+            .find(|e| e.key == "chat.defaultModel")
+            .expect("chat.defaultModel must be in registry");
+
+        assert_eq!(
+            model_entry.current_value,
+            serde_json::json!("claude-opus-4")
+        );
+    }
+
+    #[test]
+    fn resolve_settings_includes_category_label() {
+        let entries = resolve_settings(&serde_json::json!({}));
+        let mut labels_by_category: HashMap<String, String> = HashMap::new();
+        for entry in &entries {
+            labels_by_category
+                .entry(format!("{:?}", entry.category))
+                .or_insert_with(|| entry.category_label.clone());
+        }
+        for label in labels_by_category.values() {
+            assert!(!label.is_empty(), "category_label must not be empty");
         }
     }
 }

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -31,14 +31,14 @@ impl SettingCategory {
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
-            Self::Telemetry => "Telemetry",
-            Self::Chat => "Chat",
-            Self::Knowledge => "Knowledge",
+            Self::Telemetry => "Telemetry & Privacy",
+            Self::Chat => "Chat Interface",
+            Self::Knowledge => "Knowledge Base",
             Self::KeyBindings => "Key Bindings",
-            Self::Features => "Features",
-            Self::Api => "API",
+            Self::Features => "Feature Toggles",
+            Self::Api => "API & Service",
             Self::Mcp => "MCP",
-            Self::Environment => "Environment",
+            Self::Environment => "Environment Variables",
         }
     }
 }
@@ -71,11 +71,11 @@ impl SettingType {
         }
     }
 
-    /// Returns enum options if this is an `Enum` variant, otherwise `None`.
-    fn enum_options(&self) -> Option<Vec<String>> {
+    /// Returns enum options if this is an `Enum` variant, otherwise an empty vec.
+    fn enum_options(&self) -> Vec<std::string::String> {
         match self {
-            Self::Enum(opts) => Some(opts.iter().map(|s| (*s).to_owned()).collect()),
-            _ => None,
+            Self::Enum(opts) => opts.iter().map(|s| (*s).to_owned()).collect(),
+            _ => vec![],
         }
     }
 }
@@ -96,8 +96,8 @@ pub struct SettingDef {
     pub category: SettingCategory,
     /// What kind of value this setting holds.
     pub value_type: SettingType,
-    /// Default value as a JSON value.
-    pub default: JsonValue,
+    /// Default value as a JSON value. `None` when the default is unknown.
+    pub default: Option<JsonValue>,
 }
 
 // ---------------------------------------------------------------------------
@@ -109,23 +109,23 @@ pub struct SettingDef {
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct SettingEntry {
     /// Dotted JSON key path.
-    pub key: String,
+    pub key: std::string::String,
     /// Short human-readable label.
-    pub label: String,
+    pub label: std::string::String,
     /// Longer description.
-    pub description: String,
-    /// Machine-readable category identifier.
-    pub category: SettingCategory,
+    pub description: std::string::String,
+    /// Machine-readable category identifier (serialized `snake_case` string).
+    pub category: std::string::String,
     /// Human-readable category label.
-    pub category_label: String,
+    pub category_label: std::string::String,
     /// Wire-format type name (`"bool"`, `"string"`, `"enum"`, …).
-    pub value_type: String,
-    /// For `Enum` settings: the allowed values.  `None` for all other types.
-    pub enum_options: Option<Vec<String>>,
-    /// Default value as a JSON value.
-    pub default_value: JsonValue,
-    /// Current value as stored in the user's settings file.
-    pub current_value: JsonValue,
+    pub value_type: std::string::String,
+    /// For `Enum` settings: the allowed values. Empty vec for all other types.
+    pub enum_options: Vec<std::string::String>,
+    /// Default value as a JSON value. `None` when no default is known.
+    pub default_value: Option<JsonValue>,
+    /// Current value from the user's settings file. `None` means key absent (using default).
+    pub current_value: Option<JsonValue>,
 }
 
 // ---------------------------------------------------------------------------
@@ -141,351 +141,332 @@ pub struct SettingEntry {
 pub fn registry() -> Vec<SettingDef> {
     vec![
         // ----------------------------------------------------------------
-        // Telemetry
+        // Telemetry & Privacy
         // ----------------------------------------------------------------
         SettingDef {
             key: "telemetry.enabled",
             label: "Enable Telemetry",
-            description: "Send anonymous usage data to help improve Kiro.",
+            description: "Enable or disable telemetry collection",
             category: SettingCategory::Telemetry,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: Some(JsonValue::Bool(true)),
         },
         SettingDef {
-            key: "telemetry.shareCodeSnippets",
-            label: "Share Code Snippets",
-            description: "Allow telemetry to include short code snippets for context.",
+            key: "telemetryClientId",
+            label: "Telemetry Client ID",
+            description: "Client identifier for telemetry",
             category: SettingCategory::Telemetry,
-            value_type: SettingType::Bool,
-            default: JsonValue::Bool(false),
+            value_type: SettingType::String,
+            default: None,
         },
         // ----------------------------------------------------------------
-        // Chat
+        // Chat Interface
         // ----------------------------------------------------------------
         SettingDef {
             key: "chat.defaultModel",
             label: "Default Model",
-            description: "The AI model used by default for chat sessions.",
+            description: "Default AI model for conversations",
             category: SettingCategory::Chat,
-            value_type: SettingType::Enum(vec![
-                "claude-opus-4-5",
-                "claude-sonnet-4-5",
-                "claude-haiku-4-5",
-                "claude-opus-4",
-                "claude-sonnet-4",
-                "claude-haiku-3",
-            ]),
-            default: JsonValue::String("claude-sonnet-4-5".to_owned()),
+            value_type: SettingType::String,
+            default: None,
         },
         SettingDef {
-            key: "chat.temperature",
-            label: "Temperature",
-            description: "Sampling temperature for model responses (0.0\u{2013}1.0).",
+            key: "chat.defaultAgent",
+            label: "Default Agent",
+            description: "Default agent configuration",
             category: SettingCategory::Chat,
-            value_type: SettingType::Number,
-            default: serde_json::json!(0.7),
+            value_type: SettingType::String,
+            default: None,
         },
         SettingDef {
-            key: "chat.maxTokens",
-            label: "Max Tokens",
-            description: "Maximum number of tokens the model may generate per response.",
+            key: "chat.diffTool",
+            label: "Diff Tool",
+            description: "External diff tool for viewing code changes",
             category: SettingCategory::Chat,
-            value_type: SettingType::Number,
-            default: serde_json::json!(8096),
+            value_type: SettingType::String,
+            default: None,
         },
         SettingDef {
-            key: "chat.streamResponses",
-            label: "Stream Responses",
-            description: "Stream model output token-by-token as it is generated.",
+            key: "chat.greeting.enabled",
+            label: "Show Greeting",
+            description: "Show greeting message on chat start",
             category: SettingCategory::Chat,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: Some(JsonValue::Bool(true)),
         },
         SettingDef {
-            key: "chat.autoSave",
-            label: "Auto-Save Conversations",
-            description: "Automatically persist chat sessions to disk.",
+            key: "chat.editMode",
+            label: "Edit Mode",
+            description: "Enable edit mode for chat interface",
             category: SettingCategory::Chat,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "chat.contextWindow",
-            label: "Context Window",
-            description: "Number of previous messages included in each request.",
+            key: "chat.enableNotifications",
+            label: "Enable Notifications",
+            description: "Enable desktop notifications",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.disableMarkdownRendering",
+            label: "Disable Markdown Rendering",
+            description: "Disable markdown formatting in chat",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
+        },
+        SettingDef {
+            key: "chat.disableAutoCompaction",
+            label: "Disable Auto Compaction",
+            description: "Disable automatic conversation summarization",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
+        },
+        SettingDef {
+            key: "chat.enablePromptHints",
+            label: "Enable Prompt Hints",
+            description: "Show startup hints with tips and shortcuts",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(true)),
+        },
+        SettingDef {
+            key: "chat.enableHistoryHints",
+            label: "Enable History Hints",
+            description: "Show conversation history hints",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.uiMode",
+            label: "UI Mode",
+            description: "UI variant to use",
+            category: SettingCategory::Chat,
+            value_type: SettingType::String,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableContextUsageIndicator",
+            label: "Enable Context Usage Indicator",
+            description: "Show context usage percentage in prompt",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "compaction.excludeMessages",
+            label: "Compaction Exclude Messages",
+            description: "Minimum message pairs to retain during compaction",
             category: SettingCategory::Chat,
             value_type: SettingType::Number,
-            default: serde_json::json!(20),
+            default: None,
+        },
+        SettingDef {
+            key: "compaction.excludeContextWindowPercent",
+            label: "Compaction Exclude Context Window Percent",
+            description: "Minimum percentage of context window to retain during compaction",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: None,
         },
         // ----------------------------------------------------------------
-        // Knowledge
+        // Knowledge Base
         // ----------------------------------------------------------------
         SettingDef {
-            key: "knowledge.indexOnStartup",
-            label: "Index on Startup",
-            description: "Re-index the project knowledge base when Kiro starts.",
+            key: "chat.enableKnowledge",
+            label: "Enable Knowledge",
+            description: "Enable knowledge base functionality",
             category: SettingCategory::Knowledge,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "knowledge.excludePatterns",
-            label: "Exclude Patterns",
-            description: "Glob patterns for files and directories excluded from indexing.",
+            key: "knowledge.defaultIncludePatterns",
+            label: "Default Include Patterns",
+            description: "Default file patterns to include in knowledge indexing",
             category: SettingCategory::Knowledge,
             value_type: SettingType::StringArray,
-            default: serde_json::json!(["node_modules", ".git", "target", "dist"]),
+            default: None,
         },
         SettingDef {
-            key: "knowledge.maxFileSize",
-            label: "Max File Size (KB)",
-            description: "Files larger than this limit (in kilobytes) are skipped during indexing.",
+            key: "knowledge.defaultExcludePatterns",
+            label: "Default Exclude Patterns",
+            description: "Default file patterns to exclude from knowledge indexing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::StringArray,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.maxFiles",
+            label: "Max Files",
+            description: "Maximum number of files for knowledge indexing",
             category: SettingCategory::Knowledge,
             value_type: SettingType::Number,
-            default: serde_json::json!(512),
+            default: None,
         },
         SettingDef {
             key: "knowledge.chunkSize",
             label: "Chunk Size",
-            description: "Token chunk size used when splitting documents for embedding.",
+            description: "Text chunk size for knowledge processing",
             category: SettingCategory::Knowledge,
             value_type: SettingType::Number,
-            default: serde_json::json!(1000),
+            default: None,
         },
         SettingDef {
-            key: "knowledge.embeddingModel",
-            label: "Embedding Model",
-            description: "Model used to generate document embeddings for semantic search.",
+            key: "knowledge.chunkOverlap",
+            label: "Chunk Overlap",
+            description: "Overlap between text chunks in knowledge processing",
             category: SettingCategory::Knowledge,
-            value_type: SettingType::Enum(vec![
-                "amazon.titan-embed-text-v2:0",
-                "cohere.embed-english-v3",
-                "cohere.embed-multilingual-v3",
-            ]),
-            default: JsonValue::String("amazon.titan-embed-text-v2:0".to_owned()),
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.indexType",
+            label: "Index Type",
+            description: "Type of knowledge index to use",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::String,
+            default: None,
         },
         // ----------------------------------------------------------------
         // Key Bindings
         // ----------------------------------------------------------------
         SettingDef {
-            key: "keyBindings.submitChat",
-            label: "Submit Chat",
-            description: "Key combination to submit the current chat message.",
+            key: "chat.skimCommandKey",
+            label: "Skim Command Key",
+            description: "Key for fuzzy search command",
             category: SettingCategory::KeyBindings,
-            value_type: SettingType::String,
-            default: JsonValue::String("Enter".to_owned()),
+            value_type: SettingType::Char,
+            default: None,
         },
         SettingDef {
-            key: "keyBindings.newLine",
-            label: "New Line",
-            description: "Key combination to insert a newline without submitting.",
+            key: "chat.autocompletionKey",
+            label: "Autocompletion Key",
+            description: "Key for autocompletion hint acceptance",
             category: SettingCategory::KeyBindings,
-            value_type: SettingType::String,
-            default: JsonValue::String("Shift+Enter".to_owned()),
+            value_type: SettingType::Char,
+            default: None,
         },
         SettingDef {
-            key: "keyBindings.clearChat",
-            label: "Clear Chat",
-            description: "Key combination to clear the current chat session.",
+            key: "chat.tangentModeKey",
+            label: "Tangent Mode Key",
+            description: "Key for tangent mode toggle",
             category: SettingCategory::KeyBindings,
-            value_type: SettingType::String,
-            default: JsonValue::String("Ctrl+L".to_owned()),
+            value_type: SettingType::Char,
+            default: None,
         },
         SettingDef {
-            key: "keyBindings.focusChat",
-            label: "Focus Chat Input",
-            description: "Key combination to move focus to the chat input box.",
+            key: "chat.delegateModeKey",
+            label: "Delegate Mode Key",
+            description: "Key for delegate command",
             category: SettingCategory::KeyBindings,
-            value_type: SettingType::String,
-            default: JsonValue::String("Ctrl+I".to_owned()),
-        },
-        SettingDef {
-            key: "keyBindings.toggleSidebar",
-            label: "Toggle Sidebar",
-            description: "Key combination to show or hide the sidebar.",
-            category: SettingCategory::KeyBindings,
-            value_type: SettingType::String,
-            default: JsonValue::String("Ctrl+B".to_owned()),
+            value_type: SettingType::Char,
+            default: None,
         },
         // ----------------------------------------------------------------
-        // Features
+        // Feature Toggles
         // ----------------------------------------------------------------
         SettingDef {
-            key: "features.agentMode",
-            label: "Agent Mode",
-            description: "Enable autonomous agent mode for multi-step task execution.",
+            key: "chat.enableThinking",
+            label: "Enable Thinking",
+            description: "Enable thinking tool for complex reasoning",
             category: SettingCategory::Features,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "features.codeActions",
-            label: "Code Actions",
-            description: "Show inline AI-powered code actions inside the editor.",
+            key: "chat.enableTangentMode",
+            label: "Enable Tangent Mode",
+            description: "Enable tangent mode feature",
             category: SettingCategory::Features,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "features.inlineCompletions",
-            label: "Inline Completions",
-            description: "Provide ghost-text completions as you type.",
+            key: "introspect.tangentMode",
+            label: "Introspect Tangent Mode",
+            description: "Auto-enter tangent mode for introspect",
             category: SettingCategory::Features,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "features.diagnosticsIntegration",
-            label: "Diagnostics Integration",
-            description: "Surface compiler/linter diagnostics inside the AI chat.",
+            key: "chat.enableTodoList",
+            label: "Enable Todo List",
+            description: "Enable todo list feature",
             category: SettingCategory::Features,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
+            default: None,
         },
         SettingDef {
-            key: "features.experimentalTools",
-            label: "Experimental Tools",
-            description: "Enable tools that are still in beta and may change.",
+            key: "chat.enableCheckpoint",
+            label: "Enable Checkpoint",
+            description: "Enable checkpoint feature",
             category: SettingCategory::Features,
             value_type: SettingType::Bool,
-            default: JsonValue::Bool(false),
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableDelegate",
+            label: "Enable Delegate",
+            description: "Enable delegate tool",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
         },
         // ----------------------------------------------------------------
-        // API
+        // API & Service
         // ----------------------------------------------------------------
-        SettingDef {
-            key: "api.provider",
-            label: "API Provider",
-            description: "Which API backend Kiro uses to call the AI model.",
-            category: SettingCategory::Api,
-            value_type: SettingType::Enum(vec!["anthropic", "bedrock", "vertex"]),
-            default: JsonValue::String("anthropic".to_owned()),
-        },
-        SettingDef {
-            key: "api.region",
-            label: "AWS Region",
-            description: "AWS region for Bedrock or Vertex API calls.",
-            category: SettingCategory::Api,
-            value_type: SettingType::String,
-            default: JsonValue::String("us-east-1".to_owned()),
-        },
         SettingDef {
             key: "api.timeout",
-            label: "Request Timeout (s)",
-            description: "Number of seconds before an API request times out.",
+            label: "API Timeout",
+            description: "API request timeout in seconds",
             category: SettingCategory::Api,
             value_type: SettingType::Number,
-            default: serde_json::json!(60),
-        },
-        SettingDef {
-            key: "api.retries",
-            label: "Max Retries",
-            description: "How many times to retry a failed API request.",
-            category: SettingCategory::Api,
-            value_type: SettingType::Number,
-            default: serde_json::json!(3),
-        },
-        SettingDef {
-            key: "api.proxyUrl",
-            label: "Proxy URL",
-            description: "HTTP/HTTPS proxy URL for outbound API requests.",
-            category: SettingCategory::Api,
-            value_type: SettingType::String,
-            default: JsonValue::String(String::new()),
+            default: None,
         },
         // ----------------------------------------------------------------
         // MCP
         // ----------------------------------------------------------------
         SettingDef {
-            key: "mcp.enabled",
-            label: "Enable MCP",
-            description: "Enable the Model Context Protocol server integration.",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
-        },
-        SettingDef {
-            key: "mcp.autoStart",
-            label: "Auto-Start Servers",
-            description: "Automatically start configured MCP servers when Kiro launches.",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Bool,
-            default: JsonValue::Bool(true),
-        },
-        SettingDef {
-            key: "mcp.serverTimeout",
-            label: "Server Timeout (s)",
-            description: "Seconds to wait for an MCP server to become ready.",
+            key: "mcp.initTimeout",
+            label: "MCP Init Timeout",
+            description: "MCP server initialization timeout in milliseconds",
             category: SettingCategory::Mcp,
             value_type: SettingType::Number,
-            default: serde_json::json!(30),
+            default: None,
         },
         SettingDef {
-            key: "mcp.allowedHosts",
-            label: "Allowed Hosts",
-            description: "Hostnames or IP addresses that MCP servers may connect to.",
+            key: "mcp.noInteractiveTimeout",
+            label: "MCP Non-Interactive Timeout",
+            description: "Non-interactive MCP timeout in milliseconds",
             category: SettingCategory::Mcp,
-            value_type: SettingType::StringArray,
-            default: serde_json::json!([]),
-        },
-        SettingDef {
-            key: "mcp.logLevel",
-            label: "Log Level",
-            description: "Verbosity of MCP server logs.",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Enum(vec!["error", "warn", "info", "debug", "trace"]),
-            default: JsonValue::String("info".to_owned()),
-        },
-        // ----------------------------------------------------------------
-        // Environment
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "environment.shell",
-            label: "Shell",
-            description: "Shell executable used when running terminal commands.",
-            category: SettingCategory::Environment,
-            value_type: SettingType::String,
-            default: JsonValue::String(String::new()),
-        },
-        SettingDef {
-            key: "environment.workingDirectory",
-            label: "Working Directory",
-            description: "Default working directory for new chat sessions.",
-            category: SettingCategory::Environment,
-            value_type: SettingType::String,
-            default: JsonValue::String(String::new()),
-        },
-        SettingDef {
-            key: "environment.extraEnvVars",
-            label: "Extra Environment Variables",
-            description: "Additional environment variables injected into agent sub-processes.",
-            category: SettingCategory::Environment,
-            value_type: SettingType::StringArray,
-            default: serde_json::json!([]),
-        },
-        SettingDef {
-            key: "environment.theme",
-            label: "Theme",
-            description: "Color theme for the Kiro UI.",
-            category: SettingCategory::Environment,
-            value_type: SettingType::Enum(vec!["system", "light", "dark"]),
-            default: JsonValue::String("system".to_owned()),
-        },
-        SettingDef {
-            key: "environment.locale",
-            label: "Locale",
-            description: "BCP 47 locale tag used for formatting dates and numbers.",
-            category: SettingCategory::Environment,
-            value_type: SettingType::String,
-            default: JsonValue::String("en-US".to_owned()),
-        },
-        SettingDef {
-            key: "environment.fontSize",
-            label: "Font Size",
-            description: "Base font size (in pixels) for the Kiro UI.",
-            category: SettingCategory::Environment,
             value_type: SettingType::Number,
-            default: serde_json::json!(14),
+            default: None,
+        },
+        SettingDef {
+            key: "mcp.loadedBefore",
+            label: "MCP Loaded Before",
+            description: "Track previously loaded MCP servers",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        // ----------------------------------------------------------------
+        // Environment Variables
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "KIRO_LOG_NO_COLOR",
+            label: "Disable Log Color",
+            description: "Set to disable colored log output",
+            category: SettingCategory::Environment,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
         },
     ]
 }
@@ -585,21 +566,26 @@ fn remove_nested_impl(value: &mut JsonValue, segments: &[&str]) -> bool {
 /// Resolve all registry settings against a loaded JSON config, returning a
 /// [`SettingEntry`] for each definition.
 ///
-/// Settings absent from `json` fall back to their `default` values.
+/// `current_value` is `None` when the key is absent from `json` (meaning the
+/// setting is at its default). `default_value` is `None` when no default is
+/// known for that setting.
 #[must_use]
 pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
     registry()
         .into_iter()
         .map(|def| {
-            let current_value = get_nested(json, def.key)
-                .cloned()
-                .unwrap_or_else(|| def.default.clone());
+            let current_value = get_nested(json, def.key).cloned();
+
+            let category_str = serde_json::to_value(def.category)
+                .ok()
+                .and_then(|v| v.as_str().map(std::borrow::ToOwned::to_owned))
+                .unwrap_or_default();
 
             SettingEntry {
                 key: def.key.to_owned(),
                 label: def.label.to_owned(),
                 description: def.description.to_owned(),
-                category: def.category,
+                category: category_str,
                 category_label: def.category.label().to_owned(),
                 value_type: def.value_type.type_name().to_owned(),
                 enum_options: def.value_type.enum_options(),
@@ -753,44 +739,49 @@ mod tests {
     #[test]
     fn registry_defaults_match_value_type() {
         for def in registry() {
+            // Settings with no known default skip type validation.
+            let Some(ref default) = def.default else {
+                continue;
+            };
+
             match &def.value_type {
                 SettingType::Bool => {
                     assert!(
-                        def.default.is_boolean(),
+                        default.is_boolean(),
                         "key '{}' is Bool but default is not boolean: {}",
                         def.key,
-                        def.default
+                        default
                     );
                 }
                 SettingType::Number => {
                     assert!(
-                        def.default.is_number(),
+                        default.is_number(),
                         "key '{}' is Number but default is not a number: {}",
                         def.key,
-                        def.default
+                        default
                     );
                 }
                 SettingType::String | SettingType::Char => {
                     assert!(
-                        def.default.is_string(),
+                        default.is_string(),
                         "key '{}' is String/Char but default is not a string: {}",
                         def.key,
-                        def.default
+                        default
                     );
                 }
                 SettingType::StringArray => {
                     assert!(
-                        def.default.is_array(),
+                        default.is_array(),
                         "key '{}' is StringArray but default is not an array: {}",
                         def.key,
-                        def.default
+                        default
                     );
                 }
                 SettingType::Enum(opts) => {
-                    let default_str = def.default.as_str().unwrap_or_else(|| {
+                    let default_str = default.as_str().unwrap_or_else(|| {
                         panic!(
                             "key '{}' is Enum but default is not a string: {}",
-                            def.key, def.default
+                            def.key, default
                         )
                     });
                     assert!(
@@ -892,9 +883,9 @@ mod tests {
         assert!(!entries.is_empty());
 
         for entry in &entries {
-            assert_eq!(
-                entry.current_value, entry.default_value,
-                "key '{}' should use default when config is empty",
+            assert!(
+                entry.current_value.is_none(),
+                "key '{}' current_value should be None when config is empty",
                 entry.key
             );
         }
@@ -916,17 +907,27 @@ mod tests {
 
         assert_eq!(
             model_entry.current_value,
-            serde_json::json!("claude-opus-4")
+            Some(serde_json::json!("claude-opus-4"))
         );
     }
 
     #[test]
     fn resolve_settings_includes_category_label() {
         let entries = resolve_settings(&serde_json::json!({}));
+
+        let has_telemetry_privacy = entries
+            .iter()
+            .any(|e| e.category_label == "Telemetry & Privacy");
+
+        assert!(
+            has_telemetry_privacy,
+            "expected 'Telemetry & Privacy' category label to appear in resolved entries"
+        );
+
         let mut labels_by_category: HashMap<String, String> = HashMap::new();
         for entry in &entries {
             labels_by_category
-                .entry(format!("{:?}", entry.category))
+                .entry(entry.category.clone())
                 .or_insert_with(|| entry.category_label.clone());
         }
         for label in labels_by_category.values() {

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -60,7 +60,8 @@ pub enum SettingType {
 
 impl SettingType {
     /// Returns the wire-format type name used in [`SettingEntry::value_type`].
-    fn type_name(&self) -> &'static str {
+    #[must_use]
+    pub fn type_name(&self) -> &'static str {
         match self {
             Self::Bool => "bool",
             Self::String => "string",
@@ -76,6 +77,20 @@ impl SettingType {
         match self {
             Self::Enum(opts) => opts.iter().map(|s| (*s).to_owned()).collect(),
             _ => vec![],
+        }
+    }
+
+    /// Check if a JSON value is compatible with this setting type.
+    #[must_use]
+    pub fn is_compatible_value(&self, value: &JsonValue) -> bool {
+        match self {
+            Self::Bool => value.is_boolean(),
+            Self::String | Self::Char => value.is_string(),
+            Self::Number => value.is_number(),
+            Self::StringArray => value
+                .as_array()
+                .is_some_and(|arr| arr.iter().all(JsonValue::is_string)),
+            Self::Enum(opts) => value.as_str().is_some_and(|s| opts.contains(&s)),
         }
     }
 }
@@ -277,6 +292,8 @@ pub fn registry() -> Vec<SettingDef> {
         // ----------------------------------------------------------------
         // Knowledge Base
         // ----------------------------------------------------------------
+        // Key lives under the chat namespace in the upstream CLI but
+        // logically belongs to knowledge configuration.
         SettingDef {
             key: "chat.enableKnowledge",
             label: "Enable Knowledge",
@@ -504,7 +521,10 @@ pub fn get_nested<'a>(value: &'a JsonValue, path: &str) -> Option<&'a JsonValue>
 ///
 /// # Panics
 ///
-/// Panics if `path` is an empty string (i.e. contains no `.`-separated segments).
+/// The internal `expect` calls are defensive assertions that cannot be reached
+/// in practice: `str::split('.')` always produces at least one element, so
+/// `split_last` never returns `None`, and the object-mutation invariants are
+/// upheld by the preceding `if !current.is_object()` guards.
 pub fn set_nested(value: &mut JsonValue, path: &str, val: JsonValue) {
     let segments: Vec<&str> = path.split('.').collect();
     let (last, parents) = segments.split_last().expect("path must not be empty");
@@ -569,6 +589,12 @@ fn remove_nested_impl(value: &mut JsonValue, segments: &[&str]) -> bool {
 /// `current_value` is `None` when the key is absent from `json` (meaning the
 /// setting is at its default). `default_value` is `None` when no default is
 /// known for that setting.
+///
+/// # Panics
+///
+/// Cannot panic in practice: `SettingCategory` derives `Serialize` and always
+/// serializes to a `snake_case` JSON string, so both `expect` calls on the
+/// serialization result are unreachable.
 #[must_use]
 pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
     registry()
@@ -577,9 +603,10 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
             let current_value = get_nested(json, def.key).cloned();
 
             let category_str = serde_json::to_value(def.category)
-                .ok()
-                .and_then(|v| v.as_str().map(std::borrow::ToOwned::to_owned))
-                .unwrap_or_default();
+                .expect("SettingCategory serialization is infallible")
+                .as_str()
+                .expect("SettingCategory serializes to a JSON string")
+                .to_owned();
 
             SettingEntry {
                 key: def.key.to_owned(),
@@ -603,38 +630,63 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
 /// Path to the CLI settings file relative to the Kiro home directory.
 const SETTINGS_FILE: &str = "settings/cli.json";
 
+/// Errors from loading the Kiro CLI settings file.
+#[derive(Debug)]
+pub enum LoadSettingsError {
+    /// The file does not exist — use empty defaults.
+    NotFound,
+    /// An I/O error occurred reading the file.
+    Io(std::io::Error),
+    /// The file exists but contains invalid JSON.
+    InvalidJson(serde_json::Error),
+}
+
+impl std::fmt::Display for LoadSettingsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "settings file not found"),
+            Self::Io(e) => write!(f, "failed to read settings file: {e}"),
+            Self::InvalidJson(e) => write!(f, "settings file contains invalid JSON: {e}"),
+        }
+    }
+}
+
 /// Load `settings/cli.json` from the given Kiro home directory.
 ///
-/// Returns an empty JSON object (`{}`) if the file does not exist or if its
-/// contents cannot be parsed as JSON.
-#[must_use]
-pub fn load_kiro_settings_from(kiro_dir: &Path) -> JsonValue {
+/// Returns `Err(LoadSettingsError::NotFound)` if the file does not exist,
+/// `Err(LoadSettingsError::InvalidJson)` if the file contains invalid JSON,
+/// or `Err(LoadSettingsError::Io)` for other I/O errors.
+///
+/// # Errors
+///
+/// Returns a [`LoadSettingsError`] if the file cannot be read or parsed.
+pub fn load_kiro_settings_from(kiro_dir: &Path) -> Result<JsonValue, LoadSettingsError> {
     let path = kiro_dir.join(SETTINGS_FILE);
     debug!(path = %path.display(), "loading Kiro settings");
 
     match std::fs::read_to_string(&path) {
         Ok(contents) => match serde_json::from_str::<JsonValue>(&contents) {
-            Ok(json) => json,
+            Ok(json) => Ok(json),
             Err(e) => {
                 warn!(
                     path = %path.display(),
                     error = %e,
-                    "settings file contains invalid JSON, using empty config"
+                    "settings file contains invalid JSON"
                 );
-                serde_json::json!({})
+                Err(LoadSettingsError::InvalidJson(e))
             }
         },
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            debug!(path = %path.display(), "settings file not found, using empty config");
-            serde_json::json!({})
+            debug!(path = %path.display(), "settings file not found");
+            Err(LoadSettingsError::NotFound)
         }
         Err(e) => {
             warn!(
                 path = %path.display(),
                 error = %e,
-                "could not read settings file, using empty config"
+                "could not read settings file"
             );
-            serde_json::json!({})
+            Err(LoadSettingsError::Io(e))
         }
     }
 }
@@ -797,7 +849,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Task 2 — JSON path helpers
+    // JSON path helpers
     // -----------------------------------------------------------------------
 
     #[test]
@@ -820,6 +872,15 @@ mod tests {
         let v = serde_json::json!({"chat": {}});
         assert_eq!(get_nested(&v, "chat.defaultModel"), None);
         assert_eq!(get_nested(&v, "nonexistent"), None);
+    }
+
+    #[test]
+    fn get_nested_finds_three_segment_path() {
+        let json: JsonValue = serde_json::json!({"chat": {"greeting": {"enabled": true}}});
+        assert_eq!(
+            get_nested(&json, "chat.greeting.enabled"),
+            Some(&JsonValue::Bool(true))
+        );
     }
 
     #[test]
@@ -847,6 +908,30 @@ mod tests {
     }
 
     #[test]
+    fn set_nested_creates_three_segment_path() {
+        let mut json: JsonValue = serde_json::json!({});
+        set_nested(&mut json, "chat.greeting.enabled", JsonValue::Bool(true));
+        assert_eq!(
+            json,
+            serde_json::json!({"chat": {"greeting": {"enabled": true}}})
+        );
+    }
+
+    #[test]
+    fn set_nested_replaces_non_object_intermediate() {
+        let mut json: JsonValue = serde_json::json!({"chat": "not-an-object"});
+        set_nested(
+            &mut json,
+            "chat.defaultModel",
+            JsonValue::String("opus".into()),
+        );
+        assert_eq!(
+            get_nested(&json, "chat.defaultModel"),
+            Some(&JsonValue::String("opus".into()))
+        );
+    }
+
+    #[test]
     fn remove_nested_deletes_key() {
         let mut v =
             serde_json::json!({"chat": {"defaultModel": "claude-sonnet-4-5", "temperature": 0.7}});
@@ -865,6 +950,13 @@ mod tests {
         remove_nested(&mut v, "chat.defaultModel");
         // chat object should have been pruned since it became empty
         assert_eq!(get_nested(&v, "chat"), None);
+    }
+
+    #[test]
+    fn remove_nested_cleans_all_empty_ancestors() {
+        let mut json: JsonValue = serde_json::json!({"chat": {"greeting": {"enabled": true}}});
+        remove_nested(&mut json, "chat.greeting.enabled");
+        assert_eq!(json, serde_json::json!({}));
     }
 
     #[test]
@@ -936,14 +1028,14 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Task 3 — Kiro settings file I/O
+    // Kiro settings file I/O
     // -----------------------------------------------------------------------
 
     #[test]
     fn load_kiro_settings_returns_empty_when_no_file() {
         let dir = TempDir::new().unwrap();
         let result = load_kiro_settings_from(dir.path());
-        assert_eq!(result, serde_json::json!({}));
+        assert!(matches!(result, Err(LoadSettingsError::NotFound)));
     }
 
     #[test]
@@ -958,7 +1050,7 @@ mod tests {
 
         save_kiro_settings_to(dir.path(), &settings).expect("save should succeed");
 
-        let loaded = load_kiro_settings_from(dir.path());
+        let loaded = load_kiro_settings_from(dir.path()).unwrap();
         assert_eq!(loaded, settings);
     }
 
@@ -971,7 +1063,7 @@ mod tests {
 
         save_kiro_settings_to(&nested, &settings).expect("save should create parent dirs");
 
-        let loaded = load_kiro_settings_from(&nested);
+        let loaded = load_kiro_settings_from(&nested).unwrap();
         assert_eq!(loaded, settings);
     }
 
@@ -983,7 +1075,7 @@ mod tests {
         std::fs::write(settings_dir.join("cli.json"), b"{ this is not valid json }").unwrap();
 
         let result = load_kiro_settings_from(dir.path());
-        assert_eq!(result, serde_json::json!({}));
+        assert!(matches!(result, Err(LoadSettingsError::InvalidJson(_))));
     }
 
     #[test]
@@ -995,7 +1087,7 @@ mod tests {
         });
 
         save_kiro_settings_to(dir.path(), &settings).unwrap();
-        let loaded = load_kiro_settings_from(dir.path());
+        let loaded = load_kiro_settings_from(dir.path()).unwrap();
 
         assert_eq!(
             loaded["unknownFutureKey"]["nestedValue"],
@@ -1005,5 +1097,19 @@ mod tests {
             loaded["chat"]["defaultModel"],
             serde_json::json!("claude-sonnet-4-5")
         );
+    }
+
+    #[test]
+    fn is_compatible_value_validates_types() {
+        assert!(SettingType::Bool.is_compatible_value(&JsonValue::Bool(true)));
+        assert!(!SettingType::Bool.is_compatible_value(&JsonValue::String("yes".into())));
+        assert!(SettingType::Number.is_compatible_value(&serde_json::json!(42)));
+        assert!(!SettingType::Number.is_compatible_value(&JsonValue::Bool(true)));
+        assert!(SettingType::String.is_compatible_value(&JsonValue::String("hello".into())));
+        assert!(SettingType::StringArray.is_compatible_value(&serde_json::json!(["a", "b"])));
+        assert!(!SettingType::StringArray.is_compatible_value(&serde_json::json!([1, 2])));
+        let enum_type = SettingType::Enum(vec!["a", "b"]);
+        assert!(enum_type.is_compatible_value(&JsonValue::String("a".into())));
+        assert!(!enum_type.is_compatible_value(&JsonValue::String("c".into())));
     }
 }

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -1,0 +1,610 @@
+//! Kiro CLI settings registry types and definitions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+// ---------------------------------------------------------------------------
+// Setting category
+// ---------------------------------------------------------------------------
+
+/// Top-level category for a Kiro CLI setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+pub enum SettingCategory {
+    Telemetry,
+    Chat,
+    Knowledge,
+    KeyBindings,
+    Features,
+    Api,
+    Mcp,
+    Environment,
+}
+
+impl SettingCategory {
+    /// Human-readable display name for this category.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Telemetry => "Telemetry",
+            Self::Chat => "Chat",
+            Self::Knowledge => "Knowledge",
+            Self::KeyBindings => "Key Bindings",
+            Self::Features => "Features",
+            Self::Api => "API",
+            Self::Mcp => "MCP",
+            Self::Environment => "Environment",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setting value type (internal)
+// ---------------------------------------------------------------------------
+
+/// Describes what kind of value a setting holds.
+#[derive(Debug, Clone)]
+pub enum SettingType {
+    Bool,
+    String,
+    Number,
+    Char,
+    StringArray,
+    Enum(Vec<&'static str>),
+}
+
+impl SettingType {
+    /// Returns the wire-format type name used in [`SettingEntry::value_type`].
+    #[allow(dead_code)]
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::String => "string",
+            Self::Number => "number",
+            Self::Char => "char",
+            Self::StringArray => "string_array",
+            Self::Enum(_) => "enum",
+        }
+    }
+
+    /// Returns enum options if this is an `Enum` variant, otherwise `None`.
+    #[allow(dead_code)]
+    fn enum_options(&self) -> Option<Vec<String>> {
+        match self {
+            Self::Enum(opts) => Some(opts.iter().map(|s| (*s).to_owned()).collect()),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setting definition (internal registry entry)
+// ---------------------------------------------------------------------------
+
+/// Internal definition of a single Kiro CLI setting.
+pub struct SettingDef {
+    /// Dotted JSON key path (e.g. `"chat.defaultModel"`).
+    pub key: &'static str,
+    /// Short human-readable label.
+    pub label: &'static str,
+    /// Longer description shown in the settings UI.
+    pub description: &'static str,
+    /// Logical grouping category.
+    pub category: SettingCategory,
+    /// What kind of value this setting holds.
+    pub value_type: SettingType,
+    /// Default value as a JSON value.
+    pub default: JsonValue,
+}
+
+// ---------------------------------------------------------------------------
+// Setting entry (serialisable, frontend-facing)
+// ---------------------------------------------------------------------------
+
+/// A fully-resolved setting entry suitable for serialisation to a frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct SettingEntry {
+    /// Dotted JSON key path.
+    pub key: String,
+    /// Short human-readable label.
+    pub label: String,
+    /// Longer description.
+    pub description: String,
+    /// Machine-readable category identifier.
+    pub category: SettingCategory,
+    /// Human-readable category label.
+    pub category_label: String,
+    /// Wire-format type name (`"bool"`, `"string"`, `"enum"`, …).
+    pub value_type: String,
+    /// For `Enum` settings: the allowed values.  `None` for all other types.
+    pub enum_options: Option<Vec<String>>,
+    /// Default value as a JSON value.
+    pub default_value: JsonValue,
+    /// Current value as stored in the user's settings file.
+    pub current_value: JsonValue,
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/// Returns the complete list of known Kiro CLI settings definitions.
+///
+/// The returned `Vec` is ordered: categories are grouped and within each
+/// category settings appear in a logical sequence.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn registry() -> Vec<SettingDef> {
+    vec![
+        // ----------------------------------------------------------------
+        // Telemetry
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "telemetry.enabled",
+            label: "Enable Telemetry",
+            description: "Send anonymous usage data to help improve Kiro.",
+            category: SettingCategory::Telemetry,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "telemetry.shareCodeSnippets",
+            label: "Share Code Snippets",
+            description: "Allow telemetry to include short code snippets for context.",
+            category: SettingCategory::Telemetry,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(false),
+        },
+        // ----------------------------------------------------------------
+        // Chat
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "chat.defaultModel",
+            label: "Default Model",
+            description: "The AI model used by default for chat sessions.",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Enum(vec![
+                "claude-opus-4-5",
+                "claude-sonnet-4-5",
+                "claude-haiku-4-5",
+                "claude-opus-4",
+                "claude-sonnet-4",
+                "claude-haiku-3",
+            ]),
+            default: JsonValue::String("claude-sonnet-4-5".to_owned()),
+        },
+        SettingDef {
+            key: "chat.temperature",
+            label: "Temperature",
+            description: "Sampling temperature for model responses (0.0\u{2013}1.0).",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: serde_json::json!(0.7),
+        },
+        SettingDef {
+            key: "chat.maxTokens",
+            label: "Max Tokens",
+            description: "Maximum number of tokens the model may generate per response.",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: serde_json::json!(8096),
+        },
+        SettingDef {
+            key: "chat.streamResponses",
+            label: "Stream Responses",
+            description: "Stream model output token-by-token as it is generated.",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "chat.autoSave",
+            label: "Auto-Save Conversations",
+            description: "Automatically persist chat sessions to disk.",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "chat.contextWindow",
+            label: "Context Window",
+            description: "Number of previous messages included in each request.",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: serde_json::json!(20),
+        },
+        // ----------------------------------------------------------------
+        // Knowledge
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "knowledge.indexOnStartup",
+            label: "Index on Startup",
+            description: "Re-index the project knowledge base when Kiro starts.",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "knowledge.excludePatterns",
+            label: "Exclude Patterns",
+            description: "Glob patterns for files and directories excluded from indexing.",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::StringArray,
+            default: serde_json::json!(["node_modules", ".git", "target", "dist"]),
+        },
+        SettingDef {
+            key: "knowledge.maxFileSize",
+            label: "Max File Size (KB)",
+            description: "Files larger than this limit (in kilobytes) are skipped during indexing.",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Number,
+            default: serde_json::json!(512),
+        },
+        SettingDef {
+            key: "knowledge.chunkSize",
+            label: "Chunk Size",
+            description: "Token chunk size used when splitting documents for embedding.",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Number,
+            default: serde_json::json!(1000),
+        },
+        SettingDef {
+            key: "knowledge.embeddingModel",
+            label: "Embedding Model",
+            description: "Model used to generate document embeddings for semantic search.",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Enum(vec![
+                "amazon.titan-embed-text-v2:0",
+                "cohere.embed-english-v3",
+                "cohere.embed-multilingual-v3",
+            ]),
+            default: JsonValue::String("amazon.titan-embed-text-v2:0".to_owned()),
+        },
+        // ----------------------------------------------------------------
+        // Key Bindings
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "keyBindings.submitChat",
+            label: "Submit Chat",
+            description: "Key combination to submit the current chat message.",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::String,
+            default: JsonValue::String("Enter".to_owned()),
+        },
+        SettingDef {
+            key: "keyBindings.newLine",
+            label: "New Line",
+            description: "Key combination to insert a newline without submitting.",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::String,
+            default: JsonValue::String("Shift+Enter".to_owned()),
+        },
+        SettingDef {
+            key: "keyBindings.clearChat",
+            label: "Clear Chat",
+            description: "Key combination to clear the current chat session.",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::String,
+            default: JsonValue::String("Ctrl+L".to_owned()),
+        },
+        SettingDef {
+            key: "keyBindings.focusChat",
+            label: "Focus Chat Input",
+            description: "Key combination to move focus to the chat input box.",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::String,
+            default: JsonValue::String("Ctrl+I".to_owned()),
+        },
+        SettingDef {
+            key: "keyBindings.toggleSidebar",
+            label: "Toggle Sidebar",
+            description: "Key combination to show or hide the sidebar.",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::String,
+            default: JsonValue::String("Ctrl+B".to_owned()),
+        },
+        // ----------------------------------------------------------------
+        // Features
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "features.agentMode",
+            label: "Agent Mode",
+            description: "Enable autonomous agent mode for multi-step task execution.",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "features.codeActions",
+            label: "Code Actions",
+            description: "Show inline AI-powered code actions inside the editor.",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "features.inlineCompletions",
+            label: "Inline Completions",
+            description: "Provide ghost-text completions as you type.",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "features.diagnosticsIntegration",
+            label: "Diagnostics Integration",
+            description: "Surface compiler/linter diagnostics inside the AI chat.",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "features.experimentalTools",
+            label: "Experimental Tools",
+            description: "Enable tools that are still in beta and may change.",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(false),
+        },
+        // ----------------------------------------------------------------
+        // API
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "api.provider",
+            label: "API Provider",
+            description: "Which API backend Kiro uses to call the AI model.",
+            category: SettingCategory::Api,
+            value_type: SettingType::Enum(vec!["anthropic", "bedrock", "vertex"]),
+            default: JsonValue::String("anthropic".to_owned()),
+        },
+        SettingDef {
+            key: "api.region",
+            label: "AWS Region",
+            description: "AWS region for Bedrock or Vertex API calls.",
+            category: SettingCategory::Api,
+            value_type: SettingType::String,
+            default: JsonValue::String("us-east-1".to_owned()),
+        },
+        SettingDef {
+            key: "api.timeout",
+            label: "Request Timeout (s)",
+            description: "Number of seconds before an API request times out.",
+            category: SettingCategory::Api,
+            value_type: SettingType::Number,
+            default: serde_json::json!(60),
+        },
+        SettingDef {
+            key: "api.retries",
+            label: "Max Retries",
+            description: "How many times to retry a failed API request.",
+            category: SettingCategory::Api,
+            value_type: SettingType::Number,
+            default: serde_json::json!(3),
+        },
+        SettingDef {
+            key: "api.proxyUrl",
+            label: "Proxy URL",
+            description: "HTTP/HTTPS proxy URL for outbound API requests.",
+            category: SettingCategory::Api,
+            value_type: SettingType::String,
+            default: JsonValue::String(String::new()),
+        },
+        // ----------------------------------------------------------------
+        // MCP
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "mcp.enabled",
+            label: "Enable MCP",
+            description: "Enable the Model Context Protocol server integration.",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "mcp.autoStart",
+            label: "Auto-Start Servers",
+            description: "Automatically start configured MCP servers when Kiro launches.",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Bool,
+            default: JsonValue::Bool(true),
+        },
+        SettingDef {
+            key: "mcp.serverTimeout",
+            label: "Server Timeout (s)",
+            description: "Seconds to wait for an MCP server to become ready.",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Number,
+            default: serde_json::json!(30),
+        },
+        SettingDef {
+            key: "mcp.allowedHosts",
+            label: "Allowed Hosts",
+            description: "Hostnames or IP addresses that MCP servers may connect to.",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::StringArray,
+            default: serde_json::json!([]),
+        },
+        SettingDef {
+            key: "mcp.logLevel",
+            label: "Log Level",
+            description: "Verbosity of MCP server logs.",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Enum(vec!["error", "warn", "info", "debug", "trace"]),
+            default: JsonValue::String("info".to_owned()),
+        },
+        // ----------------------------------------------------------------
+        // Environment
+        // ----------------------------------------------------------------
+        SettingDef {
+            key: "environment.shell",
+            label: "Shell",
+            description: "Shell executable used when running terminal commands.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::String,
+            default: JsonValue::String(String::new()),
+        },
+        SettingDef {
+            key: "environment.workingDirectory",
+            label: "Working Directory",
+            description: "Default working directory for new chat sessions.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::String,
+            default: JsonValue::String(String::new()),
+        },
+        SettingDef {
+            key: "environment.extraEnvVars",
+            label: "Extra Environment Variables",
+            description: "Additional environment variables injected into agent sub-processes.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::StringArray,
+            default: serde_json::json!([]),
+        },
+        SettingDef {
+            key: "environment.theme",
+            label: "Theme",
+            description: "Color theme for the Kiro UI.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::Enum(vec!["system", "light", "dark"]),
+            default: JsonValue::String("system".to_owned()),
+        },
+        SettingDef {
+            key: "environment.locale",
+            label: "Locale",
+            description: "BCP 47 locale tag used for formatting dates and numbers.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::String,
+            default: JsonValue::String("en-US".to_owned()),
+        },
+        SettingDef {
+            key: "environment.fontSize",
+            label: "Font Size",
+            description: "Base font size (in pixels) for the Kiro UI.",
+            category: SettingCategory::Environment,
+            value_type: SettingType::Number,
+            default: serde_json::json!(14),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Task 1
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn registry_keys_are_unique() {
+        let reg = registry();
+        let mut seen = HashSet::new();
+        for def in &reg {
+            assert!(seen.insert(def.key), "duplicate registry key: {}", def.key);
+        }
+    }
+
+    #[test]
+    fn registry_has_all_categories() {
+        let all_categories = [
+            SettingCategory::Telemetry,
+            SettingCategory::Chat,
+            SettingCategory::Knowledge,
+            SettingCategory::KeyBindings,
+            SettingCategory::Features,
+            SettingCategory::Api,
+            SettingCategory::Mcp,
+            SettingCategory::Environment,
+        ];
+
+        let present: HashSet<SettingCategory> = registry().iter().map(|d| d.category).collect();
+
+        for cat in all_categories {
+            assert!(
+                present.contains(&cat),
+                "no settings found for category {:?}",
+                cat
+            );
+        }
+    }
+
+    #[test]
+    fn setting_category_labels_are_nonempty() {
+        let all_categories = [
+            SettingCategory::Telemetry,
+            SettingCategory::Chat,
+            SettingCategory::Knowledge,
+            SettingCategory::KeyBindings,
+            SettingCategory::Features,
+            SettingCategory::Api,
+            SettingCategory::Mcp,
+            SettingCategory::Environment,
+        ];
+
+        for cat in all_categories {
+            assert!(
+                !cat.label().is_empty(),
+                "empty label for category {:?}",
+                cat
+            );
+        }
+    }
+
+    #[test]
+    fn registry_defaults_match_value_type() {
+        for def in registry() {
+            match &def.value_type {
+                SettingType::Bool => {
+                    assert!(
+                        def.default.is_boolean(),
+                        "key '{}' is Bool but default is not boolean: {}",
+                        def.key,
+                        def.default
+                    );
+                }
+                SettingType::Number => {
+                    assert!(
+                        def.default.is_number(),
+                        "key '{}' is Number but default is not a number: {}",
+                        def.key,
+                        def.default
+                    );
+                }
+                SettingType::String | SettingType::Char => {
+                    assert!(
+                        def.default.is_string(),
+                        "key '{}' is String/Char but default is not a string: {}",
+                        def.key,
+                        def.default
+                    );
+                }
+                SettingType::StringArray => {
+                    assert!(
+                        def.default.is_array(),
+                        "key '{}' is StringArray but default is not an array: {}",
+                        def.key,
+                        def.default
+                    );
+                }
+                SettingType::Enum(opts) => {
+                    let default_str = def.default.as_str().unwrap_or_else(|| {
+                        panic!(
+                            "key '{}' is Enum but default is not a string: {}",
+                            def.key, def.default
+                        )
+                    });
+                    assert!(
+                        opts.contains(&default_str),
+                        "key '{}' default '{}' is not in enum options {:?}",
+                        def.key,
+                        default_str,
+                        opts
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -77,7 +77,8 @@ impl SettingType {
     pub fn is_compatible_value(&self, value: &JsonValue) -> bool {
         match self {
             Self::Bool => value.is_boolean(),
-            Self::String | Self::Char => value.is_string(),
+            Self::String => value.is_string(),
+            Self::Char => value.as_str().is_some_and(|s| s.chars().count() == 1),
             Self::Number => value.is_number(),
             Self::StringArray => value
                 .as_array()
@@ -159,343 +160,348 @@ pub struct SettingEntry {
 
 /// Returns the complete list of known Kiro CLI settings definitions.
 ///
-/// The returned `Vec` is ordered: categories are grouped and within each
-/// category settings appear in a logical sequence.
+/// The returned slice is ordered: categories are grouped and within each
+/// category settings appear in a logical sequence. The registry is initialized
+/// once and reused on subsequent calls.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub fn registry() -> Vec<SettingDef> {
-    vec![
-        // ----------------------------------------------------------------
-        // Telemetry & Privacy
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "telemetry.enabled",
-            label: "Enable Telemetry",
-            description: "Enable or disable telemetry collection",
-            category: SettingCategory::Telemetry,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(true)),
-        },
-        SettingDef {
-            key: "telemetryClientId",
-            label: "Telemetry Client ID",
-            description: "Client identifier for telemetry",
-            category: SettingCategory::Telemetry,
-            value_type: SettingType::String,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // Chat Interface
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "chat.defaultModel",
-            label: "Default Model",
-            description: "Default AI model for conversations",
-            category: SettingCategory::Chat,
-            value_type: SettingType::String,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.defaultAgent",
-            label: "Default Agent",
-            description: "Default agent configuration",
-            category: SettingCategory::Chat,
-            value_type: SettingType::String,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.diffTool",
-            label: "Diff Tool",
-            description: "External diff tool for viewing code changes",
-            category: SettingCategory::Chat,
-            value_type: SettingType::String,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.greeting.enabled",
-            label: "Show Greeting",
-            description: "Show greeting message on chat start",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(true)),
-        },
-        SettingDef {
-            key: "chat.editMode",
-            label: "Edit Mode",
-            description: "Enable edit mode for chat interface",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableNotifications",
-            label: "Enable Notifications",
-            description: "Enable desktop notifications",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.disableMarkdownRendering",
-            label: "Disable Markdown Rendering",
-            description: "Disable markdown formatting in chat",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(false)),
-        },
-        SettingDef {
-            key: "chat.disableAutoCompaction",
-            label: "Disable Auto Compaction",
-            description: "Disable automatic conversation summarization",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(false)),
-        },
-        SettingDef {
-            key: "chat.enablePromptHints",
-            label: "Enable Prompt Hints",
-            description: "Show startup hints with tips and shortcuts",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(true)),
-        },
-        SettingDef {
-            key: "chat.enableHistoryHints",
-            label: "Enable History Hints",
-            description: "Show conversation history hints",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.uiMode",
-            label: "UI Mode",
-            description: "UI variant to use",
-            category: SettingCategory::Chat,
-            value_type: SettingType::String,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableContextUsageIndicator",
-            label: "Enable Context Usage Indicator",
-            description: "Show context usage percentage in prompt",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "compaction.excludeMessages",
-            label: "Compaction Exclude Messages",
-            description: "Minimum message pairs to retain during compaction",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "compaction.excludeContextWindowPercent",
-            label: "Compaction Exclude Context Window Percent",
-            description: "Minimum percentage of context window to retain during compaction",
-            category: SettingCategory::Chat,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // Knowledge Base
-        // ----------------------------------------------------------------
-        // Key lives under the chat namespace in the upstream CLI but
-        // logically belongs to knowledge configuration.
-        SettingDef {
-            key: "chat.enableKnowledge",
-            label: "Enable Knowledge",
-            description: "Enable knowledge base functionality",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.defaultIncludePatterns",
-            label: "Default Include Patterns",
-            description: "Default file patterns to include in knowledge indexing",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::StringArray,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.defaultExcludePatterns",
-            label: "Default Exclude Patterns",
-            description: "Default file patterns to exclude from knowledge indexing",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::StringArray,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.maxFiles",
-            label: "Max Files",
-            description: "Maximum number of files for knowledge indexing",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.chunkSize",
-            label: "Chunk Size",
-            description: "Text chunk size for knowledge processing",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.chunkOverlap",
-            label: "Chunk Overlap",
-            description: "Overlap between text chunks in knowledge processing",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "knowledge.indexType",
-            label: "Index Type",
-            description: "Type of knowledge index to use",
-            category: SettingCategory::Knowledge,
-            value_type: SettingType::String,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // Key Bindings
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "chat.skimCommandKey",
-            label: "Skim Command Key",
-            description: "Key for fuzzy search command",
-            category: SettingCategory::KeyBindings,
-            value_type: SettingType::Char,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.autocompletionKey",
-            label: "Autocompletion Key",
-            description: "Key for autocompletion hint acceptance",
-            category: SettingCategory::KeyBindings,
-            value_type: SettingType::Char,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.tangentModeKey",
-            label: "Tangent Mode Key",
-            description: "Key for tangent mode toggle",
-            category: SettingCategory::KeyBindings,
-            value_type: SettingType::Char,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.delegateModeKey",
-            label: "Delegate Mode Key",
-            description: "Key for delegate command",
-            category: SettingCategory::KeyBindings,
-            value_type: SettingType::Char,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // Feature Toggles
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "chat.enableThinking",
-            label: "Enable Thinking",
-            description: "Enable thinking tool for complex reasoning",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableTangentMode",
-            label: "Enable Tangent Mode",
-            description: "Enable tangent mode feature",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "introspect.tangentMode",
-            label: "Introspect Tangent Mode",
-            description: "Auto-enter tangent mode for introspect",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableTodoList",
-            label: "Enable Todo List",
-            description: "Enable todo list feature",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableCheckpoint",
-            label: "Enable Checkpoint",
-            description: "Enable checkpoint feature",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        SettingDef {
-            key: "chat.enableDelegate",
-            label: "Enable Delegate",
-            description: "Enable delegate tool",
-            category: SettingCategory::Features,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // API & Service
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "api.timeout",
-            label: "API Timeout",
-            description: "API request timeout in seconds",
-            category: SettingCategory::Api,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // MCP
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "mcp.initTimeout",
-            label: "MCP Init Timeout",
-            description: "MCP server initialization timeout in milliseconds",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "mcp.noInteractiveTimeout",
-            label: "MCP Non-Interactive Timeout",
-            description: "Non-interactive MCP timeout in milliseconds",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Number,
-            default: None,
-        },
-        SettingDef {
-            key: "mcp.loadedBefore",
-            label: "MCP Loaded Before",
-            description: "Track previously loaded MCP servers",
-            category: SettingCategory::Mcp,
-            value_type: SettingType::Bool,
-            default: None,
-        },
-        // ----------------------------------------------------------------
-        // Environment Variables
-        // ----------------------------------------------------------------
-        SettingDef {
-            key: "KIRO_LOG_NO_COLOR",
-            label: "Disable Log Color",
-            description: "Set to disable colored log output",
-            category: SettingCategory::Environment,
-            value_type: SettingType::Bool,
-            default: Some(JsonValue::Bool(false)),
-        },
-    ]
+pub fn registry() -> &'static [SettingDef] {
+    use std::sync::OnceLock;
+    static REGISTRY: OnceLock<Vec<SettingDef>> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        vec![
+            // ----------------------------------------------------------------
+            // Telemetry & Privacy
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "telemetry.enabled",
+                label: "Enable Telemetry",
+                description: "Enable or disable telemetry collection",
+                category: SettingCategory::Telemetry,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(true)),
+            },
+            SettingDef {
+                key: "telemetryClientId",
+                label: "Telemetry Client ID",
+                description: "Client identifier for telemetry",
+                category: SettingCategory::Telemetry,
+                value_type: SettingType::String,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // Chat Interface
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "chat.defaultModel",
+                label: "Default Model",
+                description: "Default AI model for conversations",
+                category: SettingCategory::Chat,
+                value_type: SettingType::String,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.defaultAgent",
+                label: "Default Agent",
+                description: "Default agent configuration",
+                category: SettingCategory::Chat,
+                value_type: SettingType::String,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.diffTool",
+                label: "Diff Tool",
+                description: "External diff tool for viewing code changes",
+                category: SettingCategory::Chat,
+                value_type: SettingType::String,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.greeting.enabled",
+                label: "Show Greeting",
+                description: "Show greeting message on chat start",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(true)),
+            },
+            SettingDef {
+                key: "chat.editMode",
+                label: "Edit Mode",
+                description: "Enable edit mode for chat interface",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableNotifications",
+                label: "Enable Notifications",
+                description: "Enable desktop notifications",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.disableMarkdownRendering",
+                label: "Disable Markdown Rendering",
+                description: "Disable markdown formatting in chat",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(false)),
+            },
+            SettingDef {
+                key: "chat.disableAutoCompaction",
+                label: "Disable Auto Compaction",
+                description: "Disable automatic conversation summarization",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(false)),
+            },
+            SettingDef {
+                key: "chat.enablePromptHints",
+                label: "Enable Prompt Hints",
+                description: "Show startup hints with tips and shortcuts",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(true)),
+            },
+            SettingDef {
+                key: "chat.enableHistoryHints",
+                label: "Enable History Hints",
+                description: "Show conversation history hints",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.uiMode",
+                label: "UI Mode",
+                description: "UI variant to use",
+                category: SettingCategory::Chat,
+                value_type: SettingType::String,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableContextUsageIndicator",
+                label: "Enable Context Usage Indicator",
+                description: "Show context usage percentage in prompt",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "compaction.excludeMessages",
+                label: "Compaction Exclude Messages",
+                description: "Minimum message pairs to retain during compaction",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "compaction.excludeContextWindowPercent",
+                label: "Compaction Exclude Context Window Percent",
+                description: "Minimum percentage of context window to retain during compaction",
+                category: SettingCategory::Chat,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // Knowledge Base
+            // ----------------------------------------------------------------
+            // Key lives under the chat namespace in the upstream CLI but
+            // logically belongs to knowledge configuration.
+            SettingDef {
+                key: "chat.enableKnowledge",
+                label: "Enable Knowledge",
+                description: "Enable knowledge base functionality",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.defaultIncludePatterns",
+                label: "Default Include Patterns",
+                description: "Default file patterns to include in knowledge indexing",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::StringArray,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.defaultExcludePatterns",
+                label: "Default Exclude Patterns",
+                description: "Default file patterns to exclude from knowledge indexing",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::StringArray,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.maxFiles",
+                label: "Max Files",
+                description: "Maximum number of files for knowledge indexing",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.chunkSize",
+                label: "Chunk Size",
+                description: "Text chunk size for knowledge processing",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.chunkOverlap",
+                label: "Chunk Overlap",
+                description: "Overlap between text chunks in knowledge processing",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "knowledge.indexType",
+                label: "Index Type",
+                description: "Type of knowledge index to use",
+                category: SettingCategory::Knowledge,
+                value_type: SettingType::String,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // Key Bindings
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "chat.skimCommandKey",
+                label: "Skim Command Key",
+                description: "Key for fuzzy search command",
+                category: SettingCategory::KeyBindings,
+                value_type: SettingType::Char,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.autocompletionKey",
+                label: "Autocompletion Key",
+                description: "Key for autocompletion hint acceptance",
+                category: SettingCategory::KeyBindings,
+                value_type: SettingType::Char,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.tangentModeKey",
+                label: "Tangent Mode Key",
+                description: "Key for tangent mode toggle",
+                category: SettingCategory::KeyBindings,
+                value_type: SettingType::Char,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.delegateModeKey",
+                label: "Delegate Mode Key",
+                description: "Key for delegate command",
+                category: SettingCategory::KeyBindings,
+                value_type: SettingType::Char,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // Feature Toggles
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "chat.enableThinking",
+                label: "Enable Thinking",
+                description: "Enable thinking tool for complex reasoning",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableTangentMode",
+                label: "Enable Tangent Mode",
+                description: "Enable tangent mode feature",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "introspect.tangentMode",
+                label: "Introspect Tangent Mode",
+                description: "Auto-enter tangent mode for introspect",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableTodoList",
+                label: "Enable Todo List",
+                description: "Enable todo list feature",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableCheckpoint",
+                label: "Enable Checkpoint",
+                description: "Enable checkpoint feature",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            SettingDef {
+                key: "chat.enableDelegate",
+                label: "Enable Delegate",
+                description: "Enable delegate tool",
+                category: SettingCategory::Features,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // API & Service
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "api.timeout",
+                label: "API Timeout",
+                description: "API request timeout in seconds",
+                category: SettingCategory::Api,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // MCP
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "mcp.initTimeout",
+                label: "MCP Init Timeout",
+                description: "MCP server initialization timeout in milliseconds",
+                category: SettingCategory::Mcp,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "mcp.noInteractiveTimeout",
+                label: "MCP Non-Interactive Timeout",
+                description: "Non-interactive MCP timeout in milliseconds",
+                category: SettingCategory::Mcp,
+                value_type: SettingType::Number,
+                default: None,
+            },
+            SettingDef {
+                key: "mcp.loadedBefore",
+                label: "MCP Loaded Before",
+                description: "Track previously loaded MCP servers",
+                category: SettingCategory::Mcp,
+                value_type: SettingType::Bool,
+                default: None,
+            },
+            // ----------------------------------------------------------------
+            // Environment Variables
+            // ----------------------------------------------------------------
+            SettingDef {
+                key: "KIRO_LOG_NO_COLOR",
+                label: "Disable Log Color",
+                description: "Set to disable colored log output",
+                category: SettingCategory::Environment,
+                value_type: SettingType::Bool,
+                default: Some(JsonValue::Bool(false)),
+            },
+        ]
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -602,7 +608,7 @@ fn remove_nested_impl(value: &mut JsonValue, segments: &[&str]) -> bool {
 #[must_use]
 pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
     registry()
-        .into_iter()
+        .iter()
         .map(|def| {
             let current_value = get_nested(json, def.key).cloned();
 
@@ -624,7 +630,7 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
                 category: def.category,
                 category_label: def.category.label().to_owned(),
                 value_type,
-                default_value: def.default,
+                default_value: def.default.clone(),
                 current_value,
             }
         })
@@ -710,7 +716,7 @@ pub fn save_kiro_settings_to(kiro_dir: &Path, json: &JsonValue) -> io::Result<()
     let contents = serde_json::to_string_pretty(json)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-    std::fs::write(&path, contents)?;
+    crate::cache::atomic_write(&path, contents.as_bytes())?;
     Ok(())
 }
 
@@ -730,6 +736,7 @@ pub fn default_kiro_dir() -> Option<PathBuf> {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
+    use rstest::rstest;
     use tempfile::TempDir;
 
     use super::*;
@@ -738,7 +745,7 @@ mod tests {
     fn registry_keys_are_unique() {
         let reg = registry();
         let mut seen = HashSet::new();
-        for def in &reg {
+        for def in reg {
             assert!(seen.insert(def.key), "duplicate registry key: {}", def.key);
         }
     }
@@ -1100,17 +1107,30 @@ mod tests {
         );
     }
 
-    #[test]
-    fn is_compatible_value_validates_types() {
-        assert!(SettingType::Bool.is_compatible_value(&JsonValue::Bool(true)));
-        assert!(!SettingType::Bool.is_compatible_value(&JsonValue::String("yes".into())));
-        assert!(SettingType::Number.is_compatible_value(&serde_json::json!(42)));
-        assert!(!SettingType::Number.is_compatible_value(&JsonValue::Bool(true)));
-        assert!(SettingType::String.is_compatible_value(&JsonValue::String("hello".into())));
-        assert!(SettingType::StringArray.is_compatible_value(&serde_json::json!(["a", "b"])));
-        assert!(!SettingType::StringArray.is_compatible_value(&serde_json::json!([1, 2])));
-        let enum_type = SettingType::Enum(vec!["a", "b"]);
-        assert!(enum_type.is_compatible_value(&JsonValue::String("a".into())));
-        assert!(!enum_type.is_compatible_value(&JsonValue::String("c".into())));
+    #[rstest]
+    #[case::bool_accepts_bool(SettingType::Bool, serde_json::json!(true), true)]
+    #[case::bool_rejects_string(SettingType::Bool, serde_json::json!("yes"), false)]
+    #[case::number_accepts_number(SettingType::Number, serde_json::json!(42), true)]
+    #[case::number_rejects_bool(SettingType::Number, serde_json::json!(true), false)]
+    #[case::string_accepts_string(SettingType::String, serde_json::json!("hello"), true)]
+    #[case::string_rejects_number(SettingType::String, serde_json::json!(42), false)]
+    #[case::char_accepts_single_char(SettingType::Char, serde_json::json!("x"), true)]
+    #[case::char_rejects_multi_char(SettingType::Char, serde_json::json!("abc"), false)]
+    #[case::char_rejects_empty(SettingType::Char, serde_json::json!(""), false)]
+    #[case::string_array_accepts_array(SettingType::StringArray, serde_json::json!(["a", "b"]), true)]
+    #[case::string_array_rejects_int_array(SettingType::StringArray, serde_json::json!([1, 2]), false)]
+    #[case::string_array_accepts_empty(SettingType::StringArray, serde_json::json!([]), true)]
+    #[case::enum_accepts_valid(SettingType::Enum(vec!["a", "b"]), serde_json::json!("a"), true)]
+    #[case::enum_rejects_invalid(SettingType::Enum(vec!["a", "b"]), serde_json::json!("c"), false)]
+    fn is_compatible_value_validates_types(
+        #[case] setting_type: SettingType,
+        #[case] value: JsonValue,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(
+            setting_type.is_compatible_value(&value),
+            expected,
+            "is_compatible_value({setting_type:?}, {value}) should be {expected}"
+        );
     }
 }

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cache;
 pub mod error;
 pub mod file_lock;
 pub mod git;
+pub mod kiro_settings;
 pub mod marketplace;
 pub mod platform;
 pub mod plugin;

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -41,12 +41,36 @@ const SKIP_DIRS: &[&str] = &["node_modules", "target", "__pycache__", ".venv", "
 /// A plugin discovered by scanning a repository for `plugin.json` files.
 #[derive(Debug, Clone)]
 pub struct DiscoveredPlugin {
-    /// Plugin name from its `plugin.json`.
-    pub name: String,
-    /// Plugin description from its `plugin.json`.
-    pub description: Option<String>,
+    name: String,
+    description: Option<String>,
+    relative_path: PathBuf,
+}
+
+impl DiscoveredPlugin {
+    /// The plugin name from its `plugin.json`.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The plugin description from its `plugin.json`.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
     /// Path to the plugin directory, relative to the repo root.
-    pub relative_path: PathBuf,
+    #[must_use]
+    pub fn relative_path(&self) -> &Path {
+        &self.relative_path
+    }
+
+    /// The relative path as a `./`-prefixed string, matching the
+    /// `PluginSource::RelativePath` convention used in `marketplace.json`.
+    #[must_use]
+    pub fn as_relative_path_string(&self) -> String {
+        format!("./{}", self.relative_path.display())
+    }
 }
 
 /// Scan a repository for `plugin.json` files up to `max_depth` levels deep.
@@ -55,7 +79,7 @@ pub struct DiscoveredPlugin {
 /// (`node_modules`, `target`, etc.). Returns a list of discovered plugins with
 /// their names, descriptions, and relative paths.
 ///
-/// Malformed `plugin.json` files are warned about and skipped.
+/// Files that fail to read, parse, or have invalid plugin names are warned about and skipped.
 #[must_use]
 pub fn discover_plugins(repo_root: &Path, max_depth: usize) -> Vec<DiscoveredPlugin> {
     let mut results = Vec::new();
@@ -63,6 +87,7 @@ pub fn discover_plugins(repo_root: &Path, max_depth: usize) -> Vec<DiscoveredPlu
     results
 }
 
+#[allow(clippy::too_many_lines)]
 fn scan_for_plugins(
     repo_root: &Path,
     dir: &Path,
@@ -81,6 +106,15 @@ fn scan_for_plugins(
             match fs::read(&candidate) {
                 Ok(bytes) => match PluginManifest::from_json(&bytes) {
                     Ok(manifest) => {
+                        if let Err(e) = crate::validation::validate_name(&manifest.name) {
+                            warn!(
+                                path = %candidate.display(),
+                                name = %manifest.name,
+                                error = %e,
+                                "skipping plugin with invalid name"
+                            );
+                            return;
+                        }
                         let relative_path =
                             dir.strip_prefix(repo_root).unwrap_or(dir).to_path_buf();
                         debug!(
@@ -119,11 +153,19 @@ fn scan_for_plugins(
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(e) => {
-            debug!(
-                path = %dir.display(),
-                error = %e,
-                "failed to read directory during plugin scan"
-            );
+            if current_depth == 0 {
+                warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to read repo root during plugin scan"
+                );
+            } else {
+                debug!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to read directory during plugin scan, skipping"
+                );
+            }
             return;
         }
     };
@@ -143,9 +185,12 @@ fn scan_for_plugins(
         }
 
         // Skip hidden and noise directories.
-        let dir_name = match entry.file_name().to_str() {
-            Some(name) => name.to_owned(),
-            None => continue,
+        let Some(dir_name) = entry.file_name().to_str().map(str::to_owned) else {
+            debug!(
+                path = %entry_path.display(),
+                "skipping directory with non-UTF-8 name"
+            );
+            continue;
         };
 
         if dir_name.starts_with('.') || SKIP_DIRS.contains(&dir_name.as_str()) {
@@ -426,8 +471,8 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].name, "my-plugin");
-        assert_eq!(discovered[0].description.as_deref(), Some("A plugin"));
+        assert_eq!(discovered[0].name(), "my-plugin");
+        assert_eq!(discovered[0].description(), Some("A plugin"));
     }
 
     #[test]
@@ -443,7 +488,7 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].name, "dotnet-experimental");
+        assert_eq!(discovered[0].name(), "dotnet-experimental");
     }
 
     #[test]
@@ -455,10 +500,10 @@ mod tests {
         create_plugin_json(&root.join("plugins/beta"), "beta", None);
 
         let mut discovered = discover_plugins(root, 3);
-        discovered.sort_by(|a, b| a.name.cmp(&b.name));
+        discovered.sort_by(|a, b| a.name().cmp(b.name()));
         assert_eq!(discovered.len(), 2);
-        assert_eq!(discovered[0].name, "alpha");
-        assert_eq!(discovered[1].name, "beta");
+        assert_eq!(discovered[0].name(), "alpha");
+        assert_eq!(discovered[1].name(), "beta");
     }
 
     #[test]
@@ -483,7 +528,7 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].name, "visible");
+        assert_eq!(discovered[0].name(), "visible");
     }
 
     #[test]
@@ -497,7 +542,7 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].name, "real");
+        assert_eq!(discovered[0].name(), "real");
     }
 
     #[test]
@@ -513,7 +558,7 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].name, "good");
+        assert_eq!(discovered[0].name(), "good");
     }
 
     #[test]
@@ -532,6 +577,47 @@ mod tests {
 
         let discovered = discover_plugins(root, 3);
         assert_eq!(discovered.len(), 1);
-        assert_eq!(discovered[0].relative_path, Path::new("plugins/my-plugin"));
+        assert_eq!(
+            discovered[0].relative_path(),
+            Path::new("plugins/my-plugin")
+        );
+    }
+
+    #[test]
+    fn discover_plugins_finds_plugin_at_exact_max_depth() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        // Depth 3 exactly — should be found with max_depth 3.
+        create_plugin_json(&root.join("a/b/at-limit"), "at-limit", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(
+            discovered.len(),
+            1,
+            "should find plugin at exactly max_depth"
+        );
+        assert_eq!(discovered[0].name(), "at-limit");
+    }
+
+    #[test]
+    fn discover_plugins_skips_plugin_with_invalid_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        // Plugin with path traversal in name — should be skipped.
+        let bad_dir = root.join("plugins/bad");
+        fs::create_dir_all(&bad_dir).expect("mkdir");
+        fs::write(
+            bad_dir.join("plugin.json"),
+            r#"{"name":"../escape","skills":["./skills/"]}"#,
+        )
+        .expect("write");
+
+        create_plugin_json(&root.join("plugins/good"), "good", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name(), "good");
     }
 }

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -32,6 +32,136 @@ impl PluginManifest {
     }
 }
 
+/// Name of the plugin manifest file.
+const PLUGIN_JSON: &str = "plugin.json";
+
+/// Directories to skip during recursive plugin scanning.
+const SKIP_DIRS: &[&str] = &["node_modules", "target", "__pycache__", ".venv", "vendor"];
+
+/// A plugin discovered by scanning a repository for `plugin.json` files.
+#[derive(Debug, Clone)]
+pub struct DiscoveredPlugin {
+    /// Plugin name from its `plugin.json`.
+    pub name: String,
+    /// Plugin description from its `plugin.json`.
+    pub description: Option<String>,
+    /// Path to the plugin directory, relative to the repo root.
+    pub relative_path: PathBuf,
+}
+
+/// Scan a repository for `plugin.json` files up to `max_depth` levels deep.
+///
+/// Skips hidden directories (starting with `.`) and common noise directories
+/// (`node_modules`, `target`, etc.). Returns a list of discovered plugins with
+/// their names, descriptions, and relative paths.
+///
+/// Malformed `plugin.json` files are warned about and skipped.
+#[must_use]
+pub fn discover_plugins(repo_root: &Path, max_depth: usize) -> Vec<DiscoveredPlugin> {
+    let mut results = Vec::new();
+    scan_for_plugins(repo_root, repo_root, 0, max_depth, &mut results);
+    results
+}
+
+fn scan_for_plugins(
+    repo_root: &Path,
+    dir: &Path,
+    current_depth: usize,
+    max_depth: usize,
+    results: &mut Vec<DiscoveredPlugin>,
+) {
+    if current_depth > max_depth {
+        return;
+    }
+
+    // Check for plugin.json in this directory (skip the root itself).
+    if current_depth > 0 {
+        let candidate = dir.join(PLUGIN_JSON);
+        if candidate.is_file() {
+            match fs::read(&candidate) {
+                Ok(bytes) => match PluginManifest::from_json(&bytes) {
+                    Ok(manifest) => {
+                        let relative_path =
+                            dir.strip_prefix(repo_root).unwrap_or(dir).to_path_buf();
+                        debug!(
+                            name = %manifest.name,
+                            path = %relative_path.display(),
+                            "discovered plugin"
+                        );
+                        results.push(DiscoveredPlugin {
+                            name: manifest.name,
+                            description: manifest.description,
+                            relative_path,
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %candidate.display(),
+                            error = %e,
+                            "skipping malformed plugin.json"
+                        );
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        path = %candidate.display(),
+                        error = %e,
+                        "failed to read plugin.json, skipping"
+                    );
+                }
+            }
+            // Don't recurse into a plugin directory — it won't contain nested plugins.
+            return;
+        }
+    }
+
+    // Recurse into subdirectories.
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            debug!(
+                path = %dir.display(),
+                error = %e,
+                "failed to read directory during plugin scan"
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, "failed to read directory entry, skipping");
+                continue;
+            }
+        };
+
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        // Skip hidden and noise directories.
+        let dir_name = match entry.file_name().to_str() {
+            Some(name) => name.to_owned(),
+            None => continue,
+        };
+
+        if dir_name.starts_with('.') || SKIP_DIRS.contains(&dir_name.as_str()) {
+            continue;
+        }
+
+        scan_for_plugins(
+            repo_root,
+            &entry_path,
+            current_depth + 1,
+            max_depth,
+            results,
+        );
+    }
+}
+
 /// Name of the skill definition file.
 const SKILL_MD: &str = "SKILL.md";
 
@@ -268,5 +398,140 @@ mod tests {
             "only the valid skill should be returned, got {:?}",
             dirs[0]
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // discover_plugins
+    // -----------------------------------------------------------------------
+
+    /// Helper: create a minimal plugin.json in the given directory.
+    fn create_plugin_json(dir: &Path, name: &str, description: Option<&str>) {
+        fs::create_dir_all(dir).expect("create_dir_all");
+        let desc = description
+            .map(|d| format!(r#","description":"{d}""#))
+            .unwrap_or_default();
+        fs::write(
+            dir.join("plugin.json"),
+            format!(r#"{{"name":"{name}"{desc},"skills":["./skills/"]}}"#),
+        )
+        .expect("write plugin.json");
+    }
+
+    #[test]
+    fn discover_plugins_finds_plugin_json_at_depth_1() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join("my-plugin"), "my-plugin", Some("A plugin"));
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "my-plugin");
+        assert_eq!(discovered[0].description.as_deref(), Some("A plugin"));
+    }
+
+    #[test]
+    fn discover_plugins_finds_plugin_json_at_depth_2() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(
+            &root.join("plugins/dotnet-experimental"),
+            "dotnet-experimental",
+            Some("Experimental"),
+        );
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "dotnet-experimental");
+    }
+
+    #[test]
+    fn discover_plugins_finds_multiple_plugins() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join("plugins/alpha"), "alpha", None);
+        create_plugin_json(&root.join("plugins/beta"), "beta", None);
+
+        let mut discovered = discover_plugins(root, 3);
+        discovered.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(discovered.len(), 2);
+        assert_eq!(discovered[0].name, "alpha");
+        assert_eq!(discovered[1].name, "beta");
+    }
+
+    #[test]
+    fn discover_plugins_respects_depth_limit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join("a/b/c/deep-plugin"), "deep-plugin", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert!(discovered.is_empty(), "should not find plugin at depth 4");
+    }
+
+    #[test]
+    fn discover_plugins_skips_hidden_directories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join(".git/hooks"), "git-hooks", None);
+        create_plugin_json(&root.join(".claude-plugin"), "claude-internal", None);
+        create_plugin_json(&root.join("plugins/visible"), "visible", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "visible");
+    }
+
+    #[test]
+    fn discover_plugins_skips_noise_directories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join("node_modules/some-pkg"), "npm-thing", None);
+        create_plugin_json(&root.join("target/debug"), "build-artifact", None);
+        create_plugin_json(&root.join("plugins/real"), "real", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "real");
+    }
+
+    #[test]
+    fn discover_plugins_skips_malformed_plugin_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        let bad_dir = root.join("plugins/bad");
+        fs::create_dir_all(&bad_dir).expect("mkdir");
+        fs::write(bad_dir.join("plugin.json"), "not json").expect("write");
+
+        create_plugin_json(&root.join("plugins/good"), "good", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].name, "good");
+    }
+
+    #[test]
+    fn discover_plugins_returns_empty_for_no_plugins() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let discovered = discover_plugins(tmp.path(), 3);
+        assert!(discovered.is_empty());
+    }
+
+    #[test]
+    fn discover_plugins_includes_relative_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_plugin_json(&root.join("plugins/my-plugin"), "my-plugin", None);
+
+        let discovered = discover_plugins(root, 3);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].relative_path, Path::new("plugins/my-plugin"));
     }
 }

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -121,14 +121,17 @@ impl MarketplaceService {
     /// 1. Detect source type (GitHub, git URL, local path).
     /// 2. Clone or link into a temp directory in the cache.
     /// 3. Try to read `marketplace.json`; if missing, scan for `plugin.json` files.
-    /// 4. Merge manifest plugins with discovered plugins, deduplicating by path and name.
+    /// 4. Merge manifest plugins with discovered plugins, deduplicating by
+    ///    relative path (for `RelativePath` sources) or by name (for
+    ///    `Structured` sources).
     /// 5. Validate the name, rename to final location.
     /// 6. Register in `known_marketplaces.json`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the clone/link fails, no plugins are found (neither
-    /// via manifest nor scan), the marketplace name fails validation, or a
+    /// Returns an error if the clone/link fails, a non-`NotFound` I/O error
+    /// occurs when reading the manifest, no plugins are found (neither via
+    /// manifest nor scan), the marketplace name fails validation, or a
     /// marketplace with the same name is already registered.
     pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
         let ms = MarketplaceSource::detect(source);
@@ -159,7 +162,7 @@ impl MarketplaceService {
         }
 
         // Try to read marketplace manifest (optional).
-        let manifest = Self::try_read_manifest(&temp_dir);
+        let manifest = Self::try_read_manifest(&temp_dir)?;
 
         // Scan for plugin.json files.
         let discovered = crate::plugin::discover_plugins(&temp_dir, 3);
@@ -182,7 +185,10 @@ impl MarketplaceService {
                 .iter()
                 .filter_map(|p| match &p.source {
                     crate::marketplace::PluginSource::RelativePath(rel) => {
-                        Some(PathBuf::from(rel.trim_start_matches("./")))
+                        let normalized = rel
+                            .trim_start_matches("./")
+                            .trim_end_matches('/');
+                        Some(PathBuf::from(normalized))
                     }
                     crate::marketplace::PluginSource::Structured(_) => None,
                 })
@@ -194,12 +200,12 @@ impl MarketplaceService {
 
             // Add discovered plugins that aren't already listed.
             for dp in &discovered {
-                let path_match = listed_paths.iter().any(|lp| lp == &dp.relative_path);
-                let name_match = listed_names.contains(&dp.name.as_str());
+                let path_match = listed_paths.iter().any(|lp| lp == dp.relative_path());
+                let name_match = listed_names.contains(&dp.name());
                 if !path_match && !name_match {
                     plugins.push(PluginBasicInfo {
-                        name: dp.name.clone(),
-                        description: dp.description.clone(),
+                        name: dp.name().to_owned(),
+                        description: dp.description().map(String::from),
                     });
                 }
             }
@@ -222,8 +228,8 @@ impl MarketplaceService {
             let plugins = discovered
                 .iter()
                 .map(|dp| PluginBasicInfo {
-                    name: dp.name.clone(),
-                    description: dp.description.clone(),
+                    name: dp.name().to_owned(),
+                    description: dp.description().map(String::from),
                 })
                 .collect();
 
@@ -395,20 +401,24 @@ impl MarketplaceService {
         }
     }
 
-    /// Try to read the marketplace manifest. Returns `None` if the file is
-    /// missing or malformed, logging appropriately in each case.
-    fn try_read_manifest(repo_dir: &Path) -> Option<Marketplace> {
+    /// Try to read the marketplace manifest.
+    ///
+    /// Returns `Ok(Some(manifest))` if found and valid, `Ok(None)` if the file
+    /// is missing (logged at `debug`) or malformed (logged at `warn`).
+    /// Non-`NotFound` I/O errors (permission denied, disk errors) are
+    /// propagated as `Err` — they indicate a real problem, not an absent file.
+    fn try_read_manifest(repo_dir: &Path) -> Result<Option<Marketplace>, Error> {
         let manifest_path = repo_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
         match fs::read(&manifest_path) {
             Ok(bytes) => match Marketplace::from_json(&bytes) {
-                Ok(m) => Some(m),
+                Ok(m) => Ok(Some(m)),
                 Err(e) => {
                     warn!(
                         path = %manifest_path.display(),
                         error = %e,
                         "marketplace.json is malformed, falling back to plugin scan"
                     );
-                    None
+                    Ok(None)
                 }
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -416,16 +426,9 @@ impl MarketplaceService {
                     path = %manifest_path.display(),
                     "no marketplace.json found, will discover plugins via scan"
                 );
-                None
+                Ok(None)
             }
-            Err(e) => {
-                warn!(
-                    path = %manifest_path.display(),
-                    error = %e,
-                    "failed to read marketplace.json, falling back to plugin scan"
-                );
-                None
-            }
+            Err(e) => Err(e.into()),
         }
     }
 }
@@ -873,6 +876,119 @@ mod tests {
         assert!(
             err.to_string().contains("no plugins found"),
             "expected 'no plugins found' error, got: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Malformed manifest fallback test
+    // -----------------------------------------------------------------------
+
+    /// Mock that creates a repo with a malformed marketplace.json AND valid plugin.json files.
+    #[derive(Debug)]
+    struct MalformedManifestGitBackend;
+
+    impl GitBackend for MalformedManifestGitBackend {
+        fn clone_repo(&self, _url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+            // Create malformed marketplace.json.
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(mp_dir.join("marketplace.json"), "not valid json").unwrap();
+
+            // Create a valid plugin.
+            let plugin_dir = dest.join("plugins/fallback");
+            fs::create_dir_all(&plugin_dir).unwrap();
+            fs::write(
+                plugin_dir.join("plugin.json"),
+                r#"{"name":"fallback","description":"Found via scan","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_repo_with_malformed_manifest_falls_back_to_scan() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, MalformedManifestGitBackend);
+
+        let result = svc
+            .add("owner/fallback-repo", GitProtocol::Https)
+            .expect("add should succeed via scan fallback");
+
+        // Name derived from repo since manifest is malformed.
+        assert_eq!(result.name, "fallback-repo");
+        assert_eq!(result.plugins.len(), 1);
+        assert_eq!(result.plugins[0].name, "fallback");
+    }
+
+    // -----------------------------------------------------------------------
+    // Trailing-slash dedup test
+    // -----------------------------------------------------------------------
+
+    /// Mock that creates a repo with a marketplace.json using trailing-slash source paths
+    /// AND a matching plugin.json, to test dedup with trailing slashes.
+    #[derive(Debug)]
+    struct TrailingSlashGitBackend;
+
+    impl GitBackend for TrailingSlashGitBackend {
+        fn clone_repo(&self, _url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(
+                mp_dir.join("marketplace.json"),
+                r#"{"name":"slash-market","owner":{"name":"Test"},"plugins":[{"name":"trailing","description":"Has trailing slash","source":"./plugins/trailing/"}]}"#,
+            )
+            .unwrap();
+
+            let plugin_dir = dest.join("plugins/trailing");
+            fs::create_dir_all(&plugin_dir).unwrap();
+            fs::write(
+                plugin_dir.join("plugin.json"),
+                r#"{"name":"trailing","description":"Has trailing slash","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_repo_deduplicates_with_trailing_slash_in_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, TrailingSlashGitBackend);
+
+        let result = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect("add should succeed");
+
+        assert_eq!(result.name, "slash-market");
+        // Should have exactly 1 plugin, not 2 (dedup should handle trailing slash).
+        assert_eq!(
+            result.plugins.len(),
+            1,
+            "trailing slash should not cause duplicate: {:?}",
+            result.plugins
         );
     }
 }

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -120,15 +120,16 @@ impl MarketplaceService {
     ///
     /// 1. Detect source type (GitHub, git URL, local path).
     /// 2. Clone or link into a temp directory in the cache.
-    /// 3. Read the marketplace manifest to discover the canonical name.
-    /// 4. Validate the name, rename to final location.
-    /// 5. Register in `known_marketplaces.json`.
+    /// 3. Try to read `marketplace.json`; if missing, scan for `plugin.json` files.
+    /// 4. Merge manifest plugins with discovered plugins, deduplicating by path and name.
+    /// 5. Validate the name, rename to final location.
+    /// 6. Register in `known_marketplaces.json`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the clone/link fails, the manifest is missing or
-    /// invalid, the marketplace name fails validation, or a marketplace with
-    /// the same name is already registered.
+    /// Returns an error if the clone/link fails, no plugins are found (neither
+    /// via manifest nor scan), the marketplace name fails validation, or a
+    /// marketplace with the same name is already registered.
     pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
         let ms = MarketplaceSource::detect(source);
         self.cache.ensure_dirs()?;
@@ -136,7 +137,6 @@ impl MarketplaceService {
         let temp_name = format!("_pending_{}", std::process::id());
         let temp_dir = self.cache.marketplace_path(&temp_name);
 
-        // Clean up any leftover temp directory from a prior interrupted run.
         if temp_dir.exists()
             && let Err(e) = fs::remove_dir_all(&temp_dir)
         {
@@ -147,10 +147,8 @@ impl MarketplaceService {
             );
         }
 
-        // Guard auto-cleans temp_dir on any early return. Defuse after rename.
         let mut guard = TempDirGuard::new(temp_dir.clone());
 
-        // Clone or link based on source type.
         let link_result = self.clone_or_link(&ms, protocol, &temp_dir)?;
 
         if link_result == LinkResult::Copied {
@@ -160,23 +158,88 @@ impl MarketplaceService {
             );
         }
 
-        // Read marketplace manifest.
-        let manifest_path = temp_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
-        let manifest = Self::read_manifest(&manifest_path)?;
+        // Try to read marketplace manifest (optional).
+        let manifest = Self::try_read_manifest(&temp_dir);
 
-        let name = manifest.name.clone();
+        // Scan for plugin.json files.
+        let discovered = crate::plugin::discover_plugins(&temp_dir, 3);
+
+        // Build the plugin list: manifest entries first, then discovered (deduplicated).
+        let (name, plugins) = if let Some(m) = manifest {
+            let manifest_name = m.name.clone();
+            let mut plugins: Vec<PluginBasicInfo> = m
+                .plugins
+                .iter()
+                .map(|p| PluginBasicInfo {
+                    name: p.name.clone(),
+                    description: p.description.clone(),
+                })
+                .collect();
+
+            // Collect marketplace-listed relative paths for dedup.
+            let listed_paths: Vec<PathBuf> = m
+                .plugins
+                .iter()
+                .filter_map(|p| match &p.source {
+                    crate::marketplace::PluginSource::RelativePath(rel) => {
+                        Some(PathBuf::from(rel.trim_start_matches("./")))
+                    }
+                    crate::marketplace::PluginSource::Structured(_) => None,
+                })
+                .collect();
+
+            // Collect listed names for dedup of structured sources.
+            let listed_names: Vec<&str> =
+                m.plugins.iter().map(|p| p.name.as_str()).collect();
+
+            // Add discovered plugins that aren't already listed.
+            for dp in &discovered {
+                let path_match = listed_paths.iter().any(|lp| lp == &dp.relative_path);
+                let name_match = listed_names.contains(&dp.name.as_str());
+                if !path_match && !name_match {
+                    plugins.push(PluginBasicInfo {
+                        name: dp.name.clone(),
+                        description: dp.description.clone(),
+                    });
+                }
+            }
+
+            (manifest_name, plugins)
+        } else {
+            if discovered.is_empty() {
+                return Err(MarketplaceError::NoPluginsFound {
+                    path: temp_dir.clone(),
+                }
+                .into());
+            }
+
+            let name = ms.fallback_name().ok_or_else(|| {
+                MarketplaceError::InvalidManifest {
+                    reason: "no marketplace.json found and could not derive a name from the source; use --name to specify one".into(),
+                }
+            })?;
+
+            let plugins = discovered
+                .iter()
+                .map(|dp| PluginBasicInfo {
+                    name: dp.name.clone(),
+                    description: dp.description.clone(),
+                })
+                .collect();
+
+            (name, plugins)
+        };
+
         validation::validate_name(&name)?;
 
-        // Rename temp dir to final location.
         let final_dir = self.cache.marketplace_path(&name);
         if final_dir.exists() {
             return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
         }
 
         fs::rename(&temp_dir, &final_dir)?;
-        guard.defuse(); // Rename succeeded — don't clean up.
+        guard.defuse();
 
-        // Register in known_marketplaces.json.
         let entry = KnownMarketplace {
             name: name.clone(),
             source: ms,
@@ -184,15 +247,6 @@ impl MarketplaceService {
             added_at: chrono::Utc::now(),
         };
         self.cache.add_known_marketplace(entry)?;
-
-        let plugins = manifest
-            .plugins
-            .iter()
-            .map(|p| PluginBasicInfo {
-                name: p.name.clone(),
-                description: p.description.clone(),
-            })
-            .collect();
 
         debug!(marketplace = %name, "marketplace added");
 
@@ -341,28 +395,38 @@ impl MarketplaceService {
         }
     }
 
-    /// Read and parse the marketplace manifest. Does NOT do cleanup — the
-    /// caller (or its `TempDirGuard`) owns temp directory lifecycle.
-    fn read_manifest(manifest_path: &Path) -> Result<Marketplace, Error> {
-        let manifest_bytes = match fs::read(manifest_path) {
-            Ok(bytes) => bytes,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(MarketplaceError::ManifestNotFound {
-                    path: manifest_path.to_path_buf(),
+    /// Try to read the marketplace manifest. Returns `None` if the file is
+    /// missing or malformed, logging appropriately in each case.
+    fn try_read_manifest(repo_dir: &Path) -> Option<Marketplace> {
+        let manifest_path = repo_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
+        match fs::read(&manifest_path) {
+            Ok(bytes) => match Marketplace::from_json(&bytes) {
+                Ok(m) => Some(m),
+                Err(e) => {
+                    warn!(
+                        path = %manifest_path.display(),
+                        error = %e,
+                        "marketplace.json is malformed, falling back to plugin scan"
+                    );
+                    None
                 }
-                .into());
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!(
+                    path = %manifest_path.display(),
+                    "no marketplace.json found, will discover plugins via scan"
+                );
+                None
             }
             Err(e) => {
-                // Permission denied, I/O error, etc. — propagate the real cause.
-                return Err(e.into());
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "failed to read marketplace.json, falling back to plugin scan"
+                );
+                None
             }
-        };
-
-        Marketplace::from_json(&manifest_bytes).map_err(|e| {
-            Error::from(MarketplaceError::InvalidManifest {
-                reason: e.to_string(),
-            })
-        })
+        }
     }
 }
 
@@ -620,5 +684,195 @@ mod tests {
 
         assert_eq!(result.updated.len(), 1);
         assert_eq!(result.updated[0], "mock-market");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scan-and-merge tests
+    // -----------------------------------------------------------------------
+
+    /// Mock git backend that creates a repo with plugin.json files but no marketplace.json.
+    #[derive(Debug, Default)]
+    struct NoManifestGitBackend;
+
+    impl GitBackend for NoManifestGitBackend {
+        fn clone_repo(
+            &self,
+            _url: &str,
+            dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            let plugin_a = dest.join("plugins/alpha");
+            fs::create_dir_all(&plugin_a).unwrap();
+            fs::write(
+                plugin_a.join("plugin.json"),
+                r#"{"name":"alpha","description":"Alpha plugin","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            let plugin_b = dest.join("plugins/beta");
+            fs::create_dir_all(&plugin_b).unwrap();
+            fs::write(
+                plugin_b.join("plugin.json"),
+                r#"{"name":"beta","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    /// Mock that creates a repo with a marketplace.json AND an unlisted plugin.
+    #[derive(Debug, Default)]
+    struct MixedGitBackend;
+
+    impl GitBackend for MixedGitBackend {
+        fn clone_repo(
+            &self,
+            _url: &str,
+            dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(
+                mp_dir.join("marketplace.json"),
+                r#"{"name":"mixed-market","owner":{"name":"Test"},"plugins":[{"name":"listed","description":"A listed plugin","source":"./plugins/listed"}]}"#,
+            )
+            .unwrap();
+
+            let listed = dest.join("plugins/listed");
+            fs::create_dir_all(&listed).unwrap();
+            fs::write(
+                listed.join("plugin.json"),
+                r#"{"name":"listed","description":"A listed plugin","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            let unlisted = dest.join("plugins/unlisted");
+            fs::create_dir_all(&unlisted).unwrap();
+            fs::write(
+                unlisted.join("plugin.json"),
+                r#"{"name":"unlisted","description":"An unlisted plugin","skills":["./skills/"]}"#,
+            )
+            .unwrap();
+
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_repo_without_manifest_discovers_plugins_via_scan() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, NoManifestGitBackend);
+
+        let result = svc
+            .add("owner/skills", GitProtocol::Https)
+            .expect("add should succeed");
+
+        assert_eq!(result.name, "skills");
+        assert_eq!(result.plugins.len(), 2);
+
+        let names: Vec<&str> = result.plugins.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"alpha"), "should find alpha: {names:?}");
+        assert!(names.contains(&"beta"), "should find beta: {names:?}");
+    }
+
+    #[test]
+    fn add_repo_with_manifest_and_unlisted_plugins_merges_both() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, MixedGitBackend);
+
+        let result = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect("add should succeed");
+
+        assert_eq!(result.name, "mixed-market");
+        assert_eq!(result.plugins.len(), 2);
+
+        let names: Vec<&str> = result.plugins.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"listed"), "should find listed: {names:?}");
+        assert!(
+            names.contains(&"unlisted"),
+            "should find unlisted: {names:?}"
+        );
+    }
+
+    #[test]
+    fn add_repo_with_manifest_deduplicates_listed_plugins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, MixedGitBackend);
+
+        let result = svc
+            .add("owner/repo", GitProtocol::Https)
+            .expect("add should succeed");
+
+        let listed_count = result
+            .plugins
+            .iter()
+            .filter(|p| p.name == "listed")
+            .count();
+        assert_eq!(listed_count, 1, "listed plugin should not be duplicated");
+    }
+
+    #[test]
+    fn add_empty_repo_returns_no_plugins_found_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+
+        #[derive(Debug)]
+        struct EmptyRepoBackend;
+
+        impl GitBackend for EmptyRepoBackend {
+            fn clone_repo(
+                &self,
+                _url: &str,
+                dest: &Path,
+                _opts: &CloneOptions,
+            ) -> Result<(), GitError> {
+                fs::create_dir_all(dest).unwrap();
+                Ok(())
+            }
+
+            fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+                Ok(())
+            }
+
+            fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+                Ok(())
+            }
+        }
+
+        let svc = MarketplaceService::new(cache, EmptyRepoBackend);
+        let err = svc
+            .add("owner/empty", GitProtocol::Https)
+            .expect_err("should fail");
+
+        assert!(
+            err.to_string().contains("no plugins found"),
+            "expected 'no plugins found' error, got: {err}"
+        );
     }
 }

--- a/crates/kiro-market/src/commands/common.rs
+++ b/crates/kiro-market/src/commands/common.rs
@@ -3,34 +3,41 @@
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use kiro_market_core::marketplace::{Marketplace, PluginEntry};
 use kiro_market_core::plugin::PluginManifest;
 use tracing::{debug, warn};
 
 /// Read the marketplace manifest and find the matching plugin entry.
+///
+/// If the plugin is not listed in `marketplace.json` (or the manifest is absent),
+/// falls back to a depth-limited scan for `plugin.json` files in the repo.
 pub fn find_plugin_entry(
     marketplace_path: &Path,
     plugin_name: &str,
     marketplace_name: &str,
 ) -> Result<PluginEntry> {
+    // Try marketplace.json first.
     let manifest_path = marketplace_path.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
-    let manifest_bytes = fs::read(&manifest_path).with_context(|| {
-        format!(
-            "failed to read marketplace manifest at {}",
-            manifest_path.display()
-        )
-    })?;
-    let manifest =
-        Marketplace::from_json(&manifest_bytes).context("failed to parse marketplace manifest")?;
+    if let Ok(manifest_bytes) = fs::read(&manifest_path)
+        && let Ok(manifest) = Marketplace::from_json(&manifest_bytes)
+        && let Some(entry) = manifest.plugins.into_iter().find(|p| p.name == plugin_name)
+    {
+        return Ok(entry);
+    }
 
-    manifest
-        .plugins
-        .into_iter()
-        .find(|p| p.name == plugin_name)
-        .with_context(|| {
-            format!("plugin '{plugin_name}' not found in marketplace '{marketplace_name}'")
-        })
+    // Fall back to scanning for plugin.json.
+    let discovered = kiro_market_core::plugin::discover_plugins(marketplace_path, 3);
+    if let Some(dp) = discovered.into_iter().find(|dp| dp.name == plugin_name) {
+        let relative = format!("./{}", dp.relative_path.display());
+        return Ok(PluginEntry {
+            name: dp.name,
+            description: dp.description,
+            source: kiro_market_core::marketplace::PluginSource::RelativePath(relative),
+        });
+    }
+
+    anyhow::bail!("plugin '{plugin_name}' not found in marketplace '{marketplace_name}'")
 }
 
 /// Load skill paths from a plugin's `plugin.json`, falling back to defaults.

--- a/crates/kiro-market/src/commands/common.rs
+++ b/crates/kiro-market/src/commands/common.rs
@@ -10,30 +10,53 @@ use tracing::{debug, warn};
 
 /// Read the marketplace manifest and find the matching plugin entry.
 ///
-/// If the plugin is not listed in `marketplace.json` (or the manifest is absent),
-/// falls back to a depth-limited scan for `plugin.json` files in the repo.
+/// Falls back to a depth-limited scan for `plugin.json` files when
+/// `marketplace.json` is absent, unreadable, malformed, or does not list
+/// the requested plugin.
 pub fn find_plugin_entry(
     marketplace_path: &Path,
     plugin_name: &str,
     marketplace_name: &str,
 ) -> Result<PluginEntry> {
-    // Try marketplace.json first.
     let manifest_path = marketplace_path.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
-    if let Ok(manifest_bytes) = fs::read(&manifest_path)
-        && let Ok(manifest) = Marketplace::from_json(&manifest_bytes)
-        && let Some(entry) = manifest.plugins.into_iter().find(|p| p.name == plugin_name)
-    {
-        return Ok(entry);
+
+    match fs::read(&manifest_path) {
+        Ok(bytes) => match Marketplace::from_json(&bytes) {
+            Ok(manifest) => {
+                if let Some(entry) = manifest.plugins.into_iter().find(|p| p.name == plugin_name) {
+                    return Ok(entry);
+                }
+                // Plugin not in manifest — fall through to scan.
+            }
+            Err(e) => {
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "marketplace.json is malformed, falling back to plugin scan"
+                );
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Expected — manifest is optional.
+        }
+        Err(e) => {
+            warn!(
+                path = %manifest_path.display(),
+                error = %e,
+                "failed to read marketplace.json, falling back to plugin scan"
+            );
+        }
     }
 
     // Fall back to scanning for plugin.json.
     let discovered = kiro_market_core::plugin::discover_plugins(marketplace_path, 3);
-    if let Some(dp) = discovered.into_iter().find(|dp| dp.name == plugin_name) {
-        let relative = format!("./{}", dp.relative_path.display());
+    if let Some(dp) = discovered.into_iter().find(|dp| dp.name() == plugin_name) {
         return Ok(PluginEntry {
-            name: dp.name,
-            description: dp.description,
-            source: kiro_market_core::marketplace::PluginSource::RelativePath(relative),
+            name: dp.name().to_owned(),
+            description: dp.description().map(String::from),
+            source: kiro_market_core::marketplace::PluginSource::RelativePath(
+                dp.as_relative_path_string(),
+            ),
         });
     }
 
@@ -82,4 +105,110 @@ fn default_skill_paths() -> Vec<String> {
         .iter()
         .map(|&s| s.to_owned())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    /// Helper: create a marketplace repo layout with a manifest listing one plugin.
+    fn create_marketplace_with_manifest(root: &std::path::Path, plugin_name: &str) {
+        let mp_dir = root.join(".claude-plugin");
+        fs::create_dir_all(&mp_dir).expect("create .claude-plugin");
+        fs::write(
+            mp_dir.join("marketplace.json"),
+            format!(
+                r#"{{"name":"test-market","owner":{{"name":"Test"}},"plugins":[{{"name":"{plugin_name}","description":"Listed plugin","source":"./plugins/{plugin_name}"}}]}}"#
+            ),
+        )
+        .expect("write marketplace.json");
+
+        let plugin_dir = root.join(format!("plugins/{plugin_name}"));
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            format!(
+                r#"{{"name":"{plugin_name}","description":"Listed plugin","skills":["./skills/"]}}"#
+            ),
+        )
+        .expect("write plugin.json");
+    }
+
+    /// Helper: create a plugin directory with plugin.json but no marketplace.json.
+    fn create_plugin_without_manifest(root: &std::path::Path, plugin_name: &str) {
+        let plugin_dir = root.join(format!("plugins/{plugin_name}"));
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            format!(
+                r#"{{"name":"{plugin_name}","description":"Discovered plugin","skills":["./skills/"]}}"#
+            ),
+        )
+        .expect("write plugin.json");
+    }
+
+    #[test]
+    fn find_plugin_entry_from_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        create_marketplace_with_manifest(root, "listed");
+
+        let entry =
+            find_plugin_entry(root, "listed", "test-market").expect("should find listed plugin");
+
+        assert_eq!(entry.name, "listed");
+        assert_eq!(entry.description.as_deref(), Some("Listed plugin"));
+    }
+
+    #[test]
+    fn find_plugin_entry_falls_back_to_scan_when_no_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        create_plugin_without_manifest(root, "discovered");
+
+        let entry = find_plugin_entry(root, "discovered", "test-market")
+            .expect("should find via scan fallback");
+
+        assert_eq!(entry.name, "discovered");
+        assert_eq!(entry.description.as_deref(), Some("Discovered plugin"));
+        assert!(
+            matches!(
+                &entry.source,
+                kiro_market_core::marketplace::PluginSource::RelativePath(p) if p.contains("discovered")
+            ),
+            "source should be a RelativePath: {:?}",
+            entry.source
+        );
+    }
+
+    #[test]
+    fn find_plugin_entry_falls_back_to_scan_when_plugin_unlisted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        // Create a manifest that lists "listed" but NOT "unlisted".
+        create_marketplace_with_manifest(root, "listed");
+        create_plugin_without_manifest(root, "unlisted");
+
+        let entry = find_plugin_entry(root, "unlisted", "test-market")
+            .expect("should find unlisted via scan");
+
+        assert_eq!(entry.name, "unlisted");
+    }
+
+    #[test]
+    fn find_plugin_entry_errors_when_plugin_not_found_anywhere() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        // Empty directory — no manifest, no plugins.
+        fs::create_dir_all(root).expect("create root");
+
+        let err = find_plugin_entry(root, "nonexistent", "test-market").expect_err("should fail");
+
+        assert!(
+            err.to_string().contains("not found"),
+            "expected 'not found' in error: {err}"
+        );
+    }
 }

--- a/docs/plans/2026-04-11-kiro-settings-view-design.md
+++ b/docs/plans/2026-04-11-kiro-settings-view-design.md
@@ -1,0 +1,221 @@
+# Kiro CLI Settings View — Design
+
+## Overview
+
+Add a settings management view to the Kiro Control Center (Tauri desktop app)
+for viewing and editing Kiro CLI settings stored at `~/.kiro/settings/cli.json`.
+The view uses a sidebar category navigation pattern with search, type-appropriate
+editors, and inline descriptions/defaults.
+
+## Entry Point & Navigation
+
+A gear icon in the header bar (left of the project dropdown) opens the settings
+view. The view replaces the tab bar and main content area — it is a full-screen
+mode, not a 4th tab. This reinforces that settings are user-global, not
+project-scoped. A "Back to Marketplace" link returns to the previous tab.
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Kiro Control Center                ⚙️  [Project ▼]  │
+├──────────────────────────────────────────────────────┤
+│ ← Back to Marketplace    🔍 Search settings...       │
+├───────────────┬──────────────────────────────────────┤
+│  Telemetry    │  Chat Interface                      │
+│  Chat      ◀──│                                      │
+│  Knowledge    │  Default Model              [sonnet] │
+│  Key Bindings │    AI model for new conversations    │
+│  Features     │                                      │
+│  API          │  Enable Notifications           ⬜   │
+│  MCP          │    Desktop notifications             │
+│  Env Vars     │                                      │
+└───────────────┴──────────────────────────────────────┘
+```
+
+## Settings Data Model
+
+### Static Registry (Rust)
+
+Settings are defined as a static registry in `kiro-market-core`. Each entry
+carries everything the UI needs:
+
+```rust
+pub struct SettingDef {
+    pub key: &'static str,           // "chat.defaultModel"
+    pub label: &'static str,         // "Default Model"
+    pub description: &'static str,   // "AI model for new conversations"
+    pub category: SettingCategory,   // SettingCategory::Chat
+    pub value_type: SettingType,     // SettingType::String
+    pub default: Option<JsonValue>,  // Some("sonnet")
+}
+
+pub enum SettingCategory {
+    Telemetry,
+    Chat,
+    Knowledge,
+    KeyBindings,
+    Features,
+    Api,
+    Mcp,
+    Environment,
+}
+
+pub enum SettingType {
+    Bool,
+    String,
+    Number,
+    Char,
+    StringArray,
+    Enum(Vec<&'static str>),
+}
+```
+
+### File Format
+
+`~/.kiro/settings/cli.json` is unstructured JSON — a nested map. The registry
+gives it structure for the UI without imposing a rigid Rust struct. Dotted keys
+like `chat.defaultModel` map to `{"chat": {"defaultModel": ...}}`.
+
+## Rust Backend (Tauri Commands)
+
+Three new Tauri commands:
+
+### `get_kiro_settings`
+
+Returns the full settings state. The backend loads `cli.json`, walks the
+registry, and returns a `Vec<SettingEntry>` with current values resolved:
+
+```rust
+pub struct SettingEntry {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub category: String,
+    pub value_type: String,        // "bool", "string", "number", "char", "string_array", "enum"
+    pub enum_options: Vec<String>,
+    pub default_value: Option<JsonValue>,
+    pub current_value: Option<JsonValue>,
+}
+```
+
+The frontend groups by `category` for rendering — no dotted-path JSON
+traversal needed on the Svelte side.
+
+### `set_kiro_setting(key, value)`
+
+Loads `cli.json`, sets the value at the dotted path, writes back. Returns the
+updated `SettingEntry`.
+
+### `reset_kiro_setting(key)`
+
+Removes a key from `cli.json` so Kiro CLI falls back to its built-in default.
+
+## Svelte Frontend Components
+
+### SettingsView.svelte
+
+Top-level layout. Owns sidebar + main panel split and search state. Calls
+`get_kiro_settings` on mount, groups results by category. Manages
+`activeCategory` and `searchQuery`. During search, shows filtered results
+across all categories with category headers.
+
+### CategoryList.svelte
+
+The sidebar. Vertical list of category buttons with count badges. Active
+category highlighted. During search, categories with no matches are dimmed.
+
+### SettingsPanel.svelte
+
+Main content area. Renders `SettingControl` components for the active category
+or search results. Each setting shows label, description, editor widget, a
+"modified" indicator if value differs from default, and a "reset to default"
+action.
+
+### SettingControl.svelte
+
+Single setting row. Switches on `value_type` for the appropriate editor:
+
+| Type           | Widget                              |
+|----------------|-------------------------------------|
+| `bool`         | Toggle switch                       |
+| `string`       | Text input                          |
+| `number`       | Number input with increment/decrement |
+| `char`         | Single-character input              |
+| `string_array` | Chip list with add/remove           |
+| `enum`         | Dropdown select                     |
+
+Changes auto-persist immediately (no save button). Optimistic UI update with
+error toast on failure.
+
+### Integration
+
+A `showSettings` boolean in `+page.svelte` (like existing `showManageRoots`).
+The gear icon toggles it. When true, `SettingsView` replaces the tab bar and
+main content.
+
+## Error Handling
+
+- **File missing:** Return all settings with `current_value: None`. First write
+  creates the file and parent directories.
+- **Malformed JSON:** Show error banner. Do not silently overwrite.
+- **Unknown keys:** Ignore in the UI but preserve on write. Never drop
+  unrecognized keys.
+- **Concurrent edits:** No file watching. Re-read on each settings view open.
+  Last-write-wins on conflict.
+- **Registry staleness:** Compiled into the binary. Unknown-to-registry keys in
+  the file are invisible but preserved.
+
+## Settings Inventory (from kiro.dev/docs/cli/reference/settings/)
+
+### Telemetry & Privacy (2)
+- `telemetry.enabled` (bool) — Enable/disable telemetry collection
+- `telemetryClientId` (string) — Client identifier for telemetry
+
+### Chat Interface (12)
+- `chat.defaultModel` (string) — Default AI model for conversations
+- `chat.defaultAgent` (string) — Default agent configuration
+- `chat.diffTool` (string) — External diff tool for viewing code changes
+- `chat.greeting.enabled` (bool) — Show greeting message on chat start
+- `chat.editMode` (bool) — Enable edit mode for chat interface
+- `chat.enableNotifications` (bool) — Enable desktop notifications
+- `chat.disableMarkdownRendering` (bool) — Disable markdown formatting
+- `chat.disableAutoCompaction` (bool) — Disable automatic conversation summarization
+- `chat.enablePromptHints` (bool, default: true) — Show startup hints
+- `chat.enableHistoryHints` (bool) — Show conversation history hints
+- `chat.uiMode` (string) — UI variant to use
+- `chat.enableContextUsageIndicator` (bool) — Show context usage percentage
+- `compaction.excludeMessages` (number) — Min message pairs to retain during compaction
+- `compaction.excludeContextWindowPercent` (number) — Min % of context window to retain
+
+### Knowledge Base (7)
+- `chat.enableKnowledge` (bool) — Enable knowledge base functionality
+- `knowledge.defaultIncludePatterns` (string_array) — Default file patterns to include
+- `knowledge.defaultExcludePatterns` (string_array) — Default file patterns to exclude
+- `knowledge.maxFiles` (number) — Maximum files for indexing
+- `knowledge.chunkSize` (number) — Text chunk size for processing
+- `knowledge.chunkOverlap` (number) — Overlap between text chunks
+- `knowledge.indexType` (string) — Type of knowledge index
+
+### Key Bindings (4)
+- `chat.skimCommandKey` (char) — Key for fuzzy search command
+- `chat.autocompletionKey` (char) — Key for autocompletion hint acceptance
+- `chat.tangentModeKey` (char) — Key for tangent mode toggle
+- `chat.delegateModeKey` (char) — Key for delegate command
+
+### Feature Toggles (5)
+- `chat.enableThinking` (bool) — Enable thinking tool for complex reasoning
+- `chat.enableTangentMode` (bool) — Enable tangent mode feature
+- `introspect.tangentMode` (bool) — Auto-enter tangent mode for introspect
+- `chat.enableTodoList` (bool) — Enable todo list feature
+- `chat.enableCheckpoint` (bool) — Enable checkpoint feature
+- `chat.enableDelegate` (bool) — Enable delegate tool
+
+### API & Service (1)
+- `api.timeout` (number) — API request timeout in seconds
+
+### MCP (3)
+- `mcp.initTimeout` (number) — MCP server initialization timeout
+- `mcp.noInteractiveTimeout` (number) — Non-interactive MCP timeout
+- `mcp.loadedBefore` (bool) — Track previously loaded MCP servers
+
+### Environment Variables (1)
+- `KIRO_LOG_NO_COLOR` (bool-like) — Set to 1 to disable colored log output

--- a/docs/plans/2026-04-11-kiro-settings-view-plan.md
+++ b/docs/plans/2026-04-11-kiro-settings-view-plan.md
@@ -1,0 +1,1780 @@
+# Kiro CLI Settings View — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a settings management view to the Kiro Control Center Tauri app for viewing and editing Kiro CLI settings at `~/.kiro/settings/cli.json`, with sidebar category navigation, search, type-appropriate editors, and inline descriptions/defaults.
+
+**Architecture:** A static settings registry in `kiro-market-core` defines all ~40 Kiro CLI settings with metadata (key, label, description, category, type, default). Three Tauri commands (get/set/reset) resolve the registry against the JSON file. Four new Svelte 5 components render the sidebar + panel layout with search and auto-persist editing.
+
+**Tech Stack:** Rust (kiro-market-core + Tauri commands), Svelte 5 ($state/$derived/$props), Tailwind CSS (existing kiro-* theme tokens), tauri-specta (TypeScript binding generation), serde_json (unstructured JSON manipulation).
+
+---
+
+### Task 1: Settings Registry Types
+
+Add the static settings registry types to kiro-market-core. These define the metadata for every Kiro CLI setting.
+
+**Files:**
+- Create: `crates/kiro-market-core/src/kiro_settings.rs`
+- Modify: `crates/kiro-market-core/src/lib.rs`
+
+**Step 1: Write tests for the registry**
+
+Create `crates/kiro-market-core/src/kiro_settings.rs` with test-first approach. Start with the types and a test that the registry is well-formed:
+
+```rust
+//! Kiro CLI settings registry.
+//!
+//! Defines metadata for all known Kiro CLI settings, enabling the Control
+//! Center to render a guided settings editor without hardcoding UI knowledge
+//! of each setting.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Category grouping for settings in the sidebar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+pub enum SettingCategory {
+    Telemetry,
+    Chat,
+    Knowledge,
+    KeyBindings,
+    Features,
+    Api,
+    Mcp,
+    Environment,
+}
+
+impl SettingCategory {
+    /// Human-readable label for display.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Telemetry => "Telemetry & Privacy",
+            Self::Chat => "Chat Interface",
+            Self::Knowledge => "Knowledge Base",
+            Self::KeyBindings => "Key Bindings",
+            Self::Features => "Feature Toggles",
+            Self::Api => "API & Service",
+            Self::Mcp => "MCP",
+            Self::Environment => "Environment Variables",
+        }
+    }
+}
+
+/// Value type of a setting, determines the editor widget in the UI.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SettingType {
+    Bool,
+    String,
+    Number,
+    Char,
+    StringArray,
+    Enum(Vec<&'static str>),
+}
+
+/// Definition of a single Kiro CLI setting.
+#[derive(Debug, Clone)]
+pub struct SettingDef {
+    /// Dotted key path in cli.json (e.g. "chat.defaultModel").
+    pub key: &'static str,
+    /// Short human-readable label.
+    pub label: &'static str,
+    /// Description shown below the label.
+    pub description: &'static str,
+    /// Category for sidebar grouping.
+    pub category: SettingCategory,
+    /// Value type (determines editor widget).
+    pub value_type: SettingType,
+    /// Default value (None means no default known).
+    pub default: Option<JsonValue>,
+}
+
+/// A resolved setting entry with current value, ready for the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct SettingEntry {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub category: String,
+    pub category_label: String,
+    /// One of: "bool", "string", "number", "char", "string_array", "enum".
+    pub value_type: String,
+    /// Populated only for enum settings.
+    pub enum_options: Vec<String>,
+    pub default_value: Option<JsonValue>,
+    /// None means using the default (key absent from cli.json).
+    pub current_value: Option<JsonValue>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_keys_are_unique() {
+        let registry = registry();
+        let mut keys: Vec<&str> = registry.iter().map(|d| d.key).collect();
+        let len_before = keys.len();
+        keys.sort_unstable();
+        keys.dedup();
+        assert_eq!(keys.len(), len_before, "duplicate keys in registry");
+    }
+
+    #[test]
+    fn registry_has_all_categories() {
+        let registry = registry();
+        let categories: std::collections::HashSet<SettingCategory> =
+            registry.iter().map(|d| d.category).collect();
+        // Every category enum variant should have at least one setting.
+        assert!(categories.contains(&SettingCategory::Telemetry));
+        assert!(categories.contains(&SettingCategory::Chat));
+        assert!(categories.contains(&SettingCategory::Knowledge));
+        assert!(categories.contains(&SettingCategory::KeyBindings));
+        assert!(categories.contains(&SettingCategory::Features));
+        assert!(categories.contains(&SettingCategory::Api));
+        assert!(categories.contains(&SettingCategory::Mcp));
+        assert!(categories.contains(&SettingCategory::Environment));
+    }
+
+    #[test]
+    fn setting_category_labels_are_nonempty() {
+        let categories = [
+            SettingCategory::Telemetry,
+            SettingCategory::Chat,
+            SettingCategory::Knowledge,
+            SettingCategory::KeyBindings,
+            SettingCategory::Features,
+            SettingCategory::Api,
+            SettingCategory::Mcp,
+            SettingCategory::Environment,
+        ];
+        for cat in categories {
+            assert!(!cat.label().is_empty(), "{cat:?} has empty label");
+        }
+    }
+
+    #[test]
+    fn registry_defaults_match_value_type() {
+        let registry = registry();
+        for def in &registry {
+            if let Some(ref default) = def.default {
+                match &def.value_type {
+                    SettingType::Bool => assert!(
+                        default.is_boolean(),
+                        "{}: default should be bool, got {default}",
+                        def.key
+                    ),
+                    SettingType::Number => assert!(
+                        default.is_number(),
+                        "{}: default should be number, got {default}",
+                        def.key
+                    ),
+                    SettingType::String | SettingType::Char | SettingType::Enum(_) => assert!(
+                        default.is_string(),
+                        "{}: default should be string, got {default}",
+                        def.key
+                    ),
+                    SettingType::StringArray => assert!(
+                        default.is_array(),
+                        "{}: default should be array, got {default}",
+                        def.key
+                    ),
+                }
+            }
+        }
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: FAIL — `registry()` function doesn't exist yet.
+
+**Step 3: Add the registry function and all setting definitions**
+
+Add below the types in the same file:
+
+```rust
+/// The complete registry of known Kiro CLI settings.
+///
+/// This is the single source of truth for what appears in the settings UI.
+/// Add new settings here when Kiro CLI introduces them.
+#[must_use]
+pub fn registry() -> Vec<SettingDef> {
+    vec![
+        // -- Telemetry & Privacy --
+        SettingDef {
+            key: "telemetry.enabled",
+            label: "Enable Telemetry",
+            description: "Enable or disable telemetry collection",
+            category: SettingCategory::Telemetry,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(true)),
+        },
+        SettingDef {
+            key: "telemetryClientId",
+            label: "Telemetry Client ID",
+            description: "Client identifier for telemetry",
+            category: SettingCategory::Telemetry,
+            value_type: SettingType::String,
+            default: None,
+        },
+        // -- Chat Interface --
+        SettingDef {
+            key: "chat.defaultModel",
+            label: "Default Model",
+            description: "Default AI model for conversations",
+            category: SettingCategory::Chat,
+            value_type: SettingType::String,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.defaultAgent",
+            label: "Default Agent",
+            description: "Default agent configuration",
+            category: SettingCategory::Chat,
+            value_type: SettingType::String,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.diffTool",
+            label: "Diff Tool",
+            description: "External diff tool for viewing code changes",
+            category: SettingCategory::Chat,
+            value_type: SettingType::String,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.greeting.enabled",
+            label: "Show Greeting",
+            description: "Show greeting message on chat start",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(true)),
+        },
+        SettingDef {
+            key: "chat.editMode",
+            label: "Edit Mode",
+            description: "Enable edit mode for chat interface",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableNotifications",
+            label: "Enable Notifications",
+            description: "Enable desktop notifications",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.disableMarkdownRendering",
+            label: "Disable Markdown Rendering",
+            description: "Disable markdown formatting in chat",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
+        },
+        SettingDef {
+            key: "chat.disableAutoCompaction",
+            label: "Disable Auto Compaction",
+            description: "Disable automatic conversation summarization",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
+        },
+        SettingDef {
+            key: "chat.enablePromptHints",
+            label: "Show Prompt Hints",
+            description: "Show startup hints with tips and shortcuts",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(true)),
+        },
+        SettingDef {
+            key: "chat.enableHistoryHints",
+            label: "Show History Hints",
+            description: "Show conversation history hints",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.uiMode",
+            label: "UI Mode",
+            description: "UI variant to use",
+            category: SettingCategory::Chat,
+            value_type: SettingType::String,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableContextUsageIndicator",
+            label: "Context Usage Indicator",
+            description: "Show context usage percentage in prompt",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "compaction.excludeMessages",
+            label: "Compaction Exclude Messages",
+            description: "Minimum message pairs to retain during compaction",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "compaction.excludeContextWindowPercent",
+            label: "Compaction Exclude Context %",
+            description: "Minimum percentage of context window to retain during compaction",
+            category: SettingCategory::Chat,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        // -- Knowledge Base --
+        SettingDef {
+            key: "chat.enableKnowledge",
+            label: "Enable Knowledge Base",
+            description: "Enable knowledge base functionality",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.defaultIncludePatterns",
+            label: "Include Patterns",
+            description: "Default file patterns to include in knowledge indexing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::StringArray,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.defaultExcludePatterns",
+            label: "Exclude Patterns",
+            description: "Default file patterns to exclude from knowledge indexing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::StringArray,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.maxFiles",
+            label: "Max Files",
+            description: "Maximum number of files for knowledge indexing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.chunkSize",
+            label: "Chunk Size",
+            description: "Text chunk size for knowledge processing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.chunkOverlap",
+            label: "Chunk Overlap",
+            description: "Overlap between text chunks in knowledge processing",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "knowledge.indexType",
+            label: "Index Type",
+            description: "Type of knowledge index to use",
+            category: SettingCategory::Knowledge,
+            value_type: SettingType::String,
+            default: None,
+        },
+        // -- Key Bindings --
+        SettingDef {
+            key: "chat.skimCommandKey",
+            label: "Skim Command Key",
+            description: "Key for fuzzy search command",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::Char,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.autocompletionKey",
+            label: "Autocompletion Key",
+            description: "Key for autocompletion hint acceptance",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::Char,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.tangentModeKey",
+            label: "Tangent Mode Key",
+            description: "Key for tangent mode toggle",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::Char,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.delegateModeKey",
+            label: "Delegate Mode Key",
+            description: "Key for delegate command",
+            category: SettingCategory::KeyBindings,
+            value_type: SettingType::Char,
+            default: None,
+        },
+        // -- Feature Toggles --
+        SettingDef {
+            key: "chat.enableThinking",
+            label: "Enable Thinking",
+            description: "Enable thinking tool for complex reasoning",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableTangentMode",
+            label: "Enable Tangent Mode",
+            description: "Enable tangent mode feature",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "introspect.tangentMode",
+            label: "Introspect Tangent Mode",
+            description: "Auto-enter tangent mode for introspect",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableTodoList",
+            label: "Enable Todo List",
+            description: "Enable todo list feature",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableCheckpoint",
+            label: "Enable Checkpoint",
+            description: "Enable checkpoint feature",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        SettingDef {
+            key: "chat.enableDelegate",
+            label: "Enable Delegate",
+            description: "Enable delegate tool",
+            category: SettingCategory::Features,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        // -- API & Service --
+        SettingDef {
+            key: "api.timeout",
+            label: "API Timeout",
+            description: "API request timeout in seconds",
+            category: SettingCategory::Api,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        // -- MCP --
+        SettingDef {
+            key: "mcp.initTimeout",
+            label: "Init Timeout",
+            description: "MCP server initialization timeout in milliseconds",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "mcp.noInteractiveTimeout",
+            label: "Non-Interactive Timeout",
+            description: "Non-interactive MCP timeout in milliseconds",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Number,
+            default: None,
+        },
+        SettingDef {
+            key: "mcp.loadedBefore",
+            label: "Loaded Before",
+            description: "Track previously loaded MCP servers",
+            category: SettingCategory::Mcp,
+            value_type: SettingType::Bool,
+            default: None,
+        },
+        // -- Environment Variables --
+        SettingDef {
+            key: "KIRO_LOG_NO_COLOR",
+            label: "Disable Log Colors",
+            description: "Set to disable colored log output",
+            category: SettingCategory::Environment,
+            value_type: SettingType::Bool,
+            default: Some(JsonValue::Bool(false)),
+        },
+    ]
+}
+```
+
+**Step 4: Register module in lib.rs**
+
+Add to `crates/kiro-market-core/src/lib.rs`:
+
+```rust
+pub mod kiro_settings;
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: PASS — all 4 tests green.
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/kiro_settings.rs crates/kiro-market-core/src/lib.rs
+git commit -m "feat(core): add Kiro CLI settings registry types and definitions"
+```
+
+---
+
+### Task 2: JSON Path Helpers and Settings Resolution
+
+Add functions to traverse nested JSON by dotted key paths, and to resolve the registry against a `cli.json` file.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/kiro_settings.rs`
+
+**Step 1: Write tests for JSON path helpers**
+
+Add to the `tests` module:
+
+```rust
+#[test]
+fn get_nested_finds_top_level_key() {
+    let json: JsonValue = serde_json::json!({"foo": "bar"});
+    assert_eq!(get_nested(&json, "foo"), Some(&JsonValue::String("bar".into())));
+}
+
+#[test]
+fn get_nested_finds_dotted_path() {
+    let json: JsonValue = serde_json::json!({"chat": {"defaultModel": "sonnet"}});
+    assert_eq!(
+        get_nested(&json, "chat.defaultModel"),
+        Some(&JsonValue::String("sonnet".into()))
+    );
+}
+
+#[test]
+fn get_nested_returns_none_for_missing() {
+    let json: JsonValue = serde_json::json!({"chat": {}});
+    assert_eq!(get_nested(&json, "chat.defaultModel"), None);
+}
+
+#[test]
+fn set_nested_creates_intermediate_objects() {
+    let mut json: JsonValue = serde_json::json!({});
+    set_nested(&mut json, "chat.defaultModel", JsonValue::String("sonnet".into()));
+    assert_eq!(json, serde_json::json!({"chat": {"defaultModel": "sonnet"}}));
+}
+
+#[test]
+fn set_nested_overwrites_existing() {
+    let mut json: JsonValue = serde_json::json!({"chat": {"defaultModel": "old"}});
+    set_nested(&mut json, "chat.defaultModel", JsonValue::String("new".into()));
+    assert_eq!(json, serde_json::json!({"chat": {"defaultModel": "new"}}));
+}
+
+#[test]
+fn remove_nested_deletes_key() {
+    let mut json: JsonValue = serde_json::json!({"chat": {"defaultModel": "sonnet", "other": true}});
+    remove_nested(&mut json, "chat.defaultModel");
+    assert_eq!(json, serde_json::json!({"chat": {"other": true}}));
+}
+
+#[test]
+fn remove_nested_cleans_empty_parents() {
+    let mut json: JsonValue = serde_json::json!({"chat": {"defaultModel": "sonnet"}});
+    remove_nested(&mut json, "chat.defaultModel");
+    assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn remove_nested_noop_for_missing() {
+    let mut json: JsonValue = serde_json::json!({"foo": "bar"});
+    remove_nested(&mut json, "chat.defaultModel");
+    assert_eq!(json, serde_json::json!({"foo": "bar"}));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: FAIL — `get_nested`, `set_nested`, `remove_nested` don't exist.
+
+**Step 3: Implement the JSON path helpers**
+
+Add above the `registry()` function:
+
+```rust
+// ---------------------------------------------------------------------------
+// JSON path helpers
+// ---------------------------------------------------------------------------
+
+/// Get a value from nested JSON by dotted path (e.g. "chat.defaultModel").
+#[must_use]
+pub fn get_nested<'a>(value: &'a JsonValue, path: &str) -> Option<&'a JsonValue> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+/// Set a value in nested JSON by dotted path, creating intermediate objects.
+pub fn set_nested(value: &mut JsonValue, path: &str, val: JsonValue) {
+    let segments: Vec<&str> = path.split('.').collect();
+    let mut current = value;
+
+    // Navigate/create intermediate objects.
+    for &segment in &segments[..segments.len() - 1] {
+        if !current.get(segment).is_some_and(JsonValue::is_object) {
+            current[segment] = JsonValue::Object(serde_json::Map::new());
+        }
+        current = current.get_mut(segment).expect("just created");
+    }
+
+    if let Some(last) = segments.last() {
+        current[*last] = val;
+    }
+}
+
+/// Remove a key from nested JSON by dotted path.
+///
+/// Cleans up empty parent objects after removal.
+pub fn remove_nested(value: &mut JsonValue, path: &str) {
+    let segments: Vec<&str> = path.split('.').collect();
+    remove_nested_recursive(value, &segments);
+}
+
+fn remove_nested_recursive(value: &mut JsonValue, segments: &[&str]) -> bool {
+    let Some((&first, rest)) = segments.split_first() else {
+        return false;
+    };
+
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+
+    if rest.is_empty() {
+        // Leaf segment — remove the key.
+        obj.remove(first);
+    } else if let Some(child) = obj.get_mut(first) {
+        // Recurse, then clean up if child became an empty object.
+        remove_nested_recursive(child, rest);
+        if child.as_object().is_some_and(serde_json::Map::is_empty) {
+            obj.remove(first);
+        }
+    }
+
+    obj.is_empty()
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: PASS.
+
+**Step 5: Write tests for resolve_settings**
+
+Add to the `tests` module:
+
+```rust
+#[test]
+fn resolve_settings_uses_defaults_when_no_file() {
+    let json = serde_json::json!({});
+    let entries = resolve_settings(&json);
+    assert!(!entries.is_empty());
+    // All current_value should be None.
+    for entry in &entries {
+        assert!(entry.current_value.is_none(), "{} should have no value", entry.key);
+    }
+}
+
+#[test]
+fn resolve_settings_picks_up_user_values() {
+    let json = serde_json::json!({
+        "chat": {"defaultModel": "opus"}
+    });
+    let entries = resolve_settings(&json);
+    let model = entries.iter().find(|e| e.key == "chat.defaultModel").expect("should exist");
+    assert_eq!(model.current_value, Some(JsonValue::String("opus".into())));
+}
+
+#[test]
+fn resolve_settings_includes_category_label() {
+    let json = serde_json::json!({});
+    let entries = resolve_settings(&json);
+    let telemetry = entries.iter().find(|e| e.key == "telemetry.enabled").expect("should exist");
+    assert_eq!(telemetry.category_label, "Telemetry & Privacy");
+}
+```
+
+**Step 6: Implement resolve_settings**
+
+```rust
+/// Resolve the registry against a loaded JSON value, producing entries
+/// with current values filled in.
+#[must_use]
+pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
+    registry()
+        .into_iter()
+        .map(|def| {
+            let current_value = get_nested(json, def.key).cloned();
+            let value_type_str = match &def.value_type {
+                SettingType::Bool => "bool",
+                SettingType::String => "string",
+                SettingType::Number => "number",
+                SettingType::Char => "char",
+                SettingType::StringArray => "string_array",
+                SettingType::Enum(_) => "enum",
+            };
+            let enum_options = match &def.value_type {
+                SettingType::Enum(opts) => opts.iter().map(|&s| s.to_owned()).collect(),
+                _ => Vec::new(),
+            };
+
+            SettingEntry {
+                key: def.key.to_owned(),
+                label: def.label.to_owned(),
+                description: def.description.to_owned(),
+                category: serde_json::to_value(def.category)
+                    .ok()
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default(),
+                category_label: def.category.label().to_owned(),
+                value_type: value_type_str.to_owned(),
+                enum_options,
+                default_value: def.default,
+                current_value,
+            }
+        })
+        .collect()
+}
+```
+
+**Step 7: Run tests**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: PASS.
+
+**Step 8: Commit**
+
+```bash
+git add crates/kiro-market-core/src/kiro_settings.rs
+git commit -m "feat(core): add JSON path helpers and settings resolution"
+```
+
+---
+
+### Task 3: Kiro Settings File I/O
+
+Add functions to load and save `~/.kiro/settings/cli.json` as unstructured JSON.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/kiro_settings.rs`
+
+**Step 1: Write tests for file I/O**
+
+```rust
+#[test]
+fn load_kiro_settings_returns_empty_when_no_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let json = load_kiro_settings_from(dir.path());
+    assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn save_and_load_kiro_settings_roundtrip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let json = serde_json::json!({"chat": {"defaultModel": "opus"}});
+    save_kiro_settings_to(dir.path(), &json).expect("save");
+    let loaded = load_kiro_settings_from(dir.path());
+    assert_eq!(loaded, json);
+}
+
+#[test]
+fn save_kiro_settings_creates_parent_dirs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let nested = dir.path().join("deep").join("path");
+    let json = serde_json::json!({"foo": "bar"});
+    save_kiro_settings_to(&nested, &json).expect("save");
+    let loaded = load_kiro_settings_from(&nested);
+    assert_eq!(loaded, json);
+}
+
+#[test]
+fn load_kiro_settings_returns_empty_on_corrupt_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("settings")).expect("mkdir");
+    std::fs::write(dir.path().join("settings").join("cli.json"), "{{not json}}")
+        .expect("write");
+    let json = load_kiro_settings_from(dir.path());
+    assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn save_kiro_settings_preserves_unknown_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let original = serde_json::json!({"unknown_future_setting": true, "chat": {"defaultModel": "opus"}});
+    save_kiro_settings_to(dir.path(), &original).expect("save");
+
+    // Modify one key.
+    let mut json = load_kiro_settings_from(dir.path());
+    set_nested(&mut json, "chat.defaultModel", JsonValue::String("sonnet".into()));
+    save_kiro_settings_to(dir.path(), &json).expect("save");
+
+    // Verify unknown key survived.
+    let loaded = load_kiro_settings_from(dir.path());
+    assert_eq!(loaded["unknown_future_setting"], JsonValue::Bool(true));
+    assert_eq!(loaded["chat"]["defaultModel"], JsonValue::String("sonnet".into()));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: FAIL — `load_kiro_settings_from`, `save_kiro_settings_to` don't exist.
+
+**Step 3: Implement I/O functions**
+
+Add to the file:
+
+```rust
+use std::fs;
+use std::path::Path;
+
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+const KIRO_SETTINGS_PATH: &str = "settings/cli.json";
+
+/// Load `settings/cli.json` from the given Kiro config directory.
+///
+/// Returns an empty JSON object if the file is missing or corrupt.
+#[must_use]
+pub fn load_kiro_settings_from(kiro_dir: &Path) -> JsonValue {
+    let path = kiro_dir.join(KIRO_SETTINGS_PATH);
+    match fs::read(&path) {
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "cli.json is corrupt, returning empty");
+                JsonValue::Object(serde_json::Map::new())
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            debug!(path = %path.display(), "cli.json not found, returning empty");
+            JsonValue::Object(serde_json::Map::new())
+        }
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "failed to read cli.json");
+            JsonValue::Object(serde_json::Map::new())
+        }
+    }
+}
+
+/// Save JSON to `settings/cli.json` under the given Kiro config directory.
+///
+/// Creates parent directories as needed.
+///
+/// # Errors
+///
+/// Returns an I/O error if directory creation or file write fails.
+pub fn save_kiro_settings_to(kiro_dir: &Path, json: &JsonValue) -> std::io::Result<()> {
+    let path = kiro_dir.join(KIRO_SETTINGS_PATH);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let formatted = serde_json::to_string_pretty(json)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(&path, formatted)?;
+    debug!(path = %path.display(), "cli.json saved");
+    Ok(())
+}
+
+/// Resolve the default Kiro config directory (`~/.kiro`).
+#[must_use]
+pub fn default_kiro_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".kiro"))
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p kiro-market-core kiro_settings`
+Expected: PASS.
+
+**Step 5: Run clippy**
+
+Run: `cargo clippy -p kiro-market-core -- -D warnings`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/kiro_settings.rs
+git commit -m "feat(core): add Kiro CLI settings file I/O"
+```
+
+---
+
+### Task 4: Tauri Commands for Settings
+
+Add three new Tauri commands that bridge the core settings logic to the frontend.
+
+**Files:**
+- Create: `crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/mod.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/lib.rs`
+
+**Step 1: Create the commands module**
+
+Create `crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs`:
+
+```rust
+//! Kiro CLI settings management: get, set, and reset individual settings.
+
+use kiro_market_core::kiro_settings::{
+    self, SettingEntry,
+    default_kiro_dir, load_kiro_settings_from, save_kiro_settings_to,
+    get_nested, set_nested, remove_nested, resolve_settings, registry,
+};
+use serde_json::Value as JsonValue;
+
+use crate::error::{CommandError, ErrorType};
+
+/// Helper: resolve the Kiro config directory or return an error.
+fn kiro_dir() -> Result<std::path::PathBuf, CommandError> {
+    default_kiro_dir().ok_or_else(|| {
+        CommandError::new(
+            "could not determine home directory",
+            ErrorType::IoError,
+        )
+    })
+}
+
+/// Load all Kiro CLI settings, resolved against the registry.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError> {
+    let dir = kiro_dir()?;
+    let json = load_kiro_settings_from(&dir);
+    Ok(resolve_settings(&json))
+}
+
+/// Update a single Kiro CLI setting by dotted key path.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn set_kiro_setting(
+    key: String,
+    value: JsonValue,
+) -> Result<SettingEntry, CommandError> {
+    // Validate the key exists in the registry.
+    let reg = registry();
+    let def = reg.iter().find(|d| d.key == key).ok_or_else(|| {
+        CommandError::new(
+            format!("unknown setting: {key}"),
+            ErrorType::Validation,
+        )
+    })?;
+
+    let dir = kiro_dir()?;
+    let mut json = load_kiro_settings_from(&dir);
+    set_nested(&mut json, &key, value);
+    save_kiro_settings_to(&dir, &json).map_err(|e| {
+        CommandError::new(
+            format!("failed to save settings: {e}"),
+            ErrorType::IoError,
+        )
+    })?;
+
+    // Return the updated entry.
+    let current_value = get_nested(&json, &key).cloned();
+    Ok(SettingEntry {
+        key: def.key.to_owned(),
+        label: def.label.to_owned(),
+        description: def.description.to_owned(),
+        category: serde_json::to_value(def.category)
+            .ok()
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_default(),
+        category_label: def.category.label().to_owned(),
+        value_type: match &def.value_type {
+            kiro_settings::SettingType::Bool => "bool",
+            kiro_settings::SettingType::String => "string",
+            kiro_settings::SettingType::Number => "number",
+            kiro_settings::SettingType::Char => "char",
+            kiro_settings::SettingType::StringArray => "string_array",
+            kiro_settings::SettingType::Enum(_) => "enum",
+        }.to_owned(),
+        enum_options: match &def.value_type {
+            kiro_settings::SettingType::Enum(opts) => opts.iter().map(|&s| s.to_owned()).collect(),
+            _ => Vec::new(),
+        },
+        default_value: def.default.clone(),
+        current_value,
+    })
+}
+
+/// Reset a Kiro CLI setting to its default (remove from cli.json).
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::unused_async)]
+pub async fn reset_kiro_setting(key: String) -> Result<(), CommandError> {
+    // Validate the key exists.
+    let reg = registry();
+    if !reg.iter().any(|d| d.key == key) {
+        return Err(CommandError::new(
+            format!("unknown setting: {key}"),
+            ErrorType::Validation,
+        ));
+    }
+
+    let dir = kiro_dir()?;
+    let mut json = load_kiro_settings_from(&dir);
+    remove_nested(&mut json, &key);
+    save_kiro_settings_to(&dir, &json).map_err(|e| {
+        CommandError::new(
+            format!("failed to save settings: {e}"),
+            ErrorType::IoError,
+        )
+    })?;
+    Ok(())
+}
+```
+
+**Step 2: Register the module**
+
+Add to `crates/kiro-control-center/src-tauri/src/commands/mod.rs`:
+
+```rust
+pub mod kiro_settings;
+```
+
+**Step 3: Register commands in lib.rs**
+
+Add to the `collect_commands!` macro in `crates/kiro-control-center/src-tauri/src/lib.rs`:
+
+```rust
+commands::kiro_settings::get_kiro_settings,
+commands::kiro_settings::set_kiro_setting,
+commands::kiro_settings::reset_kiro_setting,
+```
+
+**Step 4: Build to verify compilation and generate bindings**
+
+Run: `cargo build -p kiro-control-center`
+Expected: PASS.
+
+**Step 5: Regenerate TypeScript bindings**
+
+Run: `cargo test -p kiro-control-center generate_types -- --exact --ignored`
+Expected: `bindings.ts` regenerated with `getKiroSettings`, `setKiroSetting`, `resetKiroSetting`.
+
+**Step 6: Verify the new types appear in bindings.ts**
+
+Run: `grep -n "kiro_setting\|KiroSetting\|SettingEntry" crates/kiro-control-center/src/lib/bindings.ts`
+Expected: Shows the new command functions and `SettingEntry` type.
+
+**Step 7: Commit**
+
+```bash
+git add crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs \
+        crates/kiro-control-center/src-tauri/src/commands/mod.rs \
+        crates/kiro-control-center/src-tauri/src/lib.rs \
+        crates/kiro-control-center/src/lib/bindings.ts
+git commit -m "feat(tauri): add get/set/reset Kiro CLI settings commands"
+```
+
+---
+
+### Task 5: SettingControl Component
+
+The leaf component that renders a single setting row with a type-appropriate editor.
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/SettingControl.svelte`
+
+**Step 1: Create the component**
+
+Create `crates/kiro-control-center/src/lib/components/SettingControl.svelte`:
+
+```svelte
+<script lang="ts">
+  import { commands } from "$lib/bindings";
+  import type { SettingEntry } from "$lib/bindings";
+
+  let { entry, onUpdate }: {
+    entry: SettingEntry;
+    onUpdate: (updated: SettingEntry) => void;
+  } = $props();
+
+  let saving = $state(false);
+  let error: string | null = $state(null);
+
+  // Chips input state for string_array type.
+  let chipInput = $state("");
+
+  let isModified = $derived(entry.current_value !== null && entry.current_value !== undefined);
+
+  let displayValue = $derived(entry.current_value ?? entry.default_value);
+
+  async function setValue(value: unknown) {
+    saving = true;
+    error = null;
+    const result = await commands.setKiroSetting(entry.key, value as any);
+    if (result.status === "ok") {
+      onUpdate(result.data);
+    } else {
+      error = result.error.message;
+    }
+    saving = false;
+  }
+
+  async function resetValue() {
+    saving = true;
+    error = null;
+    const result = await commands.resetKiroSetting(entry.key);
+    if (result.status === "ok") {
+      // Reset current_value to null (use default).
+      onUpdate({ ...entry, current_value: null });
+    } else {
+      error = result.error.message;
+    }
+    saving = false;
+  }
+
+  function handleBoolToggle() {
+    const current = displayValue as boolean | null;
+    setValue(!current);
+  }
+
+  function handleStringChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    setValue(target.value);
+  }
+
+  function handleNumberChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const num = Number(target.value);
+    if (!Number.isNaN(num)) {
+      setValue(num);
+    }
+  }
+
+  function handleCharChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    // Take only the last character typed.
+    const char = target.value.slice(-1);
+    target.value = char;
+    if (char) {
+      setValue(char);
+    }
+  }
+
+  function handleEnumChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    setValue(target.value);
+  }
+
+  function addChip() {
+    const val = chipInput.trim();
+    if (!val) return;
+    const current = (displayValue as string[] | null) ?? [];
+    if (!current.includes(val)) {
+      setValue([...current, val]);
+    }
+    chipInput = "";
+  }
+
+  function removeChip(chip: string) {
+    const current = (displayValue as string[] | null) ?? [];
+    setValue(current.filter((c: string) => c !== chip));
+  }
+
+  function handleChipKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addChip();
+    }
+  }
+</script>
+
+<div class="flex items-start justify-between gap-4 py-3 px-4 rounded-lg hover:bg-kiro-overlay/50 transition-colors">
+  <div class="flex-1 min-w-0">
+    <div class="flex items-center gap-2">
+      <span class="text-sm font-medium text-kiro-text">{entry.label}</span>
+      {#if isModified}
+        <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-kiro-accent-900/20 text-kiro-accent-400">
+          Modified
+        </span>
+      {/if}
+    </div>
+    <p class="mt-0.5 text-xs text-kiro-subtle">{entry.description}</p>
+    <p class="mt-0.5 text-[10px] text-kiro-subtle/60 font-mono">{entry.key}</p>
+    {#if error}
+      <p class="mt-1 text-xs text-kiro-error">{error}</p>
+    {/if}
+  </div>
+
+  <div class="flex items-center gap-2 flex-shrink-0">
+    {#if entry.value_type === "bool"}
+      <button
+        class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors
+          {displayValue ? 'bg-kiro-accent-500' : 'bg-kiro-muted'}"
+        onclick={handleBoolToggle}
+        disabled={saving}
+        aria-label="Toggle {entry.label}"
+      >
+        <span
+          class="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform
+            {displayValue ? 'translate-x-4' : 'translate-x-0.5'}"
+        />
+      </button>
+
+    {:else if entry.value_type === "string"}
+      <input
+        type="text"
+        value={displayValue ?? ""}
+        onchange={handleStringChange}
+        disabled={saving}
+        placeholder={entry.default_value?.toString() ?? ""}
+        class="w-48 px-2 py-1 text-sm rounded border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle/50 focus:outline-none focus:ring-1 focus:ring-kiro-accent-500"
+      />
+
+    {:else if entry.value_type === "number"}
+      <input
+        type="number"
+        value={displayValue ?? ""}
+        onchange={handleNumberChange}
+        disabled={saving}
+        placeholder={entry.default_value?.toString() ?? ""}
+        class="w-28 px-2 py-1 text-sm rounded border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle/50 focus:outline-none focus:ring-1 focus:ring-kiro-accent-500"
+      />
+
+    {:else if entry.value_type === "char"}
+      <input
+        type="text"
+        value={displayValue ?? ""}
+        oninput={handleCharChange}
+        disabled={saving}
+        maxlength={1}
+        class="w-12 px-2 py-1 text-sm text-center rounded border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-1 focus:ring-kiro-accent-500 font-mono"
+      />
+
+    {:else if entry.value_type === "enum"}
+      <select
+        value={displayValue ?? ""}
+        onchange={handleEnumChange}
+        disabled={saving}
+        class="w-48 px-2 py-1 text-sm rounded border border-kiro-muted bg-kiro-overlay text-kiro-text focus:outline-none focus:ring-1 focus:ring-kiro-accent-500"
+      >
+        <option value="">Default</option>
+        {#each entry.enum_options as opt (opt)}
+          <option value={opt}>{opt}</option>
+        {/each}
+      </select>
+
+    {:else if entry.value_type === "string_array"}
+      <div class="w-64">
+        <div class="flex flex-wrap gap-1 mb-1">
+          {#each (displayValue as string[] ?? []) as chip (chip)}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-kiro-muted text-kiro-text-secondary">
+              {chip}
+              <button
+                class="text-kiro-subtle hover:text-kiro-error"
+                onclick={() => removeChip(chip)}
+                aria-label="Remove {chip}"
+              >x</button>
+            </span>
+          {/each}
+        </div>
+        <div class="flex gap-1">
+          <input
+            type="text"
+            bind:value={chipInput}
+            onkeydown={handleChipKeydown}
+            disabled={saving}
+            placeholder="Add pattern..."
+            class="flex-1 px-2 py-1 text-xs rounded border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle/50 focus:outline-none focus:ring-1 focus:ring-kiro-accent-500"
+          />
+          <button
+            class="px-2 py-1 text-xs rounded border border-kiro-muted text-kiro-text-secondary hover:bg-kiro-overlay"
+            onclick={addChip}
+            disabled={saving || !chipInput.trim()}
+          >+</button>
+        </div>
+      </div>
+    {/if}
+
+    {#if isModified}
+      <button
+        class="text-xs text-kiro-subtle hover:text-kiro-accent-400 transition-colors"
+        onclick={resetValue}
+        disabled={saving}
+        title="Reset to default"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+      </button>
+    {/if}
+  </div>
+</div>
+```
+
+**Step 2: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/SettingControl.svelte
+git commit -m "feat(ui): add SettingControl component with type-appropriate editors"
+```
+
+---
+
+### Task 6: CategoryList Component
+
+The sidebar listing all setting categories with counts and active state.
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/CategoryList.svelte`
+
+**Step 1: Create the component**
+
+Create `crates/kiro-control-center/src/lib/components/CategoryList.svelte`:
+
+```svelte
+<script lang="ts">
+  let { categories, activeCategory, onSelect, matchCounts }: {
+    categories: { key: string; label: string; count: number }[];
+    activeCategory: string;
+    onSelect: (key: string) => void;
+    matchCounts: Record<string, number> | null;
+  } = $props();
+</script>
+
+<nav class="w-48 flex-shrink-0 border-r border-kiro-muted bg-kiro-surface overflow-y-auto p-3">
+  <h3 class="text-xs font-semibold text-kiro-subtle uppercase tracking-wider mb-2">
+    Categories
+  </h3>
+  {#each categories as cat (cat.key)}
+    {@const isActive = activeCategory === cat.key}
+    {@const searchCount = matchCounts?.[cat.key]}
+    {@const dimmed = matchCounts !== null && (searchCount === undefined || searchCount === 0)}
+    <button
+      class="w-full text-left px-3 py-2 text-sm rounded-md transition-colors duration-100 mb-0.5
+        {isActive
+          ? 'bg-kiro-muted text-kiro-text font-medium'
+          : dimmed
+            ? 'text-kiro-subtle/40'
+            : 'text-kiro-text-secondary hover:bg-kiro-overlay'}"
+      onclick={() => onSelect(cat.key)}
+      disabled={dimmed}
+    >
+      <span class="flex items-center justify-between">
+        <span class="truncate">{cat.label}</span>
+        <span class="text-xs {isActive ? 'text-kiro-accent-400' : 'text-kiro-subtle'}">
+          {matchCounts !== null ? (searchCount ?? 0) : cat.count}
+        </span>
+      </span>
+    </button>
+  {/each}
+</nav>
+```
+
+**Step 2: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/CategoryList.svelte
+git commit -m "feat(ui): add CategoryList sidebar component"
+```
+
+---
+
+### Task 7: SettingsPanel Component
+
+The main content area that renders a list of `SettingControl` components.
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/SettingsPanel.svelte`
+
+**Step 1: Create the component**
+
+Create `crates/kiro-control-center/src/lib/components/SettingsPanel.svelte`:
+
+```svelte
+<script lang="ts">
+  import type { SettingEntry } from "$lib/bindings";
+  import SettingControl from "./SettingControl.svelte";
+
+  let { entries, showCategoryHeaders, onUpdate }: {
+    entries: SettingEntry[];
+    showCategoryHeaders: boolean;
+    onUpdate: (updated: SettingEntry) => void;
+  } = $props();
+
+  // Group entries by category_label for rendering headers.
+  let grouped = $derived.by(() => {
+    if (!showCategoryHeaders) {
+      return [{ label: "", entries }];
+    }
+    const groups: { label: string; entries: SettingEntry[] }[] = [];
+    let currentLabel = "";
+    for (const entry of entries) {
+      if (entry.category_label !== currentLabel) {
+        currentLabel = entry.category_label;
+        groups.push({ label: currentLabel, entries: [] });
+      }
+      groups[groups.length - 1].entries.push(entry);
+    }
+    return groups;
+  });
+</script>
+
+<div class="flex-1 overflow-y-auto px-2 py-3">
+  {#if entries.length === 0}
+    <div class="flex items-center justify-center h-full text-kiro-subtle">
+      <p class="text-sm">No settings match the search</p>
+    </div>
+  {:else}
+    {#each grouped as group (group.label)}
+      {#if group.label}
+        <h3 class="text-xs font-semibold text-kiro-subtle uppercase tracking-wider px-4 pt-4 pb-2">
+          {group.label}
+        </h3>
+      {/if}
+      <div class="space-y-1">
+        {#each group.entries as entry (entry.key)}
+          <SettingControl {entry} {onUpdate} />
+        {/each}
+      </div>
+    {/each}
+  {/if}
+</div>
+```
+
+**Step 2: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/SettingsPanel.svelte
+git commit -m "feat(ui): add SettingsPanel component"
+```
+
+---
+
+### Task 8: SettingsView Component
+
+The top-level settings layout that owns all state: loading, search, category navigation.
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/SettingsView.svelte`
+
+**Step 1: Create the component**
+
+Create `crates/kiro-control-center/src/lib/components/SettingsView.svelte`:
+
+```svelte
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { commands } from "$lib/bindings";
+  import type { SettingEntry } from "$lib/bindings";
+  import CategoryList from "./CategoryList.svelte";
+  import SettingsPanel from "./SettingsPanel.svelte";
+
+  let { onClose }: { onClose: () => void } = $props();
+
+  let allEntries: SettingEntry[] = $state([]);
+  let loading = $state(true);
+  let loadError: string | null = $state(null);
+  let searchQuery = $state("");
+  let activeCategory = $state("");
+
+  // Build categories from loaded entries.
+  let categories = $derived.by(() => {
+    const seen = new Map<string, { key: string; label: string; count: number }>();
+    for (const e of allEntries) {
+      const existing = seen.get(e.category);
+      if (existing) {
+        existing.count++;
+      } else {
+        seen.set(e.category, { key: e.category, label: e.category_label, count: 1 });
+      }
+    }
+    return Array.from(seen.values());
+  });
+
+  // Filter by search query.
+  let filteredEntries = $derived.by(() => {
+    if (!searchQuery.trim()) return allEntries;
+    const q = searchQuery.toLowerCase();
+    return allEntries.filter(
+      (e) =>
+        e.label.toLowerCase().includes(q) ||
+        e.description.toLowerCase().includes(q) ||
+        e.key.toLowerCase().includes(q)
+    );
+  });
+
+  // During search, compute per-category match counts.
+  let matchCounts: Record<string, number> | null = $derived.by(() => {
+    if (!searchQuery.trim()) return null;
+    const counts: Record<string, number> = {};
+    for (const e of filteredEntries) {
+      counts[e.category] = (counts[e.category] ?? 0) + 1;
+    }
+    return counts;
+  });
+
+  // Entries to display in the panel.
+  let displayEntries = $derived.by(() => {
+    if (searchQuery.trim()) {
+      // During search, show all matches grouped by category.
+      return filteredEntries;
+    }
+    // Otherwise, show only the active category.
+    return allEntries.filter((e) => e.category === activeCategory);
+  });
+
+  let showCategoryHeaders = $derived(!!searchQuery.trim());
+
+  function handleUpdate(updated: SettingEntry) {
+    allEntries = allEntries.map((e) => (e.key === updated.key ? updated : e));
+  }
+
+  onMount(async () => {
+    const result = await commands.getKiroSettings();
+    if (result.status === "ok") {
+      allEntries = result.data;
+      if (result.data.length > 0) {
+        activeCategory = result.data[0].category;
+      }
+    } else {
+      loadError = result.error.message;
+    }
+    loading = false;
+  });
+</script>
+
+<div class="flex flex-col h-full bg-kiro-base text-kiro-text">
+  <!-- Top bar: back + search -->
+  <div class="flex items-center gap-4 px-4 py-3 border-b border-kiro-muted bg-kiro-surface">
+    <button
+      class="text-sm text-kiro-accent-400 hover:text-kiro-accent-300 transition-colors flex items-center gap-1"
+      onclick={onClose}
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+      Back
+    </button>
+    <input
+      type="text"
+      placeholder="Search settings..."
+      bind:value={searchQuery}
+      class="flex-1 px-3 py-1.5 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
+    />
+  </div>
+
+  {#if loading}
+    <div class="flex items-center justify-center flex-1">
+      <p class="text-sm text-kiro-subtle">Loading settings...</p>
+    </div>
+  {:else if loadError}
+    <div class="flex items-center justify-center flex-1 p-4">
+      <div class="max-w-md text-center">
+        <p class="text-sm text-kiro-error mb-2">Failed to load settings</p>
+        <p class="text-xs text-kiro-subtle">{loadError}</p>
+      </div>
+    </div>
+  {:else}
+    <div class="flex flex-1 overflow-hidden">
+      <CategoryList
+        {categories}
+        {activeCategory}
+        {matchCounts}
+        onSelect={(key) => (activeCategory = key)}
+      />
+      <SettingsPanel
+        entries={displayEntries}
+        {showCategoryHeaders}
+        onUpdate={handleUpdate}
+      />
+    </div>
+  {/if}
+</div>
+```
+
+**Step 2: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/SettingsView.svelte
+git commit -m "feat(ui): add SettingsView layout with sidebar and search"
+```
+
+---
+
+### Task 9: Wire Settings into the Main Page
+
+Add the gear icon to the header and the `showSettings` toggle to `+page.svelte`.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/routes/+page.svelte`
+
+**Step 1: Add import and state**
+
+Add `SettingsView` import alongside the other imports:
+
+```svelte
+import SettingsView from "$lib/components/SettingsView.svelte";
+```
+
+Add state variable:
+
+```svelte
+let showSettings = $state(false);
+```
+
+**Step 2: Add gear icon to the header**
+
+In the `<header>` element, add a gear button between the title and `ProjectDropdown`:
+
+```svelte
+<header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
+  <h1 class="text-lg font-semibold">Kiro Control Center</h1>
+  <div class="flex items-center gap-3">
+    <button
+      class="text-kiro-subtle hover:text-kiro-text-secondary transition-colors"
+      onclick={() => (showSettings = true)}
+      title="Kiro CLI Settings"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    </button>
+    <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
+  </div>
+</header>
+```
+
+**Step 3: Add conditional rendering**
+
+When `showSettings` is true, replace the tab bar + main content with `SettingsView`. Wrap the existing `{#if store.projectPath}` block so the settings view takes over the full area below the header:
+
+The project-selected block should become:
+
+```svelte
+{:else if store.projectPath}
+  <div class="flex flex-col h-screen bg-kiro-base text-kiro-text">
+    <header class="flex items-center justify-between px-6 py-3 bg-kiro-surface border-b border-kiro-muted shadow-sm">
+      <h1 class="text-lg font-semibold">Kiro Control Center</h1>
+      <div class="flex items-center gap-3">
+        <button
+          class="text-kiro-subtle hover:text-kiro-text-secondary transition-colors"
+          onclick={() => (showSettings = true)}
+          title="Kiro CLI Settings"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+        <ProjectDropdown onManageRoots={() => (showManageRoots = true)} />
+      </div>
+    </header>
+
+    {#if showSettings}
+      <SettingsView onClose={() => (showSettings = false)} />
+    {:else}
+      <TabBar {tabs} {activeTab} onTabChange={(tab) => (activeTab = tab)} />
+
+      <main class="flex-1 overflow-hidden">
+        {#if activeTab === "Browse"}
+          <BrowseTab projectPath={store.projectPath} />
+        {:else if activeTab === "Installed"}
+          <InstalledTab projectPath={store.projectPath} />
+        {:else if activeTab === "Marketplaces"}
+          <MarketplacesTab />
+        {/if}
+      </main>
+    {/if}
+  </div>
+```
+
+**Step 4: Build frontend**
+
+Run: `cd crates/kiro-control-center && npm run check`
+Expected: No type errors.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/routes/+page.svelte
+git commit -m "feat(ui): wire settings view into main page with gear icon"
+```
+
+---
+
+### Task 10: Manual Testing and Polish
+
+Start the dev server and verify the full flow works.
+
+**Step 1: Start the app**
+
+Run: `cd crates/kiro-control-center && cargo tauri dev`
+
+**Step 2: Test checklist**
+
+- [ ] Gear icon visible in header
+- [ ] Clicking gear shows settings view (replaces tabs)
+- [ ] "Back" button returns to marketplace tabs
+- [ ] Categories listed in sidebar with correct counts
+- [ ] Clicking categories shows correct settings
+- [ ] Search filters across all categories
+- [ ] Search highlights matching categories, dims others
+- [ ] Boolean toggles persist immediately
+- [ ] String inputs persist on blur/change
+- [ ] Number inputs persist on change
+- [ ] "Modified" badge appears on changed settings
+- [ ] Reset button removes the value and clears "Modified" badge
+- [ ] Settings survive app restart (check `~/.kiro/settings/cli.json`)
+- [ ] App handles missing cli.json gracefully (all defaults)
+
+**Step 3: Fix any issues found**
+
+Apply fixes as needed.
+
+**Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "fix(ui): polish settings view from manual testing"
+```

--- a/docs/plans/2026-04-14-plugin-discovery-design.md
+++ b/docs/plans/2026-04-14-plugin-discovery-design.md
@@ -1,0 +1,92 @@
+# Plugin Discovery: Scan-and-Merge for Unlisted Plugins
+
+## Problem
+
+Some skill repositories contain plugins that are not listed in their `marketplace.json`. For example, `dotnet/skills` has `plugins/dotnet-experimental/plugin.json` but it does not appear in the marketplace manifest. Additionally, some repositories have no `marketplace.json` at all but still contain valid `plugin.json` files. The current tool requires a marketplace manifest to function and cannot see unlisted plugins.
+
+## Approach
+
+Scan-and-merge on `marketplace add`. After cloning a repo, the tool reads `marketplace.json` if present, then performs a depth-limited directory scan for `plugin.json` files not covered by the manifest. The two sources are deduplicated and merged into a single plugin list. Repos without `marketplace.json` are supported — the scan is the sole discovery mechanism.
+
+## Discovery Mechanism
+
+New function `discover_plugins(repo_root, max_depth) -> Vec<DiscoveredPlugin>`:
+
+- Walks the directory tree from `repo_root` up to `max_depth` levels (default: 3)
+- At each directory, checks for `plugin.json`
+- Parses it into a `PluginManifest` to get name and description
+- Skips hidden directories (`.git`, `.claude-plugin`) and noise directories (`node_modules`, `target`, etc.)
+- Returns discovered plugins with their relative paths
+
+Deduplication compares resolved paths of scanned plugins against resolved paths of marketplace entries. If they overlap, the marketplace entry wins (it may carry a richer description).
+
+**Location:** `crates/kiro-market-core/src/plugin.rs` alongside the existing `discover_skill_dirs` function.
+
+## Type Changes
+
+### New internal type (not user-facing)
+
+```rust
+/// A plugin found by scanning a repo for `plugin.json` files.
+pub struct DiscoveredPlugin {
+    pub name: String,
+    pub description: Option<String>,
+    /// Path to the directory containing plugin.json, relative to repo root.
+    pub relative_path: PathBuf,
+}
+```
+
+### No changes to existing types
+
+`PluginBasicInfo`, `Marketplace`, `PluginEntry`, `PluginManifest`, and `PluginSource` are unchanged. Discovered plugins are converted to `PluginBasicInfo` values and merged into the same list — no `discovered` flag, no distinction visible to the user.
+
+## Changes to `MarketplaceService::add()`
+
+```
+1. Clone/link repo                              (unchanged)
+2. Try to read marketplace.json
+   - If found -> parse, collect listed plugins
+   - If not found -> empty list (NOT an error)
+3. Scan repo for plugin.json files up to depth 3
+4. Deduplicate: remove scanned plugins whose paths overlap with marketplace entries
+5. Merge: marketplace plugins ++ remaining discovered plugins -> Vec<PluginBasicInfo>
+6. Validate name, rename, register              (unchanged)
+```
+
+`ManifestNotFound` is no longer a terminal error. The only new error case: no `marketplace.json` AND the scan finds zero plugins -> `MarketplaceError::NoPluginsFound`.
+
+## Name Derivation
+
+When `marketplace.json` is absent, the marketplace name is derived from the source:
+
+| Source type | Input | Derived name |
+|---|---|---|
+| `GitHub { repo }` | `"dotnet/skills"` | `"skills"` |
+| `GitUrl { url }` | `"https://github.com/dotnet/skills.git"` | `"skills"` |
+| `LocalPath { path }` | `"~/my-plugins"` | `"my-plugins"` |
+
+New method `MarketplaceSource::fallback_name() -> Option<String>`: takes the last path/URL segment, strips `.git` suffix, validates with `validate_name()`. Returns `None` if validation fails — `add()` errors with a message suggesting `--name`.
+
+## Install Fallback
+
+No structural changes to the install flow. When `install` cannot find a plugin in `marketplace.json`, it re-runs the depth-limited scan on the cached clone and looks for a matching `plugin.json` by name. The scan is fast (depth 3) and avoids staleness — if `update` pulls new content, the next `install` picks it up automatically.
+
+No sidecar files, no persistence of scan results.
+
+## Error Handling
+
+- `marketplace.json` missing -> fall through to scan (not an error)
+- Scan finds zero plugins AND no marketplace.json -> `MarketplaceError::NoPluginsFound`
+- Name derivation fails validation -> error suggesting `--name` override
+- Plugin not in marketplace.json, scan finds no match -> existing `PluginError::NotFound`
+
+## Testing Strategy
+
+1. Repo with marketplace.json + unlisted plugins: merged list contains both
+2. Repo with no marketplace.json, has plugin.json files: scan is sole source, name derived from repo
+3. Repo with neither: `NoPluginsFound` error
+4. Deduplication: marketplace entry and scan overlap -> single entry
+5. Depth limit respected: plugin.json at depth 4 is not found
+6. Hidden/noise directories skipped: `.git/plugin.json` is ignored
+7. Install fallback: plugin not in marketplace.json but discoverable by scan
+8. Name derivation: GitHub, git URL, local path all produce correct names

--- a/docs/plans/2026-04-14-plugin-discovery-plan.md
+++ b/docs/plans/2026-04-14-plugin-discovery-plan.md
@@ -1,0 +1,989 @@
+# Plugin Discovery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Support importing skills from repos that have no `marketplace.json` or contain unlisted plugins, via depth-limited `plugin.json` scanning merged with marketplace entries.
+
+**Architecture:** A new `discover_plugins()` function in `plugin.rs` walks a repo up to depth 3, finding `plugin.json` files. `MarketplaceService::add()` calls it after (optionally) reading `marketplace.json`, deduplicates, and merges both sets into the same `Vec<PluginBasicInfo>`. At install time, `find_plugin_entry` falls back to the same scan when a plugin isn't in the manifest. `MarketplaceSource` gains a `fallback_name()` method for repos without a manifest.
+
+**Tech Stack:** Rust (edition 2024), `serde`/`serde_json`, `thiserror`, `tracing`, `rstest`, `tempfile`
+
+---
+
+### Task 1: Add `MarketplaceError::NoPluginsFound` variant
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/error.rs:18-34` (add variant to `MarketplaceError`)
+
+**Step 1: Write the failing test**
+
+Add a display test case to the existing `marketplace_error_display` rstest in `error.rs`:
+
+```rust
+#[case::no_plugins_found(
+    MarketplaceError::NoPluginsFound { path: PathBuf::from("/tmp/repo") },
+    "no plugins found in /tmp/repo"
+)]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kiro-market-core -- marketplace_error_display`
+Expected: compile error — `NoPluginsFound` variant does not exist
+
+**Step 3: Add the variant**
+
+Add to the `MarketplaceError` enum after `ManifestNotFound`:
+
+```rust
+/// No `marketplace.json` and no `plugin.json` files found via scan.
+#[error("no plugins found in {path}")]
+NoPluginsFound { path: PathBuf },
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p kiro-market-core -- marketplace_error_display`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/error.rs
+git commit -m "feat: add NoPluginsFound error variant for repos without marketplace or plugins"
+```
+
+---
+
+### Task 2: Add `MarketplaceSource::fallback_name()`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/cache.rs:38-79` (add method to `impl MarketplaceSource`)
+
+**Step 1: Write the failing tests**
+
+Add to the existing `mod tests` in `cache.rs`:
+
+```rust
+#[rstest]
+#[case::github("owner/skills", "skills")]
+#[case::github_nested("org/sub-repo", "sub-repo")]
+#[case::git_url_https("https://github.com/dotnet/skills.git", "skills")]
+#[case::git_url_no_suffix("https://github.com/dotnet/skills", "skills")]
+#[case::git_ssh("git@github.com:owner/repo.git", "repo")]
+#[case::local_path("/home/user/my-plugins", "my-plugins")]
+#[case::local_tilde("~/marketplaces/mine", "mine")]
+#[case::local_relative("./my-market", "my-market")]
+fn fallback_name_derives_from_source(#[case] source_str: &str, #[case] expected: &str) {
+    let source = MarketplaceSource::detect(source_str);
+    let name = source.fallback_name();
+    assert_eq!(
+        name.as_deref(),
+        Some(expected),
+        "fallback name for '{source_str}'"
+    );
+}
+
+#[test]
+fn fallback_name_returns_none_for_invalid_name() {
+    // A source whose last segment is ".." should fail validation and return None.
+    let source = MarketplaceSource::LocalPath {
+        path: "/home/user/..".into(),
+    };
+    assert!(
+        source.fallback_name().is_none(),
+        "should return None for invalid name"
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kiro-market-core -- fallback_name`
+Expected: compile error — `fallback_name` method does not exist
+
+**Step 3: Implement `fallback_name()`**
+
+Add to the existing `impl MarketplaceSource` block in `cache.rs`:
+
+```rust
+/// Derive a marketplace name from the source when no manifest provides one.
+///
+/// Extracts the last path/URL segment, strips a `.git` suffix if present,
+/// and validates the result. Returns `None` if the derived name fails
+/// validation.
+#[must_use]
+pub fn fallback_name(&self) -> Option<String> {
+    let raw = match self {
+        Self::GitHub { repo } => repo.rsplit('/').next(),
+        Self::GitUrl { url } => url
+            .rsplit('/')
+            .next()
+            .or_else(|| url.rsplit(':').next()),
+        Self::LocalPath { path } => {
+            let trimmed = path.trim_end_matches(['/', '\\']);
+            trimmed.rsplit(['/', '\\']).next()
+        }
+    };
+
+    let segment = raw?;
+    let name = segment.strip_suffix(".git").unwrap_or(segment);
+
+    if name.is_empty() {
+        return None;
+    }
+
+    validation::validate_name(name).ok()?;
+    Some(name.to_owned())
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p kiro-market-core -- fallback_name`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/cache.rs
+git commit -m "feat: add fallback_name() to derive marketplace name from source"
+```
+
+---
+
+### Task 3: Add `discover_plugins()` to `plugin.rs`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/plugin.rs` (add `DiscoveredPlugin` type and `discover_plugins()` function)
+
+**Step 1: Write the failing tests**
+
+Add to the existing `mod tests` in `plugin.rs`:
+
+```rust
+use std::path::Path;
+
+/// Helper: create a minimal plugin.json in the given directory.
+fn create_plugin_json(dir: &Path, name: &str, description: Option<&str>) {
+    fs::create_dir_all(dir).expect("create_dir_all");
+    let desc = description
+        .map(|d| format!(r#","description":"{d}""#))
+        .unwrap_or_default();
+    fs::write(
+        dir.join("plugin.json"),
+        format!(r#"{{"name":"{name}"{desc},"skills":["./skills/"]}}"#),
+    )
+    .expect("write plugin.json");
+}
+
+#[test]
+fn discover_plugins_finds_plugin_json_at_depth_1() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(&root.join("my-plugin"), "my-plugin", Some("A plugin"));
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "my-plugin");
+    assert_eq!(discovered[0].description.as_deref(), Some("A plugin"));
+}
+
+#[test]
+fn discover_plugins_finds_plugin_json_at_depth_2() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(
+        &root.join("plugins/dotnet-experimental"),
+        "dotnet-experimental",
+        Some("Experimental"),
+    );
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "dotnet-experimental");
+}
+
+#[test]
+fn discover_plugins_finds_multiple_plugins() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(&root.join("plugins/alpha"), "alpha", None);
+    create_plugin_json(&root.join("plugins/beta"), "beta", None);
+
+    let mut discovered = discover_plugins(root, 3);
+    discovered.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(discovered.len(), 2);
+    assert_eq!(discovered[0].name, "alpha");
+    assert_eq!(discovered[1].name, "beta");
+}
+
+#[test]
+fn discover_plugins_respects_depth_limit() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    // Depth 4 — should NOT be found with max_depth 3.
+    create_plugin_json(
+        &root.join("a/b/c/deep-plugin"),
+        "deep-plugin",
+        None,
+    );
+
+    let discovered = discover_plugins(root, 3);
+    assert!(discovered.is_empty(), "should not find plugin at depth 4");
+}
+
+#[test]
+fn discover_plugins_skips_hidden_directories() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(&root.join(".git/hooks"), "git-hooks", None);
+    create_plugin_json(&root.join(".claude-plugin"), "claude-internal", None);
+    create_plugin_json(&root.join("plugins/visible"), "visible", None);
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "visible");
+}
+
+#[test]
+fn discover_plugins_skips_noise_directories() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(&root.join("node_modules/some-pkg"), "npm-thing", None);
+    create_plugin_json(&root.join("target/debug"), "build-artifact", None);
+    create_plugin_json(&root.join("plugins/real"), "real", None);
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "real");
+}
+
+#[test]
+fn discover_plugins_skips_malformed_plugin_json() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let bad_dir = root.join("plugins/bad");
+    fs::create_dir_all(&bad_dir).expect("mkdir");
+    fs::write(bad_dir.join("plugin.json"), "not json").expect("write");
+
+    create_plugin_json(&root.join("plugins/good"), "good", None);
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "good");
+}
+
+#[test]
+fn discover_plugins_returns_empty_for_no_plugins() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let discovered = discover_plugins(tmp.path(), 3);
+    assert!(discovered.is_empty());
+}
+
+#[test]
+fn discover_plugins_includes_relative_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    create_plugin_json(&root.join("plugins/my-plugin"), "my-plugin", None);
+
+    let discovered = discover_plugins(root, 3);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(
+        discovered[0].relative_path,
+        Path::new("plugins/my-plugin")
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kiro-market-core -- discover_plugins`
+Expected: compile error — `discover_plugins` and `DiscoveredPlugin` do not exist
+
+**Step 3: Implement `DiscoveredPlugin` and `discover_plugins()`**
+
+Add to `plugin.rs`, above the existing `discover_skill_dirs` function:
+
+```rust
+/// Name of the plugin manifest file.
+const PLUGIN_JSON: &str = "plugin.json";
+
+/// Directories to skip during recursive plugin scanning.
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    ".claude-plugin",
+    ".github",
+    ".kiro",
+    "node_modules",
+    "target",
+    "__pycache__",
+    ".venv",
+    "vendor",
+];
+
+/// A plugin discovered by scanning a repository for `plugin.json` files.
+#[derive(Debug, Clone)]
+pub struct DiscoveredPlugin {
+    /// Plugin name from its `plugin.json`.
+    pub name: String,
+    /// Plugin description from its `plugin.json`.
+    pub description: Option<String>,
+    /// Path to the plugin directory, relative to the repo root.
+    pub relative_path: PathBuf,
+}
+
+/// Scan a repository for `plugin.json` files up to `max_depth` levels deep.
+///
+/// Skips hidden directories and common noise directories (node_modules, target,
+/// etc.). Returns a list of discovered plugins with their names, descriptions,
+/// and relative paths.
+///
+/// Malformed `plugin.json` files are warned about and skipped.
+#[must_use]
+pub fn discover_plugins(repo_root: &Path, max_depth: usize) -> Vec<DiscoveredPlugin> {
+    let mut results = Vec::new();
+    scan_for_plugins(repo_root, repo_root, 0, max_depth, &mut results);
+    results
+}
+
+fn scan_for_plugins(
+    repo_root: &Path,
+    dir: &Path,
+    current_depth: usize,
+    max_depth: usize,
+    results: &mut Vec<DiscoveredPlugin>,
+) {
+    if current_depth > max_depth {
+        return;
+    }
+
+    // Check for plugin.json in this directory (skip the root itself).
+    if current_depth > 0 {
+        let candidate = dir.join(PLUGIN_JSON);
+        if candidate.is_file() {
+            match fs::read(&candidate) {
+                Ok(bytes) => match PluginManifest::from_json(&bytes) {
+                    Ok(manifest) => {
+                        let relative_path = dir
+                            .strip_prefix(repo_root)
+                            .unwrap_or(dir)
+                            .to_path_buf();
+                        debug!(
+                            name = %manifest.name,
+                            path = %relative_path.display(),
+                            "discovered plugin"
+                        );
+                        results.push(DiscoveredPlugin {
+                            name: manifest.name,
+                            description: manifest.description,
+                            relative_path,
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %candidate.display(),
+                            error = %e,
+                            "skipping malformed plugin.json"
+                        );
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        path = %candidate.display(),
+                        error = %e,
+                        "failed to read plugin.json, skipping"
+                    );
+                }
+            }
+            // Don't recurse into a plugin directory — it won't contain nested plugins.
+            return;
+        }
+    }
+
+    // Recurse into subdirectories.
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            debug!(
+                path = %dir.display(),
+                error = %e,
+                "failed to read directory during plugin scan"
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, "failed to read directory entry, skipping");
+                continue;
+            }
+        };
+
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        // Skip hidden and noise directories.
+        let dir_name = match entry.file_name().to_str() {
+            Some(name) => name.to_owned(),
+            None => continue,
+        };
+
+        if dir_name.starts_with('.') || SKIP_DIRS.contains(&dir_name.as_str()) {
+            continue;
+        }
+
+        scan_for_plugins(repo_root, &entry_path, current_depth + 1, max_depth, results);
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core -- discover_plugins`
+Expected: all PASS
+
+**Step 5: Run clippy**
+
+Run: `cargo clippy -p kiro-market-core -- -D warnings`
+Expected: no warnings
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/plugin.rs
+git commit -m "feat: add discover_plugins() for depth-limited plugin.json scanning"
+```
+
+---
+
+### Task 4: Modify `MarketplaceService::add()` to use scan-and-merge
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service.rs:132-199` (update `add()` method)
+- Modify: `crates/kiro-market-core/src/service.rs:346-366` (update `read_manifest()`)
+
+**Step 1: Write the failing tests**
+
+Add to the existing `mod tests` in `service.rs`. First, update `MockGitBackend` to support repos without a marketplace manifest and repos with extra plugins.
+
+Add a new mock that creates a repo with plugin.json files but no marketplace.json:
+
+```rust
+/// Mock git backend that creates a repo with plugin.json files but no marketplace.json.
+#[derive(Debug, Default)]
+struct NoManifestGitBackend;
+
+impl GitBackend for NoManifestGitBackend {
+    fn clone_repo(&self, _url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+        // Create two plugin directories with plugin.json but no marketplace.json.
+        let plugin_a = dest.join("plugins/alpha");
+        fs::create_dir_all(&plugin_a).unwrap();
+        fs::write(
+            plugin_a.join("plugin.json"),
+            r#"{"name":"alpha","description":"Alpha plugin","skills":["./skills/"]}"#,
+        )
+        .unwrap();
+
+        let plugin_b = dest.join("plugins/beta");
+        fs::create_dir_all(&plugin_b).unwrap();
+        fs::write(
+            plugin_b.join("plugin.json"),
+            r#"{"name":"beta","skills":["./skills/"]}"#,
+        )
+        .unwrap();
+
+        Ok(())
+    }
+
+    fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+        Ok(())
+    }
+
+    fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+        Ok(())
+    }
+}
+
+/// Mock that creates a repo with a marketplace.json AND an unlisted plugin.
+#[derive(Debug, Default)]
+struct MixedGitBackend;
+
+impl GitBackend for MixedGitBackend {
+    fn clone_repo(&self, _url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+        // Create marketplace.json listing one plugin.
+        let mp_dir = dest.join(".claude-plugin");
+        fs::create_dir_all(&mp_dir).unwrap();
+        fs::write(
+            mp_dir.join("marketplace.json"),
+            r#"{"name":"mixed-market","owner":{"name":"Test"},"plugins":[{"name":"listed","description":"A listed plugin","source":"./plugins/listed"}]}"#,
+        )
+        .unwrap();
+
+        // Create the listed plugin directory with plugin.json.
+        let listed = dest.join("plugins/listed");
+        fs::create_dir_all(&listed).unwrap();
+        fs::write(
+            listed.join("plugin.json"),
+            r#"{"name":"listed","description":"A listed plugin","skills":["./skills/"]}"#,
+        )
+        .unwrap();
+
+        // Create an unlisted plugin directory with plugin.json.
+        let unlisted = dest.join("plugins/unlisted");
+        fs::create_dir_all(&unlisted).unwrap();
+        fs::write(
+            unlisted.join("plugin.json"),
+            r#"{"name":"unlisted","description":"An unlisted plugin","skills":["./skills/"]}"#,
+        )
+        .unwrap();
+
+        Ok(())
+    }
+
+    fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+        Ok(())
+    }
+
+    fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn add_repo_without_manifest_discovers_plugins_via_scan() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = CacheDir::with_root(dir.path().to_path_buf());
+    cache.ensure_dirs().expect("ensure_dirs");
+    let svc = MarketplaceService::new(cache, NoManifestGitBackend);
+
+    let result = svc
+        .add("owner/skills", GitProtocol::Https)
+        .expect("add should succeed");
+
+    // Name derived from repo: "skills"
+    assert_eq!(result.name, "skills");
+    assert_eq!(result.plugins.len(), 2);
+
+    let names: Vec<&str> = result.plugins.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"alpha"), "should find alpha: {names:?}");
+    assert!(names.contains(&"beta"), "should find beta: {names:?}");
+}
+
+#[test]
+fn add_repo_with_manifest_and_unlisted_plugins_merges_both() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = CacheDir::with_root(dir.path().to_path_buf());
+    cache.ensure_dirs().expect("ensure_dirs");
+    let svc = MarketplaceService::new(cache, MixedGitBackend);
+
+    let result = svc
+        .add("owner/repo", GitProtocol::Https)
+        .expect("add should succeed");
+
+    assert_eq!(result.name, "mixed-market");
+    assert_eq!(result.plugins.len(), 2);
+
+    let names: Vec<&str> = result.plugins.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"listed"), "should find listed: {names:?}");
+    assert!(names.contains(&"unlisted"), "should find unlisted: {names:?}");
+}
+
+#[test]
+fn add_repo_with_manifest_deduplicates_listed_plugins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = CacheDir::with_root(dir.path().to_path_buf());
+    cache.ensure_dirs().expect("ensure_dirs");
+    let svc = MarketplaceService::new(cache, MixedGitBackend);
+
+    let result = svc
+        .add("owner/repo", GitProtocol::Https)
+        .expect("add should succeed");
+
+    // "listed" should appear only once, not duplicated from scan + manifest.
+    let listed_count = result
+        .plugins
+        .iter()
+        .filter(|p| p.name == "listed")
+        .count();
+    assert_eq!(listed_count, 1, "listed plugin should not be duplicated");
+}
+
+#[test]
+fn add_empty_repo_returns_no_plugins_found_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = CacheDir::with_root(dir.path().to_path_buf());
+    cache.ensure_dirs().expect("ensure_dirs");
+
+    // A backend that creates an empty repo — no marketplace.json, no plugin.json.
+    #[derive(Debug)]
+    struct EmptyRepoBackend;
+
+    impl GitBackend for EmptyRepoBackend {
+        fn clone_repo(
+            &self,
+            _url: &str,
+            dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            fs::create_dir_all(dest).unwrap();
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    let svc = MarketplaceService::new(cache, EmptyRepoBackend);
+    let err = svc
+        .add("owner/empty", GitProtocol::Https)
+        .expect_err("should fail");
+
+    assert!(
+        err.to_string().contains("no plugins found"),
+        "expected 'no plugins found' error, got: {err}"
+    );
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core -- add_repo_without_manifest add_repo_with_manifest add_empty_repo`
+Expected: FAIL — current `add()` errors on missing marketplace.json
+
+**Step 3: Modify `add()` to support scan-and-merge**
+
+Update the `add()` method in `service.rs`. The key changes:
+
+1. `read_manifest()` returns `Option<Marketplace>` instead of `Result<Marketplace, Error>` when the file is simply missing.
+2. After reading the manifest (or noting its absence), call `discover_plugins()`.
+3. Deduplicate by comparing scanned plugin paths against marketplace `RelativePath` entries.
+4. If no manifest and no scanned plugins, return `NoPluginsFound` error.
+5. Use manifest name if available, else `fallback_name()`.
+
+Replace `service.rs` `add()` body (lines 132-199) with:
+
+```rust
+pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
+    let ms = MarketplaceSource::detect(source);
+    self.cache.ensure_dirs()?;
+
+    let temp_name = format!("_pending_{}", std::process::id());
+    let temp_dir = self.cache.marketplace_path(&temp_name);
+
+    if temp_dir.exists()
+        && let Err(e) = fs::remove_dir_all(&temp_dir)
+    {
+        warn!(
+            path = %temp_dir.display(),
+            error = %e,
+            "failed to clean up leftover temp directory"
+        );
+    }
+
+    let mut guard = TempDirGuard::new(temp_dir.clone());
+
+    let link_result = self.clone_or_link(&ms, protocol, &temp_dir)?;
+
+    if link_result == LinkResult::Copied {
+        warn!(
+            source = %source,
+            "marketplace was copied, not linked — local changes will NOT be live-tracked"
+        );
+    }
+
+    // Try to read marketplace manifest (optional).
+    let manifest = self.try_read_manifest(&temp_dir);
+
+    // Scan for plugin.json files.
+    let discovered = crate::plugin::discover_plugins(&temp_dir, 3);
+
+    // Build the plugin list: manifest entries first, then discovered (deduplicated).
+    let (name, plugins) = match manifest {
+        Some(m) => {
+            let manifest_name = m.name.clone();
+            let mut plugins: Vec<PluginBasicInfo> = m
+                .plugins
+                .iter()
+                .map(|p| PluginBasicInfo {
+                    name: p.name.clone(),
+                    description: p.description.clone(),
+                })
+                .collect();
+
+            // Collect marketplace-listed relative paths for dedup.
+            let listed_paths: Vec<PathBuf> = m
+                .plugins
+                .iter()
+                .filter_map(|p| match &p.source {
+                    crate::marketplace::PluginSource::RelativePath(rel) => {
+                        Some(PathBuf::from(rel.trim_start_matches("./")))
+                    }
+                    _ => None,
+                })
+                .collect();
+
+            // Collect listed names for dedup of structured sources.
+            let listed_names: Vec<&str> =
+                m.plugins.iter().map(|p| p.name.as_str()).collect();
+
+            // Add discovered plugins that aren't already listed.
+            for dp in &discovered {
+                let path_match = listed_paths
+                    .iter()
+                    .any(|lp| lp == &dp.relative_path);
+                let name_match = listed_names.contains(&dp.name.as_str());
+                if !path_match && !name_match {
+                    plugins.push(PluginBasicInfo {
+                        name: dp.name.clone(),
+                        description: dp.description.clone(),
+                    });
+                }
+            }
+
+            (manifest_name, plugins)
+        }
+        None => {
+            if discovered.is_empty() {
+                return Err(MarketplaceError::NoPluginsFound {
+                    path: temp_dir.clone(),
+                }
+                .into());
+            }
+
+            let name = ms.fallback_name().ok_or_else(|| {
+                MarketplaceError::InvalidManifest {
+                    reason: "no marketplace.json found and could not derive a name from the source; use --name to specify one".into(),
+                }
+            })?;
+
+            let plugins = discovered
+                .iter()
+                .map(|dp| PluginBasicInfo {
+                    name: dp.name.clone(),
+                    description: dp.description.clone(),
+                })
+                .collect();
+
+            (name, plugins)
+        }
+    };
+
+    validation::validate_name(&name)?;
+
+    let final_dir = self.cache.marketplace_path(&name);
+    if final_dir.exists() {
+        return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
+    }
+
+    fs::rename(&temp_dir, &final_dir)?;
+    guard.defuse();
+
+    let entry = KnownMarketplace {
+        name: name.clone(),
+        source: ms,
+        protocol: Some(protocol),
+        added_at: chrono::Utc::now(),
+    };
+    self.cache.add_known_marketplace(entry)?;
+
+    debug!(marketplace = %name, "marketplace added");
+
+    Ok(MarketplaceAddResult { name, plugins })
+}
+```
+
+Add the `try_read_manifest` helper:
+
+```rust
+/// Try to read the marketplace manifest. Returns `None` if the file is missing,
+/// `None` (with a warning) if malformed, or `Some(manifest)` on success.
+fn try_read_manifest(&self, repo_dir: &Path) -> Option<Marketplace> {
+    let manifest_path = repo_dir.join(crate::MARKETPLACE_MANIFEST_PATH);
+    match fs::read(&manifest_path) {
+        Ok(bytes) => match Marketplace::from_json(&bytes) {
+            Ok(m) => Some(m),
+            Err(e) => {
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "marketplace.json is malformed, falling back to plugin scan"
+                );
+                None
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            debug!(
+                path = %manifest_path.display(),
+                "no marketplace.json found, will discover plugins via scan"
+            );
+            None
+        }
+        Err(e) => {
+            warn!(
+                path = %manifest_path.display(),
+                error = %e,
+                "failed to read marketplace.json, falling back to plugin scan"
+            );
+            None
+        }
+    }
+}
+```
+
+Remove the old `read_manifest` static method (it's replaced by `try_read_manifest`).
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core -- add_`
+Expected: all PASS (both old and new tests)
+
+**Step 5: Run clippy**
+
+Run: `cargo clippy -p kiro-market-core -- -D warnings`
+Expected: no warnings
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service.rs
+git commit -m "feat: scan-and-merge in marketplace add — support repos without marketplace.json"
+```
+
+---
+
+### Task 5: Update `find_plugin_entry` in CLI to fall back to scan
+
+**Files:**
+- Modify: `crates/kiro-market/src/commands/common.rs:12-34` (update `find_plugin_entry`)
+
+**Step 1: Update `find_plugin_entry` to scan on miss**
+
+Change the function to: try marketplace.json first, fall back to `discover_plugins` if the plugin isn't listed:
+
+```rust
+/// Read the marketplace manifest and find the matching plugin entry.
+///
+/// If the plugin is not listed in `marketplace.json` (or the manifest is absent),
+/// falls back to a depth-limited scan for `plugin.json` files in the repo.
+pub fn find_plugin_entry(
+    marketplace_path: &Path,
+    plugin_name: &str,
+    marketplace_name: &str,
+) -> Result<PluginEntry> {
+    // Try marketplace.json first.
+    let manifest_path = marketplace_path.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
+    if let Ok(manifest_bytes) = fs::read(&manifest_path) {
+        if let Ok(manifest) = Marketplace::from_json(&manifest_bytes) {
+            if let Some(entry) = manifest
+                .plugins
+                .into_iter()
+                .find(|p| p.name == plugin_name)
+            {
+                return Ok(entry);
+            }
+        }
+    }
+
+    // Fall back to scanning for plugin.json.
+    let discovered = kiro_market_core::plugin::discover_plugins(marketplace_path, 3);
+    if let Some(dp) = discovered.into_iter().find(|dp| dp.name == plugin_name) {
+        let relative = format!("./{}", dp.relative_path.display());
+        return Ok(PluginEntry {
+            name: dp.name,
+            description: dp.description,
+            source: kiro_market_core::marketplace::PluginSource::RelativePath(relative),
+        });
+    }
+
+    anyhow::bail!("plugin '{plugin_name}' not found in marketplace '{marketplace_name}'")
+}
+```
+
+**Step 2: Run the full test suite**
+
+Run: `cargo test --workspace`
+Expected: all PASS
+
+**Step 3: Run clippy**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: no warnings
+
+**Step 4: Commit**
+
+```bash
+git add crates/kiro-market/src/commands/common.rs
+git commit -m "feat: install falls back to plugin.json scan when not in marketplace manifest"
+```
+
+---
+
+### Task 6: Update CLI output to show discovered plugins on add
+
+**Files:**
+- Modify: `crates/kiro-market/src/commands/marketplace.rs` (the `add` subcommand output)
+
+**Step 1: Check current add output formatting**
+
+Read the marketplace add command handler to find where `MarketplaceAddResult.plugins` is printed. Update the output to show the total count naturally — since there's no `discovered` flag, the output just shows all plugins the same way. No code change may be needed if the current output already iterates over all plugins.
+
+**Step 2: Verify the full workflow end-to-end**
+
+Run manually with a real repo (if available) or verify via the test suite:
+
+Run: `cargo test --workspace`
+Expected: all PASS
+
+**Step 3: Commit (only if changes were needed)**
+
+```bash
+git add crates/kiro-market/src/commands/marketplace.rs
+git commit -m "chore: update add command output to show all discovered plugins"
+```
+
+---
+
+### Task 7: Final verification and cleanup
+
+**Step 1: Run full test suite**
+
+Run: `cargo test --workspace`
+Expected: all PASS
+
+**Step 2: Run clippy on entire workspace**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: no warnings
+
+**Step 3: Run cargo build**
+
+Run: `cargo build`
+Expected: clean build
+
+**Step 4: Verify existing tests still pass (regression check)**
+
+Run: `cargo test -p kiro-market-core -- add_marketplace add_duplicate remove_marketplace update_`
+Expected: all existing service tests still PASS
+
+**Step 5: Commit any final cleanup**
+
+Only if needed.


### PR DESCRIPTION
## Summary

- **Settings view** — Full sidebar-based UI for managing Kiro CLI settings (`~/.kiro/settings/cli.json`) with categorized navigation, search, type-appropriate editors (bool toggles, string/number/char inputs, enum dropdowns, string_array chip lists), auto-persist, and reset-to-default
- **File locking** — Advisory file locking via `fs4` for `installed-skills.json` and `known_marketplaces.json` to prevent concurrent write corruption
- **Skill card UX** — Expand/collapse for long skill descriptions in the Browse tab

## Settings view details

- Static settings registry in `kiro-market-core` with 38 Kiro CLI settings across 8 categories (Telemetry, Chat, Knowledge, Key Bindings, Features, API, MCP, Environment)
- Three Tauri commands: `get_kiro_settings`, `set_kiro_setting` (with type validation), `reset_kiro_setting`
- `LoadSettingsError` enum distinguishes missing file (use defaults) from corrupt/unreadable (surface error)
- `SettingValueInfo` discriminated union replaces stringly-typed `value_type` + `enum_options`
- Mutex-based write serialization prevents lost-update races from rapid UI interactions
- 25 tests covering registry invariants, JSON path operations, file I/O, and type validation
- Gear icon in header opens settings; project dropdown hidden in settings view

## Test plan

- [ ] `cargo test -p kiro-market-core kiro_settings` — 25 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `npm run check` in `crates/kiro-control-center/` — 0 errors
- [ ] Settings view: click gear icon, verify sidebar categories with correct counts
- [ ] Settings view: toggle a bool setting, verify persists to `~/.kiro/settings/cli.json`
- [ ] Settings view: reset a modified setting, verify "Modified" badge clears
- [ ] Settings view: search filters across all categories
- [ ] Settings view: corrupt cli.json shows error instead of silently losing data
- [ ] File locking: concurrent skill install/remove doesn't corrupt tracking file

🤖 Generated with [Claude Code](https://claude.com/claude-code)