### PR TITLE
Import Claude and Copilot agents as Kiro agent configs

### DIFF
--- a/crates/kiro-market-core/src/agent/discover.rs
+++ b/crates/kiro-market-core/src/agent/discover.rs
@@ -1,36 +1,63 @@
 //! Scan a plugin directory for agent markdown files.
 
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 /// Files commonly found in `agents/` directories that are documentation,
-/// not agents. Excluded by name so plugins can keep READMEs alongside
-/// their agent files without producing install-time warnings.
+/// not agents. Compared case-insensitively so `readme.md` is also excluded.
 const EXCLUDED_FILENAMES: &[&str] = &["README.md", "CONTRIBUTING.md", "CHANGELOG.md"];
 
 /// Find agent markdown files inside `plugin_dir` according to `scan_paths`.
 ///
-/// `scan_paths` are relative to `plugin_dir`. Files ending in `.md` or
-/// `.agent.md` are included; the caller uses `detect_dialect` at parse time
-/// to route to the right parser. Scans are non-recursive: only direct
-/// children of each scan directory are considered. This avoids grabbing
-/// nested `prompts/*.md` or editor backup files.
+/// `scan_paths` are relative to `plugin_dir`. Files whose extension is `md`
+/// (case-insensitive) are included; the caller uses `detect_dialect` at
+/// parse time to route to the right parser. Scans are non-recursive: only
+/// direct children of each scan directory are considered. This avoids
+/// grabbing nested `prompts/*.md` or editor backup files.
 ///
-/// Files listed in [`EXCLUDED_FILENAMES`] are skipped so shared
-/// documentation doesn't surface as parse-failure warnings. Other
-/// non-agent `.md` files (e.g. ad-hoc notes a plugin author drops in)
+/// README / CONTRIBUTING / CHANGELOG are excluded by filename so plugins
+/// can keep docs in their `agents/` directory without producing
+/// parse-failure warnings. Other non-agent `.md` files (e.g. ad-hoc notes)
 /// will still be picked up, parsed, and surfaced as `AgentParseFailed`
-/// warnings. The service layer further demotes the "no frontmatter fence"
-/// flavor of parse error to a debug log so it doesn't spam the user.
+/// warnings — the service layer demotes the `MissingFrontmatter` flavor
+/// specifically via a variant match on `ParseFailure`.
+///
+/// `read_dir` failures are handled narrowly: `NotFound` silently yields
+/// an empty list (the scan dir may legitimately not exist), but every
+/// other I/O error is logged via `warn!` so a permission-denied or
+/// filesystem error cannot present as "no agents here".
 #[must_use]
 pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for rel in scan_paths {
         let dir = plugin_dir.join(rel.trim_start_matches("./"));
-        let Ok(entries) = fs::read_dir(&dir) else {
-            continue;
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to read agent scan directory; skipping"
+                );
+                continue;
+            }
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(
+                        dir = %dir.display(),
+                        error = %e,
+                        "failed to read directory entry; skipping"
+                    );
+                    continue;
+                }
+            };
             let path = entry.path();
             if !path.is_file() {
                 continue;
@@ -38,7 +65,10 @@ pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if EXCLUDED_FILENAMES.contains(&name) {
+            if EXCLUDED_FILENAMES
+                .iter()
+                .any(|excluded| excluded.eq_ignore_ascii_case(name))
+            {
                 continue;
             }
             if Path::new(name)
@@ -84,13 +114,14 @@ mod tests {
     }
 
     #[test]
-    fn discover_excludes_readme_and_contributing() {
+    fn discover_excludes_readme_and_contributing_case_insensitive() {
         let tmp = tempdir().unwrap();
         let agents = tmp.path().join("agents");
         fs::create_dir_all(&agents).unwrap();
         fs::write(agents.join("README.md"), "# README").unwrap();
         fs::write(agents.join("CONTRIBUTING.md"), "# Contrib").unwrap();
         fs::write(agents.join("CHANGELOG.md"), "# Changelog").unwrap();
+        fs::write(agents.join("readme.md"), "# lowercase readme").unwrap();
         fs::write(agents.join("real.md"), "---\nname: r\n---\n").unwrap();
 
         let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
@@ -99,6 +130,18 @@ mod tests {
             .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
             .collect();
         assert_eq!(names, vec!["real.md"]);
+    }
+
+    #[test]
+    fn discover_accepts_uppercase_md_extension() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("Uppercase.MD"), "---\nname: u\n---\n").unwrap();
+        fs::write(agents.join("normal.md"), "---\nname: n\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        assert_eq!(found.len(), 2, "both extensions should be matched");
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/discover.rs
+++ b/crates/kiro-market-core/src/agent/discover.rs
@@ -1,0 +1,143 @@
+//! Scan a plugin directory for agent markdown files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Files commonly found in `agents/` directories that are documentation,
+/// not agents. Excluded by name so plugins can keep READMEs alongside
+/// their agent files without producing install-time warnings.
+const EXCLUDED_FILENAMES: &[&str] = &["README.md", "CONTRIBUTING.md", "CHANGELOG.md"];
+
+/// Find agent markdown files inside `plugin_dir` according to `scan_paths`.
+///
+/// `scan_paths` are relative to `plugin_dir`. Files ending in `.md` or
+/// `.agent.md` are included; the caller uses `detect_dialect` at parse time
+/// to route to the right parser. Scans are non-recursive: only direct
+/// children of each scan directory are considered. This avoids grabbing
+/// nested `prompts/*.md` or editor backup files.
+///
+/// Files listed in [`EXCLUDED_FILENAMES`] are skipped so shared
+/// documentation doesn't surface as parse-failure warnings. Other
+/// non-agent `.md` files (e.g. ad-hoc notes a plugin author drops in)
+/// will still be picked up, parsed, and surfaced as `AgentParseFailed`
+/// warnings. The service layer further demotes the "no frontmatter fence"
+/// flavor of parse error to a debug log so it doesn't spam the user.
+#[must_use]
+pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for rel in scan_paths {
+        let dir = plugin_dir.join(rel.trim_start_matches("./"));
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if EXCLUDED_FILENAMES.contains(&name) {
+                continue;
+            }
+            if name.ends_with(".md") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn discover_finds_both_md_and_agent_md() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("claude.md"), "---\nname: c\n---\n").unwrap();
+        fs::write(agents.join("copilot.agent.md"), "---\nname: o\n---\n").unwrap();
+        fs::write(agents.join("notes.txt"), "ignored").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"claude.md".to_string()));
+        assert!(names.contains(&"copilot.agent.md".to_string()));
+        assert!(!names.contains(&"notes.txt".to_string()));
+    }
+
+    #[test]
+    fn discover_returns_empty_when_directory_missing() {
+        let tmp = tempdir().unwrap();
+        let found = discover_agents_in_dirs(tmp.path(), &["./nope/".to_string()]);
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn discover_excludes_readme_and_contributing() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("README.md"), "# README").unwrap();
+        fs::write(agents.join("CONTRIBUTING.md"), "# Contrib").unwrap();
+        fs::write(agents.join("CHANGELOG.md"), "# Changelog").unwrap();
+        fs::write(agents.join("real.md"), "---\nname: r\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["real.md"]);
+    }
+
+    #[test]
+    fn discover_does_not_recurse_into_subdirectories() {
+        // Prevents accidentally picking up nested `agents/prompts/*.md` or
+        // backup directories.
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let nested = agents.join("archived");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(agents.join("top.md"), "---\nname: t\n---\n").unwrap();
+        fs::write(nested.join("deep.md"), "---\nname: d\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["top.md"]);
+    }
+
+    #[test]
+    fn discover_handles_relative_path_without_leading_dot_slash() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("x.md"), "---\nname: x\n---\n").unwrap();
+
+        // Caller passes bare "agents/" (no ./), should still work.
+        let found = discover_agents_in_dirs(tmp.path(), &["agents/".to_string()]);
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn discover_scans_multiple_paths() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("a")).unwrap();
+        fs::create_dir_all(tmp.path().join("b")).unwrap();
+        fs::write(tmp.path().join("a").join("x.md"), "---\nname: x\n---\n").unwrap();
+        fs::write(tmp.path().join("b").join("y.md"), "---\nname: y\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./a/".to_string(), "./b/".to_string()]);
+        assert_eq!(found.len(), 2);
+    }
+}

--- a/crates/kiro-market-core/src/agent/discover.rs
+++ b/crates/kiro-market-core/src/agent/discover.rs
@@ -41,7 +41,10 @@ pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<
             if EXCLUDED_FILENAMES.contains(&name) {
                 continue;
             }
-            if name.ends_with(".md") {
+            if Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+            {
                 out.push(path);
             }
         }

--- a/crates/kiro-market-core/src/agent/discover.rs
+++ b/crates/kiro-market-core/src/agent/discover.rs
@@ -12,11 +12,17 @@ const EXCLUDED_FILENAMES: &[&str] = &["README.md", "CONTRIBUTING.md", "CHANGELOG
 
 /// Find agent markdown files inside `plugin_dir` according to `scan_paths`.
 ///
-/// `scan_paths` are relative to `plugin_dir`. Files whose extension is `md`
-/// (case-insensitive) are included; the caller uses `detect_dialect` at
-/// parse time to route to the right parser. Scans are non-recursive: only
-/// direct children of each scan directory are considered. This avoids
-/// grabbing nested `prompts/*.md` or editor backup files.
+/// `scan_paths` are relative to `plugin_dir`. Each entry is first validated
+/// by [`crate::validation::validate_relative_path`] so a malicious plugin
+/// manifest cannot escape the plugin root via absolute paths or `..`
+/// components. Invalid entries are skipped with a `warn!`. This matches
+/// the skill discovery guard in `plugin::discover_skill_dirs`.
+///
+/// Files whose extension is `md` (case-insensitive) are included; the
+/// caller uses `detect_dialect` at parse time to route to the right
+/// parser. Scans are non-recursive: only direct children of each scan
+/// directory are considered. This avoids grabbing nested `prompts/*.md`
+/// or editor backup files.
 ///
 /// README / CONTRIBUTING / CHANGELOG are excluded by filename so plugins
 /// can keep docs in their `agents/` directory without producing
@@ -33,6 +39,14 @@ const EXCLUDED_FILENAMES: &[&str] = &["README.md", "CONTRIBUTING.md", "CHANGELOG
 pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for rel in scan_paths {
+        if let Err(e) = crate::validation::validate_relative_path(rel) {
+            warn!(
+                path = %rel,
+                error = %e,
+                "skipping agent scan path that fails validation"
+            );
+            continue;
+        }
         let dir = plugin_dir.join(rel.trim_start_matches("./"));
         let entries = match fs::read_dir(&dir) {
             Ok(entries) => entries,
@@ -173,6 +187,58 @@ mod tests {
         // Caller passes bare "agents/" (no ./), should still work.
         let found = discover_agents_in_dirs(tmp.path(), &["agents/".to_string()]);
         assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn discover_rejects_path_traversal_in_scan_paths() {
+        // A malicious plugin manifest claims agents live outside the plugin
+        // root. The returned list must be empty; the warn! fires but does
+        // not fail the call.
+        let tmp = tempdir().unwrap();
+        let plugin = tmp.path().join("plugin");
+        fs::create_dir_all(&plugin).unwrap();
+
+        // Prime a directory next to the plugin that would otherwise be
+        // readable.
+        let escape = tmp.path().join("secrets");
+        fs::create_dir_all(&escape).unwrap();
+        fs::write(escape.join("loot.md"), "---\nname: loot\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(&plugin, &["../secrets/".to_string()]);
+        assert!(
+            found.is_empty(),
+            "path traversal must not escape plugin root: {found:?}"
+        );
+    }
+
+    #[test]
+    fn discover_rejects_absolute_scan_paths() {
+        let tmp = tempdir().unwrap();
+        let plugin = tmp.path().join("plugin");
+        fs::create_dir_all(&plugin).unwrap();
+
+        let found = discover_agents_in_dirs(&plugin, &["/etc/".to_string()]);
+        assert!(found.is_empty(), "absolute path must be rejected");
+    }
+
+    #[test]
+    fn discover_scans_valid_paths_alongside_rejected_ones() {
+        // Mixed list: one bad, one good. The good one still works.
+        let tmp = tempdir().unwrap();
+        let plugin = tmp.path().join("plugin");
+        let agents = plugin.join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("legit.md"), "---\nname: ok\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(
+            &plugin,
+            &["../../etc/".to_string(), "./agents/".to_string()],
+        );
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["legit.md"]);
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/emit.rs
+++ b/crates/kiro-market-core/src/agent/emit.rs
@@ -268,6 +268,47 @@ mod tests {
     }
 
     #[test]
+    fn emit_serializes_keys_alphabetically() {
+        // The emitted JSON's on-disk key order depends on whether
+        // `serde_json` was built with the `preserve_order` feature. This
+        // crate does NOT enable it, so keys land alphabetically. If
+        // someone flips that flag we want a loud test failure, not a
+        // silent shape change that confuses downstream parsers.
+        let mapped = vec![
+            MappedTool::Native("read".into()),
+            MappedTool::McpRef("@terraform".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        let s = serde_json::to_string(&out).unwrap();
+
+        // Build an iterator of the positions of each expected key to verify
+        // they appear in alphabetical order.
+        let keys = [
+            "allowedTools",
+            "description",
+            "model",
+            "name",
+            "prompt",
+            "tools",
+        ];
+        let positions: Vec<_> = keys
+            .iter()
+            .map(|k| (k, s.find(&format!("\"{k}\"")).expect(k)))
+            .collect();
+        for w in positions.windows(2) {
+            assert!(
+                w[0].1 < w[1].1,
+                "key `{}` should come before `{}` alphabetically, \
+                 got positions {} and {} in: {s}",
+                w[0].0,
+                w[1].0,
+                w[0].1,
+                w[1].1
+            );
+        }
+    }
+
+    #[test]
     fn emit_preserves_non_local_mcp_server_type() {
         let mut def = sample_claude_def();
         def.mcp_servers.insert(

--- a/crates/kiro-market-core/src/agent/emit.rs
+++ b/crates/kiro-market-core/src/agent/emit.rs
@@ -1,0 +1,239 @@
+//! Emit Kiro agent JSON from an [`AgentDefinition`].
+//!
+//! The emitted JSON matches the schema at `agent-schema.json`. The `prompt`
+//! field uses Kiro's `file://` URI to reference the externalized prompt
+//! markdown, so the `.md` remains the source of truth after install.
+//!
+//! Routing: native Kiro tool names go into `allowedTools` (explicit
+//! allowlist); MCP server refs go into `tools` (the field documented as
+//! carrying `@server` / `@server/tool` entries per `agent-schema.json`).
+//!
+//! NOTE on field ordering: workspace `serde_json` does not enable the
+//! `preserve_order` feature, so `serde_json::Map` is BTreeMap-backed and
+//! emits keys alphabetically in the on-disk JSON. Tests index by key so
+//! they're unaffected, but reviewers reading the file should not expect
+//! insertion order.
+
+use serde_json::{Map, Value};
+
+use super::tools::MappedTool;
+use super::types::AgentDefinition;
+
+/// Build the Kiro-compatible JSON for an agent, given the parsed definition
+/// and the already-mapped tool list.
+///
+/// `mapped_tools` is the output of [`super::tools::map_claude_tools`] or
+/// [`super::tools::map_copilot_tools`]. Native entries land in `allowedTools`;
+/// MCP refs land in `tools` per the Kiro agent schema.
+///
+/// # Errors
+///
+/// Currently infallible in practice (all inputs are already validated
+/// upstream) but returns `serde_json::Result` so future extensions can
+/// surface serialization failures.
+pub fn build_kiro_json(
+    def: &AgentDefinition,
+    mapped_tools: &[MappedTool],
+) -> serde_json::Result<Value> {
+    let mut obj = Map::new();
+    obj.insert("name".into(), Value::String(def.name.clone()));
+    if let Some(desc) = &def.description {
+        obj.insert("description".into(), Value::String(desc.clone()));
+    }
+    obj.insert(
+        "prompt".into(),
+        Value::String(format!("file://./prompts/{}.md", def.name)),
+    );
+    if let Some(model) = &def.model {
+        obj.insert("model".into(), Value::String(model.clone()));
+    }
+
+    let mut allowed: Vec<Value> = Vec::new();
+    let mut tools: Vec<Value> = Vec::new();
+    for entry in mapped_tools {
+        match entry {
+            MappedTool::Native(s) => allowed.push(Value::String(s.clone())),
+            MappedTool::McpRef(s) => tools.push(Value::String(s.clone())),
+        }
+    }
+    if !allowed.is_empty() {
+        obj.insert("allowedTools".into(), Value::Array(allowed));
+    }
+    if !tools.is_empty() {
+        obj.insert("tools".into(), Value::Array(tools));
+    }
+
+    if !def.mcp_servers.is_empty() {
+        let mut servers = Map::new();
+        for (name, raw) in &def.mcp_servers {
+            servers.insert(name.clone(), normalize_mcp_server(raw));
+        }
+        obj.insert("mcpServers".into(), Value::Object(servers));
+    }
+    Ok(Value::Object(obj))
+}
+
+/// Normalize a Copilot MCP server entry toward Kiro's `CustomToolConfig` shape.
+///
+/// Rules:
+/// - `type: "local"` → `type: "stdio"` (Copilot's `local` means "spawn
+///   this as a subprocess"; Kiro's equivalent vocabulary is `stdio`).
+/// - inner `tools` allowlist → dropped. Kiro has no per-server allowlist
+///   field on the server config itself; the outer `tools` array already
+///   handles whole-server access via `@name` references.
+fn normalize_mcp_server(raw: &Value) -> Value {
+    let Some(obj) = raw.as_object() else {
+        return raw.clone();
+    };
+    let mut out = Map::new();
+    for (k, v) in obj {
+        if k == "tools" {
+            continue;
+        }
+        if k == "type" && v.as_str() == Some("local") {
+            out.insert("type".into(), Value::String("stdio".into()));
+            continue;
+        }
+        out.insert(k.clone(), v.clone());
+    }
+    Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::tools::MappedTool;
+    use crate::agent::types::{AgentDefinition, AgentDialect};
+    use std::collections::BTreeMap;
+
+    fn sample_claude_def() -> AgentDefinition {
+        AgentDefinition {
+            name: "reviewer".into(),
+            description: Some("Reviews code".into()),
+            prompt_body: "You are a reviewer.\n".into(),
+            model: Some("opus".into()),
+            source_tools: vec!["Read".into(), "Bash".into()],
+            mcp_servers: BTreeMap::new(),
+            dialect: AgentDialect::Claude,
+        }
+    }
+
+    #[test]
+    fn emit_sets_prompt_to_file_uri_relative_to_config() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert_eq!(out["name"], "reviewer");
+        assert_eq!(out["prompt"], "file://./prompts/reviewer.md");
+    }
+
+    #[test]
+    fn emit_includes_description_and_model_when_present() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert_eq!(out["description"], "Reviews code");
+        assert_eq!(out["model"], "opus");
+    }
+
+    #[test]
+    fn emit_omits_model_when_none() {
+        let mut def = sample_claude_def();
+        def.model = None;
+        let out = build_kiro_json(&def, &[]).unwrap();
+        assert!(out.get("model").is_none());
+    }
+
+    #[test]
+    fn emit_routes_native_tools_into_allowed_tools() {
+        let mapped = vec![
+            MappedTool::Native("read".into()),
+            MappedTool::Native("shell".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        let allowed = out["allowedTools"].as_array().unwrap();
+        assert_eq!(
+            allowed,
+            &vec![
+                serde_json::Value::String("read".into()),
+                serde_json::Value::String("shell".into()),
+            ]
+        );
+        // Native names must NOT leak into `tools` (which is for MCP refs).
+        assert!(
+            out.get("tools").is_none(),
+            "no MCP refs in this list — `tools` field must be omitted"
+        );
+    }
+
+    #[test]
+    fn emit_routes_mcp_refs_into_tools_field() {
+        let mapped = vec![
+            MappedTool::McpRef("@terraform".into()),
+            MappedTool::McpRef("@playwright/click".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        let tools = out["tools"].as_array().unwrap();
+        assert_eq!(tools[0], "@terraform");
+        assert_eq!(tools[1], "@playwright/click");
+        assert!(
+            out.get("allowedTools").is_none(),
+            "no native names — `allowedTools` field must be omitted"
+        );
+    }
+
+    #[test]
+    fn emit_routes_mixed_lists_to_both_fields() {
+        let mapped = vec![
+            MappedTool::Native("read".into()),
+            MappedTool::McpRef("@terraform".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        assert_eq!(out["allowedTools"][0], "read");
+        assert_eq!(out["tools"][0], "@terraform");
+    }
+
+    #[test]
+    fn emit_omits_tool_arrays_when_empty() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert!(out.get("allowedTools").is_none());
+        assert!(
+            out.get("tools").is_none(),
+            "empty tool list must omit both arrays so Kiro inherits full parent toolset"
+        );
+    }
+
+    #[test]
+    fn emit_normalizes_mcp_server_type_local_to_stdio() {
+        let mut def = sample_claude_def();
+        def.mcp_servers.insert(
+            "terraform".into(),
+            serde_json::json!({
+                "type": "local",
+                "command": "docker",
+                "args": ["run", "-i"],
+                "tools": ["*"]
+            }),
+        );
+        let out = build_kiro_json(&def, &[]).unwrap();
+        let tf = &out["mcpServers"]["terraform"];
+        assert_eq!(tf["type"], "stdio");
+        // Inner `tools: ["*"]` allowlist is stripped — Kiro has no equivalent
+        // and @{server} already covers "all tools".
+        assert!(tf.get("tools").is_none());
+    }
+
+    #[test]
+    fn emit_preserves_non_local_mcp_server_type() {
+        let mut def = sample_claude_def();
+        def.mcp_servers.insert(
+            "hosted".into(),
+            serde_json::json!({
+                "type": "http",
+                "url": "https://example.com/mcp",
+            }),
+        );
+        let out = build_kiro_json(&def, &[]).unwrap();
+        assert_eq!(out["mcpServers"]["hosted"]["type"], "http");
+        assert_eq!(
+            out["mcpServers"]["hosted"]["url"],
+            "https://example.com/mcp"
+        );
+    }
+}

--- a/crates/kiro-market-core/src/agent/emit.rs
+++ b/crates/kiro-market-core/src/agent/emit.rs
@@ -42,7 +42,10 @@ pub fn build_kiro_json(
     }
     obj.insert(
         "prompt".into(),
-        Value::String(format!("file://./prompts/{}.md", def.name)),
+        Value::String(format!(
+            "file://./prompts/{}.md",
+            percent_encode_path_segment(&def.name)
+        )),
     );
     if let Some(model) = &def.model {
         obj.insert("model".into(), Value::String(model.clone()));
@@ -71,6 +74,27 @@ pub fn build_kiro_json(
         obj.insert("mcpServers".into(), Value::Object(servers));
     }
     Ok(Value::Object(obj))
+}
+
+/// Percent-encode characters that are invalid in a URI path segment.
+///
+/// `validate_name` already forbids `/`, `\`, `..`, `.`, and empty names,
+/// so the only characters that can appear here and break RFC 3986 are
+/// whitespace and other non-unreserved printables (Copilot agents like
+/// "Terraform Agent" contain spaces). Unreserved per RFC 3986: ASCII
+/// alphanumeric, `-`, `_`, `.`, `~`. Everything else is percent-encoded.
+fn percent_encode_path_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        let unreserved = byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~');
+        if unreserved {
+            out.push(byte as char);
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(out, "%{byte:02X}");
+        }
+    }
+    out
 }
 
 /// Normalize a Copilot MCP server entry toward Kiro's `CustomToolConfig` shape.
@@ -123,6 +147,30 @@ mod tests {
         let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
         assert_eq!(out["name"], "reviewer");
         assert_eq!(out["prompt"], "file://./prompts/reviewer.md");
+    }
+
+    #[test]
+    fn emit_percent_encodes_spaces_in_prompt_uri() {
+        // Copilot agents like "Terraform Agent" have spaces in the name.
+        // The JSON `name` field keeps the space; the file:// URI must
+        // percent-encode it per RFC 3986.
+        let mut def = sample_claude_def();
+        def.name = "Terraform Agent".into();
+        let out = build_kiro_json(&def, &[]).unwrap();
+        assert_eq!(out["name"], "Terraform Agent");
+        assert_eq!(out["prompt"], "file://./prompts/Terraform%20Agent.md");
+    }
+
+    #[test]
+    fn emit_preserves_unreserved_chars_in_prompt_uri() {
+        let mut def = sample_claude_def();
+        def.name = "pr-review_toolkit.v2~beta".into();
+        let out = build_kiro_json(&def, &[]).unwrap();
+        // Unreserved chars per RFC 3986: alphanumeric and -_.~ — no encoding.
+        assert_eq!(
+            out["prompt"],
+            "file://./prompts/pr-review_toolkit.v2~beta.md"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/frontmatter.rs
+++ b/crates/kiro-market-core/src/agent/frontmatter.rs
@@ -1,42 +1,32 @@
-//! Dialect-agnostic YAML frontmatter splitter.
-//!
-//! Both Claude (`*.md`) and Copilot (`*.agent.md`) agents use the same
-//! `---`-fenced frontmatter convention, so the fence-handling logic lives
-//! in one place rather than being duplicated (or worse, reached into via
-//! a `pub(super)` shim) between the two parsers.
+//! Dialect-agnostic YAML frontmatter splitter. Shared by `parse_claude`
+//! and `parse_copilot`.
+
+use super::types::ParseFailure;
 
 /// Split `---`-fenced YAML frontmatter from the body. Returns `(yaml, body)`.
 ///
 /// # Errors
 ///
-/// Returns a human-readable error if the opening or closing fence is missing.
-pub(super) fn split_frontmatter(content: &str) -> Result<(&str, &str), String> {
+/// Returns [`ParseFailure::MissingFrontmatter`] when the opening fence is
+/// absent, or [`ParseFailure::UnclosedFrontmatter`] when only the opening
+/// fence is present.
+pub(super) fn split_frontmatter(content: &str) -> Result<(&str, &str), ParseFailure> {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
-        return Err("missing opening `---` frontmatter fence".into());
+        return Err(ParseFailure::MissingFrontmatter);
     }
     let after_open = trimmed[3..]
         .strip_prefix('\n')
         .or_else(|| trimmed[3..].strip_prefix("\r\n"))
         .unwrap_or(&trimmed[3..]);
     let Some(close_pos) = after_open.find("\n---") else {
-        return Err("unclosed frontmatter: missing closing `---` fence".into());
+        return Err(ParseFailure::UnclosedFrontmatter);
     };
     let yaml = &after_open[..close_pos];
-    // After `\n---`, consume any number of blank lines (CRLF or LF). Most
-    // editors (and the GitHub frontmatter convention) put a blank line
-    // between the closing fence and the body, so callers should not have to
-    // strip it themselves.
-    let mut body = &after_open[close_pos + 4..];
-    loop {
-        if let Some(rest) = body.strip_prefix("\r\n") {
-            body = rest;
-        } else if let Some(rest) = body.strip_prefix('\n') {
-            body = rest;
-        } else {
-            break;
-        }
-    }
+    // After `\n---`, strip any run of `\r` / `\n`. The GitHub frontmatter
+    // convention puts a blank line between the closing fence and the body,
+    // and some editors add a trailing `\r` before the newline.
+    let body = after_open[close_pos + 4..].trim_start_matches(['\r', '\n']);
     Ok((yaml, body))
 }
 
@@ -52,15 +42,15 @@ mod tests {
     }
 
     #[test]
-    fn missing_open_fence_errors() {
+    fn missing_open_fence_returns_missing_frontmatter() {
         let err = split_frontmatter("body\n").unwrap_err();
-        assert!(err.contains("opening"));
+        assert_eq!(err, ParseFailure::MissingFrontmatter);
     }
 
     #[test]
-    fn missing_close_fence_errors() {
+    fn missing_close_fence_returns_unclosed_frontmatter() {
         let err = split_frontmatter("---\nname: a\nbody\n").unwrap_err();
-        assert!(err.contains("closing") || err.contains("unclosed"));
+        assert_eq!(err, ParseFailure::UnclosedFrontmatter);
     }
 
     #[test]
@@ -68,6 +58,12 @@ mod tests {
         let (yaml, body) = split_frontmatter("---\r\nname: a\r\n---\r\nbody\r\n").unwrap();
         assert!(yaml.contains("name: a"));
         assert!(body.starts_with("body"));
+    }
+
+    #[test]
+    fn consumes_multiple_blank_lines_before_body() {
+        let (_yaml, body) = split_frontmatter("---\nname: a\n---\n\n\nhello\n").unwrap();
+        assert!(body.starts_with("hello"));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/frontmatter.rs
+++ b/crates/kiro-market-core/src/agent/frontmatter.rs
@@ -1,0 +1,78 @@
+//! Dialect-agnostic YAML frontmatter splitter.
+//!
+//! Both Claude (`*.md`) and Copilot (`*.agent.md`) agents use the same
+//! `---`-fenced frontmatter convention, so the fence-handling logic lives
+//! in one place rather than being duplicated (or worse, reached into via
+//! a `pub(super)` shim) between the two parsers.
+
+/// Split `---`-fenced YAML frontmatter from the body. Returns `(yaml, body)`.
+///
+/// # Errors
+///
+/// Returns a human-readable error if the opening or closing fence is missing.
+pub(super) fn split_frontmatter(content: &str) -> Result<(&str, &str), String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Err("missing opening `---` frontmatter fence".into());
+    }
+    let after_open = trimmed[3..]
+        .strip_prefix('\n')
+        .or_else(|| trimmed[3..].strip_prefix("\r\n"))
+        .unwrap_or(&trimmed[3..]);
+    let Some(close_pos) = after_open.find("\n---") else {
+        return Err("unclosed frontmatter: missing closing `---` fence".into());
+    };
+    let yaml = &after_open[..close_pos];
+    // After `\n---`, consume any number of blank lines (CRLF or LF). Most
+    // editors (and the GitHub frontmatter convention) put a blank line
+    // between the closing fence and the body, so callers should not have to
+    // strip it themselves.
+    let mut body = &after_open[close_pos + 4..];
+    loop {
+        if let Some(rest) = body.strip_prefix("\r\n") {
+            body = rest;
+        } else if let Some(rest) = body.strip_prefix('\n') {
+            body = rest;
+        } else {
+            break;
+        }
+    }
+    Ok((yaml, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_simple_frontmatter() {
+        let (yaml, body) = split_frontmatter("---\nname: a\n---\nbody\n").unwrap();
+        assert_eq!(yaml, "name: a");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn missing_open_fence_errors() {
+        let err = split_frontmatter("body\n").unwrap_err();
+        assert!(err.contains("opening"));
+    }
+
+    #[test]
+    fn missing_close_fence_errors() {
+        let err = split_frontmatter("---\nname: a\nbody\n").unwrap_err();
+        assert!(err.contains("closing") || err.contains("unclosed"));
+    }
+
+    #[test]
+    fn handles_crlf_line_endings() {
+        let (yaml, body) = split_frontmatter("---\r\nname: a\r\n---\r\nbody\r\n").unwrap();
+        assert!(yaml.contains("name: a"));
+        assert!(body.starts_with("body"));
+    }
+
+    #[test]
+    fn tolerates_leading_whitespace_before_fence() {
+        let (yaml, _body) = split_frontmatter("\n\n---\nname: a\n---\nx\n").unwrap();
+        assert_eq!(yaml, "name: a");
+    }
+}

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -5,6 +5,7 @@ mod frontmatter;
 mod parse;
 mod parse_claude;
 mod parse_copilot;
+pub mod tools;
 pub mod types;
 
 pub use parse::{detect_dialect, parse_agent_file};

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -1,8 +1,11 @@
 //! Agent import: parse Claude- and Copilot-style agent markdown files,
 //! map their tools to Kiro identifiers, and emit Kiro agent JSON.
 
+mod frontmatter;
+mod parse_claude;
 pub mod types;
 
+pub use parse_claude::parse_claude_agent;
 pub use types::{AgentDefinition, AgentDialect};
 
 #[cfg(test)]

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -2,10 +2,12 @@
 //! map their tools to Kiro identifiers, and emit Kiro agent JSON.
 
 mod frontmatter;
+mod parse;
 mod parse_claude;
 mod parse_copilot;
 pub mod types;
 
+pub use parse::{detect_dialect, parse_agent_file};
 pub use parse_claude::parse_claude_agent;
 pub use parse_copilot::parse_copilot_agent;
 pub use types::{AgentDefinition, AgentDialect};

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -1,6 +1,7 @@
 //! Agent import: parse Claude- and Copilot-style agent markdown files,
 //! map their tools to Kiro identifiers, and emit Kiro agent JSON.
 
+pub mod emit;
 mod frontmatter;
 mod parse;
 mod parse_claude;

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -3,9 +3,11 @@
 
 mod frontmatter;
 mod parse_claude;
+mod parse_copilot;
 pub mod types;
 
 pub use parse_claude::parse_claude_agent;
+pub use parse_copilot::parse_copilot_agent;
 pub use types::{AgentDefinition, AgentDialect};
 
 #[cfg(test)]

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -13,7 +13,7 @@ pub mod types;
 pub use parse::{detect_dialect, parse_agent_file};
 pub use parse_claude::parse_claude_agent;
 pub use parse_copilot::parse_copilot_agent;
-pub use types::{AgentDefinition, AgentDialect};
+pub use types::{AgentDefinition, AgentDialect, ParseFailure};
 
 #[cfg(test)]
 mod tests {

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -1,6 +1,7 @@
 //! Agent import: parse Claude- and Copilot-style agent markdown files,
 //! map their tools to Kiro identifiers, and emit Kiro agent JSON.
 
+pub mod discover;
 pub mod emit;
 mod frontmatter;
 mod parse;

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -1,0 +1,26 @@
+//! Agent import: parse Claude- and Copilot-style agent markdown files,
+//! map their tools to Kiro identifiers, and emit Kiro agent JSON.
+
+pub mod types;
+
+pub use types::{AgentDefinition, AgentDialect};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn agent_definition_constructs_with_minimum_fields() {
+        let def = AgentDefinition {
+            name: "reviewer".into(),
+            description: None,
+            prompt_body: "You are a reviewer.".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: BTreeMap::new(),
+            dialect: AgentDialect::Claude,
+        };
+        assert_eq!(def.name, "reviewer");
+    }
+}

--- a/crates/kiro-market-core/src/agent/parse.rs
+++ b/crates/kiro-market-core/src/agent/parse.rs
@@ -1,0 +1,107 @@
+//! Dialect detection and top-level parser dispatch.
+
+use std::fs;
+use std::path::Path;
+
+use crate::error::AgentError;
+
+use super::types::{AgentDefinition, AgentDialect};
+use super::{parse_claude_agent, parse_copilot_agent};
+
+/// Detect the source dialect from a filename.
+///
+/// Filenames ending in `.agent.md` are treated as Copilot; everything else
+/// as Claude. The `.agent.md` double-extension is the Copilot community
+/// convention (see `awesome-copilot/agents/`).
+#[must_use]
+pub fn detect_dialect(path: &Path) -> AgentDialect {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if name.ends_with(".agent.md") {
+        AgentDialect::Copilot
+    } else {
+        AgentDialect::Claude
+    }
+}
+
+/// Read and parse an agent file, dispatching to the correct dialect parser.
+///
+/// # Errors
+///
+/// - [`AgentError::ParseFailed`] if the file cannot be read or its contents
+///   cannot be parsed.
+/// - [`AgentError::MissingName`] if the parsed frontmatter lacks `name`.
+pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, AgentError> {
+    let content = fs::read_to_string(path).map_err(|e| AgentError::ParseFailed {
+        path: path.to_path_buf(),
+        reason: format!("read failed: {e}"),
+    })?;
+    let dialect = detect_dialect(path);
+    let result = match dialect {
+        AgentDialect::Claude => parse_claude_agent(&content),
+        AgentDialect::Copilot => parse_copilot_agent(&content),
+    };
+    result.map_err(|reason| {
+        if reason.contains("missing `name`") {
+            AgentError::MissingName {
+                path: path.to_path_buf(),
+            }
+        } else {
+            AgentError::ParseFailed {
+                path: path.to_path_buf(),
+                reason,
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn detects_copilot_by_agent_md_suffix() {
+        assert_eq!(
+            detect_dialect(Path::new("foo.agent.md")),
+            AgentDialect::Copilot
+        );
+        assert_eq!(
+            detect_dialect(Path::new("/a/b/c.agent.md")),
+            AgentDialect::Copilot
+        );
+    }
+
+    #[test]
+    fn detects_claude_for_plain_md() {
+        assert_eq!(
+            detect_dialect(Path::new("reviewer.md")),
+            AgentDialect::Claude
+        );
+    }
+
+    #[test]
+    fn parse_agent_file_dispatches_by_dialect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("sample.agent.md");
+        std::fs::write(&path, "---\nname: sample\n---\nbody\n").unwrap();
+        let def = parse_agent_file(&path).expect("parse");
+        assert_eq!(def.dialect, AgentDialect::Copilot);
+        assert_eq!(def.name, "sample");
+    }
+
+    #[test]
+    fn parse_agent_file_missing_name_returns_missing_name_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("no-name.md");
+        std::fs::write(&path, "---\ndescription: x\n---\nbody\n").unwrap();
+        let err = parse_agent_file(&path).unwrap_err();
+        assert!(matches!(err, AgentError::MissingName { .. }));
+    }
+
+    #[test]
+    fn parse_agent_file_unreadable_returns_parse_failed() {
+        let path = Path::new("/nonexistent/agent.md");
+        let err = parse_agent_file(path).unwrap_err();
+        assert!(matches!(err, AgentError::ParseFailed { .. }));
+    }
+}

--- a/crates/kiro-market-core/src/agent/parse.rs
+++ b/crates/kiro-market-core/src/agent/parse.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use crate::error::AgentError;
 
-use super::types::{AgentDefinition, AgentDialect};
+use super::types::{AgentDefinition, AgentDialect, ParseFailure};
 use super::{parse_claude_agent, parse_copilot_agent};
 
 /// Detect the source dialect from a filename.
@@ -25,32 +25,28 @@ pub fn detect_dialect(path: &Path) -> AgentDialect {
 
 /// Read and parse an agent file, dispatching to the correct dialect parser.
 ///
+/// All failures — I/O, YAML, missing frontmatter, missing name — are
+/// returned as [`AgentError::ParseFailed`] carrying a structured
+/// [`ParseFailure`] so callers can switch on the variant (e.g. to demote
+/// `MissingFrontmatter` to a debug log) without string matching.
+///
 /// # Errors
 ///
-/// - [`AgentError::ParseFailed`] if the file cannot be read or its contents
-///   cannot be parsed.
-/// - [`AgentError::MissingName`] if the parsed frontmatter lacks `name`.
+/// Always [`AgentError::ParseFailed`]; inspect its `failure` field for the
+/// specific failure mode.
 pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, AgentError> {
     let content = fs::read_to_string(path).map_err(|e| AgentError::ParseFailed {
         path: path.to_path_buf(),
-        reason: format!("read failed: {e}"),
+        failure: ParseFailure::IoError(e.to_string()),
     })?;
     let dialect = detect_dialect(path);
     let result = match dialect {
         AgentDialect::Claude => parse_claude_agent(&content),
         AgentDialect::Copilot => parse_copilot_agent(&content),
     };
-    result.map_err(|reason| {
-        if reason.contains("missing `name`") {
-            AgentError::MissingName {
-                path: path.to_path_buf(),
-            }
-        } else {
-            AgentError::ParseFailed {
-                path: path.to_path_buf(),
-                reason,
-            }
-        }
+    result.map_err(|failure| AgentError::ParseFailed {
+        path: path.to_path_buf(),
+        failure,
     })
 }
 
@@ -90,18 +86,60 @@ mod tests {
     }
 
     #[test]
-    fn parse_agent_file_missing_name_returns_missing_name_error() {
+    fn parse_agent_file_missing_name_is_typed() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("no-name.md");
         std::fs::write(&path, "---\ndescription: x\n---\nbody\n").unwrap();
         let err = parse_agent_file(&path).unwrap_err();
-        assert!(matches!(err, AgentError::MissingName { .. }));
+        assert!(matches!(
+            err,
+            AgentError::ParseFailed {
+                failure: ParseFailure::MissingName,
+                ..
+            }
+        ));
     }
 
     #[test]
-    fn parse_agent_file_unreadable_returns_parse_failed() {
+    fn parse_agent_file_missing_frontmatter_is_typed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("readme.md");
+        std::fs::write(&path, "# just a readme\n").unwrap();
+        let err = parse_agent_file(&path).unwrap_err();
+        assert!(matches!(
+            err,
+            AgentError::ParseFailed {
+                failure: ParseFailure::MissingFrontmatter,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_agent_file_invalid_yaml_is_typed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("broken.md");
+        std::fs::write(&path, "---\nname: [unclosed\n---\nbody\n").unwrap();
+        let err = parse_agent_file(&path).unwrap_err();
+        assert!(matches!(
+            err,
+            AgentError::ParseFailed {
+                failure: ParseFailure::InvalidYaml(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_agent_file_unreadable_is_io_error() {
         let path = Path::new("/nonexistent/agent.md");
         let err = parse_agent_file(path).unwrap_err();
-        assert!(matches!(err, AgentError::ParseFailed { .. }));
+        assert!(matches!(
+            err,
+            AgentError::ParseFailed {
+                failure: ParseFailure::IoError(_),
+                ..
+            }
+        ));
     }
 }

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -2,7 +2,7 @@
 //!
 //! Claude agents have YAML frontmatter with: `name` (required),
 //! `description`, `model` (`opus`/`sonnet`/`inherit`), `color` (dropped),
-//! and optional `tools` (a list of PascalCase tool names).
+//! and optional `tools` (a list of `PascalCase` tool names).
 
 use serde::Deserialize;
 use std::collections::BTreeMap;

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -1,0 +1,113 @@
+//! Parse Claude-style agent markdown files.
+//!
+//! Claude agents have YAML frontmatter with: `name` (required),
+//! `description`, `model` (`opus`/`sonnet`/`inherit`), `color` (dropped),
+//! and optional `tools` (a list of PascalCase tool names).
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use super::frontmatter::split_frontmatter;
+use super::types::{AgentDefinition, AgentDialect};
+
+#[derive(Debug, Deserialize)]
+struct ClaudeFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    model: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    // `color` is intentionally unmodeled — not in Kiro schema, silently dropped.
+}
+
+/// Parse a Claude-style `.md` agent file into an `AgentDefinition`.
+///
+/// # Errors
+///
+/// Returns a string describing the parse failure. The caller wraps this
+/// into `AgentError::ParseFailed` or `AgentError::MissingName` with the
+/// source path attached.
+pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, String> {
+    let (yaml_block, body) = split_frontmatter(content)?;
+    let fm: ClaudeFrontmatter =
+        serde_yaml::from_str(yaml_block).map_err(|e| format!("invalid YAML: {e}"))?;
+
+    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+    // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
+    // so the Kiro emitter omits the field and defers to the CLI default.
+    let model = fm.model.filter(|m| m != "inherit");
+
+    Ok(AgentDefinition {
+        name,
+        description: fm.description,
+        prompt_body: body.to_string(),
+        model,
+        source_tools: fm.tools,
+        mcp_servers: BTreeMap::new(),
+        dialect: AgentDialect::Claude,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "---\nname: code-reviewer\ndescription: Reviews code\nmodel: opus\ncolor: green\n---\n\nYou are a code reviewer.\n";
+
+    #[test]
+    fn parse_extracts_name_description_model() {
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert_eq!(def.name, "code-reviewer");
+        assert_eq!(def.description.as_deref(), Some("Reviews code"));
+        assert_eq!(def.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn parse_extracts_body_trimming_fence_newline() {
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert!(def.prompt_body.starts_with("You are a code reviewer."));
+    }
+
+    #[test]
+    fn parse_drops_color_field_silently() {
+        // color has no Kiro equivalent and should not appear in source_tools or as model.
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert!(def.source_tools.is_empty());
+    }
+
+    #[test]
+    fn parse_model_inherit_becomes_none() {
+        let src = "---\nname: a\nmodel: inherit\n---\nbody\n";
+        let def = parse_claude_agent(src).expect("parse");
+        assert!(
+            def.model.is_none(),
+            "model: inherit should be normalized to None"
+        );
+    }
+
+    #[test]
+    fn parse_missing_name_errors() {
+        let src = "---\ndescription: x\n---\nbody\n";
+        let err = parse_claude_agent(src).unwrap_err();
+        assert!(err.contains("name"));
+    }
+
+    #[test]
+    fn parse_tools_frontmatter_captured_in_source_tools() {
+        let src = "---\nname: a\ntools: [Read, Write, Bash]\n---\nbody\n";
+        let def = parse_claude_agent(src).expect("parse");
+        assert_eq!(def.source_tools, vec!["Read", "Write", "Bash"]);
+    }
+
+    #[test]
+    fn parse_invalid_yaml_errors() {
+        let src = "---\nname: [unclosed\n---\nbody\n";
+        assert!(parse_claude_agent(src).is_err());
+    }
+
+    #[test]
+    fn parse_dialect_set_to_claude() {
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert_eq!(def.dialect, AgentDialect::Claude);
+    }
+}

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 use super::frontmatter::split_frontmatter;
-use super::types::{AgentDefinition, AgentDialect};
+use super::types::{AgentDefinition, AgentDialect, ParseFailure};
 
 #[derive(Debug, Deserialize)]
 struct ClaudeFrontmatter {
@@ -24,15 +24,15 @@ struct ClaudeFrontmatter {
 ///
 /// # Errors
 ///
-/// Returns a string describing the parse failure. The caller wraps this
-/// into `AgentError::ParseFailed` or `AgentError::MissingName` with the
-/// source path attached.
-pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, String> {
+/// Returns a [`ParseFailure`] variant describing which stage of parsing
+/// failed. The caller (`parse::parse_agent_file`) attaches the source
+/// path and lifts into `AgentError::ParseFailed`.
+pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml_block, body) = split_frontmatter(content)?;
     let fm: ClaudeFrontmatter =
-        serde_yaml::from_str(yaml_block).map_err(|e| format!("invalid YAML: {e}"))?;
+        serde_yaml::from_str(yaml_block).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
-    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+    let name = fm.name.ok_or(ParseFailure::MissingName)?;
     // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
     // so the Kiro emitter omits the field and defers to the CLI default.
     let model = fm.model.filter(|m| m != "inherit");
@@ -89,7 +89,7 @@ mod tests {
     fn parse_missing_name_errors() {
         let src = "---\ndescription: x\n---\nbody\n";
         let err = parse_claude_agent(src).unwrap_err();
-        assert!(err.contains("name"));
+        assert_eq!(err, ParseFailure::MissingName);
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -33,6 +33,14 @@ pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure
         serde_yaml::from_str(yaml_block).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
+    // Validate the name at parse time so downstream fs operations (and the
+    // file:// URI in the emitted JSON) can trust it without re-checking.
+    crate::validation::validate_name(&name).map_err(|e| match e {
+        crate::error::ValidationError::InvalidName { reason, .. } => {
+            ParseFailure::InvalidName(reason)
+        }
+        other => ParseFailure::InvalidName(other.to_string()),
+    })?;
     // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
     // so the Kiro emitter omits the field and defers to the CLI default.
     let model = fm.model.filter(|m| m != "inherit");
@@ -90,6 +98,23 @@ mod tests {
         let src = "---\ndescription: x\n---\nbody\n";
         let err = parse_claude_agent(src).unwrap_err();
         assert_eq!(err, ParseFailure::MissingName);
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal_in_name() {
+        let src = "---\nname: ../escape\n---\nbody\n";
+        let err = parse_claude_agent(src).unwrap_err();
+        assert!(
+            matches!(err, ParseFailure::InvalidName(_)),
+            "expected InvalidName for traversal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_empty_name() {
+        let src = "---\nname: \"\"\n---\nbody\n";
+        let err = parse_claude_agent(src).unwrap_err();
+        assert!(matches!(err, ParseFailure::InvalidName(_)));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 use super::frontmatter::split_frontmatter;
-use super::types::{AgentDefinition, AgentDialect};
+use super::types::{AgentDefinition, AgentDialect, ParseFailure};
 
 #[derive(Debug, Deserialize)]
 struct CopilotFrontmatter {
@@ -22,23 +22,27 @@ struct CopilotFrontmatter {
     tools: Vec<String>,
     #[serde(rename = "mcp-servers", default)]
     mcp_servers: BTreeMap<String, serde_json::Value>,
-    // `model` intentionally not modeled — Copilot uses display names (e.g.
-    // "Claude Sonnet 4") which cannot be mapped to Kiro model IDs.
+    // `model` accepted and ignored: Copilot uses display names ("Claude
+    // Sonnet 4") with no reliable mapping to Kiro model IDs. We take it
+    // as Option<String> rather than `#[serde(deny_unknown_fields)]` so
+    // real-world Copilot files continue to parse.
+    #[allow(dead_code)]
+    model: Option<String>,
 }
 
 /// Parse a Copilot-style `.agent.md` file into an `AgentDefinition`.
 ///
 /// # Errors
 ///
-/// Returns a string describing the parse failure. The caller wraps this
-/// into `AgentError::ParseFailed` or `AgentError::MissingName` with the
-/// source path attached.
-pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, String> {
+/// Returns a [`ParseFailure`] variant describing which stage of parsing
+/// failed. The caller (`parse::parse_agent_file`) attaches the source
+/// path and lifts into `AgentError::ParseFailed`.
+pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml, body) = split_frontmatter(content)?;
     let fm: CopilotFrontmatter =
-        serde_yaml::from_str(yaml).map_err(|e| format!("invalid YAML: {e}"))?;
+        serde_yaml::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
-    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+    let name = fm.name.ok_or(ParseFailure::MissingName)?;
 
     Ok(AgentDefinition {
         name,

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -43,6 +43,14 @@ pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailur
         serde_yaml::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
+    // Validate the name at parse time so downstream fs operations (and the
+    // file:// URI in the emitted JSON) can trust it without re-checking.
+    crate::validation::validate_name(&name).map_err(|e| match e {
+        crate::error::ValidationError::InvalidName { reason, .. } => {
+            ParseFailure::InvalidName(reason)
+        }
+        other => ParseFailure::InvalidName(other.to_string()),
+    })?;
 
     Ok(AgentDefinition {
         name,

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -1,0 +1,119 @@
+//! Parse Copilot-style `*.agent.md` files.
+//!
+//! Copilot frontmatter differs from Claude's in notable ways:
+//! - `model` holds display names (`Claude Sonnet 4`), not model IDs.
+//!   We drop it — the user can edit the emitted JSON to set a real ID.
+//! - `mcp-servers` is a nested map of server configs (kebab-case key).
+//!   We capture it opaquely as `serde_json::Value` and translate at emit time.
+//! - `tools` uses mixed conventions (bare names, `namespace/tool`,
+//!   `server/*` wildcards). We keep raw strings; mapping lives elsewhere.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use super::frontmatter::split_frontmatter;
+use super::types::{AgentDefinition, AgentDialect};
+
+#[derive(Debug, Deserialize)]
+struct CopilotFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    #[serde(rename = "mcp-servers", default)]
+    mcp_servers: BTreeMap<String, serde_json::Value>,
+    // `model` intentionally not modeled — Copilot uses display names (e.g.
+    // "Claude Sonnet 4") which cannot be mapped to Kiro model IDs.
+}
+
+/// Parse a Copilot-style `.agent.md` file into an `AgentDefinition`.
+///
+/// # Errors
+///
+/// Returns a string describing the parse failure. The caller wraps this
+/// into `AgentError::ParseFailed` or `AgentError::MissingName` with the
+/// source path attached.
+pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, String> {
+    let (yaml, body) = split_frontmatter(content)?;
+    let fm: CopilotFrontmatter =
+        serde_yaml::from_str(yaml).map_err(|e| format!("invalid YAML: {e}"))?;
+
+    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+
+    Ok(AgentDefinition {
+        name,
+        description: fm.description,
+        prompt_body: body.to_string(),
+        model: None,
+        source_tools: fm.tools,
+        mcp_servers: fm.mcp_servers,
+        dialect: AgentDialect::Copilot,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TERRAFORM: &str = r#"---
+name: Terraform Agent
+description: "Terraform specialist"
+tools: ['read', 'edit', 'search', 'shell', 'terraform/*']
+mcp-servers:
+  terraform:
+    type: 'local'
+    command: 'docker'
+    args: ['run', '-i', 'hashicorp/terraform-mcp-server:latest']
+    tools: ["*"]
+---
+
+Body text.
+"#;
+
+    #[test]
+    fn parse_extracts_name_and_body() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(def.name, "Terraform Agent");
+        assert!(def.prompt_body.starts_with("Body text."));
+    }
+
+    #[test]
+    fn parse_captures_tools_list_verbatim() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(
+            def.source_tools,
+            vec!["read", "edit", "search", "shell", "terraform/*"]
+        );
+    }
+
+    #[test]
+    fn parse_captures_mcp_servers_as_opaque_json() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(def.mcp_servers.len(), 1);
+        let tf = def.mcp_servers.get("terraform").expect("terraform entry");
+        // `type: 'local'` is preserved opaquely; normalization happens at emit time.
+        assert_eq!(tf["type"], "local");
+        assert_eq!(tf["command"], "docker");
+    }
+
+    #[test]
+    fn parse_drops_display_model_name() {
+        // Copilot model values are display names, not IDs. Per design decision,
+        // we drop them and let Kiro use the default model.
+        let src = "---\nname: a\nmodel: Claude Sonnet 4\n---\nbody\n";
+        let def = parse_copilot_agent(src).expect("parse");
+        assert!(def.model.is_none(), "display-name model should be dropped");
+    }
+
+    #[test]
+    fn parse_missing_name_errors() {
+        let src = "---\ndescription: x\n---\nbody\n";
+        assert!(parse_copilot_agent(src).is_err());
+    }
+
+    #[test]
+    fn parse_dialect_set_to_copilot() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(def.dialect, AgentDialect::Copilot);
+    }
+}

--- a/crates/kiro-market-core/src/agent/tools.rs
+++ b/crates/kiro-market-core/src/agent/tools.rs
@@ -83,6 +83,42 @@ pub fn map_claude_tools(source: &[String]) -> (Vec<MappedTool>, Vec<UnmappedTool
     (mapped, unmapped)
 }
 
+/// Map a list of Copilot source tool names to Kiro identifiers.
+///
+/// Copilot tools use mixed conventions:
+/// - `{server}/*`     → [`MappedTool::McpRef("@{server}")`]        (whole-server access)
+/// - `{server}/{tool}` → [`MappedTool::McpRef("@{server}/{tool}")`] (specific MCP tool)
+/// - bare names (`codebase`, `findTestFiles`) → unmapped ([`UnmappedReason::BareCopilotName`])
+///
+/// The bare-name drop is intentional: Copilot's bare names are internal
+/// GitHub Copilot concepts with no reliable Kiro equivalent. Users see the
+/// source tool list in the install output and can restrict the emitted
+/// agent manually if desired.
+#[must_use]
+pub fn map_copilot_tools(source: &[String]) -> (Vec<MappedTool>, Vec<UnmappedTool>) {
+    let mut mapped: Vec<MappedTool> = Vec::new();
+    let mut unmapped: Vec<UnmappedTool> = Vec::new();
+    for tool in source {
+        if let Some((server, rest)) = tool.split_once('/') {
+            let kiro = if rest == "*" {
+                format!("@{server}")
+            } else {
+                format!("@{server}/{rest}")
+            };
+            let entry = MappedTool::McpRef(kiro);
+            if !mapped.contains(&entry) {
+                mapped.push(entry);
+            }
+        } else {
+            unmapped.push(UnmappedTool {
+                source: tool.clone(),
+                reason: UnmappedReason::BareCopilotName,
+            });
+        }
+    }
+    (mapped, unmapped)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,5 +178,52 @@ mod tests {
                 MappedTool::Native("read".into()),
             ]
         );
+    }
+
+    #[test]
+    fn copilot_mcp_wildcard_maps_to_kiro_server_ref() {
+        let (mapped, unmapped) =
+            map_copilot_tools(&["terraform/*".into(), "playwright/click".into()]);
+        assert_eq!(
+            mapped,
+            vec![
+                MappedTool::McpRef("@terraform".into()),
+                MappedTool::McpRef("@playwright/click".into()),
+            ]
+        );
+        assert!(unmapped.is_empty());
+    }
+
+    #[test]
+    fn copilot_bare_names_drop_with_structured_reason() {
+        let (mapped, unmapped) =
+            map_copilot_tools(&["codebase".into(), "findTestFiles".into(), "problems".into()]);
+        assert!(mapped.is_empty());
+        assert_eq!(unmapped.len(), 3);
+        assert!(
+            unmapped
+                .iter()
+                .all(|u| u.reason == UnmappedReason::BareCopilotName)
+        );
+        assert_eq!(unmapped[0].source, "codebase");
+    }
+
+    #[test]
+    fn copilot_mixed_list_preserves_mcp_refs_drops_bare() {
+        let (mapped, unmapped) = map_copilot_tools(&[
+            "edit/editFiles".into(),
+            "terraform/*".into(),
+            "codebase".into(),
+        ]);
+        assert!(mapped.contains(&MappedTool::McpRef("@edit/editFiles".into())));
+        assert!(mapped.contains(&MappedTool::McpRef("@terraform".into())));
+        assert_eq!(unmapped.len(), 1);
+        assert_eq!(unmapped[0].source, "codebase");
+    }
+
+    #[test]
+    fn copilot_dedupes_repeated_refs() {
+        let (mapped, _) = map_copilot_tools(&["terraform/*".into(), "terraform/*".into()]);
+        assert_eq!(mapped, vec![MappedTool::McpRef("@terraform".into())]);
     }
 }

--- a/crates/kiro-market-core/src/agent/tools.rs
+++ b/crates/kiro-market-core/src/agent/tools.rs
@@ -10,7 +10,9 @@
 //! can re-render them as `InstallWarning` variants without string surgery.
 //!
 //! Kiro tool names are verified against
-//! <https://kiro.dev/docs/cli/reference/built-in-tools/>.
+//! <https://kiro.dev/docs/cli/reference/built-in-tools/>
+//! (retrieved 2026-04-16). Update this comment with a new retrieval date
+//! whenever the table below is re-validated.
 
 /// A single source tool that has been successfully mapped to a Kiro identifier.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,6 +221,37 @@ mod tests {
         assert!(mapped.contains(&MappedTool::McpRef("@terraform".into())));
         assert_eq!(unmapped.len(), 1);
         assert_eq!(unmapped[0].source, "codebase");
+    }
+
+    #[test]
+    fn claude_dedupes_edit_and_write_across_mixed_input() {
+        // Input order: Edit, Read, Write, Edit — should dedupe to write+read.
+        let (mapped, _) =
+            map_claude_tools(&["Edit".into(), "Read".into(), "Write".into(), "Edit".into()]);
+        assert_eq!(
+            mapped,
+            vec![
+                MappedTool::Native("write".into()),
+                MappedTool::Native("read".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn copilot_dedupes_mixed_refs_and_wildcards() {
+        let (mapped, _) = map_copilot_tools(&[
+            "terraform/*".into(),
+            "playwright/click".into(),
+            "terraform/*".into(),
+            "playwright/click".into(),
+        ]);
+        assert_eq!(
+            mapped,
+            vec![
+                MappedTool::McpRef("@terraform".into()),
+                MappedTool::McpRef("@playwright/click".into()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/tools.rs
+++ b/crates/kiro-market-core/src/agent/tools.rs
@@ -1,0 +1,146 @@
+//! Source-to-Kiro tool name mapping.
+//!
+//! Tools land in two different fields of the emitted agent JSON:
+//! - native tool names (`read`, `shell`, etc.) → `allowedTools`
+//! - MCP server references (`@server`, `@server/tool`) → `tools`
+//!
+//! The mapper returns a typed [`MappedTool`] so the emitter can route each
+//! result to the correct field without re-parsing strings. Unmapped source
+//! tools are returned structurally (not as pre-rendered messages) so callers
+//! can re-render them as `InstallWarning` variants without string surgery.
+//!
+//! Kiro tool names are verified against
+//! <https://kiro.dev/docs/cli/reference/built-in-tools/>.
+
+/// A single source tool that has been successfully mapped to a Kiro identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MappedTool {
+    /// Native Kiro tool. Routed to `allowedTools` in the emitted JSON.
+    Native(String),
+    /// MCP server reference (`@server` or `@server/tool`). Routed to `tools`.
+    McpRef(String),
+}
+
+/// A source tool that could not be mapped to any Kiro identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnmappedTool {
+    pub source: String,
+    pub reason: UnmappedReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum UnmappedReason {
+    /// Claude PascalCase name with no Kiro equivalent (e.g. `NotebookEdit`).
+    NoKiroEquivalent,
+    /// Copilot bare name (e.g. `codebase`, `findTestFiles`) — internal Copilot
+    /// concept with no reliable Kiro mapping.
+    BareCopilotName,
+}
+
+/// Look up the Kiro tool name for a Claude-style PascalCase tool name.
+///
+/// Returns `None` for tools with no Kiro equivalent. The caller is expected
+/// to surface a warning for `None` results so the user knows the restriction
+/// will not carry over.
+#[must_use]
+pub fn map_claude_tool(name: &str) -> Option<String> {
+    let mapped = match name {
+        "Read" => "read",
+        "Write" | "Edit" => "write",
+        "Bash" => "shell",
+        "Grep" => "grep",
+        "Glob" => "glob",
+        "WebFetch" => "web_fetch",
+        "WebSearch" => "web_search",
+        "TodoWrite" => "todo",
+        "Task" => "subagent",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+/// Map a list of Claude tool names, returning the deduped Kiro list and a
+/// vector of structured records for tools that had no mapping.
+#[must_use]
+pub fn map_claude_tools(source: &[String]) -> (Vec<MappedTool>, Vec<UnmappedTool>) {
+    let mut mapped: Vec<MappedTool> = Vec::new();
+    let mut unmapped: Vec<UnmappedTool> = Vec::new();
+    for tool in source {
+        match map_claude_tool(tool) {
+            Some(kiro) => {
+                let entry = MappedTool::Native(kiro);
+                if !mapped.contains(&entry) {
+                    mapped.push(entry);
+                }
+            }
+            None => unmapped.push(UnmappedTool {
+                source: tool.clone(),
+                reason: UnmappedReason::NoKiroEquivalent,
+            }),
+        }
+    }
+    (mapped, unmapped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("Read", Some("read"))]
+    #[case("Write", Some("write"))]
+    #[case("Edit", Some("write"))]
+    #[case("Bash", Some("shell"))]
+    #[case("Grep", Some("grep"))]
+    #[case("Glob", Some("glob"))]
+    #[case("WebFetch", Some("web_fetch"))]
+    #[case("WebSearch", Some("web_search"))]
+    #[case("TodoWrite", Some("todo"))]
+    #[case("Task", Some("subagent"))]
+    #[case("NotebookEdit", None)]
+    #[case("Skill", None)]
+    #[case("Unknown", None)]
+    fn claude_tool_maps_to_kiro(#[case] input: &str, #[case] expected: Option<&str>) {
+        assert_eq!(map_claude_tool(input), expected.map(String::from));
+    }
+
+    #[test]
+    fn map_claude_tools_returns_native_mapped_tools() {
+        let (mapped, unmapped) =
+            map_claude_tools(&["Read".into(), "NotebookEdit".into(), "Skill".into()]);
+        assert_eq!(mapped, vec![MappedTool::Native("read".into())]);
+        assert_eq!(
+            unmapped,
+            vec![
+                UnmappedTool {
+                    source: "NotebookEdit".into(),
+                    reason: UnmappedReason::NoKiroEquivalent
+                },
+                UnmappedTool {
+                    source: "Skill".into(),
+                    reason: UnmappedReason::NoKiroEquivalent
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn map_claude_tools_dedupes_write_from_edit_and_write() {
+        let (mapped, _) = map_claude_tools(&["Edit".into(), "Write".into()]);
+        assert_eq!(mapped, vec![MappedTool::Native("write".into())]);
+    }
+
+    #[test]
+    fn map_claude_tools_preserves_input_order() {
+        let (mapped, _) = map_claude_tools(&["Bash".into(), "Read".into()]);
+        assert_eq!(
+            mapped,
+            vec![
+                MappedTool::Native("shell".into()),
+                MappedTool::Native("read".into()),
+            ]
+        );
+    }
+}

--- a/crates/kiro-market-core/src/agent/tools.rs
+++ b/crates/kiro-market-core/src/agent/tools.rs
@@ -31,14 +31,14 @@ pub struct UnmappedTool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum UnmappedReason {
-    /// Claude PascalCase name with no Kiro equivalent (e.g. `NotebookEdit`).
+    /// Claude `PascalCase` name with no Kiro equivalent (e.g. `NotebookEdit`).
     NoKiroEquivalent,
     /// Copilot bare name (e.g. `codebase`, `findTestFiles`) — internal Copilot
     /// concept with no reliable Kiro mapping.
     BareCopilotName,
 }
 
-/// Look up the Kiro tool name for a Claude-style PascalCase tool name.
+/// Look up the Kiro tool name for a Claude-style `PascalCase` tool name.
 ///
 /// Returns `None` for tools with no Kiro equivalent. The caller is expected
 /// to surface a warning for `None` results so the user knows the restriction

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -1,0 +1,33 @@
+//! Dialect-agnostic representation of an agent after parsing.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Which source dialect the agent came from. Used for applying
+/// dialect-specific tool-mapping rules and for warnings.
+///
+/// Serializes to `"claude"` / `"copilot"` so it can live directly in the
+/// installed-agents tracking file without a string sidecar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentDialect {
+    Claude,
+    Copilot,
+}
+
+/// Agent definition normalized across Claude and Copilot source formats.
+///
+/// This is what both parsers produce and what the emitter consumes.
+#[derive(Debug, Clone)]
+pub struct AgentDefinition {
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt_body: String,
+    pub model: Option<String>,
+    /// Raw tool identifiers from the source frontmatter (pre-mapping).
+    pub source_tools: Vec<String>,
+    /// MCP server entries as captured from Copilot `mcp-servers:` frontmatter.
+    /// Serialized opaquely and passed through to Kiro's `mcpServers` field.
+    pub mcp_servers: BTreeMap<String, serde_json::Value>,
+    pub dialect: AgentDialect,
+}

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -69,6 +69,9 @@ pub enum ParseFailure {
     InvalidYaml(String),
     /// Frontmatter parsed but lacks the required `name` key.
     MissingName,
+    /// Frontmatter `name` failed validation (unsafe for use as a filename).
+    /// Carries the validator's human-readable reason.
+    InvalidName(String),
     /// File read failed (permission denied, not found during racy delete,
     /// etc.). Carries the rendered I/O error message.
     IoError(String),
@@ -85,6 +88,7 @@ impl std::fmt::Display for ParseFailure {
             }
             ParseFailure::InvalidYaml(msg) => write!(f, "invalid YAML: {msg}"),
             ParseFailure::MissingName => f.write_str("missing required `name` field"),
+            ParseFailure::InvalidName(reason) => write!(f, "invalid `name` value: {reason}"),
             ParseFailure::IoError(msg) => write!(f, "read failed: {msg}"),
         }
     }

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -8,8 +8,13 @@ use std::collections::BTreeMap;
 ///
 /// Serializes to `"claude"` / `"copilot"` so it can live directly in the
 /// installed-agents tracking file without a string sidecar.
+///
+/// Marked `#[non_exhaustive]` so adding a future dialect is not a breaking
+/// change for external consumers, and so the tracking file's Deserialize
+/// can be tolerantly extended later.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum AgentDialect {
     Claude,
     Copilot,
@@ -17,17 +22,70 @@ pub enum AgentDialect {
 
 /// Agent definition normalized across Claude and Copilot source formats.
 ///
-/// This is what both parsers produce and what the emitter consumes.
+/// Constructed only by the parsers in this module. Fields are `pub` for
+/// emitter and install-layer access, but callers should not mutate `name`
+/// after construction without re-running name validation — the parsers
+/// enforce path-safe naming up front so downstream fs operations can rely
+/// on it.
 #[derive(Debug, Clone)]
 pub struct AgentDefinition {
+    /// Short identifier used as the filename stem and Kiro agent `name` key.
     pub name: String,
+    /// Optional human-readable blurb. Not shown to the model.
     pub description: Option<String>,
+    /// Markdown body (everything after the closing YAML fence).
     pub prompt_body: String,
+    /// Optional model ID (Claude only). Dropped for Copilot since its
+    /// `model:` values are display names, not IDs.
     pub model: Option<String>,
     /// Raw tool identifiers from the source frontmatter (pre-mapping).
     pub source_tools: Vec<String>,
     /// MCP server entries as captured from Copilot `mcp-servers:` frontmatter.
     /// Serialized opaquely and passed through to Kiro's `mcpServers` field.
     pub mcp_servers: BTreeMap<String, serde_json::Value>,
+    /// Which source dialect produced this definition.
     pub dialect: AgentDialect,
+}
+
+/// Structured reason a source agent file could not be parsed.
+///
+/// Replaces the pre-rendered `reason: String` that earlier versions carried
+/// on `AgentError` and `InstallWarning`. Callers switch on variants
+/// (e.g. to demote `MissingFrontmatter` to debug logs for README-style
+/// files) rather than substring-matching on error text — which would
+/// silently break the moment a message is reworded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[non_exhaustive]
+pub enum ParseFailure {
+    /// No opening `---` fence. Usually a README or other prose file
+    /// accidentally scanned from the agents directory. Service layer
+    /// demotes this to a debug log.
+    MissingFrontmatter,
+    /// Opening fence present but no closing fence — a broken file that
+    /// the user probably wants to hear about.
+    UnclosedFrontmatter,
+    /// YAML parser rejected the frontmatter block.
+    InvalidYaml(String),
+    /// Frontmatter parsed but lacks the required `name` key.
+    MissingName,
+    /// File read failed (permission denied, not found during racy delete,
+    /// etc.). Carries the rendered I/O error message.
+    IoError(String),
+}
+
+impl std::fmt::Display for ParseFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseFailure::MissingFrontmatter => {
+                f.write_str("missing opening `---` frontmatter fence")
+            }
+            ParseFailure::UnclosedFrontmatter => {
+                f.write_str("unclosed frontmatter: missing closing `---` fence")
+            }
+            ParseFailure::InvalidYaml(msg) => write!(f, "invalid YAML: {msg}"),
+            ParseFailure::MissingName => f.write_str("missing required `name` field"),
+            ParseFailure::IoError(msg) => write!(f, "read failed: {msg}"),
+        }
+    }
 }

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::agent::ParseFailure;
+
 // ---------------------------------------------------------------------------
 // Marketplace errors
 // ---------------------------------------------------------------------------
@@ -95,13 +97,15 @@ pub enum AgentError {
     #[error("agent `{name}` is not installed")]
     NotInstalled { name: String },
 
-    /// The source markdown could not be parsed.
-    #[error("failed to parse agent at {path}: {reason}")]
-    ParseFailed { path: PathBuf, reason: String },
-
-    /// Frontmatter lacks a required `name` field.
-    #[error("agent at {path} is missing required `name` field")]
-    MissingName { path: PathBuf },
+    /// The source file could not be parsed. Inspect `failure` for the
+    /// specific stage (missing frontmatter, invalid YAML, missing name,
+    /// I/O error) — callers switch on the variant rather than
+    /// substring-matching this Display.
+    #[error("failed to parse agent at {path}: {failure}")]
+    ParseFailed {
+        path: PathBuf,
+        failure: ParseFailure,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -338,13 +342,26 @@ mod tests {
         AgentError::NotInstalled { name: "missing".into() },
         "agent `missing` is not installed"
     )]
-    #[case::agent_parse_failed(
-        AgentError::ParseFailed { path: PathBuf::from("a.md"), reason: "bad yaml".into() },
-        "failed to parse agent at a.md: bad yaml"
+    #[case::agent_parse_invalid_yaml(
+        AgentError::ParseFailed {
+            path: PathBuf::from("a.md"),
+            failure: ParseFailure::InvalidYaml("bad yaml".into()),
+        },
+        "failed to parse agent at a.md: invalid YAML: bad yaml"
     )]
-    #[case::agent_missing_name(
-        AgentError::MissingName { path: PathBuf::from("a.md") },
-        "agent at a.md is missing required `name` field"
+    #[case::agent_parse_missing_name(
+        AgentError::ParseFailed {
+            path: PathBuf::from("a.md"),
+            failure: ParseFailure::MissingName,
+        },
+        "failed to parse agent at a.md: missing required `name` field"
+    )]
+    #[case::agent_parse_missing_frontmatter(
+        AgentError::ParseFailed {
+            path: PathBuf::from("readme.md"),
+            failure: ParseFailure::MissingFrontmatter,
+        },
+        "failed to parse agent at readme.md: missing opening `---` frontmatter fence"
     )]
     fn agent_error_display(#[case] err: AgentError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -1,8 +1,8 @@
 //! Domain error types for kiro-market-core.
 //!
 //! Errors are organised into thematic groups ([`MarketplaceError`],
-//! [`PluginError`], [`SkillError`], [`GitError`]) and a top-level [`Error`]
-//! enum that unifies them via `From` conversions.
+//! [`PluginError`], [`SkillError`], [`AgentError`], [`GitError`]) and a
+//! top-level [`Error`] enum that unifies them via `From` conversions.
 
 use std::path::PathBuf;
 
@@ -77,6 +77,31 @@ pub enum SkillError {
     /// No `SKILL.md` was found for the skill.
     #[error("SKILL.md not found at {path}")]
     SkillMdNotFound { path: PathBuf },
+}
+
+// ---------------------------------------------------------------------------
+// Agent errors
+// ---------------------------------------------------------------------------
+
+/// Errors related to agent operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AgentError {
+    /// The agent is already installed in the target project.
+    #[error("agent `{name}` is already installed")]
+    AlreadyInstalled { name: String },
+
+    /// The agent is not installed in the target project.
+    #[error("agent `{name}` is not installed")]
+    NotInstalled { name: String },
+
+    /// The source markdown could not be parsed.
+    #[error("failed to parse agent at {path}: {reason}")]
+    ParseFailed { path: PathBuf, reason: String },
+
+    /// Frontmatter lacks a required `name` field.
+    #[error("agent at {path} is missing required `name` field")]
+    MissingName { path: PathBuf },
 }
 
 // ---------------------------------------------------------------------------
@@ -164,6 +189,9 @@ pub enum Error {
 
     #[error(transparent)]
     Skill(#[from] SkillError),
+
+    #[error(transparent)]
+    Agent(#[from] AgentError),
 
     #[error(transparent)]
     Git(#[from] GitError),
@@ -301,6 +329,27 @@ mod tests {
         assert_eq!(err.to_string(), expected);
     }
 
+    #[rstest]
+    #[case::agent_already_installed(
+        AgentError::AlreadyInstalled { name: "reviewer".into() },
+        "agent `reviewer` is already installed"
+    )]
+    #[case::agent_not_installed(
+        AgentError::NotInstalled { name: "missing".into() },
+        "agent `missing` is not installed"
+    )]
+    #[case::agent_parse_failed(
+        AgentError::ParseFailed { path: PathBuf::from("a.md"), reason: "bad yaml".into() },
+        "failed to parse agent at a.md: bad yaml"
+    )]
+    #[case::agent_missing_name(
+        AgentError::MissingName { path: PathBuf::from("a.md") },
+        "agent at a.md is missing required `name` field"
+    )]
+    fn agent_error_display(#[case] err: AgentError, #[case] expected: &str) {
+        assert_eq!(err.to_string(), expected);
+    }
+
     #[test]
     fn git_clone_failed_display() {
         let err = GitError::CloneFailed {
@@ -434,6 +483,13 @@ mod tests {
         };
         let err: Error = inner.into();
         assert!(matches!(err, Error::Validation(_)));
+    }
+
+    #[test]
+    fn from_agent_error() {
+        let inner = AgentError::NotInstalled { name: "x".into() };
+        let err: Error = inner.into();
+        assert!(matches!(err, Error::Agent(_)));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -25,3 +25,7 @@ pub const MARKETPLACE_MANIFEST_PATH: &str = ".claude-plugin/marketplace.json";
 /// Default skill scan paths when a plugin has no `plugin.json` or its skills
 /// list is empty.
 pub const DEFAULT_SKILL_PATHS: &[&str] = &["./skills/"];
+
+/// Default agent scan paths when a plugin has no `plugin.json` or its
+/// `agents` list is empty.
+pub const DEFAULT_AGENT_PATHS: &[&str] = &["./agents/"];

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides types and logic for discovering and installing Claude Code
 //! marketplace skills into Kiro CLI projects.
 
+pub mod agent;
 pub mod cache;
 pub mod error;
 pub mod file_lock;

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -18,6 +18,11 @@ pub struct PluginManifest {
     pub description: Option<String>,
     #[serde(default)]
     pub skills: Vec<String>,
+    /// Optional list of directories (relative to the plugin root) to scan
+    /// for agent markdown files. Empty means "use the default scan paths"
+    /// ([`crate::DEFAULT_AGENT_PATHS`]).
+    #[serde(default)]
+    pub agents: Vec<String>,
 }
 
 impl PluginManifest {
@@ -396,6 +401,25 @@ mod tests {
         assert!(m.version.is_none());
         assert!(m.description.is_none());
         assert!(m.skills.is_empty());
+        assert!(m.agents.is_empty());
+    }
+
+    #[test]
+    fn parse_with_explicit_agents_list() {
+        let json = br#"{
+            "name": "agent-plugin",
+            "skills": ["./skills/"],
+            "agents": ["./agents/"]
+        }"#;
+        let m = PluginManifest::from_json(json).expect("should parse");
+        assert_eq!(m.agents, vec!["./agents/"]);
+    }
+
+    #[test]
+    fn parse_without_agents_defaults_to_empty() {
+        let json = br#"{ "name": "p" }"#;
+        let m = PluginManifest::from_json(json).expect("should parse");
+        assert!(m.agents.is_empty());
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -528,6 +528,13 @@ impl KiroProject {
 
     /// Remove any `_installing-agent-<name>-*` staging directories left over
     /// from prior crashed installs. Caller must hold the agent tracking lock.
+    ///
+    /// Best-effort: per-entry iteration errors are logged via `warn!` and
+    /// skipped rather than aborting the install. A transient filesystem
+    /// glitch reading one entry under `.kiro/` should not prevent the
+    /// install — the staging dir is unreachable user-facing state, and
+    /// the subsequent `fresh_agent_staging_dir` uses a unique per-attempt
+    /// path regardless of whether cleanup fully succeeded.
     fn cleanup_leftover_agent_staging(&self, name: &str) -> std::io::Result<()> {
         let prefix = format!("_installing-agent-{name}-");
         let kiro_dir = self.kiro_dir();
@@ -537,7 +544,17 @@ impl KiroProject {
             Err(e) => return Err(e),
         };
         for entry in entries {
-            let entry = entry?;
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(
+                        dir = %kiro_dir.display(),
+                        error = %e,
+                        "failed to read entry during agent staging cleanup; skipping"
+                    );
+                    continue;
+                }
+            };
             let file_name = entry.file_name();
             let Some(name_str) = file_name.to_str() else {
                 continue;

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -85,14 +85,14 @@ const INSTALLED_AGENTS_FILE: &str = "installed-agents.json";
 /// already returning a more meaningful error and the staging dir is
 /// unreachable user-facing state.
 fn remove_staging_dir(staging: &Path) {
-    if let Err(e) = fs::remove_dir_all(staging) {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            warn!(
-                path = %staging.display(),
-                error = %e,
-                "failed to remove staging directory"
-            );
-        }
+    if let Err(e) = fs::remove_dir_all(staging)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(
+            path = %staging.display(),
+            error = %e,
+            "failed to remove staging directory"
+        );
     }
 }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use crate::agent::AgentDialect;
 use crate::error::SkillError;
 use crate::validation;
 
@@ -45,12 +46,39 @@ pub struct InstalledSkills {
     pub skills: HashMap<String, InstalledSkillMeta>,
 }
 
+/// Metadata recorded for each installed agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledAgentMeta {
+    /// Name of the marketplace the agent came from.
+    pub marketplace: String,
+    /// Name of the plugin that owns the agent.
+    pub plugin: String,
+    /// Optional version string from the plugin manifest.
+    pub version: Option<String>,
+    /// Timestamp when the agent was installed.
+    pub installed_at: DateTime<Utc>,
+    /// Which source dialect the agent was parsed from. Persisted via the
+    /// enum's serde rename so the wire format stays `"claude"` / `"copilot"`.
+    pub dialect: AgentDialect,
+}
+
+/// The on-disk structure of `installed-agents.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InstalledAgents {
+    /// Map from agent name to its installation metadata.
+    pub agents: HashMap<String, InstalledAgentMeta>,
+}
+
 // ---------------------------------------------------------------------------
 // KiroProject
 // ---------------------------------------------------------------------------
 
-/// Name of the tracking file inside `.kiro/`.
+/// Name of the skill tracking file inside `.kiro/`.
 const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
+
+/// Name of the agent tracking file inside `.kiro/`.
+#[allow(dead_code)] // Consumed by `install_agent` in Task 10.
+const INSTALLED_AGENTS_FILE: &str = "installed-agents.json";
 
 /// Recursively copy a directory tree from `src` to `dest`.
 ///
@@ -458,6 +486,47 @@ mod tests {
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
         }
+    }
+
+    #[test]
+    fn installed_agent_meta_roundtrips_json() {
+        let meta = InstalledAgentMeta {
+            marketplace: "mp".into(),
+            plugin: "pr-review-toolkit".into(),
+            version: Some("1.2.3".into()),
+            installed_at: Utc::now(),
+            dialect: AgentDialect::Claude,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.plugin, "pr-review-toolkit");
+        assert_eq!(back.dialect, AgentDialect::Claude);
+        // Spot-check the wire format: dialect serializes lowercase.
+        assert!(
+            json.contains("\"dialect\":\"claude\""),
+            "unexpected wire format: {json}"
+        );
+    }
+
+    #[test]
+    fn installed_agent_meta_roundtrips_copilot_dialect() {
+        let meta = InstalledAgentMeta {
+            marketplace: "mp".into(),
+            plugin: "p".into(),
+            version: None,
+            installed_at: Utc::now(),
+            dialect: AgentDialect::Copilot,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("\"dialect\":\"copilot\""));
+        let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.dialect, AgentDialect::Copilot);
+    }
+
+    #[test]
+    fn installed_agents_default_is_empty() {
+        let ia = InstalledAgents::default();
+        assert!(ia.agents.is_empty());
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -80,6 +80,22 @@ const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
 /// Name of the agent tracking file inside `.kiro/`.
 const INSTALLED_AGENTS_FILE: &str = "installed-agents.json";
 
+/// Best-effort removal of a staging directory, logging on failure instead
+/// of propagating the error. Used in rollback paths where the caller is
+/// already returning a more meaningful error and the staging dir is
+/// unreachable user-facing state.
+fn remove_staging_dir(staging: &Path) {
+    if let Err(e) = fs::remove_dir_all(staging) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            warn!(
+                path = %staging.display(),
+                error = %e,
+                "failed to remove staging directory"
+            );
+        }
+    }
+}
+
 /// Recursively copy a directory tree from `src` to `dest`.
 ///
 /// Creates `dest` and all intermediate directories. Files are copied
@@ -396,7 +412,7 @@ impl KiroProject {
     ) -> crate::error::Result<()> {
         validation::validate_name(&def.name)?;
 
-        // Build JSON outside the lock — this can't fail due to concurrency.
+        // CPU-bound work outside the lock to keep the critical section short.
         let json = crate::agent::emit::build_kiro_json(def, mapped_tools)?;
         let json_bytes = serde_json::to_vec_pretty(&json)?;
 
@@ -411,6 +427,11 @@ impl KiroProject {
                     .into());
                 }
 
+                // Sweep leftover staging dirs for THIS agent from prior crashed
+                // attempts. Safe because we hold the lock — no other installer
+                // of this agent is currently running.
+                self.cleanup_leftover_agent_staging(&def.name)?;
+
                 let staging = self.fresh_agent_staging_dir(&def.name);
                 let staging_json = staging.join("agent.json");
                 let staging_prompt_dir = staging.join("prompts");
@@ -421,27 +442,40 @@ impl KiroProject {
                 if let Err(e) = fs::write(&staging_json, &json_bytes)
                     .and_then(|()| fs::write(&staging_prompt, def.prompt_body.as_bytes()))
                 {
-                    if let Err(cleanup_err) = fs::remove_dir_all(&staging) {
-                        warn!(
-                            path = %staging.display(),
-                            error = %cleanup_err,
-                            "failed to clean up agent staging directory after write failure"
-                        );
-                    }
+                    remove_staging_dir(&staging);
                     return Err(e.into());
                 }
 
-                // Ensure target directories exist.
                 fs::create_dir_all(self.agent_prompts_dir())?;
 
                 let json_target = self.agents_dir().join(format!("{}.json", def.name));
                 let prompt_target = self.agent_prompts_dir().join(format!("{}.md", def.name));
 
+                // Tracking is authoritative: duplicate detection above rejects
+                // already-installed agents. But a prior crash could leave
+                // orphaned files on disk without a tracking entry. Refuse to
+                // silently clobber — the user should either manually clean up
+                // or a future `install_agent_force` can handle it explicitly.
+                if json_target.exists() || prompt_target.exists() {
+                    remove_staging_dir(&staging);
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        format!(
+                            "agent files for `{}` exist on disk but have no tracking entry; \
+                             remove {} and {} manually before re-installing",
+                            def.name,
+                            json_target.display(),
+                            prompt_target.display(),
+                        ),
+                    )
+                    .into());
+                }
+
                 // Rename JSON first. If the prompt rename fails afterwards,
                 // roll back the JSON rename so we never leave an agent with
                 // only half its files on disk.
                 if let Err(e) = fs::rename(&staging_json, &json_target) {
-                    let _ = fs::remove_dir_all(&staging);
+                    remove_staging_dir(&staging);
                     return Err(e.into());
                 }
                 if let Err(e) = fs::rename(&staging_prompt, &prompt_target) {
@@ -452,13 +486,13 @@ impl KiroProject {
                             "failed to roll back agent JSON after prompt-rename failure"
                         );
                     }
-                    let _ = fs::remove_dir_all(&staging);
+                    remove_staging_dir(&staging);
                     return Err(e.into());
                 }
 
-                // Staging directory itself should now be empty (or contain
-                // the empty prompts subdir). Remove it.
-                let _ = fs::remove_dir_all(&staging);
+                // Staging directory should now be empty (or contain the empty
+                // prompts subdir).
+                remove_staging_dir(&staging);
 
                 // Tracking last. On failure, roll back both files.
                 installed.agents.insert(def.name.clone(), meta);
@@ -468,8 +502,21 @@ impl KiroProject {
                         error = %e,
                         "agent tracking update failed after rename; rolling back files"
                     );
-                    let _ = fs::remove_file(&json_target);
-                    let _ = fs::remove_file(&prompt_target);
+                    if let Err(rb_err) = fs::remove_file(&json_target) {
+                        warn!(
+                            path = %json_target.display(),
+                            error = %rb_err,
+                            "failed to roll back agent JSON after tracking failure — \
+                             agent is on disk but not tracked"
+                        );
+                    }
+                    if let Err(rb_err) = fs::remove_file(&prompt_target) {
+                        warn!(
+                            path = %prompt_target.display(),
+                            error = %rb_err,
+                            "failed to roll back agent prompt after tracking failure"
+                        );
+                    }
                     return Err(e);
                 }
 
@@ -477,6 +524,41 @@ impl KiroProject {
                 Ok(())
             },
         )
+    }
+
+    /// Remove any `_installing-agent-<name>-*` staging directories left over
+    /// from prior crashed installs. Caller must hold the agent tracking lock.
+    fn cleanup_leftover_agent_staging(&self, name: &str) -> std::io::Result<()> {
+        let prefix = format!("_installing-agent-{name}-");
+        let kiro_dir = self.kiro_dir();
+        let entries = match fs::read_dir(&kiro_dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(name_str) = file_name.to_str() else {
+                continue;
+            };
+            if !name_str.starts_with(&prefix) {
+                continue;
+            }
+            let path = entry.path();
+            debug!(
+                path = %path.display(),
+                "removing leftover agent staging directory from prior install"
+            );
+            if let Err(e) = fs::remove_dir_all(&path) {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to remove leftover agent staging directory"
+                );
+            }
+        }
+        Ok(())
     }
 
     // -- internal helpers --------------------------------------------------
@@ -858,6 +940,171 @@ mod tests {
         assert!(
             leftovers.is_empty(),
             "no staging directories should remain after successful install"
+        );
+    }
+
+    #[test]
+    fn install_agent_sweeps_leftover_staging_from_prior_crash() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "sweep", "---\nname: sweep\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        // Simulate a crashed prior attempt that left staging around.
+        fs::create_dir_all(project.root.join(".kiro")).unwrap();
+        let ghost = project.root.join(".kiro/_installing-agent-sweep-99999-0");
+        fs::create_dir_all(ghost.join("prompts")).unwrap();
+        fs::write(ghost.join("agent.json"), b"{}").unwrap();
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .expect("install should succeed and sweep leftover");
+
+        assert!(!ghost.exists(), "leftover staging should have been swept");
+        assert!(project.root.join(".kiro/agents/sweep.json").exists());
+    }
+
+    #[test]
+    fn install_agent_refuses_to_clobber_orphaned_files() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "orphan", "---\nname: orphan\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        // Pre-create an orphan JSON (no tracking entry) — a prior crash or
+        // manual tinkering.
+        let agents_dir = project.root.join(".kiro/agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("orphan.json"), b"{}").unwrap();
+
+        let err = project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap_err();
+        // Surfaced as an Io error (AlreadyExists) with a message pointing at
+        // the offending files.
+        assert!(matches!(err, crate::error::Error::Io(_)));
+        assert!(err.to_string().contains("orphan"));
+    }
+
+    #[test]
+    fn install_agent_rollback_removes_json_when_prompt_target_already_a_dir() {
+        // Force `fs::rename(staging_prompt, prompt_target)` to fail by making
+        // prompt_target a non-empty directory. After the failure, the JSON
+        // rollback must remove `.kiro/agents/<name>.json`.
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "rb", "---\nname: rb\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        // Pre-create a non-empty directory where the prompt file would go.
+        let prompts_dir = project.root.join(".kiro/agents/prompts");
+        fs::create_dir_all(prompts_dir.join("rb.md")).unwrap();
+        fs::write(prompts_dir.join("rb.md").join("inside.txt"), b"x").unwrap();
+
+        let err = project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap_err();
+        assert!(matches!(err, crate::error::Error::Io(_)));
+
+        // JSON target must not exist (rolled back).
+        assert!(
+            !project.root.join(".kiro/agents/rb.json").exists(),
+            "JSON file should have been rolled back after prompt-rename failure"
+        );
+        // Tracking must not contain the agent.
+        let tracking = project.load_installed_agents().unwrap();
+        assert!(!tracking.agents.contains_key("rb"));
+    }
+
+    #[test]
+    fn install_agent_serializes_concurrent_same_name_installs() {
+        // Mirrors `install_skill_from_dir_serializes_concurrent_same_name_installs`:
+        // two threads racing to install the same agent name. Exactly one
+        // should succeed; the other must see AlreadyInstalled. No staging
+        // dirs may leak under `.kiro/`.
+        let (_dir, project) = temp_project();
+        let project = std::sync::Arc::new(project);
+
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "racey", "---\nname: racey\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+        let def = std::sync::Arc::new(def);
+        let mapped = std::sync::Arc::new(mapped);
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let project = std::sync::Arc::clone(&project);
+                let barrier = std::sync::Arc::clone(&barrier);
+                let def = std::sync::Arc::clone(&def);
+                let mapped = std::sync::Arc::clone(&mapped);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    project.install_agent(&def, &mapped, sample_agent_meta())
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        let already_count = results
+            .iter()
+            .filter(|r| {
+                matches!(
+                    r,
+                    Err(crate::error::Error::Agent(
+                        AgentError::AlreadyInstalled { .. }
+                    ))
+                )
+            })
+            .count();
+        assert_eq!(ok_count, 1, "exactly one install should succeed");
+        assert_eq!(already_count, 1, "the other should be AlreadyInstalled");
+
+        let kiro = project.root.join(".kiro");
+        let leftover: Vec<_> = fs::read_dir(&kiro)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("_installing-agent-")
+            })
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "no agent staging dirs should remain after race: {leftover:?}"
+        );
+    }
+
+    #[test]
+    fn install_agent_rollback_removes_files_when_tracking_write_fails() {
+        // Pre-create the tracking path as a directory — `write_agent_tracking`
+        // will fail, and the flow should roll back both files.
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "trkfail", "---\nname: trkfail\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        // `.kiro/installed-agents.json` as a directory → atomic_write fails.
+        fs::create_dir_all(project.root.join(".kiro/installed-agents.json")).unwrap();
+
+        let err = project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap_err();
+        assert!(matches!(err, crate::error::Error::Io(_)));
+
+        assert!(
+            !project.root.join(".kiro/agents/trkfail.json").exists(),
+            "JSON file should have been rolled back after tracking failure"
+        );
+        assert!(
+            !project
+                .root
+                .join(".kiro/agents/prompts/trkfail.md")
+                .exists(),
+            "prompt file should have been rolled back after tracking failure"
         );
     }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -13,8 +13,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use crate::agent::AgentDialect;
-use crate::error::SkillError;
+use crate::agent::tools::MappedTool;
+use crate::agent::{AgentDefinition, AgentDialect};
+use crate::error::{AgentError, SkillError};
 use crate::validation;
 
 /// Process-local sequence used to disambiguate concurrent staging directories.
@@ -77,7 +78,6 @@ pub struct InstalledAgents {
 const INSTALLED_SKILLS_FILE: &str = "installed-skills.json";
 
 /// Name of the agent tracking file inside `.kiro/`.
-#[allow(dead_code)] // Consumed by `install_agent` in Task 10.
 const INSTALLED_AGENTS_FILE: &str = "installed-agents.json";
 
 /// Recursively copy a directory tree from `src` to `dest`.
@@ -309,6 +309,176 @@ impl KiroProject {
         self.write_skill_dir(name, source_dir, meta, true)
     }
 
+    // -- agent installation ------------------------------------------------
+
+    /// The `.kiro/agents/` directory.
+    fn agents_dir(&self) -> PathBuf {
+        self.kiro_dir().join("agents")
+    }
+
+    /// The `.kiro/agents/prompts/` directory.
+    fn agent_prompts_dir(&self) -> PathBuf {
+        self.agents_dir().join("prompts")
+    }
+
+    /// Path to the agent tracking file.
+    fn agent_tracking_path(&self) -> PathBuf {
+        self.kiro_dir().join(INSTALLED_AGENTS_FILE)
+    }
+
+    /// Load the installed-agents tracking file.
+    ///
+    /// Returns a default (empty) [`InstalledAgents`] if the file does not
+    /// exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on I/O or JSON parse failures.
+    pub fn load_installed_agents(&self) -> crate::error::Result<InstalledAgents> {
+        let path = self.agent_tracking_path();
+        match fs::read(&path) {
+            Ok(bytes) => {
+                let installed: InstalledAgents = serde_json::from_slice(&bytes)?;
+                Ok(installed)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!(path = %path.display(), "agent tracking file not found, returning default");
+                Ok(InstalledAgents::default())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Persist the agent tracking file to disk atomically.
+    fn write_agent_tracking(&self, installed: &InstalledAgents) -> crate::error::Result<()> {
+        let path = self.agent_tracking_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(installed)?;
+        crate::cache::atomic_write(&path, json.as_bytes())?;
+        Ok(())
+    }
+
+    /// Generate a per-attempt staging directory path for an agent install.
+    fn fresh_agent_staging_dir(&self, name: &str) -> PathBuf {
+        use std::sync::atomic::Ordering;
+        let pid = std::process::id();
+        let seq = STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+        self.kiro_dir()
+            .join(format!("_installing-agent-{name}-{pid}-{seq}"))
+    }
+
+    /// Install a parsed agent: emit its Kiro JSON + externalized prompt
+    /// markdown under `.kiro/agents/`, and record metadata in
+    /// `installed-agents.json`.
+    ///
+    /// The caller is responsible for parsing the source file and mapping the
+    /// tool list — the service layer does both upstream so warnings can be
+    /// surfaced before the install lock is acquired. This method is purely
+    /// the on-disk write step.
+    ///
+    /// File writes use a staging-and-rename pattern: prompt + JSON are
+    /// written to `_installing-agent-<name>-<pid>-<seq>/` under `.kiro/`,
+    /// renamed into place after the duplicate check, then tracking is
+    /// written last. The whole flow runs under the agent tracking lock.
+    ///
+    /// # Errors
+    ///
+    /// - [`AgentError::AlreadyInstalled`] if an agent with this name already exists.
+    /// - Validation errors for unsafe names.
+    /// - I/O errors or JSON serialization failures.
+    pub fn install_agent(
+        &self,
+        def: &AgentDefinition,
+        mapped_tools: &[MappedTool],
+        meta: InstalledAgentMeta,
+    ) -> crate::error::Result<()> {
+        validation::validate_name(&def.name)?;
+
+        // Build JSON outside the lock — this can't fail due to concurrency.
+        let json = crate::agent::emit::build_kiro_json(def, mapped_tools)?;
+        let json_bytes = serde_json::to_vec_pretty(&json)?;
+
+        crate::file_lock::with_file_lock(
+            &self.agent_tracking_path(),
+            || -> crate::error::Result<()> {
+                let mut installed = self.load_installed_agents()?;
+                if installed.agents.contains_key(&def.name) {
+                    return Err(AgentError::AlreadyInstalled {
+                        name: def.name.clone(),
+                    }
+                    .into());
+                }
+
+                let staging = self.fresh_agent_staging_dir(&def.name);
+                let staging_json = staging.join("agent.json");
+                let staging_prompt_dir = staging.join("prompts");
+                let staging_prompt = staging_prompt_dir.join(format!("{}.md", def.name));
+
+                // Stage both files.
+                fs::create_dir_all(&staging_prompt_dir)?;
+                if let Err(e) = fs::write(&staging_json, &json_bytes)
+                    .and_then(|()| fs::write(&staging_prompt, def.prompt_body.as_bytes()))
+                {
+                    if let Err(cleanup_err) = fs::remove_dir_all(&staging) {
+                        warn!(
+                            path = %staging.display(),
+                            error = %cleanup_err,
+                            "failed to clean up agent staging directory after write failure"
+                        );
+                    }
+                    return Err(e.into());
+                }
+
+                // Ensure target directories exist.
+                fs::create_dir_all(self.agent_prompts_dir())?;
+
+                let json_target = self.agents_dir().join(format!("{}.json", def.name));
+                let prompt_target = self.agent_prompts_dir().join(format!("{}.md", def.name));
+
+                // Rename JSON first. If the prompt rename fails afterwards,
+                // roll back the JSON rename so we never leave an agent with
+                // only half its files on disk.
+                if let Err(e) = fs::rename(&staging_json, &json_target) {
+                    let _ = fs::remove_dir_all(&staging);
+                    return Err(e.into());
+                }
+                if let Err(e) = fs::rename(&staging_prompt, &prompt_target) {
+                    if let Err(rb_err) = fs::remove_file(&json_target) {
+                        warn!(
+                            path = %json_target.display(),
+                            error = %rb_err,
+                            "failed to roll back agent JSON after prompt-rename failure"
+                        );
+                    }
+                    let _ = fs::remove_dir_all(&staging);
+                    return Err(e.into());
+                }
+
+                // Staging directory itself should now be empty (or contain
+                // the empty prompts subdir). Remove it.
+                let _ = fs::remove_dir_all(&staging);
+
+                // Tracking last. On failure, roll back both files.
+                installed.agents.insert(def.name.clone(), meta);
+                if let Err(e) = self.write_agent_tracking(&installed) {
+                    warn!(
+                        name = %def.name,
+                        error = %e,
+                        "agent tracking update failed after rename; rolling back files"
+                    );
+                    let _ = fs::remove_file(&json_target);
+                    let _ = fs::remove_file(&prompt_target);
+                    return Err(e);
+                }
+
+                debug!(name = %def.name, "agent installed");
+                Ok(())
+            },
+        )
+    }
+
     // -- internal helpers --------------------------------------------------
 
     /// Copy a source skill directory and update tracking.
@@ -527,6 +697,168 @@ mod tests {
     fn installed_agents_default_is_empty() {
         let ia = InstalledAgents::default();
         assert!(ia.agents.is_empty());
+    }
+
+    fn write_agent(tmp: &Path, name: &str, body: &str) -> PathBuf {
+        let p = tmp.join(format!("{name}.md"));
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn parse_and_map(source: &Path) -> (AgentDefinition, Vec<MappedTool>) {
+        let def = crate::agent::parse_agent_file(source).expect("parse");
+        let (mapped, _unmapped) = match def.dialect {
+            AgentDialect::Claude => crate::agent::tools::map_claude_tools(&def.source_tools),
+            AgentDialect::Copilot => crate::agent::tools::map_copilot_tools(&def.source_tools),
+        };
+        (def, mapped)
+    }
+
+    fn sample_agent_meta() -> InstalledAgentMeta {
+        InstalledAgentMeta {
+            marketplace: "mp".into(),
+            plugin: "p".into(),
+            version: None,
+            installed_at: Utc::now(),
+            dialect: AgentDialect::Claude,
+        }
+    }
+
+    #[test]
+    fn install_agent_writes_json_and_prompt() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(
+            src_tmp.path(),
+            "reviewer",
+            "---\nname: reviewer\ndescription: Reviews\n---\nYou are a reviewer.\n",
+        );
+        let (def, mapped) = parse_and_map(&src);
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .expect("install");
+
+        let json_path = project.root.join(".kiro/agents/reviewer.json");
+        let prompt_path = project.root.join(".kiro/agents/prompts/reviewer.md");
+        assert!(json_path.exists(), "JSON written");
+        assert!(prompt_path.exists(), "prompt markdown written");
+
+        let json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&json_path).unwrap()).unwrap();
+        assert_eq!(json["name"], "reviewer");
+        assert_eq!(json["prompt"], "file://./prompts/reviewer.md");
+        assert_eq!(json["description"], "Reviews");
+
+        let prompt = fs::read_to_string(&prompt_path).unwrap();
+        assert!(
+            prompt.starts_with("You are a reviewer."),
+            "prompt body written without frontmatter, got: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn install_agent_rejects_duplicate() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "a", "---\nname: a\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap();
+        let err = project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::Agent(AgentError::AlreadyInstalled { .. })
+        ));
+    }
+
+    #[test]
+    fn install_agent_updates_tracking() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "a", "---\nname: a\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap();
+
+        let tracking_path = project.root.join(".kiro/installed-agents.json");
+        let tracking: InstalledAgents =
+            serde_json::from_str(&fs::read_to_string(tracking_path).unwrap()).unwrap();
+        assert!(tracking.agents.contains_key("a"));
+        assert_eq!(tracking.agents["a"].dialect, AgentDialect::Claude);
+    }
+
+    #[test]
+    fn install_agent_rejects_unsafe_name() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "x", "---\nname: x\n---\nbody\n");
+        let (mut def, mapped) = parse_and_map(&src);
+        def.name = "../escape".into();
+        let err = project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap_err();
+        assert!(matches!(err, crate::error::Error::Validation(_)));
+    }
+
+    #[test]
+    fn install_agent_emits_tools_and_allowed_tools_from_mapping() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(
+            src_tmp.path(),
+            "mixed",
+            "---\nname: mixed\ntools: [Read, Bash]\n---\nbody\n",
+        );
+        let (def, mapped) = parse_and_map(&src);
+        assert_eq!(mapped.len(), 2, "sanity: both tools mapped");
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .expect("install");
+
+        let json_path = project.root.join(".kiro/agents/mixed.json");
+        let json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&json_path).unwrap()).unwrap();
+        let allowed = json["allowedTools"].as_array().unwrap();
+        // Native tools go to allowedTools, not tools.
+        assert!(allowed.contains(&serde_json::Value::String("read".into())));
+        assert!(allowed.contains(&serde_json::Value::String("shell".into())));
+        assert!(json.get("tools").is_none(), "no MCP refs here");
+    }
+
+    #[test]
+    fn install_agent_no_staging_dir_left_behind_on_success() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(src_tmp.path(), "clean", "---\nname: clean\n---\nbody\n");
+        let (def, mapped) = parse_and_map(&src);
+
+        project
+            .install_agent(&def, &mapped, sample_agent_meta())
+            .unwrap();
+
+        // Staging lives directly under .kiro/, not under agents/.
+        let kiro_dir = project.root.join(".kiro");
+        let leftovers: Vec<_> = fs::read_dir(&kiro_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|s| s.starts_with("_installing-agent"))
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no staging directories should remain after successful install"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -660,6 +660,81 @@ impl MarketplaceService {
         result
     }
 
+    /// Discover, parse, and install all agents from a plugin directory.
+    ///
+    /// Returns `(installed_count, warnings)`. Parse failures on individual
+    /// agents are captured as warnings and do not abort the whole install.
+    /// Each file is parsed exactly once — the parsed `AgentDefinition` is
+    /// passed straight into `project.install_agent`, so the project layer
+    /// never re-reads the source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only for fatal problems (e.g. filesystem errors
+    /// writing the tracking file). Per-file parse failures become warnings.
+    pub fn install_plugin_agents(
+        &self,
+        project: &crate::project::KiroProject,
+        plugin_dir: &Path,
+        scan_paths: &[String],
+        marketplace: &str,
+        plugin: &str,
+        version: Option<&str>,
+    ) -> crate::error::Result<(usize, Vec<InstallWarning>)> {
+        let files = crate::agent::discover::discover_agents_in_dirs(plugin_dir, scan_paths);
+        let mut installed = 0_usize;
+        let mut warnings: Vec<InstallWarning> = Vec::new();
+
+        for path in files {
+            let def = match crate::agent::parse_agent_file(&path) {
+                Ok(d) => d,
+                Err(e) => {
+                    let reason = e.to_string();
+                    // Demote "no frontmatter at all" — these are usually
+                    // human-readable docs that share an `agents/` directory
+                    // with real agent files.
+                    if reason.contains("missing opening `---` frontmatter fence") {
+                        debug!(path = %path.display(), "skipping non-agent markdown");
+                    } else {
+                        warnings.push(InstallWarning::AgentParseFailed {
+                            path: path.clone(),
+                            reason,
+                        });
+                    }
+                    continue;
+                }
+            };
+
+            let (mapped, unmapped) = match def.dialect {
+                crate::agent::AgentDialect::Claude => {
+                    crate::agent::tools::map_claude_tools(&def.source_tools)
+                }
+                crate::agent::AgentDialect::Copilot => {
+                    crate::agent::tools::map_copilot_tools(&def.source_tools)
+                }
+            };
+            for u in unmapped {
+                warnings.push(InstallWarning::UnmappedTool {
+                    agent: def.name.clone(),
+                    tool: u.source,
+                    reason: u.reason,
+                });
+            }
+
+            let meta = crate::project::InstalledAgentMeta {
+                marketplace: marketplace.to_string(),
+                plugin: plugin.to_string(),
+                version: version.map(String::from),
+                installed_at: chrono::Utc::now(),
+                dialect: def.dialect,
+            };
+            project.install_agent(&def, &mapped, meta)?;
+            installed += 1;
+        }
+
+        Ok((installed, warnings))
+    }
+
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
@@ -895,6 +970,121 @@ mod tests {
         let s = w.to_string();
         assert!(s.contains("/tmp/bad.md"));
         assert!(s.contains("invalid YAML"));
+    }
+
+    #[test]
+    fn install_plugin_agents_emits_json_and_warnings_per_file() {
+        use crate::agent::tools::UnmappedReason;
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+
+        // Claude agent with a mappable tool and an unmapped one.
+        fs::write(
+            agents_dir.join("reviewer.md"),
+            "---\nname: reviewer\ndescription: Reviews\ntools: [Read, NotebookEdit]\n---\nYou are a reviewer.\n",
+        ).unwrap();
+        // Copilot agent with a bare (unmapped) tool and an MCP ref.
+        fs::write(
+            agents_dir.join("tester.agent.md"),
+            "---\nname: tester\ntools: ['codebase', 'terraform/*']\n---\nBody.\n",
+        )
+        .unwrap();
+        // A README that should be silently excluded.
+        fs::write(agents_dir.join("README.md"), "# agents").unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let (count, warnings) = svc
+            .install_plugin_agents(
+                &project,
+                plugin_tmp.path(),
+                &["./agents/".to_string()],
+                "mp",
+                "plugin-x",
+                None,
+            )
+            .expect("install");
+
+        assert_eq!(count, 2, "both agents installed, README excluded");
+        assert!(
+            project_tmp
+                .path()
+                .join(".kiro/agents/reviewer.json")
+                .exists()
+        );
+        assert!(project_tmp.path().join(".kiro/agents/tester.json").exists());
+        assert!(
+            project_tmp
+                .path()
+                .join(".kiro/agents/prompts/reviewer.md")
+                .exists()
+        );
+
+        // Warnings are structured.
+        let unmapped: Vec<_> = warnings
+            .iter()
+            .filter_map(|w| match w {
+                InstallWarning::UnmappedTool { tool, reason, .. } => Some((tool.as_str(), *reason)),
+                InstallWarning::AgentParseFailed { .. } => None,
+            })
+            .collect();
+        assert!(
+            unmapped.contains(&("NotebookEdit", UnmappedReason::NoKiroEquivalent)),
+            "expected NotebookEdit unmapped: {unmapped:?}"
+        );
+        assert!(
+            unmapped.contains(&("codebase", UnmappedReason::BareCopilotName)),
+            "expected codebase unmapped: {unmapped:?}"
+        );
+        // No parse-failed warning for README (silently demoted in discover/service).
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, InstallWarning::AgentParseFailed { .. })),
+            "README should not produce a parse-failed warning"
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_surfaces_parse_failures_other_than_missing_fence() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        // Well-formed fence but YAML inside is invalid — should surface a warning.
+        fs::write(
+            agents_dir.join("broken.md"),
+            "---\nname: [unclosed\n---\nbody\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let (count, warnings) = svc
+            .install_plugin_agents(
+                &project,
+                plugin_tmp.path(),
+                &["./agents/".to_string()],
+                "mp",
+                "p",
+                None,
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, InstallWarning::AgentParseFailed { .. })),
+            "expected AgentParseFailed: {warnings:?}"
+        );
     }
 
     /// Mock git backend that records calls and creates a minimal marketplace

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -1217,6 +1217,49 @@ mod tests {
     }
 
     #[test]
+    fn install_plugin_agents_demotes_missing_fence_for_non_readme_files() {
+        // Coverage for the service-layer demotion path: a plain `.md` file
+        // (not README/CONTRIBUTING/CHANGELOG) with no frontmatter fence
+        // must not surface as a warning — it should be debug-logged and
+        // dropped. Previously only the README exclusion in `discover`
+        // was tested, which short-circuited this path.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        // A non-excluded filename that lacks frontmatter entirely.
+        fs::write(
+            agents_dir.join("notes.md"),
+            "# just notes, no frontmatter\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+        assert!(result.installed.is_empty());
+        assert!(result.failed.is_empty());
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| matches!(w, InstallWarning::AgentParseFailed { .. })),
+            "missing-fence non-README file must be demoted silently, got: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
     fn install_plugin_agents_already_installed_goes_to_skipped() {
         use crate::project::KiroProject;
 

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -153,6 +153,44 @@ pub struct FailedSkill {
     pub error: String,
 }
 
+/// Non-fatal issue produced during install. Surfaced in install results
+/// so the CLI / Tauri frontend can render them without blocking the install.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum InstallWarning {
+    /// A source-declared tool had no Kiro equivalent and was dropped.
+    /// The emitted agent will inherit the full parent toolset for that slot.
+    UnmappedTool {
+        agent: String,
+        tool: String,
+        reason: crate::agent::tools::UnmappedReason,
+    },
+    /// An agent file could not be parsed; it was skipped.
+    AgentParseFailed { path: PathBuf, reason: String },
+}
+
+impl std::fmt::Display for InstallWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::agent::tools::UnmappedReason;
+        match self {
+            InstallWarning::UnmappedTool {
+                agent,
+                tool,
+                reason,
+            } => {
+                let why = match reason {
+                    UnmappedReason::NoKiroEquivalent => "no Kiro equivalent",
+                    UnmappedReason::BareCopilotName => "Copilot bare name; not portable",
+                };
+                write!(f, "agent `{agent}`: tool `{tool}` dropped ({why})")
+            }
+            InstallWarning::AgentParseFailed { path, reason } => {
+                write!(f, "skipped agent at {}: {reason}", path.display())
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -821,6 +859,43 @@ mod tests {
     use crate::cache::CacheDir;
     use crate::error::GitError;
     use crate::git::CloneOptions;
+
+    #[test]
+    fn install_warning_unmapped_tool_renders_with_reason() {
+        use crate::agent::tools::UnmappedReason;
+        let w = InstallWarning::UnmappedTool {
+            agent: "reviewer".into(),
+            tool: "NotebookEdit".into(),
+            reason: UnmappedReason::NoKiroEquivalent,
+        };
+        let s = w.to_string();
+        assert!(s.contains("reviewer"));
+        assert!(s.contains("NotebookEdit"));
+        assert!(s.contains("no Kiro equivalent"));
+    }
+
+    #[test]
+    fn install_warning_bare_copilot_name_reason_rendered() {
+        use crate::agent::tools::UnmappedReason;
+        let w = InstallWarning::UnmappedTool {
+            agent: "tester".into(),
+            tool: "codebase".into(),
+            reason: UnmappedReason::BareCopilotName,
+        };
+        let s = w.to_string();
+        assert!(s.contains("Copilot bare name"));
+    }
+
+    #[test]
+    fn install_warning_agent_parse_failed_renders_path_and_reason() {
+        let w = InstallWarning::AgentParseFailed {
+            path: PathBuf::from("/tmp/bad.md"),
+            reason: "invalid YAML".into(),
+        };
+        let s = w.to_string();
+        assert!(s.contains("/tmp/bad.md"));
+        assert!(s.contains("invalid YAML"));
+    }
 
     /// Mock git backend that records calls and creates a minimal marketplace
     /// manifest in the destination directory during clone.

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -1111,6 +1111,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn install_plugin_agents_rejects_frontmatter_path_traversal_end_to_end() {
+        use crate::agent::ParseFailure;
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        // Attack: name in YAML attempts to escape the agents directory.
+        fs::write(
+            agents_dir.join("evil.md"),
+            "---\nname: ../escape\n---\nbody\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let (count, warnings) = svc
+            .install_plugin_agents(
+                &project,
+                plugin_tmp.path(),
+                &["./agents/".to_string()],
+                "mp",
+                "p",
+                None,
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+        // Rejection happens at parse time with a typed InvalidName.
+        let has_invalid_name = warnings.iter().any(|w| {
+            matches!(
+                w,
+                InstallWarning::AgentParseFailed {
+                    failure: ParseFailure::InvalidName(_),
+                    ..
+                }
+            )
+        });
+        assert!(
+            has_invalid_name,
+            "expected InvalidName warning: {warnings:?}"
+        );
+        // Nothing should have been written outside project_tmp.
+        assert!(
+            !project_tmp.path().parent().unwrap().join("escape").exists(),
+            "traversal must not have escaped project root"
+        );
+    }
+
     /// Mock git backend that records calls and creates a minimal marketplace
     /// manifest in the destination directory during clone.
     #[derive(Debug, Default)]

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -153,6 +153,35 @@ pub struct FailedSkill {
     pub error: String,
 }
 
+/// Outcome of installing the agents from one plugin.
+///
+/// Mirrors [`InstallSkillsResult`]: per-agent successes and failures are
+/// collected so a single broken agent never aborts the rest of the batch,
+/// and accumulated warnings always reach the caller even when some agents
+/// fail.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallAgentsResult {
+    /// Agent names successfully installed.
+    pub installed: Vec<String>,
+    /// Agent names that were already installed and left untouched.
+    pub skipped: Vec<String>,
+    /// Agents whose install attempt failed (parse, validation, or fs error).
+    pub failed: Vec<FailedAgent>,
+    /// Non-fatal issues (unmapped tools, skipped non-agent files).
+    pub warnings: Vec<InstallWarning>,
+}
+
+/// An agent that failed to install, with the reason.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct FailedAgent {
+    /// Best-known identifier — the agent name if parse reached that far,
+    /// otherwise the source file path.
+    pub name: String,
+    pub error: String,
+}
+
 /// Non-fatal issue produced during install. Surfaced in install results
 /// so the CLI / Tauri frontend can render them without blocking the install.
 ///
@@ -670,16 +699,19 @@ impl MarketplaceService {
 
     /// Discover, parse, and install all agents from a plugin directory.
     ///
-    /// Returns `(installed_count, warnings)`. Parse failures on individual
-    /// agents are captured as warnings and do not abort the whole install.
-    /// Each file is parsed exactly once — the parsed `AgentDefinition` is
-    /// passed straight into `project.install_agent`, so the project layer
-    /// never re-reads the source.
+    /// All per-agent outcomes are collected into the returned
+    /// [`InstallAgentsResult`] — a single broken agent never aborts the
+    /// batch, and accumulated warnings always reach the caller. Each file
+    /// is parsed exactly once; the parsed `AgentDefinition` flows straight
+    /// into `project.install_agent` without re-reading the source.
     ///
-    /// # Errors
-    ///
-    /// Returns an error only for fatal problems (e.g. filesystem errors
-    /// writing the tracking file). Per-file parse failures become warnings.
+    /// Returns:
+    /// - `installed`: agent names the call wrote to disk.
+    /// - `skipped`: agents that were already installed (left untouched).
+    /// - `failed`: agents whose parse / validation / install raised an
+    ///   error. The CLI surfaces these with a non-zero exit status.
+    /// - `warnings`: non-fatal issues (unmapped tools, README-like files
+    ///   skipped, missing-name frontmatter).
     pub fn install_plugin_agents(
         &self,
         project: &crate::project::KiroProject,
@@ -688,31 +720,39 @@ impl MarketplaceService {
         marketplace: &str,
         plugin: &str,
         version: Option<&str>,
-    ) -> crate::error::Result<(usize, Vec<InstallWarning>)> {
+    ) -> InstallAgentsResult {
         let files = crate::agent::discover::discover_agents_in_dirs(plugin_dir, scan_paths);
-        let mut installed = 0_usize;
-        let mut warnings: Vec<InstallWarning> = Vec::new();
+        let mut result = InstallAgentsResult::default();
 
         for path in files {
             let def = match crate::agent::parse_agent_file(&path) {
                 Ok(d) => d,
-                Err(crate::error::AgentError::ParseFailed { path, failure }) => {
+                Err(crate::error::AgentError::ParseFailed {
+                    path: err_path,
+                    failure,
+                }) => {
                     // Demote "no frontmatter at all" to debug — these are
                     // almost always human-readable docs sharing the agents
-                    // directory, not broken agent files. Matches the variant
-                    // directly; no string-based classification.
+                    // directory, not broken agent files.
                     if matches!(failure, crate::agent::ParseFailure::MissingFrontmatter) {
-                        debug!(path = %path.display(), "skipping non-agent markdown");
+                        debug!(path = %err_path.display(), "skipping non-agent markdown");
                     } else {
-                        warnings.push(InstallWarning::AgentParseFailed { path, failure });
+                        result.warnings.push(InstallWarning::AgentParseFailed {
+                            path: err_path,
+                            failure,
+                        });
                     }
                     continue;
                 }
                 Err(e) => {
                     // Install-layer variants (AlreadyInstalled/NotInstalled)
-                    // are not produced by parse_agent_file today, but are
-                    // part of the same enum — propagate to be safe.
-                    return Err(e.into());
+                    // shouldn't come from parse_agent_file, but we collect
+                    // them as failures rather than crashing the batch.
+                    result.failed.push(FailedAgent {
+                        name: path.display().to_string(),
+                        error: crate::error::error_full_chain(&e),
+                    });
+                    continue;
                 }
             };
 
@@ -725,7 +765,7 @@ impl MarketplaceService {
                 }
             };
             for u in unmapped {
-                warnings.push(InstallWarning::UnmappedTool {
+                result.warnings.push(InstallWarning::UnmappedTool {
                     agent: def.name.clone(),
                     tool: u.source,
                     reason: u.reason,
@@ -739,11 +779,21 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
             };
-            project.install_agent(&def, &mapped, meta)?;
-            installed += 1;
+            match project.install_agent(&def, &mapped, meta) {
+                Ok(()) => result.installed.push(def.name),
+                Err(Error::Agent(crate::error::AgentError::AlreadyInstalled { name })) => {
+                    result.skipped.push(name);
+                }
+                Err(e) => {
+                    result.failed.push(FailedAgent {
+                        name: def.name,
+                        error: crate::error::error_full_chain(&e),
+                    });
+                }
+            }
         }
 
-        Ok((installed, warnings))
+        result
     }
 
     // -----------------------------------------------------------------------
@@ -1023,18 +1073,22 @@ mod tests {
         let project_tmp = tempfile::tempdir().unwrap();
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
-        let (count, warnings) = svc
-            .install_plugin_agents(
-                &project,
-                plugin_tmp.path(),
-                &["./agents/".to_string()],
-                "mp",
-                "plugin-x",
-                None,
-            )
-            .expect("install");
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "plugin-x",
+            None,
+        );
+        let warnings = &result.warnings;
 
-        assert_eq!(count, 2, "both agents installed, README excluded");
+        assert_eq!(
+            result.installed.len(),
+            2,
+            "both agents installed, README excluded"
+        );
+        assert!(result.failed.is_empty(), "no failures: {:?}", result.failed);
         assert!(
             project_tmp
                 .path()
@@ -1092,23 +1146,113 @@ mod tests {
         let project_tmp = tempfile::tempdir().unwrap();
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
-        let (count, warnings) = svc
-            .install_plugin_agents(
-                &project,
-                plugin_tmp.path(),
-                &["./agents/".to_string()],
-                "mp",
-                "p",
-                None,
-            )
-            .unwrap();
-        assert_eq!(count, 0);
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+        assert!(result.installed.is_empty());
         assert!(
-            warnings
+            result
+                .warnings
                 .iter()
                 .any(|w| matches!(w, InstallWarning::AgentParseFailed { .. })),
-            "expected AgentParseFailed: {warnings:?}"
+            "expected AgentParseFailed: {:?}",
+            result.warnings
         );
+    }
+
+    #[test]
+    fn install_plugin_agents_partial_success_preserves_warnings_and_failures() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        // Agent A: well-formed, will install.
+        fs::write(
+            agents_dir.join("a.md"),
+            "---\nname: aaa\ntools: [NotebookEdit]\n---\nbody a\n",
+        )
+        .unwrap();
+        // Agent B: pre-existing orphan file makes install fail.
+        fs::write(agents_dir.join("b.md"), "---\nname: bbb\n---\nbody b\n").unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        // Pre-plant orphan file for "bbb" so its install_agent fails.
+        let agents_out = project_tmp.path().join(".kiro/agents");
+        fs::create_dir_all(&agents_out).unwrap();
+        fs::write(agents_out.join("bbb.json"), b"{}").unwrap();
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+
+        // A succeeded, B failed, and the unmapped-tool warning for A still
+        // surfaces despite B's failure.
+        assert_eq!(result.installed, vec!["aaa".to_string()]);
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "bbb");
+        let has_unmapped = result.warnings.iter().any(|w| {
+            matches!(
+                w,
+                InstallWarning::UnmappedTool { tool, .. } if tool == "NotebookEdit"
+            )
+        });
+        assert!(
+            has_unmapped,
+            "warnings should include unmapped NotebookEdit even when a later agent fails: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_already_installed_goes_to_skipped() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("dup.md"), "---\nname: dup\n---\nbody\n").unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        // First install: should succeed.
+        let r1 = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+        assert_eq!(r1.installed, vec!["dup".to_string()]);
+        assert!(r1.failed.is_empty());
+
+        // Second install: should be reported as skipped, not failed.
+        let r2 = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+        assert!(r2.installed.is_empty());
+        assert_eq!(r2.skipped, vec!["dup".to_string()]);
+        assert!(r2.failed.is_empty(), "AlreadyInstalled must not be failed");
     }
 
     #[test]
@@ -1130,19 +1274,17 @@ mod tests {
         let project_tmp = tempfile::tempdir().unwrap();
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
-        let (count, warnings) = svc
-            .install_plugin_agents(
-                &project,
-                plugin_tmp.path(),
-                &["./agents/".to_string()],
-                "mp",
-                "p",
-                None,
-            )
-            .unwrap();
-        assert_eq!(count, 0);
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            "mp",
+            "p",
+            None,
+        );
+        assert!(result.installed.is_empty());
         // Rejection happens at parse time with a typed InvalidName.
-        let has_invalid_name = warnings.iter().any(|w| {
+        let has_invalid_name = result.warnings.iter().any(|w| {
             matches!(
                 w,
                 InstallWarning::AgentParseFailed {
@@ -1153,7 +1295,8 @@ mod tests {
         });
         assert!(
             has_invalid_name,
-            "expected InvalidName warning: {warnings:?}"
+            "expected InvalidName warning: {:?}",
+            result.warnings
         );
         // Nothing should have been written outside project_tmp.
         assert!(

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -155,8 +155,13 @@ pub struct FailedSkill {
 
 /// Non-fatal issue produced during install. Surfaced in install results
 /// so the CLI / Tauri frontend can render them without blocking the install.
+///
+/// Carries structured reason enums (not pre-rendered strings) so consumers
+/// can switch on them — the CLI formats for a human, the Tauri frontend
+/// can localize or map to its own UI states.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
+#[non_exhaustive]
 pub enum InstallWarning {
     /// A source-declared tool had no Kiro equivalent and was dropped.
     /// The emitted agent will inherit the full parent toolset for that slot.
@@ -166,7 +171,10 @@ pub enum InstallWarning {
         reason: crate::agent::tools::UnmappedReason,
     },
     /// An agent file could not be parsed; it was skipped.
-    AgentParseFailed { path: PathBuf, reason: String },
+    AgentParseFailed {
+        path: PathBuf,
+        failure: crate::agent::ParseFailure,
+    },
 }
 
 impl std::fmt::Display for InstallWarning {
@@ -184,8 +192,8 @@ impl std::fmt::Display for InstallWarning {
                 };
                 write!(f, "agent `{agent}`: tool `{tool}` dropped ({why})")
             }
-            InstallWarning::AgentParseFailed { path, reason } => {
-                write!(f, "skipped agent at {}: {reason}", path.display())
+            InstallWarning::AgentParseFailed { path, failure } => {
+                write!(f, "skipped agent at {}: {failure}", path.display())
             }
         }
     }
@@ -688,20 +696,23 @@ impl MarketplaceService {
         for path in files {
             let def = match crate::agent::parse_agent_file(&path) {
                 Ok(d) => d,
-                Err(e) => {
-                    let reason = e.to_string();
-                    // Demote "no frontmatter at all" — these are usually
-                    // human-readable docs that share an `agents/` directory
-                    // with real agent files.
-                    if reason.contains("missing opening `---` frontmatter fence") {
+                Err(crate::error::AgentError::ParseFailed { path, failure }) => {
+                    // Demote "no frontmatter at all" to debug — these are
+                    // almost always human-readable docs sharing the agents
+                    // directory, not broken agent files. Matches the variant
+                    // directly; no string-based classification.
+                    if matches!(failure, crate::agent::ParseFailure::MissingFrontmatter) {
                         debug!(path = %path.display(), "skipping non-agent markdown");
                     } else {
-                        warnings.push(InstallWarning::AgentParseFailed {
-                            path: path.clone(),
-                            reason,
-                        });
+                        warnings.push(InstallWarning::AgentParseFailed { path, failure });
                     }
                     continue;
+                }
+                Err(e) => {
+                    // Install-layer variants (AlreadyInstalled/NotInstalled)
+                    // are not produced by parse_agent_file today, but are
+                    // part of the same enum — propagate to be safe.
+                    return Err(e.into());
                 }
             };
 
@@ -962,14 +973,27 @@ mod tests {
     }
 
     #[test]
-    fn install_warning_agent_parse_failed_renders_path_and_reason() {
+    fn install_warning_agent_parse_failed_renders_path_and_failure() {
+        use crate::agent::ParseFailure;
         let w = InstallWarning::AgentParseFailed {
             path: PathBuf::from("/tmp/bad.md"),
-            reason: "invalid YAML".into(),
+            failure: ParseFailure::InvalidYaml("unexpected token".into()),
         };
         let s = w.to_string();
         assert!(s.contains("/tmp/bad.md"));
         assert!(s.contains("invalid YAML"));
+        assert!(s.contains("unexpected token"));
+    }
+
+    #[test]
+    fn install_warning_agent_parse_failed_missing_name_renders_cleanly() {
+        use crate::agent::ParseFailure;
+        let w = InstallWarning::AgentParseFailed {
+            path: PathBuf::from("/tmp/noname.md"),
+            failure: ParseFailure::MissingName,
+        };
+        let s = w.to_string();
+        assert!(s.contains("name"));
     }
 
     #[test]

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -11,7 +11,8 @@ use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource}
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
-    FailedSkill, InstallFilter, InstallSkillsResult, InstallWarning, MarketplaceService,
+    FailedAgent, FailedSkill, InstallAgentsResult, InstallFilter, InstallSkillsResult,
+    MarketplaceService,
 };
 use tracing::{debug, warn};
 
@@ -21,6 +22,7 @@ use crate::cli;
 ///
 /// Resolves `plugin_ref` to a plugin, discovers skills, copies skill
 /// directories, and installs into the current Kiro project.
+#[allow(clippy::too_many_lines)]
 pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<()> {
     let (plugin_name, marketplace_name) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
         format!("invalid plugin reference '{plugin_ref}': expected plugin@marketplace")
@@ -101,36 +103,45 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
 
     // Agents: only run when the user did NOT pass `--skill <name>`. A skill
     // filter narrows the install to one skill and never includes agents.
-    let (agents_installed, agent_warnings) = if skill_filter.is_none() {
-        match svc.install_plugin_agents(
+    let agent_result = if skill_filter.is_none() {
+        svc.install_plugin_agents(
             &project,
             &plugin_dir,
             &agent_scan_paths,
             marketplace_name,
             plugin_name,
             version.as_deref(),
-        ) {
-            Ok(tup) => tup,
-            Err(e) => {
-                eprintln!(
-                    "  {} Agent install failed: {}",
-                    "✗".red().bold(),
-                    format_args!("{e}")
-                );
-                (0, Vec::new())
-            }
-        }
+        )
     } else {
-        (0, Vec::new())
+        InstallAgentsResult::default()
     };
-    print_agent_outcome(agents_installed, &agent_warnings);
+    print_agent_outcome(&agent_result);
 
-    if skill_result.installed.is_empty() && skill_result.skipped.is_empty() && agents_installed == 0
-    {
-        if skill_filter.is_some() {
-            bail!("no skills were installed from '{plugin_ref}'");
-        }
-        bail!("no skills or agents were installed from '{plugin_ref}'");
+    let nothing_installed = skill_result.installed.is_empty()
+        && skill_result.skipped.is_empty()
+        && agent_result.installed.is_empty()
+        && agent_result.skipped.is_empty();
+    if nothing_installed && agent_result.failed.is_empty() && skill_result.failed.is_empty() {
+        let kind = if skill_filter.is_some() {
+            "skills"
+        } else {
+            "skills or agents"
+        };
+        bail!("no {kind} were installed from '{plugin_ref}'");
+    }
+
+    // Any per-agent or per-skill failure surfaces as a non-zero exit so CI
+    // catches partial-success regressions.
+    if !agent_result.failed.is_empty() || !skill_result.failed.is_empty() {
+        bail!(
+            "{} item{} failed during install from '{plugin_ref}'",
+            agent_result.failed.len() + skill_result.failed.len(),
+            if agent_result.failed.len() + skill_result.failed.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
     }
 
     Ok(())
@@ -148,18 +159,28 @@ fn agent_scan_paths(plugin_manifest: Option<&PluginManifest>) -> Vec<String> {
     }
 }
 
-/// Render the agent install summary and any warnings. Warnings go to
-/// stderr so they don't pollute stdout piping, matching the skill flow.
-fn print_agent_outcome(installed: usize, warnings: &[InstallWarning]) {
-    if installed > 0 {
+/// Render the agent install summary plus any warnings and per-agent
+/// failures. Warnings and failures go to stderr so they don't pollute
+/// stdout piping, matching the skill flow.
+fn print_agent_outcome(result: &InstallAgentsResult) {
+    for name in &result.installed {
+        println!("  {} Installed agent '{}'", "✓".green().bold(), name.bold());
+    }
+    for name in &result.skipped {
         println!(
-            "  {} Installed {} agent{}",
-            "✓".green().bold(),
-            installed,
-            if installed == 1 { "" } else { "s" }
+            "  {} Agent '{}' already installed",
+            "·".yellow().bold(),
+            name.bold()
         );
     }
-    for w in warnings {
+    for FailedAgent { name, error } in &result.failed {
+        eprintln!(
+            "  {} Failed to install agent '{}': {error}",
+            "✗".red().bold(),
+            name
+        );
+    }
+    for w in &result.warnings {
         eprintln!("  {} {w}", "!".yellow().bold());
     }
 }

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -11,7 +11,7 @@ use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource}
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
-    FailedSkill, InstallFilter, InstallSkillsResult, MarketplaceService,
+    FailedSkill, InstallFilter, InstallSkillsResult, InstallWarning, MarketplaceService,
 };
 use tracing::{debug, warn};
 
@@ -70,39 +70,98 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
 
     let plugin_manifest = load_plugin_manifest(&plugin_dir);
     let skill_dirs = discover_plugin_skills(&plugin_dir, plugin_manifest.as_ref());
-
-    if skill_dirs.is_empty() {
-        bail!("no skills found in plugin '{plugin_name}'");
-    }
+    let agent_scan_paths = agent_scan_paths(plugin_manifest.as_ref());
 
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let project = KiroProject::new(cwd);
     let version = plugin_manifest.as_ref().and_then(|m| m.version.clone());
 
-    // Build a one-off service just to drive `install_skills` — the CLI only
-    // needs the install loop here, not the full add/update lifecycle.
+    // Build a one-off service just to drive the install loops — the CLI only
+    // needs the install calls here, not the full add/update lifecycle.
     let svc = MarketplaceService::new(cache.clone(), GixCliBackend::default());
-    let filter = match skill_filter {
-        Some(name) => InstallFilter::SingleName(name),
-        None => InstallFilter::All,
+
+    let skill_result = if skill_dirs.is_empty() {
+        InstallSkillsResult::default()
+    } else {
+        let filter = match skill_filter {
+            Some(name) => InstallFilter::SingleName(name),
+            None => InstallFilter::All,
+        };
+        svc.install_skills(
+            &project,
+            &skill_dirs,
+            &filter,
+            force,
+            marketplace_name,
+            plugin_name,
+            version.as_deref(),
+        )
     };
-    let result = svc.install_skills(
-        &project,
-        &skill_dirs,
-        &filter,
-        force,
-        marketplace_name,
-        plugin_name,
-        version.as_deref(),
-    );
+    print_install_outcome(plugin_ref, &skill_result);
 
-    print_install_outcome(plugin_ref, &result);
+    // Agents: only run when the user did NOT pass `--skill <name>`. A skill
+    // filter narrows the install to one skill and never includes agents.
+    let (agents_installed, agent_warnings) = if skill_filter.is_none() {
+        match svc.install_plugin_agents(
+            &project,
+            &plugin_dir,
+            &agent_scan_paths,
+            marketplace_name,
+            plugin_name,
+            version.as_deref(),
+        ) {
+            Ok(tup) => tup,
+            Err(e) => {
+                eprintln!(
+                    "  {} Agent install failed: {}",
+                    "✗".red().bold(),
+                    format_args!("{e}")
+                );
+                (0, Vec::new())
+            }
+        }
+    } else {
+        (0, Vec::new())
+    };
+    print_agent_outcome(agents_installed, &agent_warnings);
 
-    if result.installed.is_empty() && result.skipped.is_empty() {
-        bail!("no skills were installed from '{plugin_ref}'");
+    if skill_result.installed.is_empty() && skill_result.skipped.is_empty() && agents_installed == 0
+    {
+        if skill_filter.is_some() {
+            bail!("no skills were installed from '{plugin_ref}'");
+        }
+        bail!("no skills or agents were installed from '{plugin_ref}'");
     }
 
     Ok(())
+}
+
+/// Resolve the list of agent scan paths for a plugin.
+fn agent_scan_paths(plugin_manifest: Option<&PluginManifest>) -> Vec<String> {
+    if let Some(m) = plugin_manifest.filter(|m| !m.agents.is_empty()) {
+        m.agents.clone()
+    } else {
+        kiro_market_core::DEFAULT_AGENT_PATHS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect()
+    }
+}
+
+/// Render the agent install summary and any warnings. Warnings go to
+/// stderr so they don't pollute stdout piping, matching the skill flow.
+fn print_agent_outcome(installed: usize, warnings: &[InstallWarning]) {
+    if installed > 0 {
+        println!(
+            "  {} Installed {} agent{}",
+            "✓".green().bold(),
+            installed,
+            if installed == 1 { "" } else { "s" }
+        );
+    }
+    for w in warnings {
+        eprintln!("  {} {w}", "!".yellow().bold());
+    }
 }
 
 /// Discover skill directories from a plugin, using its manifest or defaults.

--- a/docs/plans/2026-04-16-agent-import-plan.md
+++ b/docs/plans/2026-04-16-agent-import-plan.md
@@ -1,0 +1,2235 @@
+# Agent Import Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Import Claude-style and Copilot-style markdown agents from plugins into Kiro projects as JSON config files plus externalized prompt files, with best-effort tool-name mapping.
+
+**Architecture:** A new `agent` module in `kiro-market-core` parses two source dialects (Claude `.md` and Copilot `.agent.md`) into a shared `AgentDefinition`, then emits a Kiro-compatible `{name}.json` next to a `prompts/{name}.md` file. The JSON's `prompt` field uses Kiro's `file://` URI scheme (`file://./prompts/{name}.md`) so the `.md` remains the live source of truth. Installs are tracked in a new `installed-agents.json`, parallel to the existing `installed-skills.json`. `MarketplaceService::add()` discovers both skills and agents during install and surfaces warnings (dropped tools, unmapped models) in a structured `InstallWarning` list that the CLI renders.
+
+**Tech Stack:** Rust edition 2024, `serde` / `serde_json` / `serde_yaml`, `thiserror`, `tracing`, `rstest`, `tempfile`
+
+**Non-goals (deferred):**
+- Support for awesome-copilot repos that are not Claude Code plugins (no `plugin.json`).
+- Interactive tool-mapping prompts at install time.
+- Converting agent `hooks` frontmatter (Claude agents rarely declare these).
+
+---
+
+### Task 1: Add `AgentError` variants and `Error::Agent` wrapper
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/error.rs` (add `AgentError` enum between `SkillError` and `GitError`; add `Agent(#[from] AgentError)` variant to `Error`; extend the display rstest)
+
+**Step 1: Write the failing tests**
+
+Add to the `mod tests` in `error.rs`:
+
+```rust
+#[rstest]
+#[case::agent_already_installed(
+    AgentError::AlreadyInstalled { name: "reviewer".into() },
+    "agent `reviewer` is already installed"
+)]
+#[case::agent_not_installed(
+    AgentError::NotInstalled { name: "missing".into() },
+    "agent `missing` is not installed"
+)]
+#[case::agent_parse_failed(
+    AgentError::ParseFailed { path: PathBuf::from("a.md"), reason: "bad yaml".into() },
+    "failed to parse agent at a.md: bad yaml"
+)]
+#[case::agent_missing_name(
+    AgentError::MissingName { path: PathBuf::from("a.md") },
+    "agent at a.md is missing required `name` field"
+)]
+fn agent_error_display(#[case] err: AgentError, #[case] expected: &str) {
+    assert_eq!(err.to_string(), expected);
+}
+
+#[test]
+fn from_agent_error() {
+    let inner = AgentError::NotInstalled { name: "x".into() };
+    let err: Error = inner.into();
+    assert!(matches!(err, Error::Agent(_)));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core -- agent_error`
+Expected: compile error — `AgentError` does not exist.
+
+**Step 3: Add `AgentError` and `Error::Agent`**
+
+Insert between `SkillError` and `GitError` sections:
+
+```rust
+// ---------------------------------------------------------------------------
+// Agent errors
+// ---------------------------------------------------------------------------
+
+/// Errors related to agent operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AgentError {
+    /// The agent is already installed in the target project.
+    #[error("agent `{name}` is already installed")]
+    AlreadyInstalled { name: String },
+
+    /// The agent is not installed in the target project.
+    #[error("agent `{name}` is not installed")]
+    NotInstalled { name: String },
+
+    /// The source markdown could not be parsed.
+    #[error("failed to parse agent at {path}: {reason}")]
+    ParseFailed { path: PathBuf, reason: String },
+
+    /// Frontmatter lacks a required `name` field.
+    #[error("agent at {path} is missing required `name` field")]
+    MissingName { path: PathBuf },
+}
+```
+
+Add the `From` variant to `Error`:
+
+```rust
+    #[error(transparent)]
+    Agent(#[from] AgentError),
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core -- agent_error`
+Expected: PASS (4 cases).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/error.rs
+git commit -m "feat: add AgentError variants for agent install domain"
+```
+
+---
+
+### Task 2: Create `AgentDefinition` common type
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/mod.rs`
+- Create: `crates/kiro-market-core/src/agent/types.rs`
+- Modify: `crates/kiro-market-core/src/lib.rs` (add `pub mod agent;`)
+
+**Step 1: Write the failing test**
+
+Create `crates/kiro-market-core/src/agent/types.rs`:
+
+```rust
+//! Dialect-agnostic representation of an agent after parsing.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Which source dialect the agent came from. Used for applying
+/// dialect-specific tool-mapping rules and for warnings.
+///
+/// Serializes to `"claude"` / `"copilot"` so it can live directly in the
+/// installed-agents tracking file without a string sidecar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentDialect {
+    Claude,
+    Copilot,
+}
+
+/// Agent definition normalized across Claude and Copilot source formats.
+///
+/// This is what both parsers produce and what the emitter consumes.
+#[derive(Debug, Clone)]
+pub struct AgentDefinition {
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt_body: String,
+    pub model: Option<String>,
+    /// Raw tool identifiers from the source frontmatter (pre-mapping).
+    pub source_tools: Vec<String>,
+    /// MCP server entries as captured from Copilot `mcp-servers:` frontmatter.
+    /// Serialized opaquely and passed through to Kiro's `mcpServers` field.
+    pub mcp_servers: BTreeMap<String, serde_json::Value>,
+    pub dialect: AgentDialect,
+}
+```
+
+Add `pub mod types;` and `pub use types::{AgentDefinition, AgentDialect};` to `crates/kiro-market-core/src/agent/mod.rs`.
+
+Add `pub mod agent;` to `crates/kiro-market-core/src/lib.rs` (alphabetically, after `cache`).
+
+Add a smoke test at the bottom of `agent/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn agent_definition_constructs_with_minimum_fields() {
+        let def = AgentDefinition {
+            name: "reviewer".into(),
+            description: None,
+            prompt_body: "You are a reviewer.".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: BTreeMap::new(),
+            dialect: AgentDialect::Claude,
+        };
+        assert_eq!(def.name, "reviewer");
+    }
+}
+```
+
+**Step 2: Run test to verify it compiles and passes**
+
+Run: `cargo test -p kiro-market-core --lib agent::`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/ crates/kiro-market-core/src/lib.rs
+git commit -m "feat: add AgentDefinition common type for agent parsing"
+```
+
+---
+
+### Task 3: Parse Claude-style agent frontmatter
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/frontmatter.rs` (shared `split_frontmatter` helper, dialect-agnostic)
+- Create: `crates/kiro-market-core/src/agent/parse_claude.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `mod frontmatter; mod parse_claude; pub use parse_claude::parse_claude_agent;`)
+
+**Why a shared `frontmatter` module:** Both Claude and Copilot parsers need identical YAML-fence splitting. Putting the helper in its own module avoids the layering hack of one parser reaching into the other's `pub(super)` shim (which the original draft of Task 4 introduced).
+
+**Step 1: Write the failing tests**
+
+In `agent/parse_claude.rs` add a `mod tests` section:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "---\nname: code-reviewer\ndescription: Reviews code\nmodel: opus\ncolor: green\n---\n\nYou are a code reviewer.\n";
+
+    #[test]
+    fn parse_extracts_name_description_model() {
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert_eq!(def.name, "code-reviewer");
+        assert_eq!(def.description.as_deref(), Some("Reviews code"));
+        assert_eq!(def.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn parse_extracts_body_trimming_fence_newline() {
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert!(def.prompt_body.starts_with("You are a code reviewer."));
+    }
+
+    #[test]
+    fn parse_drops_color_field_silently() {
+        // color has no Kiro equivalent and should not appear in source_tools or as model.
+        let def = parse_claude_agent(SAMPLE).expect("parse");
+        assert!(def.source_tools.is_empty());
+    }
+
+    #[test]
+    fn parse_model_inherit_becomes_none() {
+        let src = "---\nname: a\nmodel: inherit\n---\nbody\n";
+        let def = parse_claude_agent(src).expect("parse");
+        assert!(def.model.is_none(), "model: inherit should be normalized to None");
+    }
+
+    #[test]
+    fn parse_missing_name_errors() {
+        let src = "---\ndescription: x\n---\nbody\n";
+        let err = parse_claude_agent(src).unwrap_err();
+        assert!(err.to_string().contains("name"));
+    }
+
+    #[test]
+    fn parse_tools_frontmatter_captured_in_source_tools() {
+        let src = "---\nname: a\ntools: [Read, Write, Bash]\n---\nbody\n";
+        let def = parse_claude_agent(src).expect("parse");
+        assert_eq!(def.source_tools, vec!["Read", "Write", "Bash"]);
+    }
+
+    #[test]
+    fn parse_invalid_yaml_errors() {
+        let src = "---\nname: [unclosed\n---\nbody\n";
+        assert!(parse_claude_agent(src).is_err());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse_claude`
+Expected: compile error — `parse_claude_agent` does not exist.
+
+**Step 3: Implement the shared splitter and the Claude parser**
+
+Create `crates/kiro-market-core/src/agent/frontmatter.rs`:
+
+```rust
+//! Dialect-agnostic YAML frontmatter splitter.
+//!
+//! Both Claude (`*.md`) and Copilot (`*.agent.md`) agents use the same
+//! `---`-fenced frontmatter convention, so the fence-handling logic lives
+//! in one place rather than being duplicated (or worse, reached into via
+//! a `pub(super)` shim) between the two parsers.
+
+/// Split `---`-fenced YAML frontmatter from the body. Returns `(yaml, body)`.
+///
+/// # Errors
+///
+/// Returns a human-readable error if the opening or closing fence is missing.
+pub(super) fn split_frontmatter(content: &str) -> Result<(&str, &str), String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Err("missing opening `---` frontmatter fence".into());
+    }
+    let after_open = trimmed[3..]
+        .strip_prefix('\n')
+        .or_else(|| trimmed[3..].strip_prefix("\r\n"))
+        .unwrap_or(&trimmed[3..]);
+    let Some(close_pos) = after_open.find("\n---") else {
+        return Err("unclosed frontmatter: missing closing `---` fence".into());
+    };
+    let yaml = &after_open[..close_pos];
+    let body_start = &after_open[close_pos + 4..];
+    let body = body_start
+        .strip_prefix('\n')
+        .or_else(|| body_start.strip_prefix("\r\n"))
+        .unwrap_or(body_start);
+    Ok((yaml, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_simple_frontmatter() {
+        let (yaml, body) = split_frontmatter("---\nname: a\n---\nbody\n").unwrap();
+        assert_eq!(yaml, "name: a");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn missing_open_fence_errors() {
+        assert!(split_frontmatter("body\n").is_err());
+    }
+
+    #[test]
+    fn missing_close_fence_errors() {
+        assert!(split_frontmatter("---\nname: a\nbody\n").is_err());
+    }
+}
+```
+
+Create `crates/kiro-market-core/src/agent/parse_claude.rs`:
+
+```rust
+//! Parse Claude-style agent markdown files.
+//!
+//! Claude agents have YAML frontmatter with: `name` (required),
+//! `description`, `model` (`opus`/`sonnet`/`inherit`), `color` (dropped),
+//! and optional `tools` (a list of PascalCase tool names).
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use super::frontmatter::split_frontmatter;
+use super::types::{AgentDefinition, AgentDialect};
+
+#[derive(Debug, Deserialize)]
+struct ClaudeFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    model: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    // `color` is intentionally unmodeled — not in Kiro schema, silently dropped.
+}
+
+/// Parse a Claude-style `.md` agent file into an `AgentDefinition`.
+///
+/// # Errors
+///
+/// Returns a string describing the parse failure. The caller wraps this
+/// into `AgentError::ParseFailed` or `AgentError::MissingName` with the
+/// source path attached.
+pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, String> {
+    let (yaml_block, body) = split_frontmatter(content)?;
+    let fm: ClaudeFrontmatter = serde_yaml::from_str(yaml_block)
+        .map_err(|e| format!("invalid YAML: {e}"))?;
+
+    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+    // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
+    // so the Kiro emitter omits the field and defers to the CLI default.
+    let model = fm.model.filter(|m| m != "inherit");
+
+    Ok(AgentDefinition {
+        name,
+        description: fm.description,
+        prompt_body: body.to_string(),
+        model,
+        source_tools: fm.tools,
+        mcp_servers: BTreeMap::new(),
+        dialect: AgentDialect::Claude,
+    })
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+mod frontmatter;
+mod parse_claude;
+pub use parse_claude::parse_claude_agent;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse_claude`
+Expected: PASS (7 cases).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: parse Claude-style agent markdown frontmatter"
+```
+
+---
+
+### Task 4: Parse Copilot-style agent frontmatter
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/parse_copilot.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `mod parse_copilot; pub use parse_copilot::parse_copilot_agent;`)
+
+**Step 1: Write the failing tests**
+
+In `agent/parse_copilot.rs` add `mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TERRAFORM: &str = r#"---
+name: Terraform Agent
+description: "Terraform specialist"
+tools: ['read', 'edit', 'search', 'shell', 'terraform/*']
+mcp-servers:
+  terraform:
+    type: 'local'
+    command: 'docker'
+    args: ['run', '-i', 'hashicorp/terraform-mcp-server:latest']
+    tools: ["*"]
+---
+
+Body text.
+"#;
+
+    #[test]
+    fn parse_extracts_name_and_body() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(def.name, "Terraform Agent");
+        assert!(def.prompt_body.starts_with("Body text."));
+    }
+
+    #[test]
+    fn parse_captures_tools_list_verbatim() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(
+            def.source_tools,
+            vec!["read", "edit", "search", "shell", "terraform/*"]
+        );
+    }
+
+    #[test]
+    fn parse_captures_mcp_servers_as_opaque_json() {
+        let def = parse_copilot_agent(TERRAFORM).expect("parse");
+        assert_eq!(def.mcp_servers.len(), 1);
+        let tf = def.mcp_servers.get("terraform").expect("terraform entry");
+        // `type: 'local'` is preserved opaquely; normalization happens at emit time.
+        assert_eq!(tf["type"], "local");
+        assert_eq!(tf["command"], "docker");
+    }
+
+    #[test]
+    fn parse_drops_display_model_name() {
+        // Copilot model values are display names, not IDs. Per design decision,
+        // we drop them and let Kiro use the default model.
+        let src = "---\nname: a\nmodel: Claude Sonnet 4\n---\nbody\n";
+        let def = parse_copilot_agent(src).expect("parse");
+        assert!(def.model.is_none(), "display-name model should be dropped");
+    }
+
+    #[test]
+    fn parse_missing_name_errors() {
+        let src = "---\ndescription: x\n---\nbody\n";
+        assert!(parse_copilot_agent(src).is_err());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse_copilot`
+Expected: compile error.
+
+**Step 3: Implement the parser**
+
+Create `crates/kiro-market-core/src/agent/parse_copilot.rs`:
+
+```rust
+//! Parse Copilot-style `*.agent.md` files.
+//!
+//! Copilot frontmatter differs from Claude's in notable ways:
+//! - `model` holds display names (`Claude Sonnet 4`), not model IDs.
+//!   We drop it — the user can edit the emitted JSON to set a real ID.
+//! - `mcp-servers` is a nested map of server configs (kebab-case key).
+//!   We capture it opaquely as `serde_json::Value` and translate at emit time.
+//! - `tools` uses mixed conventions (bare names, `namespace/tool`,
+//!   `server/*` wildcards). We keep raw strings; mapping lives elsewhere.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use super::frontmatter::split_frontmatter;
+use super::types::{AgentDefinition, AgentDialect};
+
+#[derive(Debug, Deserialize)]
+struct CopilotFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    #[serde(rename = "mcp-servers", default)]
+    mcp_servers: BTreeMap<String, serde_json::Value>,
+    // `model` intentionally not modeled — Copilot uses display names (e.g.
+    // "Claude Sonnet 4") which cannot be mapped to Kiro model IDs.
+}
+
+/// Parse a Copilot-style `.agent.md` file into an `AgentDefinition`.
+pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, String> {
+    let (yaml, body) = split_frontmatter(content)?;
+    let fm: CopilotFrontmatter = serde_yaml::from_str(yaml)
+        .map_err(|e| format!("invalid YAML: {e}"))?;
+
+    let name = fm.name.ok_or_else(|| "missing `name` field".to_string())?;
+
+    Ok(AgentDefinition {
+        name,
+        description: fm.description,
+        prompt_body: body.to_string(),
+        model: None,
+        source_tools: fm.tools,
+        mcp_servers: fm.mcp_servers,
+        dialect: AgentDialect::Copilot,
+    })
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+mod parse_copilot;
+pub use parse_copilot::parse_copilot_agent;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse_copilot`
+Expected: PASS (5 cases).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: parse Copilot-style agent markdown frontmatter"
+```
+
+---
+
+### Task 5: Dialect detection by filename
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/parse.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `mod parse; pub use parse::parse_agent_file;`)
+
+**Step 1: Write the failing tests**
+
+In `agent/parse.rs` add `mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn detects_copilot_by_agent_md_suffix() {
+        assert_eq!(
+            detect_dialect(Path::new("foo.agent.md")),
+            AgentDialect::Copilot
+        );
+        assert_eq!(
+            detect_dialect(Path::new("/a/b/c.agent.md")),
+            AgentDialect::Copilot
+        );
+    }
+
+    #[test]
+    fn detects_claude_for_plain_md() {
+        assert_eq!(
+            detect_dialect(Path::new("reviewer.md")),
+            AgentDialect::Claude
+        );
+    }
+
+    #[test]
+    fn parse_agent_file_dispatches_by_dialect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("sample.agent.md");
+        std::fs::write(
+            &path,
+            "---\nname: sample\n---\nbody\n",
+        ).unwrap();
+        let def = parse_agent_file(&path).expect("parse");
+        assert_eq!(def.dialect, AgentDialect::Copilot);
+        assert_eq!(def.name, "sample");
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse::`
+Expected: compile error.
+
+**Step 3: Implement dispatch**
+
+Create `crates/kiro-market-core/src/agent/parse.rs`:
+
+```rust
+//! Dialect detection and top-level parser dispatch.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::AgentError;
+
+use super::types::{AgentDefinition, AgentDialect};
+use super::{parse_claude_agent, parse_copilot_agent};
+
+/// Detect the source dialect from a filename.
+///
+/// Filenames ending in `.agent.md` are treated as Copilot; everything else
+/// as Claude. The `.agent.md` double-extension is the Copilot community
+/// convention (see `awesome-copilot/agents/`).
+pub fn detect_dialect(path: &Path) -> AgentDialect {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if name.ends_with(".agent.md") {
+        AgentDialect::Copilot
+    } else {
+        AgentDialect::Claude
+    }
+}
+
+/// Read and parse an agent file, dispatching to the correct dialect parser.
+pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, AgentError> {
+    let content = fs::read_to_string(path).map_err(|e| AgentError::ParseFailed {
+        path: path.to_path_buf(),
+        reason: format!("read failed: {e}"),
+    })?;
+    let dialect = detect_dialect(path);
+    let result = match dialect {
+        AgentDialect::Claude => parse_claude_agent(&content),
+        AgentDialect::Copilot => parse_copilot_agent(&content),
+    };
+    result.map_err(|reason| {
+        if reason.contains("missing `name`") {
+            AgentError::MissingName { path: path.to_path_buf() }
+        } else {
+            AgentError::ParseFailed { path: path.to_path_buf(), reason }
+        }
+    })
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+mod parse;
+pub use parse::{detect_dialect, parse_agent_file};
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::parse::`
+Expected: PASS (3 cases).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: detect Claude vs Copilot agent dialect from filename"
+```
+
+---
+
+### Task 6: Tool-name mapping (Claude dialect)
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/tools.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `pub mod tools;`)
+
+**Step 0: Verify the Kiro tool-name table**
+
+Before writing the table, confirm the actual Kiro CLI tool names. The table below is provisional. Check by running:
+
+```bash
+# In a Kiro install:
+kiro --help            # or the equivalent introspection command
+# Or grep the Kiro source / agent-schema.json examples for tool name strings.
+```
+
+If the canonical names differ (e.g. Kiro uses `fs_read` instead of `read`), update the table in Step 3 before continuing. This is the single point where a wrong assumption silently corrupts every emitted agent — verify once, hard-code with confidence.
+
+**Step 1: Write the failing tests**
+
+In `agent/tools.rs` add `mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("Read", Some("read"))]
+    #[case("Write", Some("write"))]
+    #[case("Edit", Some("write"))]
+    #[case("Bash", Some("shell"))]
+    #[case("Grep", Some("grep"))]
+    #[case("Glob", Some("glob"))]
+    #[case("WebFetch", Some("web_fetch"))]
+    #[case("WebSearch", Some("web_search"))]
+    #[case("TodoWrite", Some("todo"))]
+    #[case("Task", Some("subagent"))]
+    #[case("NotebookEdit", None)]
+    #[case("Skill", None)]
+    #[case("Unknown", None)]
+    fn claude_tool_maps_to_kiro(#[case] input: &str, #[case] expected: Option<&str>) {
+        assert_eq!(map_claude_tool(input), expected.map(String::from));
+    }
+
+    #[test]
+    fn map_claude_tools_returns_native_mapped_tools() {
+        let (mapped, unmapped) = map_claude_tools(&[
+            "Read".into(),
+            "NotebookEdit".into(),
+            "Skill".into(),
+        ]);
+        assert_eq!(mapped, vec![MappedTool::Native("read".into())]);
+        assert_eq!(
+            unmapped,
+            vec![
+                UnmappedTool { source: "NotebookEdit".into(), reason: UnmappedReason::NoKiroEquivalent },
+                UnmappedTool { source: "Skill".into(), reason: UnmappedReason::NoKiroEquivalent },
+            ]
+        );
+    }
+
+    #[test]
+    fn map_claude_tools_dedupes_write_from_edit_and_write() {
+        let (mapped, _) = map_claude_tools(&["Edit".into(), "Write".into()]);
+        assert_eq!(mapped, vec![MappedTool::Native("write".into())]);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::tools::`
+Expected: compile error.
+
+**Step 3: Implement the structured types and the Claude tool map**
+
+Create `crates/kiro-market-core/src/agent/tools.rs`:
+
+```rust
+//! Source-to-Kiro tool name mapping.
+//!
+//! Tools land in two different fields of the emitted agent JSON:
+//! - native tool names (`read`, `shell`, etc.) → `allowedTools`
+//! - MCP server references (`@server`, `@server/tool`) → `tools`
+//!
+//! The mapper returns a typed `MappedTool` so the emitter can route each
+//! result to the correct field without re-parsing strings. Unmapped source
+//! tools are returned structurally (not as pre-rendered messages) so callers
+//! can re-render them as `InstallWarning` variants without string surgery.
+
+/// A single source tool that has been successfully mapped to a Kiro identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MappedTool {
+    /// Native Kiro tool. Routed to `allowedTools` in the emitted JSON.
+    Native(String),
+    /// MCP server reference (`@server` or `@server/tool`). Routed to `tools`.
+    McpRef(String),
+}
+
+/// A source tool that could not be mapped to any Kiro identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnmappedTool {
+    pub source: String,
+    pub reason: UnmappedReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum UnmappedReason {
+    /// Claude PascalCase name with no Kiro equivalent (e.g. `NotebookEdit`).
+    NoKiroEquivalent,
+    /// Copilot bare name (e.g. `codebase`, `findTestFiles`) — internal Copilot
+    /// concept with no reliable Kiro mapping.
+    BareCopilotName,
+}
+
+/// Look up the Kiro tool name for a Claude-style PascalCase tool name.
+///
+/// Returns `None` for tools with no Kiro equivalent. The caller is expected
+/// to surface a warning for `None` results so the user knows the restriction
+/// will not carry over.
+#[must_use]
+pub fn map_claude_tool(name: &str) -> Option<String> {
+    // NOTE: Names verified in Step 0. Update this table if Kiro names diverge.
+    let mapped = match name {
+        "Read" => "read",
+        "Write" | "Edit" => "write",
+        "Bash" => "shell",
+        "Grep" => "grep",
+        "Glob" => "glob",
+        "WebFetch" => "web_fetch",
+        "WebSearch" => "web_search",
+        "TodoWrite" => "todo",
+        "Task" => "subagent",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+/// Map a list of Claude tool names, returning the deduped Kiro list and a
+/// vector of structured records for tools that had no mapping.
+#[must_use]
+pub fn map_claude_tools(source: &[String]) -> (Vec<MappedTool>, Vec<UnmappedTool>) {
+    let mut mapped: Vec<MappedTool> = Vec::new();
+    let mut unmapped: Vec<UnmappedTool> = Vec::new();
+    for tool in source {
+        match map_claude_tool(tool) {
+            Some(kiro) => {
+                let entry = MappedTool::Native(kiro);
+                if !mapped.contains(&entry) {
+                    mapped.push(entry);
+                }
+            }
+            None => unmapped.push(UnmappedTool {
+                source: tool.clone(),
+                reason: UnmappedReason::NoKiroEquivalent,
+            }),
+        }
+    }
+    (mapped, unmapped)
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+pub mod tools;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::tools::`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: map Claude PascalCase tool names to Kiro tool names"
+```
+
+---
+
+### Task 7: Tool-name mapping (Copilot dialect)
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/agent/tools.rs`
+
+**Step 1: Write the failing tests**
+
+Add to `mod tests`:
+
+```rust
+#[test]
+fn copilot_mcp_wildcard_maps_to_kiro_server_ref() {
+    let (mapped, unmapped) = map_copilot_tools(&[
+        "terraform/*".into(),
+        "playwright/click".into(),
+    ]);
+    assert_eq!(
+        mapped,
+        vec![
+            MappedTool::McpRef("@terraform".into()),
+            MappedTool::McpRef("@playwright/click".into()),
+        ]
+    );
+    assert!(unmapped.is_empty());
+}
+
+#[test]
+fn copilot_bare_names_drop_with_structured_reason() {
+    let (mapped, unmapped) = map_copilot_tools(&[
+        "codebase".into(),
+        "findTestFiles".into(),
+        "problems".into(),
+    ]);
+    assert!(mapped.is_empty());
+    assert_eq!(unmapped.len(), 3);
+    assert!(unmapped.iter().all(|u| u.reason == UnmappedReason::BareCopilotName));
+    assert_eq!(unmapped[0].source, "codebase");
+}
+
+#[test]
+fn copilot_mixed_list_preserves_mcp_refs_drops_bare() {
+    let (mapped, unmapped) = map_copilot_tools(&[
+        "edit/editFiles".into(),
+        "terraform/*".into(),
+        "codebase".into(),
+    ]);
+    // edit/editFiles looks like MCP syntax but `edit` is not a known MCP server
+    // in this agent; we pass it through as @edit/editFiles regardless.
+    // The user can clean up in the emitted JSON.
+    assert!(mapped.contains(&MappedTool::McpRef("@edit/editFiles".into())));
+    assert!(mapped.contains(&MappedTool::McpRef("@terraform".into())));
+    assert_eq!(unmapped.len(), 1);
+    assert_eq!(unmapped[0].source, "codebase");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::tools::copilot`
+Expected: compile error.
+
+**Step 3: Implement the Copilot tool map**
+
+Add to `agent/tools.rs`:
+
+```rust
+/// Map a list of Copilot source tool names to Kiro identifiers.
+///
+/// Copilot tools use mixed conventions:
+/// - `{server}/*`     → `MappedTool::McpRef("@{server}")`        (whole-server access)
+/// - `{server}/{tool}` → `MappedTool::McpRef("@{server}/{tool}")` (specific MCP tool)
+/// - bare names (`codebase`, `findTestFiles`) → unmapped (BareCopilotName)
+///
+/// The bare-name drop is intentional per the design discussion: Copilot's
+/// bare names are internal GitHub Copilot concepts with no reliable Kiro
+/// equivalent. Users see the source tool list in the install output and
+/// can restrict the emitted agent manually if desired.
+#[must_use]
+pub fn map_copilot_tools(source: &[String]) -> (Vec<MappedTool>, Vec<UnmappedTool>) {
+    let mut mapped: Vec<MappedTool> = Vec::new();
+    let mut unmapped: Vec<UnmappedTool> = Vec::new();
+    for tool in source {
+        if let Some((server, rest)) = tool.split_once('/') {
+            let kiro = if rest == "*" {
+                format!("@{server}")
+            } else {
+                format!("@{server}/{rest}")
+            };
+            let entry = MappedTool::McpRef(kiro);
+            if !mapped.contains(&entry) {
+                mapped.push(entry);
+            }
+        } else {
+            unmapped.push(UnmappedTool {
+                source: tool.clone(),
+                reason: UnmappedReason::BareCopilotName,
+            });
+        }
+    }
+    (mapped, unmapped)
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::tools`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/tools.rs
+git commit -m "feat: map Copilot MCP tool refs to Kiro; drop bare names with warnings"
+```
+
+---
+
+### Task 8: Emit Kiro agent JSON + externalized prompt
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/emit.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `pub mod emit;`)
+
+**Step 0: Verify the Kiro agent schema**
+
+Read `agent-schema.json` at the repo root before writing the emitter. Confirm:
+- `tools` field holds MCP refs (`@server`, `@server/tool`) per the schema description.
+- `allowedTools` field holds explicit allowlist entries with `uniqueItems: true`.
+- `mcpServers.<name>` follows the `CustomToolConfig` shape — find the `$defs/CustomToolConfig` block and note the allowed values for `type` (e.g. `stdio`, `http`, etc.). The `local → stdio` rewrite below is a placeholder; if the schema accepts `local` directly or uses different vocabulary, adjust.
+
+If the schema disagrees with assumptions in the test bodies below, change the tests first, then code to them.
+
+**Step 1: Write the failing tests**
+
+In `agent/emit.rs` add `mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::tools::MappedTool;
+    use crate::agent::types::{AgentDefinition, AgentDialect};
+    use std::collections::BTreeMap;
+
+    fn sample_claude_def() -> AgentDefinition {
+        AgentDefinition {
+            name: "reviewer".into(),
+            description: Some("Reviews code".into()),
+            prompt_body: "You are a reviewer.\n".into(),
+            model: Some("opus".into()),
+            source_tools: vec!["Read".into(), "Bash".into()],
+            mcp_servers: BTreeMap::new(),
+            dialect: AgentDialect::Claude,
+        }
+    }
+
+    #[test]
+    fn emit_sets_prompt_to_file_uri_relative_to_config() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert_eq!(out["name"], "reviewer");
+        assert_eq!(out["prompt"], "file://./prompts/reviewer.md");
+    }
+
+    #[test]
+    fn emit_includes_description_and_model_when_present() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert_eq!(out["description"], "Reviews code");
+        assert_eq!(out["model"], "opus");
+    }
+
+    #[test]
+    fn emit_omits_model_when_none() {
+        let mut def = sample_claude_def();
+        def.model = None;
+        let out = build_kiro_json(&def, &[]).unwrap();
+        assert!(out.get("model").is_none());
+    }
+
+    #[test]
+    fn emit_routes_native_tools_into_allowed_tools() {
+        let mapped = vec![
+            MappedTool::Native("read".into()),
+            MappedTool::Native("shell".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        let allowed = out["allowedTools"].as_array().unwrap();
+        assert_eq!(allowed, &vec![
+            serde_json::Value::String("read".into()),
+            serde_json::Value::String("shell".into()),
+        ]);
+        // Native names must NOT leak into `tools` (which is for MCP refs).
+        assert!(out.get("tools").is_none(),
+            "no MCP refs in this list — `tools` field must be omitted");
+    }
+
+    #[test]
+    fn emit_routes_mcp_refs_into_tools_field() {
+        let mapped = vec![
+            MappedTool::McpRef("@terraform".into()),
+            MappedTool::McpRef("@playwright/click".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        let tools = out["tools"].as_array().unwrap();
+        assert_eq!(tools[0], "@terraform");
+        assert_eq!(tools[1], "@playwright/click");
+        assert!(out.get("allowedTools").is_none(),
+            "no native names — `allowedTools` field must be omitted");
+    }
+
+    #[test]
+    fn emit_routes_mixed_lists_to_both_fields() {
+        let mapped = vec![
+            MappedTool::Native("read".into()),
+            MappedTool::McpRef("@terraform".into()),
+        ];
+        let out = build_kiro_json(&sample_claude_def(), &mapped).unwrap();
+        assert_eq!(out["allowedTools"][0], "read");
+        assert_eq!(out["tools"][0], "@terraform");
+    }
+
+    #[test]
+    fn emit_omits_tool_arrays_when_empty() {
+        let out = build_kiro_json(&sample_claude_def(), &[]).unwrap();
+        assert!(out.get("allowedTools").is_none());
+        assert!(out.get("tools").is_none(),
+            "empty tool list must omit both arrays so Kiro inherits full parent toolset");
+    }
+
+    #[test]
+    fn emit_normalizes_mcp_server_type_local_to_stdio() {
+        // PRE-CONDITION: confirmed in Step 0 that Kiro's CustomToolConfig
+        // accepts `stdio`. If the schema names this differently, update both
+        // the assertion and `normalize_mcp_server`.
+        let mut def = sample_claude_def();
+        def.mcp_servers.insert(
+            "terraform".into(),
+            serde_json::json!({
+                "type": "local",
+                "command": "docker",
+                "args": ["run", "-i"],
+                "tools": ["*"]
+            }),
+        );
+        let out = build_kiro_json(&def, &[]).unwrap();
+        let tf = &out["mcpServers"]["terraform"];
+        assert_eq!(tf["type"], "stdio");
+        // Inner `tools: ["*"]` allowlist is stripped — Kiro has no equivalent
+        // and @{server} already covers "all tools".
+        assert!(tf.get("tools").is_none());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::emit`
+Expected: compile error.
+
+**Step 3: Implement emission**
+
+Create `crates/kiro-market-core/src/agent/emit.rs`:
+
+```rust
+//! Emit Kiro agent JSON from an `AgentDefinition`.
+//!
+//! The emitted JSON matches the schema at `agent-schema.json`. The `prompt`
+//! field uses Kiro's `file://` URI to reference the externalized prompt
+//! markdown, so the `.md` remains the source of truth after install.
+//!
+//! NOTE on field ordering: workspace `serde_json` does not enable the
+//! `preserve_order` feature, so `serde_json::Map` is BTreeMap-backed and
+//! emits keys alphabetically in the on-disk JSON. Tests index by key so
+//! they're unaffected, but reviewers reading the file should not expect
+//! insertion order.
+
+use serde_json::{Map, Value};
+
+use super::tools::MappedTool;
+use super::types::AgentDefinition;
+
+/// Build the Kiro-compatible JSON for an agent, given the parsed definition
+/// and the already-mapped tool list.
+///
+/// `mapped_tools` is the output of `tools::map_claude_tools` or
+/// `tools::map_copilot_tools`. Native entries land in `allowedTools`; MCP
+/// refs land in `tools` per the Kiro agent schema.
+pub fn build_kiro_json(
+    def: &AgentDefinition,
+    mapped_tools: &[MappedTool],
+) -> serde_json::Result<Value> {
+    let mut obj = Map::new();
+    obj.insert("name".into(), Value::String(def.name.clone()));
+    if let Some(desc) = &def.description {
+        obj.insert("description".into(), Value::String(desc.clone()));
+    }
+    obj.insert(
+        "prompt".into(),
+        Value::String(format!("file://./prompts/{}.md", def.name)),
+    );
+    if let Some(model) = &def.model {
+        obj.insert("model".into(), Value::String(model.clone()));
+    }
+
+    let mut allowed: Vec<Value> = Vec::new();
+    let mut tools: Vec<Value> = Vec::new();
+    for entry in mapped_tools {
+        match entry {
+            MappedTool::Native(s) => allowed.push(Value::String(s.clone())),
+            MappedTool::McpRef(s) => tools.push(Value::String(s.clone())),
+        }
+    }
+    if !allowed.is_empty() {
+        obj.insert("allowedTools".into(), Value::Array(allowed));
+    }
+    if !tools.is_empty() {
+        obj.insert("tools".into(), Value::Array(tools));
+    }
+
+    if !def.mcp_servers.is_empty() {
+        let mut servers = Map::new();
+        for (name, raw) in &def.mcp_servers {
+            servers.insert(name.clone(), normalize_mcp_server(raw));
+        }
+        obj.insert("mcpServers".into(), Value::Object(servers));
+    }
+    Ok(Value::Object(obj))
+}
+
+/// Normalize a Copilot MCP server entry to Kiro's `CustomToolConfig` shape.
+///
+/// Rules (verified against `agent-schema.json` `$defs/CustomToolConfig` in Step 0):
+/// - `type: "local"` → `type: "stdio"`
+/// - inner `tools` allowlist → dropped (Kiro has no per-server allowlist;
+///   the outer `tools` array already handles whole-server access via `@name`).
+fn normalize_mcp_server(raw: &Value) -> Value {
+    let Some(obj) = raw.as_object() else {
+        return raw.clone();
+    };
+    let mut out = Map::new();
+    for (k, v) in obj {
+        if k == "tools" {
+            continue;
+        }
+        if k == "type" && v.as_str() == Some("local") {
+            out.insert("type".into(), Value::String("stdio".into()));
+            continue;
+        }
+        out.insert(k.clone(), v.clone());
+    }
+    Value::Object(out)
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+pub mod emit;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::emit`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: emit Kiro agent JSON with file:// prompt reference"
+```
+
+---
+
+### Task 9: Add `InstalledAgentMeta` tracking structure
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs` (add structs near `InstalledSkillMeta`, add `INSTALLED_AGENTS_FILE` constant)
+
+**Step 1: Write the failing tests**
+
+Append to the existing `mod tests` in `project.rs`:
+
+```rust
+#[test]
+fn installed_agent_meta_roundtrips_json() {
+    let meta = InstalledAgentMeta {
+        marketplace: "mp".into(),
+        plugin: "pr-review-toolkit".into(),
+        version: Some("1.2.3".into()),
+        installed_at: Utc::now(),
+        dialect: AgentDialect::Claude,
+    };
+    let json = serde_json::to_string(&meta).unwrap();
+    let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.plugin, "pr-review-toolkit");
+    assert_eq!(back.dialect, AgentDialect::Claude);
+    // Spot-check the wire format: dialect serializes lowercase.
+    assert!(json.contains("\"dialect\":\"claude\""));
+}
+
+#[test]
+fn installed_agents_default_is_empty() {
+    let ia = InstalledAgents::default();
+    assert!(ia.agents.is_empty());
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib project::tests::installed_agent`
+Expected: compile error.
+
+**Step 3: Add the types**
+
+In `project.rs`, near the existing `InstalledSkillMeta` / `InstalledSkills`, insert:
+
+```rust
+use crate::agent::AgentDialect;
+
+/// Metadata recorded for each installed agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledAgentMeta {
+    pub marketplace: String,
+    pub plugin: String,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    /// Which source dialect the agent was parsed from. Persisted via the
+    /// enum's serde rename, not as a free-form string, to avoid drift.
+    pub dialect: AgentDialect,
+}
+
+/// The on-disk structure of `installed-agents.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InstalledAgents {
+    pub agents: HashMap<String, InstalledAgentMeta>,
+}
+
+/// Name of the agent tracking file inside `.kiro/`.
+const INSTALLED_AGENTS_FILE: &str = "installed-agents.json";
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib project::tests::installed_agent`
+Expected: PASS (2 tests).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/project.rs
+git commit -m "feat: add InstalledAgentMeta tracking type for agents"
+```
+
+---
+
+### Task 10: `KiroProject::install_agent` method
+
+**Why this signature changed from the original draft.** The original Task 10 took `(name, source_file, meta)` and re-parsed the file inside `install_agent_from_file`. But Task 14's service already parses the file to compute warnings — so the service ended up parsing once for warnings and the project method parsed again for installation. Pass the parsed `AgentDefinition` + mapped tools straight in. Each file is parsed exactly once.
+
+**Why atomic staging.** `KiroProject::write_skill_dir` (`project.rs:296`) carefully stages skill files into a temp dir under the `.kiro/` root and renames into place so a crash can never leave a half-installed skill on disk. This task mirrors that contract for agents: prompt + JSON go to a per-attempt staging directory, then renames swap them into place atomically; tracking is written last and inside the same lock.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs` (add `install_agent` method, internal staging helper, `load_installed_agents`)
+
+**Step 1: Write the failing tests**
+
+Add to `mod tests` in `project.rs`:
+
+```rust
+fn write_agent(name: &str, body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path().join(format!("{name}.md"));
+    std::fs::write(&p, body).unwrap();
+    (tmp, p)
+}
+
+fn parse_and_map(source: &Path) -> (AgentDefinition, Vec<MappedTool>) {
+    let def = crate::agent::parse_agent_file(source).expect("parse");
+    let (mapped, _unmapped) = match def.dialect {
+        AgentDialect::Claude => crate::agent::tools::map_claude_tools(&def.source_tools),
+        AgentDialect::Copilot => crate::agent::tools::map_copilot_tools(&def.source_tools),
+    };
+    (def, mapped)
+}
+
+#[test]
+fn install_agent_writes_json_and_prompt() {
+    let project = KiroProject::init_in_temp().unwrap();
+    let (_tmp, src) = write_agent(
+        "reviewer",
+        "---\nname: reviewer\ndescription: Reviews\n---\nYou are a reviewer.\n",
+    );
+    let (def, mapped) = parse_and_map(&src);
+
+    project
+        .install_agent(&def, &mapped, sample_agent_meta())
+        .expect("install");
+
+    let json_path = project.root().join(".kiro/agents/reviewer.json");
+    let prompt_path = project.root().join(".kiro/agents/prompts/reviewer.md");
+    assert!(json_path.exists(), "JSON written");
+    assert!(prompt_path.exists(), "prompt markdown written");
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&json_path).unwrap()).unwrap();
+    assert_eq!(json["name"], "reviewer");
+    assert_eq!(json["prompt"], "file://./prompts/reviewer.md");
+
+    let prompt = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(prompt.starts_with("You are a reviewer."),
+        "prompt body written without frontmatter, got: {prompt:?}");
+}
+
+#[test]
+fn install_agent_rejects_duplicate() {
+    let project = KiroProject::init_in_temp().unwrap();
+    let (_tmp, src) = write_agent("a", "---\nname: a\n---\nbody\n");
+    let (def, mapped) = parse_and_map(&src);
+
+    project.install_agent(&def, &mapped, sample_agent_meta()).unwrap();
+    let err = project
+        .install_agent(&def, &mapped, sample_agent_meta())
+        .unwrap_err();
+    assert!(matches!(err, Error::Agent(AgentError::AlreadyInstalled { .. })));
+}
+
+#[test]
+fn install_agent_updates_tracking() {
+    let project = KiroProject::init_in_temp().unwrap();
+    let (_tmp, src) = write_agent("a", "---\nname: a\n---\nbody\n");
+    let (def, mapped) = parse_and_map(&src);
+    project.install_agent(&def, &mapped, sample_agent_meta()).unwrap();
+
+    let tracking_path = project.root().join(".kiro/installed-agents.json");
+    let tracking: InstalledAgents =
+        serde_json::from_str(&std::fs::read_to_string(tracking_path).unwrap()).unwrap();
+    assert!(tracking.agents.contains_key("a"));
+    assert_eq!(tracking.agents["a"].dialect, AgentDialect::Claude);
+}
+
+#[test]
+fn install_agent_rejects_unsafe_name() {
+    let project = KiroProject::init_in_temp().unwrap();
+    let (_tmp, src) = write_agent("x", "---\nname: x\n---\nbody\n");
+    let (mut def, mapped) = parse_and_map(&src);
+    // Force an unsafe name into the parsed def to exercise validation.
+    def.name = "../escape".into();
+    let err = project.install_agent(&def, &mapped, sample_agent_meta()).unwrap_err();
+    assert!(matches!(err, Error::Validation(_)));
+}
+
+fn sample_agent_meta() -> InstalledAgentMeta {
+    InstalledAgentMeta {
+        marketplace: "mp".into(),
+        plugin: "p".into(),
+        version: None,
+        installed_at: Utc::now(),
+        dialect: AgentDialect::Claude,
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib project::tests::install_agent`
+Expected: compile error.
+
+**Step 3: Implement the method (atomic, mirroring `write_skill_dir`)**
+
+In `project.rs`, add after the existing skill install methods:
+
+```rust
+/// Install a parsed agent: emit its Kiro JSON + externalized prompt
+/// markdown under `.kiro/agents/`, and record metadata in
+/// `installed-agents.json`.
+///
+/// The caller is responsible for parsing the source file and mapping the
+/// tool list (the service layer does both upstream so warnings can be
+/// surfaced before the install lock is acquired). This method is purely
+/// the on-disk write step.
+///
+/// File writes use the same staging-and-rename pattern as
+/// [`Self::install_skill_from_dir`] — prompt + JSON are written to
+/// `_installing-agents-<name>-<pid>-<seq>/` under `.kiro/`, then renamed
+/// into `.kiro/agents/{name}.json` and `.kiro/agents/prompts/{name}.md`
+/// after the duplicate check, then tracking is written last. The whole
+/// flow runs under the existing tracking lock.
+///
+/// # Errors
+///
+/// - [`AgentError::AlreadyInstalled`] if an agent with this name already exists.
+/// - Validation errors for unsafe names.
+/// - I/O errors.
+pub fn install_agent(
+    &self,
+    def: &AgentDefinition,
+    mapped_tools: &[MappedTool],
+    meta: InstalledAgentMeta,
+) -> crate::error::Result<()> {
+    validation::validate_name(&def.name)?;
+    let json = crate::agent::emit::build_kiro_json(def, mapped_tools)?;
+    let json_bytes = serde_json::to_vec_pretty(&json)?;
+
+    let tracking_path = self.kiro_dir().join(INSTALLED_AGENTS_FILE);
+    crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
+        let mut tracking = self.load_installed_agents()?;
+        if tracking.agents.contains_key(&def.name) {
+            return Err(AgentError::AlreadyInstalled {
+                name: def.name.clone(),
+            }
+            .into());
+        }
+
+        // Stage under .kiro/ so rename is on the same filesystem as the target.
+        let staging = self
+            .kiro_dir()
+            .join(format!(
+                "_installing-agent-{name}-{pid}-{seq}",
+                name = def.name,
+                pid = std::process::id(),
+                seq = staging_seq(),
+            ));
+        fs::create_dir_all(staging.join("prompts"))?;
+        fs::write(staging.join(format!("{name}.json", name = def.name)), &json_bytes)?;
+        fs::write(
+            staging.join("prompts").join(format!("{name}.md", name = def.name)),
+            def.prompt_body.as_bytes(),
+        )?;
+
+        let agents_root = self.kiro_dir().join("agents");
+        let prompts_root = agents_root.join("prompts");
+        fs::create_dir_all(&prompts_root)?;
+
+        // Atomic rename for both files; if either fails we clean up the staging dir
+        // and propagate.
+        let json_target = agents_root.join(format!("{name}.json", name = def.name));
+        let prompt_target = prompts_root.join(format!("{name}.md", name = def.name));
+        let rename_result = fs::rename(
+            staging.join(format!("{name}.json", name = def.name)),
+            &json_target,
+        )
+        .and_then(|()| {
+            fs::rename(
+                staging.join("prompts").join(format!("{name}.md", name = def.name)),
+                &prompt_target,
+            )
+        });
+        // Best-effort cleanup of the staging directory regardless of outcome.
+        let _ = fs::remove_dir_all(&staging);
+        rename_result?;
+
+        tracking.agents.insert(def.name.clone(), meta);
+        let tracking_bytes = serde_json::to_vec_pretty(&tracking)?;
+        fs::write(&tracking_path, tracking_bytes)?;
+        Ok(())
+    })
+}
+
+fn load_installed_agents(&self) -> crate::error::Result<InstalledAgents> {
+    let path = self.kiro_dir().join(INSTALLED_AGENTS_FILE);
+    if !path.exists() {
+        return Ok(InstalledAgents::default());
+    }
+    let bytes = fs::read(path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+```
+
+`staging_seq()` should mirror whatever the skill flow uses (e.g. an `AtomicUsize::fetch_add`). If no helper exists, add one local to this file or reuse the skill version. The exact source of monotonicity matters only for distinct staging-dir names within the same process — the lock already serializes cross-process attempts.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib project::tests::install_agent`
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/project.rs
+git commit -m "feat: install parsed agent into .kiro/agents/ atomically"
+```
+
+---
+
+### Task 11: Extend `PluginManifest` with `agents` field
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/plugin.rs` (add `agents: Vec<String>` field to `PluginManifest`; add `DEFAULT_AGENT_PATHS` constant to `lib.rs`)
+- Modify: `crates/kiro-market-core/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+Add to `mod tests` in `plugin.rs`:
+
+```rust
+#[test]
+fn plugin_manifest_parses_agents_field() {
+    let json = br#"{
+        "name": "p",
+        "skills": ["./skills/"],
+        "agents": ["./agents/"]
+    }"#;
+    let m = PluginManifest::from_json(json).unwrap();
+    assert_eq!(m.agents, vec!["./agents/"]);
+}
+
+#[test]
+fn plugin_manifest_defaults_agents_to_empty() {
+    let json = br#"{"name": "p"}"#;
+    let m = PluginManifest::from_json(json).unwrap();
+    assert!(m.agents.is_empty());
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib plugin::tests::plugin_manifest_parses_agents`
+Expected: compile error — `agents` field does not exist.
+
+**Step 3: Add the field**
+
+In `plugin.rs`:
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginManifest {
+    pub name: String,
+    pub version: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub agents: Vec<String>,
+}
+```
+
+In `lib.rs`, add below `DEFAULT_SKILL_PATHS`:
+
+```rust
+/// Default agent scan paths when a plugin has no `plugin.json` or its
+/// `agents` list is empty.
+pub const DEFAULT_AGENT_PATHS: &[&str] = &["./agents/"];
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib plugin::tests::plugin_manifest`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/plugin.rs crates/kiro-market-core/src/lib.rs
+git commit -m "feat: extend PluginManifest with agents field and default paths"
+```
+
+---
+
+### Task 12: `discover_agents_in_plugin()` scan helper
+
+**Files:**
+- Create: `crates/kiro-market-core/src/agent/discover.rs`
+- Modify: `crates/kiro-market-core/src/agent/mod.rs` (add `pub mod discover;`)
+
+**Step 1: Write the failing tests**
+
+In `agent/discover.rs` add `mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn discover_finds_both_md_and_agent_md() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("claude.md"), "---\nname: c\n---\n").unwrap();
+        std::fs::write(agents.join("copilot.agent.md"), "---\nname: o\n---\n").unwrap();
+        std::fs::write(agents.join("README.txt"), "ignored").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+        assert!(names.contains(&"claude.md".to_string()));
+        assert!(names.contains(&"copilot.agent.md".to_string()));
+        assert!(!names.contains(&"README.txt".to_string()));
+    }
+
+    #[test]
+    fn discover_returns_empty_when_directory_missing() {
+        let tmp = tempdir().unwrap();
+        let found = discover_agents_in_dirs(tmp.path(), &["./nope/".to_string()]);
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn discover_excludes_readme_and_contributing() {
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("README.md"), "# README").unwrap();
+        std::fs::write(agents.join("CONTRIBUTING.md"), "# Contrib").unwrap();
+        std::fs::write(agents.join("real.md"), "---\nname: r\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+        assert_eq!(names, vec!["real.md"]);
+    }
+
+    #[test]
+    fn discover_does_not_recurse_into_subdirectories() {
+        // Prevents accidentally picking up nested `agents/prompts/*.md` or
+        // backup directories.
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let nested = agents.join("archived");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(agents.join("top.md"), "---\nname: t\n---\n").unwrap();
+        std::fs::write(nested.join("deep.md"), "---\nname: d\n---\n").unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+        assert_eq!(names, vec!["top.md"]);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib agent::discover`
+Expected: compile error.
+
+**Step 3: Implement discovery**
+
+Create `crates/kiro-market-core/src/agent/discover.rs`:
+
+```rust
+//! Scan a plugin directory for agent markdown files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Find agent markdown files inside `plugin_dir` according to `scan_paths`.
+///
+/// `scan_paths` are relative to `plugin_dir`. Files ending in `.md` or
+/// `.agent.md` are included; the caller uses `detect_dialect` at parse time
+/// to route to the right parser. Scans are non-recursive: only direct
+/// children of each scan directory are considered. This avoids grabbing
+/// nested `prompts/*.md` or editor backup files.
+///
+/// `README.md` and `CONTRIBUTING.md` are excluded by name so plugins can keep
+/// docs in their `agents/` directory without producing parse-failure warnings.
+/// Other non-agent `.md` files (e.g. notes a plugin author drops in) will
+/// still be picked up, parsed, and surfaced as `AgentParseFailed` warnings —
+/// noisy but accurate. Service-layer rule: when the parse error reason is
+/// "missing opening `---` frontmatter fence", demote to `tracing::debug!`
+/// instead of pushing an `InstallWarning`. See Task 14.
+#[must_use]
+pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<PathBuf> {
+    const EXCLUDED: &[&str] = &["README.md", "CONTRIBUTING.md", "CHANGELOG.md"];
+    let mut out = Vec::new();
+    for rel in scan_paths {
+        let dir = plugin_dir.join(rel.trim_start_matches("./"));
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if EXCLUDED.contains(&name) {
+                continue;
+            }
+            if name.ends_with(".md") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+```
+
+Wire up in `agent/mod.rs`:
+
+```rust
+pub mod discover;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib agent::discover`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/agent/
+git commit -m "feat: scan plugin directory for agent markdown files"
+```
+
+---
+
+### Task 13: `InstallWarning` structured warning type
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service.rs` (add `InstallWarning` enum + the collection type in install results)
+
+**Step 1: Write the failing tests**
+
+Add to the existing service test module (look for `mod tests` at the end):
+
+```rust
+#[test]
+fn install_warning_unmapped_tool_renders_cleanly() {
+    let w = InstallWarning::UnmappedTool {
+        agent: "reviewer".into(),
+        tool: "NotebookEdit".into(),
+    };
+    let s = w.to_string();
+    assert!(s.contains("reviewer"));
+    assert!(s.contains("NotebookEdit"));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib service::tests::install_warning`
+Expected: compile error.
+
+**Step 3: Add `InstallWarning`**
+
+In `service.rs`, near the top-level result types:
+
+```rust
+use crate::agent::tools::UnmappedReason;
+
+/// Non-fatal issue produced during install. Surfaced in install results
+/// so the CLI / Tauri frontend can render them without blocking the install.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum InstallWarning {
+    /// A source-declared tool had no Kiro equivalent and was dropped.
+    /// The emitted agent will inherit the full parent toolset for that slot.
+    UnmappedTool {
+        agent: String,
+        tool: String,
+        reason: UnmappedReason,
+    },
+    /// An agent file could not be parsed; it was skipped.
+    AgentParseFailed { path: PathBuf, reason: String },
+}
+
+impl std::fmt::Display for InstallWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InstallWarning::UnmappedTool { agent, tool, reason } => {
+                let why = match reason {
+                    UnmappedReason::NoKiroEquivalent => "no Kiro equivalent",
+                    UnmappedReason::BareCopilotName => "Copilot bare name; not portable",
+                };
+                write!(f, "agent `{agent}`: tool `{tool}` dropped ({why})")
+            }
+            InstallWarning::AgentParseFailed { path, reason } => write!(
+                f,
+                "skipped agent at {}: {reason}",
+                path.display()
+            ),
+        }
+    }
+}
+```
+
+`UnmappedReason` will need `Serialize` + `specta::Type` (under the feature). Add those derives in Task 6 if they aren't already there — easier to revisit Task 6 than to add a stringly conversion shim here.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib service::tests::install_warning`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service.rs
+git commit -m "feat: add InstallWarning type for non-fatal install issues"
+```
+
+---
+
+### Task 14: `MarketplaceService::install_plugin_agents`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service.rs` (add a method that iterates discovered agent files, parses, maps tools, installs each, and returns `(installed_count, warnings)`)
+
+**Step 1: Write the failing integration test**
+
+Add to `service::tests`:
+
+```rust
+#[test]
+fn install_plugin_agents_emits_json_and_warnings_per_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plugin_dir = tmp.path().join("plugin-x");
+    let agents_dir = plugin_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+
+    // One Claude agent with a tool that maps cleanly.
+    std::fs::write(
+        agents_dir.join("reviewer.md"),
+        "---\nname: reviewer\ndescription: Reviews\ntools: [Read, NotebookEdit]\n---\nYou are a reviewer.\n",
+    ).unwrap();
+
+    // One Copilot agent with a bare unmapped tool.
+    std::fs::write(
+        agents_dir.join("tester.agent.md"),
+        "---\nname: tester\ntools: ['codebase', 'terraform/*']\n---\nBody.\n",
+    ).unwrap();
+
+    let project = KiroProject::init_in_temp().unwrap();
+    // Match the constructor used by existing service tests in this file
+    // (see e.g. `MarketplaceService::new(cache, MockGitBackend::default())`
+    // around service.rs:649). Reuse whatever mock backend the nearest test
+    // already constructs — this method does not invoke git.
+    let svc = MarketplaceService::new(test_cache(), MockGitBackend::default());
+
+    let (count, warnings) = svc
+        .install_plugin_agents(
+            &project,
+            &plugin_dir,
+            &["./agents/".to_string()],
+            /*marketplace*/ "mp",
+            /*plugin*/ "plugin-x",
+            /*version*/ None,
+        )
+        .expect("install");
+
+    assert_eq!(count, 2, "both agents installed");
+    assert!(project.root().join(".kiro/agents/reviewer.json").exists());
+    assert!(project.root().join(".kiro/agents/tester.json").exists());
+    assert!(project.root().join(".kiro/agents/prompts/reviewer.md").exists());
+
+    // Warnings should be structured: NotebookEdit → NoKiroEquivalent,
+    // codebase → BareCopilotName. Match by variant, not by string.
+    use crate::agent::tools::UnmappedReason;
+    let unmapped: Vec<_> = warnings
+        .iter()
+        .filter_map(|w| match w {
+            InstallWarning::UnmappedTool { tool, reason, .. } => Some((tool.as_str(), *reason)),
+            _ => None,
+        })
+        .collect();
+    assert!(unmapped.contains(&("NotebookEdit", UnmappedReason::NoKiroEquivalent)),
+        "expected NotebookEdit unmapped: {unmapped:?}");
+    assert!(unmapped.contains(&("codebase", UnmappedReason::BareCopilotName)),
+        "expected codebase unmapped: {unmapped:?}");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kiro-market-core --lib service::tests::install_plugin_agents`
+Expected: compile error — method does not exist.
+
+**Step 3: Implement the method**
+
+In `service.rs`, add:
+
+```rust
+impl MarketplaceService {
+    /// Discover, parse, and install all agents from a plugin directory.
+    ///
+    /// Returns `(installed_count, warnings)`. Parse failures on individual
+    /// agents are captured as warnings and do not abort the whole install.
+    /// Each file is parsed exactly once — the parsed `AgentDefinition` is
+    /// passed straight into `project.install_agent`, so the project layer
+    /// never re-reads the source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only for fatal problems (e.g. filesystem errors
+    /// writing the tracking file). Per-file parse failures become warnings.
+    pub fn install_plugin_agents(
+        &self,
+        project: &crate::project::KiroProject,
+        plugin_dir: &Path,
+        scan_paths: &[String],
+        marketplace: &str,
+        plugin: &str,
+        version: Option<&str>,
+    ) -> crate::error::Result<(usize, Vec<InstallWarning>)> {
+        let files = crate::agent::discover::discover_agents_in_dirs(plugin_dir, scan_paths);
+        let mut installed = 0_usize;
+        let mut warnings: Vec<InstallWarning> = Vec::new();
+
+        for path in files {
+            let def = match crate::agent::parse_agent_file(&path) {
+                Ok(d) => d,
+                Err(e) => {
+                    let reason = e.to_string();
+                    // Demote "no frontmatter at all" — these are usually
+                    // human-readable docs that share an `agents/` directory
+                    // with real agent files. See discover.rs comment.
+                    if reason.contains("missing opening `---` frontmatter fence") {
+                        tracing::debug!(path = %path.display(), "skipping non-agent markdown");
+                    } else {
+                        warnings.push(InstallWarning::AgentParseFailed {
+                            path: path.clone(),
+                            reason,
+                        });
+                    }
+                    continue;
+                }
+            };
+            let (mapped, unmapped) = match def.dialect {
+                crate::agent::AgentDialect::Claude => {
+                    crate::agent::tools::map_claude_tools(&def.source_tools)
+                }
+                crate::agent::AgentDialect::Copilot => {
+                    crate::agent::tools::map_copilot_tools(&def.source_tools)
+                }
+            };
+            for u in unmapped {
+                warnings.push(InstallWarning::UnmappedTool {
+                    agent: def.name.clone(),
+                    tool: u.source,
+                    reason: u.reason,
+                });
+            }
+
+            let meta = crate::project::InstalledAgentMeta {
+                marketplace: marketplace.to_string(),
+                plugin: plugin.to_string(),
+                version: version.map(String::from),
+                installed_at: chrono::Utc::now(),
+                dialect: def.dialect,
+            };
+            project.install_agent(&def, &mapped, meta)?;
+            installed += 1;
+        }
+
+        Ok((installed, warnings))
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p kiro-market-core --lib service::tests::install_plugin_agents`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service.rs
+git commit -m "feat: install all agents from a plugin directory with warnings"
+```
+
+---
+
+### Task 15: Wire agent install into plugin install flow
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service.rs` (the existing `install_plugin` / equivalent call site — find where skills are installed per-plugin and add an agent pass right after)
+
+**Step 1: Find the skill install call site**
+
+Run: `rg 'install_skill_from_dir|install_plugin_skills' crates/kiro-market-core/src/service.rs`
+
+Note which function owns that call and what it returns. The agent install pass should run **after** all skills install for a given plugin, append warnings to any existing warning list, and include the installed agent count in the result.
+
+**Step 2: Write the failing test**
+
+Add a test that exercises the full plugin-install flow with a plugin that ships both skills and agents, asserting that:
+- The skills land in `.kiro/skills/`.
+- The agents land in `.kiro/agents/`.
+- Warnings from agent installation bubble up to the plugin install result.
+
+(Copy the shape of the existing plugin-install happy-path test as a starting point.)
+
+**Step 3: Run test to verify it fails**
+
+Expected: agents are not installed.
+
+**Step 4: Add the agent pass**
+
+Where skills are installed, after the skill loop:
+
+```rust
+let scan_paths = if plugin_manifest.agents.is_empty() {
+    crate::DEFAULT_AGENT_PATHS.iter().map(|s| (*s).to_string()).collect()
+} else {
+    plugin_manifest.agents.clone()
+};
+let (agent_count, mut agent_warnings) = self.install_plugin_agents(
+    project,
+    plugin_dir,
+    &scan_paths,
+    marketplace_name,
+    &plugin_manifest.name,
+    plugin_manifest.version.as_deref(),
+)?;
+// Append to whatever warning list the existing skill flow accumulated.
+warnings.append(&mut agent_warnings);
+```
+
+Extend the return type to include `agent_count` if it doesn't already. If the existing result struct only carries skill info, add a new `agents_installed: usize` field.
+
+**Step 5: Run tests to verify**
+
+Run: `cargo test -p kiro-market-core`
+Expected: all existing tests plus the new one pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service.rs
+git commit -m "feat: install agents as part of plugin install flow"
+```
+
+---
+
+### Task 16: Render agent install results in the CLI
+
+**Files:**
+- Modify: `crates/kiro-market/src/commands/install.rs` (print agent counts and warnings next to skill counts)
+
+**Step 1: Read the current install output**
+
+Run: `cat crates/kiro-market/src/commands/install.rs | head -80`
+
+Note the existing output format for skills — whatever pattern is used (plain `println!`, a table, colored labels) should be mirrored for agents.
+
+**Step 2: Write an integration test**
+
+Add a test to `crates/kiro-market/tests/` (or extend an existing install CLI test) that runs the install command against a fixture plugin with one agent and asserts that the stdout mentions:
+- The agent name.
+- The warning about any dropped tool.
+
+Use `assert_cmd` and `predicates` if those are already in the test dev-dependencies; otherwise match the existing CLI test style.
+
+**Step 3: Run test to verify it fails**
+
+Expected: agents are installed but not printed.
+
+**Step 4: Add CLI rendering**
+
+In `install.rs`, after the existing skill summary:
+
+```rust
+if result.agents_installed > 0 {
+    println!(
+        "{} {} agent{} installed",
+        "+".green(),
+        result.agents_installed,
+        if result.agents_installed == 1 { "" } else { "s" },
+    );
+}
+for warning in &result.warnings {
+    eprintln!("{} {warning}", "warning:".yellow());
+}
+```
+
+Adjust field names (`result.agents_installed`, `result.warnings`) to match what Task 15 actually surfaced.
+
+**Step 4a: Re-install messaging**
+
+There's no `install_agent_force` in this plan (deferred to follow-ups). When a user re-runs `install` against a plugin whose agents are already on disk, the command will fail with `AgentError::AlreadyInstalled` per agent. Make the CLI surface a single actionable line on that error rather than a raw error dump:
+
+```rust
+Err(Error::Agent(AgentError::AlreadyInstalled { name })) => {
+    eprintln!(
+        "{} agent `{name}` already installed; remove it manually \
+         (`rm .kiro/agents/{name}.json .kiro/agents/prompts/{name}.md`) \
+         and edit `.kiro/installed-agents.json` to re-install",
+        "error:".red(),
+    );
+    std::process::exit(2);
+}
+```
+
+This is a stop-gap until the follow-up adds proper `update`/`remove`/`force` commands.
+
+**Step 5: Run tests to verify**
+
+Run: `cargo test -p kiro-market`
+Expected: PASS.
+
+Also run a smoke install against a real plugin that ships agents to eyeball the output:
+
+```bash
+cargo run -- add <marketplace-url>
+cargo run -- install <plugin-name>
+```
+
+**Step 6: Commit**
+
+```bash
+git add crates/kiro-market/src/commands/install.rs
+git commit -m "feat: render installed agents and warnings in CLI install output"
+```
+
+---
+
+### Task 17: Full-workspace verification
+
+**Step 1: Run the complete test suite**
+
+Run: `cargo test --workspace`
+Expected: all tests PASS.
+
+**Step 2: Run clippy**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: clean.
+
+**Step 3: Manual smoke test**
+
+In a scratch Kiro project:
+
+```bash
+cargo run -- add https://github.com/anthropics/claude-plugins-official
+cargo run -- install pr-review-toolkit
+ls .kiro/agents/
+cat .kiro/agents/code-reviewer.json
+cat .kiro/agents/prompts/code-reviewer.md
+```
+
+Verify:
+- Each pr-review-toolkit agent has a matching `.json` + `prompts/*.md` pair.
+- The `.json` files validate against `agent-schema.json`.
+- The `prompt` field is `file://./prompts/{name}.md`.
+- Warnings were printed for any source tools that could not be mapped.
+
+**Step 4: Final commit (if any docs updated)**
+
+If README or CLAUDE.md needs a note about agent support, update and commit:
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: document agent import support"
+```
+
+---
+
+## Post-implementation follow-ups (not part of this plan)
+
+- Add `remove_agent` / `update_agent` / `install_agent_force` service methods paralleling the skill versions, then drop the manual-removal stop-gap from Task 16 Step 4a.
+- Extend `list` command output to show installed agents.
+- Validate every emitted JSON against `agent-schema.json` in tests (use `jsonschema` crate against the schema file in repo root). This is the most reliable defense against silent schema drift.
+- Support awesome-copilot-style repos that are not Claude Code plugins (discovery at repo root instead of per-plugin).
+- Honor `hooks:` frontmatter from source agents (currently dropped).
+- Consider enabling the `preserve_order` feature on `serde_json` if reviewers complain about alphabetical key order in the emitted agent JSON.


### PR DESCRIPTION
## Summary
- New `agent` module in `kiro-market-core` that parses Claude-style `.md` and Copilot-style `.agent.md` agent files into a shared `AgentDefinition`, maps their tool lists to Kiro tool names, and emits Kiro-compatible `{name}.json` + externalized `prompts/{name}.md` pairs.
- Agents are installed alongside skills during `kiro-market install`, tracked in `.kiro/installed-agents.json`, and surface structured `InstallWarning`s (unmapped tools, skipped non-agent markdown) without failing the batch.
- Atomic staging + rename mirroring the existing skill install flow, with a per-agent `cleanup_leftover_agent_staging` sweep and `warn!`-on-rollback so crashes never leave the project in an inconsistent state.

## Plan
Full implementation plan lives in `docs/plans/2026-04-16-agent-import-plan.md` — reviewed and revised before execution, then updated after a `/pr-review-toolkit:review-pr` pass.

## Behavior highlights
- **Dialect detection** by filename: `.agent.md` → Copilot, anything else → Claude.
- **Tool mapping** verified against <https://kiro.dev/docs/cli/reference/built-in-tools/>: native Claude PascalCase names (`Read` → `read`, `Bash` → `shell`, `Task` → `subagent`, etc.) route to `allowedTools`; Copilot MCP refs (`terraform/*` → `@terraform`) route to `tools`. Copilot bare names (`codebase`, `findTestFiles`) drop with a structured warning.
- **Typed `ParseFailure`** (MissingFrontmatter, UnclosedFrontmatter, InvalidYaml, MissingName, InvalidName, IoError) replaces stringly-typed error classification — the README-demotion and warning surface both switch on variants.
- **Name validation at parse time** rejects path traversal in YAML frontmatter before any fs op; `install_agent` retains `validate_name` as defense-in-depth.
- **Percent-encoded file:// prompt URI** so Copilot agents like `Terraform Agent` emit `file://./prompts/Terraform%20Agent.md`.
- **Per-agent outcome collection**: `InstallAgentsResult { installed, skipped, failed, warnings }` mirrors the skill flow — a single broken agent never aborts the batch, and the CLI sets a non-zero exit when any item fails so CI catches partial-success regressions.

## Review pass
Comprehensive `/pr-review-toolkit:review-pr` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier) flagged 5 critical / 6 important / 7 suggestions; all resolved. See the last 8 commits for the targeted fixes (typed errors, read_dir narrowing, per-agent outcomes, atomic-rollback tests, `#[non_exhaustive]`, URL-encoded paths, ordering tests, etc.).

## Test plan
- [x] `cargo test --workspace` — 421 tests pass (348 in kiro-market-core, +70 from this PR)
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Concurrent-install race test (`install_agent_serializes_concurrent_same_name_installs`)
- [x] Atomic-rollback test matrix: JSON-rename fail, prompt-rename fail, tracking-write fail, orphan-file refusal, leftover-staging sweep
- [x] End-to-end path-traversal rejection via frontmatter YAML (`install_plugin_agents_rejects_frontmatter_path_traversal_end_to_end`)
- [x] Partial-success preserves warnings (`install_plugin_agents_partial_success_preserves_warnings_and_failures`)
- [ ] Manual smoke test against a real plugin with agents — recommended before merge:
  ```
  cargo run -p kiro-market -- marketplace add https://github.com/anthropics/claude-plugins-official
  cargo run -p kiro-market -- install pr-review-toolkit@claude-plugins-official
  ls .kiro/agents/
  ```

## Out of scope (follow-ups)
- `remove_agent` / `update_agent` / `install_agent_force` service methods.
- Dedicated Tauri endpoint for agent install (the existing `install_skills` Tauri command is targeted-by-name and intentionally unchanged).
- Honoring `hooks:` frontmatter from source agents.
- JSON-schema validation of emitted files against `agent-schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)