### PR TITLE
fix: rollback ordering, guard lifecycle, and Windows path compatibility

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/settings.rs
@@ -193,7 +193,8 @@ fn shellexpand_tilde(path: &str) -> String {
             return home.to_string_lossy().into_owned();
         }
     }
-    if let Some(rest) = path.strip_prefix("~/") {
+    let rest = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\"));
+    if let Some(rest) = rest {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest).to_string_lossy().into_owned();
         }

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -45,6 +45,7 @@ impl From<CoreError> for CommandError {
             CoreError::Marketplace(MarketplaceError::AlreadyRegistered { .. }) => {
                 ErrorType::AlreadyExists
             }
+            CoreError::Marketplace(MarketplaceError::NoPluginsFound { .. }) => ErrorType::NotFound,
             CoreError::Marketplace(_) => ErrorType::ParseError,
             CoreError::Skill(SkillError::AlreadyInstalled { .. }) => ErrorType::AlreadyExists,
             CoreError::Skill(SkillError::NotInstalled { .. }) => ErrorType::NotFound,
@@ -105,6 +106,10 @@ mod tests {
     #[case::marketplace_already_registered(
         CoreError::Marketplace(MarketplaceError::AlreadyRegistered { name: "acme".into() }),
         ErrorType::AlreadyExists
+    )]
+    #[case::marketplace_no_plugins_found(
+        CoreError::Marketplace(MarketplaceError::NoPluginsFound { path: PathBuf::from("/tmp/repo") }),
+        ErrorType::NotFound
     )]
     #[case::marketplace_invalid_manifest(
         CoreError::Marketplace(MarketplaceError::InvalidManifest { reason: "bad json".into() }),

--- a/crates/kiro-market-core/src/cache.rs
+++ b/crates/kiro-market-core/src/cache.rs
@@ -58,6 +58,8 @@ impl MarketplaceSource {
             || source.starts_with('/')
             || source.starts_with("./")
             || source.starts_with("../")
+            || source.starts_with(".\\")
+            || source.starts_with("..\\")
             || source.starts_with('~')
         {
             Self::LocalPath {
@@ -134,7 +136,7 @@ pub fn resolve_local_path(path_str: &str) -> std::io::Result<PathBuf> {
         if rest.is_empty() {
             home
         } else {
-            home.join(rest.trim_start_matches('/'))
+            home.join(rest.trim_start_matches(['/', '\\']))
         }
     } else {
         PathBuf::from(path_str)
@@ -536,10 +538,11 @@ mod tests {
         let (_dir, cache) = temp_cache();
 
         let mp = cache.marketplace_path("my-market");
-        assert!(mp.ends_with("marketplaces/my-market"));
+        // Use Path::ends_with which compares by components (cross-platform).
+        assert!(mp.ends_with(Path::new("marketplaces").join("my-market")));
 
         let pp = cache.plugin_path("my-market", "my-plugin");
-        assert!(pp.ends_with("plugins/my-market/my-plugin"));
+        assert!(pp.ends_with(Path::new("plugins").join("my-market").join("my-plugin")));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/file_lock.rs
+++ b/crates/kiro-market-core/src/file_lock.rs
@@ -1,7 +1,7 @@
 //! Advisory file locking for concurrent marketplace operations.
 //!
 //! Uses [`fs4`] exclusive advisory locks to serialise read-modify-write cycles
-//! on shared JSON files (`installed-skills.json`, `marketplace-cache.json`, etc.).
+//! on shared JSON files (`installed-skills.json`, `known_marketplaces.json`, etc.).
 //!
 //! ## Windows caveat
 //!

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -65,11 +65,24 @@ impl DiscoveredPlugin {
         &self.relative_path
     }
 
-    /// The relative path as a `./`-prefixed string, matching the
-    /// `PluginSource::RelativePath` convention used in `marketplace.json`.
+    /// The relative path as a `./`-prefixed string with forward slashes,
+    /// matching the `PluginSource::RelativePath` convention used in
+    /// `marketplace.json`. Uses forward slashes on all platforms.
     #[must_use]
     pub fn as_relative_path_string(&self) -> String {
-        format!("./{}", self.relative_path.display())
+        let unix_path = self.relative_path_unix();
+        format!("./{unix_path}")
+    }
+
+    /// The relative path with forward slashes, suitable for cross-platform
+    /// comparison against manifest paths.
+    #[must_use]
+    pub fn relative_path_unix(&self) -> String {
+        self.relative_path
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/")
     }
 }
 
@@ -236,7 +249,7 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Path
 
         let candidate = plugin_root.join(path_str);
 
-        if path_str.ends_with('/') {
+        if path_str.ends_with('/') || path_str.ends_with('\\') {
             // Scan subdirectories for those containing SKILL.md.
             match fs::read_dir(&candidate) {
                 Ok(entries) => {

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::error::SkillError;
 use crate::validation;
@@ -181,7 +181,7 @@ impl KiroProject {
     pub fn remove_skill(&self, name: &str) -> crate::error::Result<()> {
         validation::validate_name(name)?;
 
-        crate::file_lock::with_file_lock(&self.tracking_path(), || {
+        crate::file_lock::with_file_lock(&self.tracking_path(), || -> crate::error::Result<()> {
             let dir = self.skill_dir(name);
 
             if !dir.exists() {
@@ -191,11 +191,43 @@ impl KiroProject {
                 .into());
             }
 
-            fs::remove_dir_all(&dir)?;
-
+            // Update tracking BEFORE deleting the directory so a crash
+            // between the two operations leaves the directory on disk
+            // (harmless) rather than a phantom tracking entry (confusing).
             let mut installed = self.load_installed()?;
-            installed.skills.remove(name);
-            self.write_tracking(&installed)
+            let saved_meta = installed.skills.remove(name);
+            self.write_tracking(&installed)?;
+
+            if let Err(e) = fs::remove_dir_all(&dir) {
+                // Directory delete failed after tracking was already updated.
+                // Re-insert the entry so the tracking file stays consistent.
+                warn!(
+                    name,
+                    error = %e,
+                    "failed to delete skill directory after tracking update; \
+                     restoring tracking entry"
+                );
+                if let Some(meta) = saved_meta {
+                    installed.skills.insert(name.to_owned(), meta);
+                    if let Err(restore_err) = self.write_tracking(&installed) {
+                        warn!(
+                            name,
+                            error = %restore_err,
+                            "failed to restore tracking entry — skill may be \
+                             untracked on disk"
+                        );
+                    }
+                } else {
+                    debug!(
+                        name,
+                        "skill directory exists on disk but had no tracking \
+                         entry; no restore needed"
+                    );
+                }
+                return Err(e.into());
+            }
+
+            Ok(())
         })?;
 
         debug!(name, "skill removed");
@@ -287,7 +319,7 @@ impl KiroProject {
         if let Err(e) = copy_dir_recursive(source_dir, &staging_dir) {
             // Clean up the partial staging directory.
             if let Err(cleanup_err) = fs::remove_dir_all(&staging_dir) {
-                debug!(
+                warn!(
                     path = %staging_dir.display(),
                     error = %cleanup_err,
                     "failed to clean up partial staging directory"
@@ -318,16 +350,17 @@ impl KiroProject {
         });
 
         if let Err(e) = tracking_result {
-            debug!(
+            warn!(
                 name,
                 error = %e,
                 "tracking update failed after rename, rolling back"
             );
             if let Err(rollback_err) = fs::remove_dir_all(&dir) {
-                debug!(
+                warn!(
                     path = %dir.display(),
                     error = %rollback_err,
-                    "failed to roll back skill directory after tracking failure"
+                    "failed to roll back skill directory after tracking failure — \
+                     skill is installed on disk but not tracked"
                 );
             }
             return Err(e);
@@ -581,13 +614,11 @@ mod tests {
         let content = fs::read_to_string(project.skill_dir("s").join("SKILL.md")).expect("read");
         assert!(content.contains("Updated."));
 
-        assert!(
-            project
-                .skill_dir("s")
-                .join("references")
-                .join("new.md")
-                .exists()
-        );
+        assert!(project
+            .skill_dir("s")
+            .join("references")
+            .join("new.md")
+            .exists());
     }
 
     #[test]
@@ -694,13 +725,11 @@ mod tests {
         project
             .install_skill_from_dir("s", src1.path(), sample_meta())
             .expect("first install");
-        assert!(
-            project
-                .skill_dir("s")
-                .join("references")
-                .join("old.md")
-                .exists()
-        );
+        assert!(project
+            .skill_dir("s")
+            .join("references")
+            .join("old.md")
+            .exists());
 
         // v2: SKILL.md only, no references/
         fs::write(

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -133,6 +133,7 @@ impl MarketplaceService {
     /// occurs when reading the manifest, no plugins are found (neither via
     /// manifest nor scan), the marketplace name fails validation, or a
     /// marketplace with the same name is already registered.
+    #[allow(clippy::too_many_lines)]
     pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
         let ms = MarketplaceSource::detect(source);
         self.cache.ensure_dirs()?;
@@ -180,15 +181,18 @@ impl MarketplaceService {
                 .collect();
 
             // Collect marketplace-listed relative paths for dedup.
-            let listed_paths: Vec<PathBuf> = m
+            // Normalize to forward slashes so comparisons work on Windows.
+            let listed_paths: Vec<String> = m
                 .plugins
                 .iter()
                 .filter_map(|p| match &p.source {
                     crate::marketplace::PluginSource::RelativePath(rel) => {
                         let normalized = rel
                             .trim_start_matches("./")
-                            .trim_end_matches('/');
-                        Some(PathBuf::from(normalized))
+                            .trim_start_matches(".\\")
+                            .trim_end_matches(['/', '\\'])
+                            .replace('\\', "/");
+                        Some(normalized)
                     }
                     crate::marketplace::PluginSource::Structured(_) => None,
                 })
@@ -199,8 +203,10 @@ impl MarketplaceService {
                 m.plugins.iter().map(|p| p.name.as_str()).collect();
 
             // Add discovered plugins that aren't already listed.
+            // Use forward-slash relative paths for cross-platform comparison.
             for dp in &discovered {
-                let path_match = listed_paths.iter().any(|lp| lp == dp.relative_path());
+                let dp_path = dp.relative_path_unix();
+                let path_match = listed_paths.contains(&dp_path);
                 let name_match = listed_names.contains(&dp.name());
                 if !path_match && !name_match {
                     plugins.push(PluginBasicInfo {
@@ -244,7 +250,9 @@ impl MarketplaceService {
         }
 
         fs::rename(&temp_dir, &final_dir)?;
-        guard.defuse();
+        // Point the guard at the renamed location so its Drop targets the
+        // right path if we bail out before defusing.
+        guard.path.clone_from(&final_dir);
 
         let entry = KnownMarketplace {
             name: name.clone(),
@@ -252,7 +260,25 @@ impl MarketplaceService {
             protocol: Some(protocol),
             added_at: chrono::Utc::now(),
         };
-        self.cache.add_known_marketplace(entry)?;
+        if let Err(e) = self.cache.add_known_marketplace(entry) {
+            warn!(
+                path = %final_dir.display(),
+                error = %e,
+                "registry write failed after rename; rolling back"
+            );
+            if let Err(rb) = fs::remove_dir_all(&final_dir) {
+                warn!(
+                    path = %final_dir.display(),
+                    rollback_error = %rb,
+                    "failed to roll back renamed directory — remove it manually"
+                );
+            }
+            // Defuse so the guard doesn't attempt a second removal of the
+            // same path (or log a spurious warning if rollback succeeded).
+            guard.defuse();
+            return Err(e);
+        }
+        guard.defuse();
 
         debug!(marketplace = %name, "marketplace added");
 
@@ -990,5 +1016,74 @@ mod tests {
             "trailing slash should not cause duplicate: {:?}",
             result.plugins
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Manifest name validation test (security)
+    // -----------------------------------------------------------------------
+
+    /// Mock that creates a repo with a marketplace.json whose name contains path traversal.
+    #[derive(Debug)]
+    struct InvalidNameGitBackend;
+
+    impl GitBackend for InvalidNameGitBackend {
+        fn clone_repo(
+            &self,
+            _url: &str,
+            dest: &Path,
+            _opts: &CloneOptions,
+        ) -> Result<(), GitError> {
+            let mp_dir = dest.join(".claude-plugin");
+            fs::create_dir_all(&mp_dir).unwrap();
+            fs::write(
+                mp_dir.join("marketplace.json"),
+                r#"{"name":"../escape","owner":{"name":"Evil"},"plugins":[{"name":"evil","description":"Bad","source":"./plugins/evil"}]}"#,
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+            Ok(())
+        }
+
+        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_repo_with_path_traversal_name_returns_validation_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        cache.ensure_dirs().expect("ensure_dirs");
+        let svc = MarketplaceService::new(cache, InvalidNameGitBackend);
+
+        let err = svc
+            .add("owner/evil", GitProtocol::Https)
+            .expect_err("should reject path traversal name");
+
+        assert!(
+            err.to_string().contains("invalid name"),
+            "expected validation error, got: {err}"
+        );
+
+        // Verify no directory was left behind (TempDirGuard should clean up).
+        let marketplaces_dir = dir.path().join("marketplaces");
+        if marketplaces_dir.exists() {
+            let entries: Vec<_> = fs::read_dir(&marketplaces_dir)
+                .expect("read dir")
+                .filter_map(Result::ok)
+                .filter(|e| {
+                    let name = e.file_name();
+                    let name = name.to_string_lossy();
+                    !name.starts_with('_')
+                })
+                .collect();
+            assert!(
+                entries.is_empty(),
+                "no marketplace directory should remain after validation failure: {entries:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
- Move guard.defuse() after registry write succeeds in service::add(), preventing orphaned invisible directories on registry failure
- Update guard.path after rename so Drop targets the correct location, eliminating spurious "failed to clean up temp directory" warnings
- Reorder remove_skill to write tracking before deleting directory, with restore logic if directory deletion fails
- Upgrade rollback/cleanup logging from debug! to warn! so failures are visible in production
- Add NoPluginsFound match arm in Tauri error handler (was falling through to ParseError wildcard)
- Normalize paths to forward slashes for cross-platform dedup in service::add() and plugin::relative_path_unix()
- Handle backslash separators in skill dir scanning, tilde expansion, local path detection, and manifest path normalization
- Fix test assertions to use Path::ends_with(Path::join) for cross-platform correctness
- Add security test for path traversal in manifest marketplace name
- Fix doc comment referencing nonexistent marketplace-cache.json