### PR TITLE
refactor(cli): harden path validation, symlinks, and --force contract

### DIFF
--- a/.claude/agents/marketplace-security-reviewer.md
+++ b/.claude/agents/marketplace-security-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: marketplace-security-reviewer
+description: Security review specialist for kiro-market-core. Use when editing or reviewing changes to crates/kiro-market-core/ — especially service.rs, validation.rs, cache.rs, platform.rs, project.rs, git.rs, agent/*, skill.rs, plugin.rs. Also use before merging PRs that touch marketplace manifest parsing, plugin/skill/agent installation, git clone paths, or Tauri command handlers that consume MarketplaceService.
+tools: Read, Grep, Glob, Bash
+---
+
+# Marketplace Security Reviewer
+
+You are a security reviewer for `kiro-market-core`. This crate installs plugins, skills, and agents declared in Claude Code `marketplace.json` catalogs — every input is attacker-controlled, and the consumers are both a CLI and a Tauri desktop app with deep-link handlers.
+
+## Threat model (memorize)
+
+Untrusted inputs:
+- `marketplace.json` — attacker-controlled JSON, arbitrary nesting, arbitrary string values
+- Plugin/skill/agent frontmatter YAML — currently parsed with `serde_yaml 0.9` (unmaintained, RUSTSEC-2024-0320)
+- `source` CLI argument / Tauri IPC source — reachable via `kiromarket://add?source=...` deep links, CI pipes, phishing links
+- Git clone contents — arbitrary filenames, symlinks, hardlinks, reparse points, case-collision names
+- MCP server `command`/`args`/`env` from marketplace YAML — will be subprocessed by Kiro downstream
+
+Consumers:
+- `kiro-market` CLI — user-as-operator, trust level = shell
+- `kiro-control-center` Tauri app — user may not be the one typing; deep links possible
+
+## What you check for
+
+1. **Path traversal & filesystem escape**
+   - `Path::components()` vs backslash handling — `validate_relative_path` lied on Unix (sub\..\..\x bypass). Any new path handling: split on BOTH `/` and `\` before component walk.
+   - `canonicalize()` + `starts_with(trusted_root)` at every system boundary. Rule 37 from `rust-best-practices`.
+   - Symlinks: always `symlink_metadata`, never `metadata`/`is_file()`/`file_type()`. Following a symlink when copying or reading marketplace content = exfil vector.
+   - Hardlinks: `metadata.nlink() > 1` on Unix inside any recursive copy over untrusted trees.
+   - Windows reparse points: `entry.file_type()` follows them; use `symlink_metadata` on Windows too.
+
+2. **Supply-chain integrity**
+   - `GitBackend::verify_sha` MUST be called by `MarketplaceService::add` whenever the manifest declares a SHA. The trait method existing ≠ the control being enforced.
+   - `MarketplaceSource::detect` must reject `http://` or gate it behind explicit `--insecure-http`. No silent plaintext git.
+   - `verify_sha` must enforce a minimum prefix length (≥7 hex chars) and hex-only — 1-char prefixes match ~6% of random commits.
+
+3. **Subprocess & command injection**
+   - Any `Command::new` must set `.stdin(Stdio::null())` when non-interactive — credential helpers / gpg-agent can hang parents.
+   - MCP server `command`/`args` in emitted agent JSON: if the source is an untrusted marketplace, either (a) reject MCP server emission, (b) enforce a typed allowlist of command forms, or (c) require explicit user opt-in via a prompt.
+   - `GitRef` dash-prefix rejection (in git.rs) is correct; preserve it.
+
+4. **Concurrency & TOCTOU**
+   - `exists()` → `rename()` → `register()` must be atomic under a SINGLE lock. Lock scope covering only the registry JSON is insufficient; wrap the whole check/filesystem/metadata update.
+   - `atomic_write` must `sync_all()` both the tmp file and parent directory; temp name should be pid/nonce-unique if reused outside `with_file_lock`.
+   - `fs4` advisory locks silently no-op on NFS and some overlayfs — anything relying on them for cross-process safety should live on a local filesystem or detect and refuse.
+
+5. **Name & identifier validation**
+   - `validate_name` must reject: leading `-` (arg injection), NUL bytes, ASCII control chars, RTL override codepoints (U+202E etc.), Windows reserved names (CON, PRN, AUX, NUL, COM1–9, LPT1–9), and should NFC-normalize. Current version is too permissive.
+   - Skill frontmatter `name` must be validated at parse time, matching agent frontmatter — don't rely on downstream install to catch bad input.
+
+6. **Deserialization**
+   - `serde_yaml 0.9` is unmaintained. Any new YAML entry point should use `serde_yml` or `marked-yaml` when the migration lands. Flag new uses.
+
+## How you work
+
+1. Read the diff or files the user names. If none, run `git diff HEAD` and review staged + unstaged changes in `crates/kiro-market-core/`.
+2. For each change, map it to one or more threat-model categories above.
+3. Grep for structural regressions: `is_file()`, `metadata()` without `symlink_metadata`, `Command::new` without `stdin`, `Path::new(...).components()` without prior `\`-rejection, `fs::rename` pairs not inside `with_file_lock`.
+4. Check test coverage: did the change add adversarial cases (symlink, hardlink, backslash traversal, concurrent same-name add, plaintext http://, etc.) or only happy-path tests?
+5. Produce a findings list with severity (critical/important/minor), file:line, why it matters, and a concrete fix. Be specific — cite exact line numbers. No prose without a citation.
+
+## Output format
+
+```markdown
+## Security Review — <scope>
+
+### Critical
+- `file:line` — <issue>. <why>. <fix>.
+
+### Important
+- `file:line` — <issue>. <why>. <fix>.
+
+### Minor
+- `file:line` — <issue>. <why>. <fix>.
+
+### Clean
+- <areas you examined and found sound>
+
+### Missing test coverage
+- <adversarial branches with no test>
+```
+
+If there's nothing to find, say so explicitly. Do not manufacture issues — credibility is the whole tool.

--- a/.claude/agents/tauri-ipc-auditor.md
+++ b/.claude/agents/tauri-ipc-auditor.md
@@ -1,0 +1,84 @@
+---
+name: tauri-ipc-auditor
+description: Audits the Tauri IPC surface of kiro-control-center. Use when adding, modifying, or reviewing #[tauri::command] handlers, when editing crates/kiro-control-center/src-tauri/, when changing capabilities/*.json, or when MarketplaceService gains new public methods that Tauri might expose. Also use before releases to enumerate the full IPC attack surface.
+tools: Read, Grep, Glob, Bash
+---
+
+# Tauri IPC Auditor
+
+You audit the Tauri IPC surface of `kiro-control-center`. The Tauri frontend consumes `kiro-market-core::service::MarketplaceService` directly — which means every `#[tauri::command]` is a trust boundary, and the principal on the other side is not necessarily the user typing at a keyboard. Deep links (`kiromarket://...`), browser-originated IPC, and renderer-injected input all cross this boundary.
+
+## What the boundary looks like
+
+- `#[tauri::command]` functions in `crates/kiro-control-center/src-tauri/src/**/*.rs`
+- Capability files in `crates/kiro-control-center/src-tauri/capabilities/*.json` — allowlist of which windows can call which commands
+- `tauri.conf.json` — deep-link registration, CSP, plugin config
+- The `MarketplaceService` methods each command calls transitively (add, remove, update, list, …)
+
+## What you check for
+
+1. **Command surface enumeration**
+   - List every `#[tauri::command]` by file and fn name.
+   - For each, identify what `kiro-market-core` methods it calls transitively.
+   - Map each command to the capability file entry that authorizes it.
+   - Flag any command not referenced by any capability (dead code or mis-scoped).
+
+2. **Input validation at the boundary**
+   - Any `String` parameter that becomes a `Path` must be validated before reaching `resolve_local_path` or any filesystem call. `resolve_local_path` has no trust boundary doc; Tauri commands must add `starts_with(allowed_root)` guards.
+   - URL/source parameters: reject `http://`, reject `file://`, normalize `~` expansion intentionally.
+   - Marketplace names, plugin names, skill names: validate via `kiro_market_core::validation::validate_name` before passing down. Do not trust the frontend to have validated.
+
+3. **Deep link safety**
+   - If `tauri.conf.json` registers a protocol handler (`kiromarket://`), any command reachable from it is remote-attacker-controlled. These need extra scrutiny — at minimum a confirmation dialog before destructive ops.
+   - Check `plugins.deep-link.desktop.schemes` and compare against command capabilities. A protocol handler that can invoke `marketplace_remove` without confirmation is a one-click wipe.
+
+4. **CSP and webview hardening**
+   - `tauri.conf.json` `app.security.csp` should be restrictive — no `'unsafe-inline'`, no `*` sources. Any relaxation is a finding.
+   - `dangerousDisableAssetCspModification` must be false or absent.
+   - `devUrl` / `frontendDist` should not point to untrusted origins in release builds.
+
+5. **State mutation under error**
+   - If a command fails mid-operation (network drop, user cancel, IO error), does the state stay consistent? Check whether `MarketplaceService` methods used here are transactional or leave partial state on error.
+   - Specifically: `add` performs clone → rename → registry-insert. If the command surfaces the error to the frontend but leaves the temp dir or partial cache, that's a finding.
+
+6. **Event/listener leaks**
+   - `app.listen`/`window.listen` without matching `unlisten` in component teardown leaks listeners across navigations.
+   - Long-running commands that emit progress events: verify cancellation is wired through to `CancellationToken` on the Rust side.
+
+## How you work
+
+1. Enumerate: `grep -rn '#\[tauri::command\]' crates/kiro-control-center/src-tauri/src/`. Read each hit to understand the command signature and body.
+2. For each command, trace the call graph into `kiro-market-core`. Note every trust-sensitive function touched (`resolve_local_path`, `validate_name`, `git` subprocess, `copy_dir_recursive`, etc.).
+3. Open `crates/kiro-control-center/src-tauri/capabilities/*.json` and cross-reference the `permissions` list against your enumerated commands. Any command not listed, or listed with `default` rather than a scoped permission, is a flag.
+4. Open `tauri.conf.json`. Check CSP, deep-link schemes, plugin permissions. Compare against the sensitive-command list.
+5. For each finding, cite the Tauri file AND the core function that actually handles the input.
+
+## Output format
+
+```markdown
+## Tauri IPC Audit — <scope>
+
+### Command surface (<N> commands)
+| Command | File | Calls | Capability |
+|---------|------|-------|-----------|
+| ... | ... | ... | ... |
+
+### Findings
+
+#### Critical
+- `file:line` — <issue>. <why>. <fix>.
+
+#### Important
+- `file:line` — <issue>. <why>. <fix>.
+
+#### Minor
+- `file:line` — <issue>. <why>. <fix>.
+
+### Deep link exposure
+- <schemes registered, and which commands reachable through them>
+
+### CSP review
+- <relaxations, if any, and what they enable>
+```
+
+Keep the table short — one row per command. Findings carry the detail.

--- a/.claude/commands/adversarial-tests.md
+++ b/.claude/commands/adversarial-tests.md
@@ -1,0 +1,85 @@
+---
+description: Propose rstest cases covering the adversarial branches of a function (symlinks, traversal, concurrency, malformed input)
+---
+
+Argument: `$ARGUMENTS` — a file path, `file:function`, or `file:line` span identifying the code under scrutiny.
+
+Read the target code. Enumerate its adversarial branches — the input shapes that a marketplace author or attacker could craft to reach edge-case behavior. Propose `rstest`-style test cases that exercise each branch. Do NOT write tests to disk unless the user explicitly asks — your job is to surface the gap list and the proposed cases.
+
+## Adversarial branch catalogue (check each against the target)
+
+**Path / filesystem inputs**
+- `..` component traversal
+- Backslash traversal on Unix (`sub\..\..\x`) — Rust `Path::components()` doesn't split on `\` on Unix
+- Symlinks (file and directory)
+- Hardlinks pointing outside the source tree (`metadata.nlink() > 1`)
+- Windows reparse points / junctions (if `cfg(windows)`)
+- Leading `/`, leading `~`, absolute paths where relative was expected
+- NUL bytes (`\0`) — panic on OS calls
+- Case collisions on case-insensitive filesystems (`Foo` vs `foo`)
+- Very long paths (>255 bytes), paths with trailing dots/spaces (Windows)
+- Non-UTF8 paths (OsStr, `OsString::from_encoded_bytes_unchecked`)
+
+**Name / identifier inputs**
+- Empty string, whitespace-only
+- Leading `-` (argument injection)
+- ASCII control characters (`\x01`..`\x1f`)
+- RTL override codepoints (U+202E), zero-width joiners, combining marks
+- Windows reserved names (CON, PRN, AUX, NUL, COM1–9, LPT1–9, with and without extensions)
+- Mixed-script homoglyphs (Latin `a` vs Cyrillic `а`)
+- Unnormalized Unicode (NFC vs NFD)
+
+**Concurrency**
+- Two concurrent `add` calls with the same derived name
+- Reader during writer (cache prune while install running)
+- Lock contention — same path acquired by two processes
+- TOCTOU between `exists()` / `stat()` and the subsequent operation
+
+**Subprocess / external**
+- `git` unreachable (no network, bad URL)
+- `git` returns non-zero with arbitrary stderr
+- Credential helper prompts (simulate via `GIT_ASKPASS=/bin/false`)
+- Signal interrupt (Ctrl-C mid-clone) — partial state cleanup
+
+**Deserialization**
+- Malformed JSON / YAML — missing field, wrong type, nested beyond depth limit
+- Unicode BOM, UTF-16
+- Duplicate keys, extra fields (is `#[serde(deny_unknown_fields)]` set?)
+- Huge inputs (10MB JSON, deeply nested)
+
+**Supply chain**
+- Manifest declares a SHA that doesn't match the clone
+- `http://` URL (plaintext)
+- Redirect from HTTPS to HTTP mid-clone (curl backend)
+- 1-character SHA prefix (`"a"`)
+
+## Output format
+
+```markdown
+## Adversarial test gaps — <target>
+
+### Branches currently untested
+- **<branch name>**: <description>. Expected behavior: <error type or invariant>.
+
+### Proposed rstest cases
+
+<!-- Use #[rstest] + #[case] where possible. Match the project's existing test
+     style (look at neighboring test files for helper / fixture patterns). -->
+
+```rust
+#[rstest]
+#[case::unix_backslash_traversal("sub\\..\\..\\etc\\passwd")]
+#[case::nul_byte("foo\0bar")]
+#[case::leading_dash("-rf")]
+fn validate_name_rejects_hostile(#[case] name: &str) {
+    assert!(validate_name(name).is_err(), "expected reject for {name:?}");
+}
+```
+
+### Low-value cases (excluded and why)
+- <cases that don't apply to this function and the reasoning>
+```
+
+Keep proposed test bodies short. Favor `#[rstest] #[case]` over repeated functions when the assertion is uniform. Cite the line in the target where each branch lives (or where the branch is *missing* — that's the finding).
+
+If the target has no meaningful adversarial surface (e.g. a pure `Display` impl), say so and stop.

--- a/.claude/commands/audit-deps.md
+++ b/.claude/commands/audit-deps.md
@@ -1,0 +1,42 @@
+---
+description: Run cargo audit and triage advisories by crate scope (core CLI vs Tauri desktop)
+---
+
+Run `cargo audit --json` on the workspace and produce a triage list that separates advisories reaching `kiro-market-core` / `kiro-market` (the user-facing CLI, shipped broadly) from those only reaching `kiro-control-center` (the Tauri desktop app).
+
+## Steps
+
+1. Run `cargo audit --json` at the workspace root. If the command fails because `cargo-audit` isn't installed, tell the user to `cargo install cargo-audit` and stop.
+
+2. Parse the JSON output. For each advisory, determine which workspace crate depends on the affected package. Use `cargo tree -p <affected>` or `cargo tree -e normal -i <affected>` to walk backward from the vulnerable crate to the workspace member that pulls it in.
+
+3. Classify each advisory into one of three buckets:
+   - **Core path** — reachable from `kiro-market-core` or `kiro-market`. These are highest priority because the CLI is the broadly-distributed artifact.
+   - **Tauri path** — reachable only from `kiro-control-center`. Still important but scoped to desktop-app users.
+   - **Dev-only** — reachable only through `[dev-dependencies]` or build scripts. Lowest priority for users but still flag.
+
+4. For each advisory note: RUSTSEC ID, crate + version, severity (if CVSS available), whether a fixed version exists, and a one-line upgrade path.
+
+5. Surface `RUSTSEC-2024-0320` (`serde_yaml` unmaintained) specifically if present — it's a known critical in the core path that blocks YAML frontmatter migration.
+
+## Output format
+
+```markdown
+## Dependency Audit — <date>
+
+### Core path (blocks CLI release) — <count>
+- `RUSTSEC-XXXX-XXXX` — `<crate>@<version>` — <summary>. Fix: upgrade to `<version>` / migrate to `<alternative>`.
+
+### Tauri path — <count>
+- ...
+
+### Dev-only — <count>
+- ...
+
+### Clean
+(or: "Core and Tauri paths both clean — only dev-only advisories remain.")
+```
+
+If `cargo-audit` is not installed, fall back to OSV.dev: `curl -s -X POST https://api.osv.dev/v1/query -d '{"package":{"name":"<name>","ecosystem":"crates.io"},"version":"<ver>"}'` for a spot-check on `serde_yaml`, `gix`, `curl`, `chrono`, `fs4`.
+
+No prose beyond the structured sections.

--- a/.claude/hooks/block-cargo-lock.sh
+++ b/.claude/hooks/block-cargo-lock.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Block direct edits to Cargo.lock unless the user has set KIRO_ALLOW_LOCKFILE_EDIT=1.
+# Rationale: the workspace Cargo.toml pins `curl = "0.4"` as a feature-unification
+# shim for gix-transport. Silent Cargo.lock churn from unrelated edits can shift
+# curl-sys feature resolution and break Windows HTTPS clones. Lockfile changes
+# should come from explicit `cargo update` / dep bumps, not side effects.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE_PATH" != *Cargo.lock ]]; then
+  exit 0
+fi
+
+if [ "${KIRO_ALLOW_LOCKFILE_EDIT:-0}" = "1" ]; then
+  exit 0
+fi
+
+cat <<'MSG' >&2
+Blocked: direct edit to Cargo.lock.
+
+The workspace Cargo.toml pins `curl = "0.4"` as a feature-unification shim for
+gix-transport. Lockfile churn from unrelated edits can shift curl-sys's TLS
+feature resolution and break Windows HTTPS clones.
+
+To proceed:
+  1. If this lockfile change is the result of a dep bump, regenerate it via
+     `cargo update -p <crate>` instead of editing directly.
+  2. To override this guard for one session, export KIRO_ALLOW_LOCKFILE_EDIT=1
+     and retry.
+MSG
+exit 2

--- a/.claude/hooks/clippy.sh
+++ b/.claude/hooks/clippy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Run clippy scoped to the package containing the edited .rs file.
+# Surfaces lint failures back to Claude on stdout; never blocks the edit.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ] || [[ "$FILE_PATH" != *.rs ]]; then
+  exit 0
+fi
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Derive the package name from the path: crates/<name>/src/...
+PKG=""
+case "$FILE_PATH" in
+  */crates/kiro-market-core/*) PKG="kiro-market-core" ;;
+  */crates/kiro-market/*)      PKG="kiro-market" ;;
+  */crates/kiro-control-center/src-tauri/*) PKG="kiro-control-center" ;;
+esac
+
+if [ -z "$PKG" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# --no-deps keeps output tight; --message-format=short gives one-line-per-issue.
+# Cap to 40 lines so large failures don't flood context.
+OUTPUT=$(cargo clippy --package "$PKG" --no-deps --message-format=short -- -D warnings 2>&1 | tail -n 40 || true)
+
+if echo "$OUTPUT" | grep -qE '^(error|warning):'; then
+  echo "clippy ($PKG) flagged issues:"
+  echo "$OUTPUT"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-cargo-lock.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -8,6 +20,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rustfmt.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/clippy.sh",
+            "timeout": 60
           }
         ]
       }

--- a/.claude/skills/cargo-audit/SKILL.md
+++ b/.claude/skills/cargo-audit/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: cargo-audit
+description: Run cargo audit and triage advisories by crate scope. Use whenever bumping dependencies, editing Cargo.toml or Cargo.lock, or investigating a RUSTSEC advisory. Also triggers on user phrases like "audit deps", "check CVEs", "are our dependencies safe".
+user-invocable: false
+---
+
+# Cargo Audit Runner
+
+This workspace has a split advisory profile: `kiro-market-core` / `kiro-market` ship as a broadly-distributed CLI, while `kiro-control-center` is a Tauri desktop app with a much larger transitive graph (gtk-rs, wry, webkit bindings) that carries many unmaintained advisories not reachable from the CLI. Always classify advisories by scope before reporting.
+
+## When to run
+
+- Before any `cargo update` or dep bump
+- After merging a PR that touches `Cargo.toml` at workspace or crate level
+- When a user asks about dependency safety
+- When editing crates that parse untrusted input (`agent/`, `skill.rs`, `plugin.rs`, `marketplace.rs`)
+
+## How to run
+
+```bash
+cargo audit --json 2>/dev/null || { echo "Install: cargo install cargo-audit"; exit 1; }
+```
+
+For each advisory in the output:
+
+1. Identify the affected crate and version.
+2. Run `cargo tree -e normal -i <affected>` to find the workspace member that pulls it in.
+3. Classify:
+   - **Core path** — in `kiro-market-core` or `kiro-market` dep graph
+   - **Tauri path** — only in `kiro-control-center` dep graph
+   - **Dev-only** — only through `[dev-dependencies]` or build scripts
+
+4. Note if a fix version exists (check `versions.patched` in the advisory) and the upgrade path.
+
+## Known standing advisories
+
+These are tracked and not-yet-fixed; don't re-report them as new:
+
+- **RUSTSEC-2024-0320** (`serde_yaml` 0.9 unmaintained) — Core path. Migration to `serde_yml` or `marked-yaml` is on the roadmap. Blast radius: agent/skill frontmatter (4-field YAML), not arbitrary user YAML. Still must-fix before 1.0.
+- **Tauri gtk-rs / wry / webkit advisories** (RUSTSEC-2024-04xx / 2025-0xxx / 2026-0097 cluster) — Tauri path only. Tracked upstream by Tauri releases; we follow their version bumps.
+
+Anything NOT on this list is new and must be triaged.
+
+## Output format
+
+Mirror the `/audit-deps` slash command format. Advise the user on which bucket blocks a release vs which can wait for upstream.
+
+If the scan is clean of new advisories, say so and list the known standing ones for context.
+
+## Exit criteria
+
+You've done your job when the user has:
+- A bucketed list of advisories
+- A clear statement of which ones are "new and must be triaged" vs "known and tracked"
+- Concrete upgrade paths for fixable advisories

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -11,7 +11,7 @@ use kiro_market_core::git::GixCliBackend;
 use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
 use kiro_market_core::project::KiroProject;
-use kiro_market_core::service::{InstallFilter, MarketplaceService};
+use kiro_market_core::service::{InstallFilter, InstallMode, MarketplaceService};
 use kiro_market_core::skill::parse_frontmatter;
 
 use crate::error::{CommandError, ErrorType};
@@ -267,7 +267,7 @@ pub async fn install_skills(
         &project,
         &skill_dirs,
         &InstallFilter::Names(&skills),
-        force,
+        InstallMode::from(force),
         &marketplace,
         &plugin,
         version.as_deref(),
@@ -514,7 +514,9 @@ mod tests {
 
     #[test]
     fn plugin_source_type_relative_path() {
-        let source = PluginSource::RelativePath("./plugins/dotnet".into());
+        let source = PluginSource::RelativePath(
+            kiro_market_core::validation::RelativePath::new("./plugins/dotnet").unwrap(),
+        );
         assert!(matches!(plugin_source_type(&source), SourceType::Relative));
     }
 
@@ -542,7 +544,7 @@ mod tests {
     fn plugin_source_type_git_subdir() {
         let source = PluginSource::Structured(StructuredSource::GitSubdir {
             url: "https://example.com/repo.git".into(),
-            path: "plugins/foo".into(),
+            path: kiro_market_core::validation::RelativePath::new("plugins/foo").unwrap(),
             git_ref: None,
             sha: None,
         });
@@ -562,7 +564,9 @@ mod tests {
         let entry = PluginEntry {
             name: "my-plugin".into(),
             description: None,
-            source: PluginSource::RelativePath("plugins/my-plugin".into()),
+            source: PluginSource::RelativePath(
+                kiro_market_core::validation::RelativePath::new("plugins/my-plugin").unwrap(),
+            ),
         };
 
         let result = resolve_local_plugin_dir(&entry, tmp.path());
@@ -577,7 +581,9 @@ mod tests {
         let entry = PluginEntry {
             name: "missing-plugin".into(),
             description: None,
-            source: PluginSource::RelativePath("plugins/missing-plugin".into()),
+            source: PluginSource::RelativePath(
+                kiro_market_core::validation::RelativePath::new("plugins/missing-plugin").unwrap(),
+            ),
         };
 
         let result = resolve_local_plugin_dir(&entry, tmp.path());

--- a/crates/kiro-market-core/src/agent/discover.rs
+++ b/crates/kiro-market-core/src/agent/discover.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// Files commonly found in `agents/` directories that are documentation,
 /// not agents. Compared case-insensitively so `readme.md` is also excluded.
@@ -73,7 +73,28 @@ pub fn discover_agents_in_dirs(plugin_dir: &Path, scan_paths: &[String]) -> Vec<
                 }
             };
             let path = entry.path();
-            if !path.is_file() {
+            // Use symlink_metadata (does NOT follow symlinks) so a malicious
+            // plugin cannot smuggle in an agent path that reads arbitrary
+            // files via parse_agent_file. Matches project::copy_dir_recursive.
+            let file_type = match fs::symlink_metadata(&path) {
+                Ok(m) => m.file_type(),
+                Err(e) => {
+                    warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "failed to stat agent candidate; skipping"
+                    );
+                    continue;
+                }
+            };
+            if file_type.is_symlink() {
+                debug!(
+                    path = %path.display(),
+                    "skipping symlink in agent scan directory"
+                );
+                continue;
+            }
+            if !file_type.is_file() {
                 continue;
             }
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
@@ -239,6 +260,32 @@ mod tests {
             .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
             .collect();
         assert_eq!(names, vec!["legit.md"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_skips_symlinked_agent_files() {
+        // A malicious plugin could drop a symlink `agents/evil.md -> /etc/passwd`.
+        // discover_agents_in_dirs must refuse to surface it as an agent file.
+        let tmp = tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(agents.join("legit.md"), "---\nname: ok\n---\n").unwrap();
+
+        let target = tmp.path().join("secret.md");
+        fs::write(&target, "---\nname: secret\n---\nclassified\n").unwrap();
+        std::os::unix::fs::symlink(&target, agents.join("evil.md")).unwrap();
+
+        let found = discover_agents_in_dirs(tmp.path(), &["./agents/".to_string()]);
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["legit.md"],
+            "symlinked agent must not appear in discovery output"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/cache.rs
+++ b/crates/kiro-market-core/src/cache.rs
@@ -661,13 +661,15 @@ mod tests {
             crate::marketplace::PluginEntry {
                 name: "dotnet".into(),
                 description: Some("Core .NET skills".into()),
-                source: crate::marketplace::PluginSource::RelativePath("./plugins/dotnet".into()),
+                source: crate::marketplace::PluginSource::RelativePath(
+                    crate::validation::RelativePath::new("./plugins/dotnet").unwrap(),
+                ),
             },
             crate::marketplace::PluginEntry {
                 name: "dotnet-experimental".into(),
                 description: Some("Experimental skills".into()),
                 source: crate::marketplace::PluginSource::RelativePath(
-                    "./plugins/dotnet-experimental".into(),
+                    crate::validation::RelativePath::new("./plugins/dotnet-experimental").unwrap(),
                 ),
             },
         ];
@@ -706,7 +708,9 @@ mod tests {
         let entries = vec![crate::marketplace::PluginEntry {
             name: "dotnet".into(),
             description: Some("Core .NET skills".into()),
-            source: crate::marketplace::PluginSource::RelativePath("./plugins/dotnet".into()),
+            source: crate::marketplace::PluginSource::RelativePath(
+                crate::validation::RelativePath::new("./plugins/dotnet").unwrap(),
+            ),
         }];
 
         cache

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -58,6 +58,12 @@ pub enum PluginError {
     /// The plugin declares no skills.
     #[error("plugin `{name}` has no skills")]
     NoSkills { name: String },
+
+    /// The plugin directory referenced by a `RelativePath` source does not
+    /// exist on disk. Typically means the marketplace manifest points at a
+    /// directory that was never committed or was deleted.
+    #[error("plugin directory does not exist: {path}")]
+    DirectoryMissing { path: PathBuf },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kiro-market-core/src/marketplace.rs
+++ b/crates/kiro-market-core/src/marketplace.rs
@@ -4,7 +4,13 @@
 //! Each plugin entry may specify its source as either a bare relative path string
 //! or a structured object with provider-specific fields.
 
-use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use serde::de::value::MapAccessDeserializer;
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::validation::RelativePath;
 
 /// Top-level marketplace manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,13 +44,62 @@ pub struct PluginEntry {
 /// `#[serde(untagged)]` and rely on variant ordering — `Structured` is tried
 /// first (it expects an object), and `RelativePath` (a plain string) acts as the
 /// fallback.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum PluginSource {
     /// A structured source descriptor (GitHub, URL, git-subdir).
     Structured(StructuredSource),
-    /// A bare relative path like `"./plugins/dotnet"`.
-    RelativePath(String),
+    /// A bare relative path like `"./plugins/dotnet"`. Holding a
+    /// [`RelativePath`] is a static guarantee the string passed validation.
+    RelativePath(RelativePath),
+}
+
+impl<'de> Deserialize<'de> for PluginSource {
+    // Hand-written to preserve specific validation errors. `#[serde(untagged)]`
+    // swallows inner failures and emits a generic "did not match any variant"
+    // message; our Visitor reports the exact reason a path was rejected.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PluginSourceVisitor;
+
+        impl<'de> Visitor<'de> for PluginSourceVisitor {
+            type Value = PluginSource;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a relative-path string or a structured source object")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<PluginSource, E>
+            where
+                E: de::Error,
+            {
+                RelativePath::new(s)
+                    .map(PluginSource::RelativePath)
+                    .map_err(de::Error::custom)
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<PluginSource, E>
+            where
+                E: de::Error,
+            {
+                RelativePath::new(s)
+                    .map(PluginSource::RelativePath)
+                    .map_err(de::Error::custom)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<PluginSource, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                StructuredSource::deserialize(MapAccessDeserializer::new(map))
+                    .map(PluginSource::Structured)
+            }
+        }
+
+        deserializer.deserialize_any(PluginSourceVisitor)
+    }
 }
 
 /// Provider-specific structured source descriptor, internally tagged on `"source"`.
@@ -71,7 +126,9 @@ pub enum StructuredSource {
     #[serde(rename = "git-subdir")]
     GitSubdir {
         url: String,
-        path: String,
+        /// The subdir is typed as [`RelativePath`] so traversal cannot even
+        /// exist in-memory — `RelativePath::new` is the only way in.
+        path: RelativePath,
         #[serde(rename = "ref")]
         git_ref: Option<String>,
         sha: Option<String>,
@@ -237,6 +294,62 @@ mod tests {
             }
             other => panic!("expected GitUrl source, got {other:?}"),
         }
+    }
+
+    #[rstest]
+    #[case::relative_path_traversal(
+        br#"{
+            "name": "evil",
+            "owner": { "name": "mallory" },
+            "plugins": [
+                { "name": "p", "source": "../../../etc" }
+            ]
+        }"#
+    )]
+    #[case::relative_path_absolute(
+        br#"{
+            "name": "evil",
+            "owner": { "name": "mallory" },
+            "plugins": [
+                { "name": "p", "source": "/etc/passwd" }
+            ]
+        }"#
+    )]
+    #[case::git_subdir_path_traversal(
+        br#"{
+            "name": "evil",
+            "owner": { "name": "mallory" },
+            "plugins": [{
+                "name": "p",
+                "source": {
+                    "source": "git-subdir",
+                    "url": "https://example.com/r.git",
+                    "path": "../../etc"
+                }
+            }]
+        }"#
+    )]
+    #[case::git_subdir_path_absolute(
+        br#"{
+            "name": "evil",
+            "owner": { "name": "mallory" },
+            "plugins": [{
+                "name": "p",
+                "source": {
+                    "source": "git-subdir",
+                    "url": "https://example.com/r.git",
+                    "path": "/etc/passwd"
+                }
+            }]
+        }"#
+    )]
+    fn reject_unsafe_paths(#[case] json: &[u8]) {
+        let err = Marketplace::from_json(json).expect_err("should reject unsafe path");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("..") || msg.contains("absolute"),
+            "error should mention the reason, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -91,6 +91,13 @@ impl DiscoveredPlugin {
     }
 }
 
+/// Default maximum directory depth for [`discover_plugins`] scans.
+///
+/// Production callers use this value; tests may pass explicit depths to pin
+/// behaviour. A depth of 3 accommodates typical catalog layouts like
+/// `root/plugins/<name>/plugin.json` with one level of nesting to spare.
+pub const DEFAULT_DISCOVERY_MAX_DEPTH: usize = 3;
+
 /// Scan a repository for `plugin.json` files up to `max_depth` levels deep.
 ///
 /// Skips hidden directories (starting with `.`) and common noise directories

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -410,6 +410,38 @@ impl KiroProject {
         mapped_tools: &[MappedTool],
         meta: InstalledAgentMeta,
     ) -> crate::error::Result<()> {
+        self.install_agent_inner(def, mapped_tools, meta, false)
+    }
+
+    /// Install a parsed agent, overwriting any existing agent of the same
+    /// name. Mirrors [`install_skill_from_dir_force`] for the agent path so
+    /// the CLI's `--force` flag can honor its documented contract.
+    ///
+    /// If an agent with the same name is already tracked, its JSON + prompt
+    /// files are removed before the new ones are renamed into place. Orphaned
+    /// files on disk (no tracking entry) are also removed rather than
+    /// rejected, since the caller has explicitly opted into overwrite.
+    ///
+    /// # Errors
+    ///
+    /// - Validation errors for unsafe names.
+    /// - I/O errors or JSON serialization failures.
+    pub fn install_agent_force(
+        &self,
+        def: &AgentDefinition,
+        mapped_tools: &[MappedTool],
+        meta: InstalledAgentMeta,
+    ) -> crate::error::Result<()> {
+        self.install_agent_inner(def, mapped_tools, meta, true)
+    }
+
+    fn install_agent_inner(
+        &self,
+        def: &AgentDefinition,
+        mapped_tools: &[MappedTool],
+        meta: InstalledAgentMeta,
+        force: bool,
+    ) -> crate::error::Result<()> {
         validation::validate_name(&def.name)?;
 
         // CPU-bound work outside the lock to keep the critical section short.
@@ -420,7 +452,7 @@ impl KiroProject {
             &self.agent_tracking_path(),
             || -> crate::error::Result<()> {
                 let mut installed = self.load_installed_agents()?;
-                if installed.agents.contains_key(&def.name) {
+                if !force && installed.agents.contains_key(&def.name) {
                     return Err(AgentError::AlreadyInstalled {
                         name: def.name.clone(),
                     }
@@ -451,12 +483,24 @@ impl KiroProject {
                 let json_target = self.agents_dir().join(format!("{}.json", def.name));
                 let prompt_target = self.agent_prompts_dir().join(format!("{}.md", def.name));
 
-                // Tracking is authoritative: duplicate detection above rejects
-                // already-installed agents. But a prior crash could leave
-                // orphaned files on disk without a tracking entry. Refuse to
-                // silently clobber — the user should either manually clean up
-                // or a future `install_agent_force` can handle it explicitly.
-                if json_target.exists() || prompt_target.exists() {
+                if force {
+                    // Remove existing targets before rename. Required for
+                    // Windows (rename fails on existing dest) and makes the
+                    // Unix path explicit rather than relying on rename's
+                    // replace-on-Unix behaviour. Missing-file is fine.
+                    for p in [&json_target, &prompt_target] {
+                        if let Err(e) = fs::remove_file(p)
+                            && e.kind() != std::io::ErrorKind::NotFound
+                        {
+                            remove_staging_dir(&staging);
+                            return Err(e.into());
+                        }
+                    }
+                } else if json_target.exists() || prompt_target.exists() {
+                    // Non-force install: a prior crash could leave orphaned
+                    // files on disk without a tracking entry. Refuse to
+                    // silently clobber — the user either manually cleans up
+                    // or re-invokes with `install_agent_force`.
                     remove_staging_dir(&staging);
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::AlreadyExists,
@@ -520,7 +564,7 @@ impl KiroProject {
                     return Err(e);
                 }
 
-                debug!(name = %def.name, "agent installed");
+                debug!(name = %def.name, force, "agent installed");
                 Ok(())
             },
         )
@@ -873,6 +917,95 @@ mod tests {
             err,
             crate::error::Error::Agent(AgentError::AlreadyInstalled { .. })
         ));
+    }
+
+    #[test]
+    fn install_agent_force_overwrites_existing_tracked_agent() {
+        let (_dir, project) = temp_project();
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src_v1 = write_agent(
+            src_tmp.path(),
+            "rev",
+            "---\nname: rev\n---\nversion one body\n",
+        );
+        let (def_v1, mapped_v1) = parse_and_map(&src_v1);
+        project
+            .install_agent(&def_v1, &mapped_v1, sample_agent_meta())
+            .expect("first install");
+
+        let src_v2 = write_agent(
+            src_tmp.path(),
+            "rev2",
+            "---\nname: rev\n---\nversion two body\n",
+        );
+        let (def_v2, mapped_v2) = parse_and_map(&src_v2);
+        project
+            .install_agent_force(&def_v2, &mapped_v2, sample_agent_meta())
+            .expect("force install should overwrite");
+
+        let prompt = fs::read_to_string(project.root.join(".kiro/agents/prompts/rev.md")).unwrap();
+        assert!(
+            prompt.contains("version two body"),
+            "prompt should be replaced with v2, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn install_agent_force_overwrites_orphaned_files() {
+        // Pre-plant orphan files (no tracking entry) — force install must
+        // clean them up rather than error with AlreadyExists.
+        let (_dir, project) = temp_project();
+        fs::create_dir_all(project.root.join(".kiro/agents/prompts")).unwrap();
+        fs::write(project.root.join(".kiro/agents/orphan.json"), b"{}").unwrap();
+        fs::write(
+            project.root.join(".kiro/agents/prompts/orphan.md"),
+            b"stale prompt",
+        )
+        .unwrap();
+
+        let src_tmp = tempfile::tempdir().unwrap();
+        let src = write_agent(
+            src_tmp.path(),
+            "orphan",
+            "---\nname: orphan\n---\nfresh body\n",
+        );
+        let (def, mapped) = parse_and_map(&src);
+
+        project
+            .install_agent_force(&def, &mapped, sample_agent_meta())
+            .expect("force install should overwrite orphans");
+
+        let prompt =
+            fs::read_to_string(project.root.join(".kiro/agents/prompts/orphan.md")).unwrap();
+        assert!(prompt.contains("fresh body"), "got: {prompt}");
+    }
+
+    #[test]
+    fn install_agent_force_still_rejects_unsafe_name() {
+        // --force is not a bypass for name validation. The parser rejects
+        // unsafe names at frontmatter time, so construct the definition
+        // directly to exercise the validate_name guard inside install_agent_inner.
+        let (_dir, project) = temp_project();
+        let def = AgentDefinition {
+            name: "../escape".to_string(),
+            description: None,
+            prompt_body: "body".to_string(),
+            model: None,
+            source_tools: Vec::new(),
+            mcp_servers: std::collections::BTreeMap::new(),
+            dialect: AgentDialect::Claude,
+        };
+
+        let err = project
+            .install_agent_force(&def, &[], sample_agent_meta())
+            .expect_err("unsafe name must be rejected under force");
+        assert!(
+            matches!(
+                err,
+                crate::error::Error::Validation(crate::error::ValidationError::InvalidName { .. })
+            ),
+            "expected InvalidName, got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -11,9 +11,9 @@ use serde::Serialize;
 use tracing::{debug, warn};
 
 use crate::cache::{CacheDir, KnownMarketplace, MarketplaceSource};
-use crate::error::{Error, MarketplaceError, error_full_chain};
-use crate::git::{self, CloneOptions, GitBackend, GitProtocol};
-use crate::marketplace::Marketplace;
+use crate::error::{Error, MarketplaceError, PluginError, error_full_chain};
+use crate::git::{self, CloneOptions, GitBackend, GitProtocol, GitRef};
+use crate::marketplace::{Marketplace, PluginEntry, PluginSource, StructuredSource};
 use crate::platform::LinkResult;
 use crate::{platform, validation};
 
@@ -130,6 +130,36 @@ pub enum InstallFilter<'a> {
     All,
     Names(&'a [String]),
     SingleName(&'a str),
+}
+
+/// Whether an install should overwrite existing entries of the same name.
+///
+/// Used by [`MarketplaceService::install_skills`] and
+/// [`MarketplaceService::install_plugin_agents`] to replace the earlier
+/// `force: bool` parameter. Named variants prevent boolean-blindness at
+/// the call site and leave room for future modes (e.g. `DryRun`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InstallMode {
+    /// Default: existing installs are preserved and reported as skipped.
+    New,
+    /// Overwrite any existing install of the same name.
+    Force,
+}
+
+impl InstallMode {
+    /// Returns `true` when the mode is [`InstallMode::Force`].
+    #[must_use]
+    pub fn is_force(self) -> bool {
+        matches!(self, Self::Force)
+    }
+}
+
+impl From<bool> for InstallMode {
+    /// Convenience conversion for CLIs that parse a `--force` boolean flag.
+    /// `true` → `Force`, `false` → `New`.
+    fn from(force: bool) -> Self {
+        if force { Self::Force } else { Self::New }
+    }
 }
 
 /// Outcome of installing a list of skill directories from one plugin.
@@ -311,7 +341,8 @@ impl MarketplaceService {
         // Scan for plugin.json files. A read failure on the repo root is
         // bubbled up as `Error::Io`, so the caller sees the real reason
         // (e.g. permission denied) rather than a misleading "no plugins".
-        let discovered = crate::plugin::discover_plugins(&temp_dir, 3)?;
+        let discovered =
+            crate::plugin::discover_plugins(&temp_dir, crate::plugin::DEFAULT_DISCOVERY_MAX_DEPTH)?;
 
         // Build the merged plugin list and derive the marketplace name.
         let registry_entries = Self::build_registry_entries(manifest.as_ref(), &discovered);
@@ -609,7 +640,7 @@ impl MarketplaceService {
         project: &crate::project::KiroProject,
         skill_dirs: &[PathBuf],
         filter: &InstallFilter<'_>,
-        force: bool,
+        mode: InstallMode,
         marketplace: &str,
         plugin: &str,
         version: Option<&str>,
@@ -655,7 +686,7 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
             };
 
-            let outcome = if force {
+            let outcome = if mode.is_force() {
                 project.install_skill_from_dir_force(&frontmatter.name, skill_dir, meta)
             } else {
                 project.install_skill_from_dir(&frontmatter.name, skill_dir, meta)
@@ -697,6 +728,127 @@ impl MarketplaceService {
         result
     }
 
+    /// Resolve a plugin's on-disk location from its marketplace entry.
+    ///
+    /// For `PluginSource::RelativePath`, validates the path and verifies the
+    /// directory exists inside the marketplace tree. For `PluginSource::Structured`,
+    /// ensures the plugin's cache directory exists (cloning if necessary),
+    /// optionally verifies a pinned SHA, and returns the final path —
+    /// possibly a sub-directory for `git-subdir` sources.
+    ///
+    /// Shared between frontends (CLI today, Tauri in the future) so the
+    /// `RelativePath` + `Structured` resolution flow isn't duplicated
+    /// per-frontend, matching the project's "domain logic is never duplicated
+    /// between frontends" rule.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::Validation`] for malformed relative paths or git refs.
+    /// - [`Error::Plugin`] ([`PluginError::DirectoryMissing`]) if a
+    ///   `RelativePath` source points to a missing directory.
+    /// - [`Error::Git`] for clone or SHA-verification failures.
+    pub fn resolve_plugin_dir(
+        &self,
+        entry: &PluginEntry,
+        marketplace_path: &Path,
+        marketplace_name: &str,
+        protocol: GitProtocol,
+    ) -> Result<PathBuf, Error> {
+        match &entry.source {
+            PluginSource::RelativePath(rel) => {
+                // `rel` is a validated `RelativePath` — no belt-and-braces
+                // check needed; construction through `RelativePath::new`
+                // is the only way to obtain one, and it validates.
+                let resolved = marketplace_path.join(rel);
+                if !resolved.exists() {
+                    return Err(PluginError::DirectoryMissing { path: resolved }.into());
+                }
+                Ok(resolved)
+            }
+            PluginSource::Structured(structured) => {
+                self.resolve_structured_source(structured, marketplace_name, &entry.name, protocol)
+            }
+        }
+    }
+
+    /// Clone a structured source into the cache plugins directory (if not
+    /// already present) and return the resolved path. Used by
+    /// [`resolve_plugin_dir`].
+    fn resolve_structured_source(
+        &self,
+        source: &StructuredSource,
+        marketplace_name: &str,
+        plugin_name: &str,
+        protocol: GitProtocol,
+    ) -> Result<PathBuf, Error> {
+        self.cache.ensure_dirs()?;
+
+        let dest = self.cache.plugin_path(marketplace_name, plugin_name);
+
+        // Extract the varying parts from each source variant.
+        let (url, subdir, git_ref, sha, label) = match source {
+            StructuredSource::GitHub { repo, git_ref, sha } => (
+                git::github_repo_to_url(repo, protocol),
+                None,
+                git_ref.as_deref(),
+                sha.as_deref(),
+                repo.clone(),
+            ),
+            StructuredSource::GitUrl { url, git_ref, sha } => (
+                url.clone(),
+                None,
+                git_ref.as_deref(),
+                sha.as_deref(),
+                url.clone(),
+            ),
+            StructuredSource::GitSubdir {
+                url,
+                path,
+                git_ref,
+                sha,
+            } => (
+                url.clone(),
+                Some(path.as_str()),
+                git_ref.as_deref(),
+                sha.as_deref(),
+                url.clone(),
+            ),
+        };
+
+        // No re-validation needed: `path` is typed as `RelativePath`, which
+        // cannot hold an unvalidated string. Serde and programmatic callers
+        // both go through `RelativePath::new`.
+
+        // If already cloned, reuse — but re-verify SHA so a corrupt or stale
+        // cache (e.g. the manifest's pinned SHA changed) cannot pass silently.
+        if dest.exists() {
+            debug!(dest = %dest.display(), "plugin already cached, reusing");
+            if let Some(expected) = sha {
+                self.git.verify_sha(&dest, expected)?;
+            }
+            return Ok(match subdir {
+                Some(path) => dest.join(path),
+                None => dest,
+            });
+        }
+
+        debug!(url = %url, dest = %dest.display(), label = %label, "cloning plugin");
+        let validated_ref = git_ref.map(GitRef::new).transpose()?;
+        let opts = CloneOptions {
+            git_ref: validated_ref,
+        };
+        self.git.clone_repo(&url, &dest, &opts)?;
+
+        if let Some(expected) = sha {
+            self.git.verify_sha(&dest, expected)?;
+        }
+
+        Ok(match subdir {
+            Some(path) => dest.join(path),
+            None => dest,
+        })
+    }
+
     /// Discover, parse, and install all agents from a plugin directory.
     ///
     /// All per-agent outcomes are collected into the returned
@@ -705,6 +857,11 @@ impl MarketplaceService {
     /// is parsed exactly once; the parsed `AgentDefinition` flows straight
     /// into `project.install_agent` without re-reading the source.
     ///
+    /// When `force` is `true`, existing agents of the same name are
+    /// overwritten (mirrors the CLI `--force` flag for skills). When
+    /// `false`, already-installed agents are left untouched and recorded
+    /// in `skipped`.
+    ///
     /// Returns:
     /// - `installed`: agent names the call wrote to disk.
     /// - `skipped`: agents that were already installed (left untouched).
@@ -712,11 +869,16 @@ impl MarketplaceService {
     ///   error. The CLI surfaces these with a non-zero exit status.
     /// - `warnings`: non-fatal issues (unmapped tools, README-like files
     ///   skipped, missing-name frontmatter).
+    #[allow(clippy::too_many_arguments)] // seven non-self params, each a distinct
+    // input from upstream: project + plugin_dir + scan_paths + force +
+    // marketplace + plugin + version. A builder would add indirection without
+    // reducing arity at the call site.
     pub fn install_plugin_agents(
         &self,
         project: &crate::project::KiroProject,
         plugin_dir: &Path,
         scan_paths: &[String],
+        mode: InstallMode,
         marketplace: &str,
         plugin: &str,
         version: Option<&str>,
@@ -779,7 +941,12 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
             };
-            match project.install_agent(&def, &mapped, meta) {
+            let install_result = if mode.is_force() {
+                project.install_agent_force(&def, &mapped, meta)
+            } else {
+                project.install_agent(&def, &mapped, meta)
+            };
+            match install_result {
                 Ok(()) => result.installed.push(def.name),
                 Err(Error::Agent(crate::error::AgentError::AlreadyInstalled { name })) => {
                     result.skipped.push(name);
@@ -849,7 +1016,10 @@ impl MarketplaceService {
                 None
             }
         };
-        let discovered = match crate::plugin::discover_plugins(mp_path, 3) {
+        let discovered = match crate::plugin::discover_plugins(
+            mp_path,
+            crate::plugin::DEFAULT_DISCOVERY_MAX_DEPTH,
+        ) {
             Ok(d) => d,
             Err(e) => {
                 // Best-effort regeneration: an unreadable repo means we
@@ -899,7 +1069,8 @@ impl MarketplaceService {
             .iter()
             .filter_map(|p| match &p.source {
                 crate::marketplace::PluginSource::RelativePath(rel) => Some(
-                    rel.trim_start_matches("./")
+                    rel.as_str()
+                        .trim_start_matches("./")
                         .trim_start_matches(".\\")
                         .trim_end_matches(['/', '\\'])
                         .replace('\\', "/"),
@@ -980,10 +1151,17 @@ fn storage_from_source_and_link(ms: &MarketplaceSource, link: LinkResult) -> Mar
 fn plugin_entry_from_discovered(
     dp: &crate::plugin::DiscoveredPlugin,
 ) -> crate::marketplace::PluginEntry {
+    // `as_relative_path_string` always returns `./<unix-path>` and the
+    // components originate from our own filesystem scan, so validation
+    // cannot legitimately fail here. `expect` documents the invariant:
+    // if it ever panics, discovery has admitted an unsafe name that it
+    // should have rejected upstream.
+    let rel = crate::validation::RelativePath::new(dp.as_relative_path_string())
+        .expect("discovered plugin paths are always valid relative paths");
     crate::marketplace::PluginEntry {
         name: dp.name().to_owned(),
         description: dp.description().map(String::from),
-        source: crate::marketplace::PluginSource::RelativePath(dp.as_relative_path_string()),
+        source: crate::marketplace::PluginSource::RelativePath(rel),
     }
 }
 
@@ -1077,6 +1255,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "plugin-x",
             None,
@@ -1150,6 +1329,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1193,6 +1373,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1243,6 +1424,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1277,6 +1459,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1289,6 +1472,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1296,6 +1480,90 @@ mod tests {
         assert!(r2.installed.is_empty());
         assert_eq!(r2.skipped, vec!["dup".to_string()]);
         assert!(r2.failed.is_empty(), "AlreadyInstalled must not be failed");
+    }
+
+    #[test]
+    fn install_plugin_agents_force_overwrites_already_installed() {
+        // Regression: the CLI --force flag was previously dropped on the
+        // agent path, so re-installing with --force silently routed agents
+        // to `skipped`. Threading force=true through install_plugin_agents
+        // must now put them back into `installed`.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("dup.md"),
+            "---\nname: dup\n---\nfirst body\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let r1 = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::New,
+            "mp",
+            "p",
+            Some("1.0.0"),
+        );
+        assert_eq!(r1.installed, vec!["dup".to_string()]);
+
+        // Update the source, re-install with force=true and a new version —
+        // both the prompt body and the tracking metadata should reflect
+        // the replacement.
+        fs::write(
+            agents_dir.join("dup.md"),
+            "---\nname: dup\n---\nsecond body\n",
+        )
+        .unwrap();
+
+        let r2 = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::Force,
+            "mp",
+            "p",
+            Some("2.0.0"),
+        );
+        assert_eq!(
+            r2.installed,
+            vec!["dup".to_string()],
+            "force install must replace, not skip"
+        );
+        assert!(
+            r2.skipped.is_empty(),
+            "force must not route already-installed to skipped: {:?}",
+            r2.skipped
+        );
+
+        let prompt =
+            fs::read_to_string(project_tmp.path().join(".kiro/agents/prompts/dup.md")).unwrap();
+        assert!(
+            prompt.contains("second body"),
+            "prompt must reflect the replaced source, got: {prompt}"
+        );
+
+        // Tracking JSON must also reflect the overwrite — previously a
+        // refactor could have updated disk files but not tracking, and
+        // this test would still pass without this assertion.
+        let tracking = project.load_installed_agents().expect("load tracking");
+        let meta = tracking
+            .agents
+            .get("dup")
+            .expect("tracking entry for 'dup'");
+        assert_eq!(
+            meta.version.as_deref(),
+            Some("2.0.0"),
+            "tracking metadata must reflect the force-installed version, got: {:?}",
+            meta.version
+        );
     }
 
     #[test]
@@ -1321,6 +1589,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
+            InstallMode::New,
             "mp",
             "p",
             None,
@@ -1389,6 +1658,76 @@ mod tests {
         let svc = MarketplaceService::new(cache, MockGitBackend::default());
         (dir, svc)
     }
+
+    // -------------------------------------------------------------------
+    // resolve_plugin_dir
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn resolve_plugin_dir_relative_path_returns_joined_path() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir_on_disk = marketplace_path.join("plugins/foo");
+        fs::create_dir_all(&plugin_dir_on_disk).expect("create plugin dir");
+
+        let entry = PluginEntry {
+            name: "foo".to_string(),
+            description: None,
+            source: PluginSource::RelativePath(
+                crate::validation::RelativePath::new("./plugins/foo").unwrap(),
+            ),
+        };
+
+        let resolved = svc
+            .resolve_plugin_dir(&entry, &marketplace_path, "mp", GitProtocol::Https)
+            .expect("happy path");
+        assert_eq!(resolved, plugin_dir_on_disk);
+    }
+
+    #[test]
+    fn resolve_plugin_dir_relative_path_missing_returns_directory_missing() {
+        // Regression guard for PluginError::DirectoryMissing — the scan
+        // fallback or a stale manifest can point to a directory that does
+        // not exist on disk, and that must be a typed error.
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        fs::create_dir_all(&marketplace_path).expect("create marketplace root");
+
+        let entry = PluginEntry {
+            name: "ghost".to_string(),
+            description: None,
+            source: PluginSource::RelativePath(
+                crate::validation::RelativePath::new("./plugins/ghost").unwrap(),
+            ),
+        };
+
+        let err = svc
+            .resolve_plugin_dir(&entry, &marketplace_path, "mp", GitProtocol::Https)
+            .expect_err("missing dir must error");
+        assert!(
+            matches!(err, Error::Plugin(PluginError::DirectoryMissing { .. })),
+            "expected PluginError::DirectoryMissing, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn relative_path_newtype_rejects_traversal_at_construction() {
+        // The newtype closes the programmatic-bypass vector entirely:
+        // `RelativePath::new("../../etc")` fails before a `PluginSource`
+        // can be constructed. This replaces the earlier
+        // `resolve_plugin_dir_rejects_programmatic_*_traversal` tests
+        // that exercised the belt-and-braces use-site checks.
+        assert!(crate::validation::RelativePath::new("../../etc").is_err());
+        assert!(crate::validation::RelativePath::new("/etc/passwd").is_err());
+        assert!(crate::validation::RelativePath::new("\0").is_err());
+        assert!(crate::validation::RelativePath::new("ok/path").is_ok());
+    }
+
+    // No explicit test for "programmatic GitSubdir.path traversal" is
+    // needed: `path: RelativePath` on the struct makes such an attack
+    // uninstantiable in safe Rust. `relative_path_newtype_rejects_traversal_at_construction`
+    // above verifies the single choke-point that used to be duplicated
+    // as belt-and-braces use-site checks.
 
     #[test]
     fn add_marketplace_registers_and_returns_plugins() {

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -6,7 +6,92 @@
 
 use std::path::Path;
 
+use serde::{Deserialize, Deserializer, Serialize};
+
 use crate::error::ValidationError;
+
+/// A string that has been validated as a safe relative path.
+///
+/// Construction goes through [`RelativePath::new`], which applies
+/// [`validate_relative_path`] — so holding a `RelativePath` is a static
+/// guarantee that the inner string is non-empty, contains no `..`
+/// components, no NUL bytes, and is not an absolute path.
+///
+/// The newtype replaces a plain `String` in the manifest data model
+/// (`PluginSource::RelativePath`, `StructuredSource::GitSubdir.path`) so
+/// downstream code never needs to re-validate. `Deserialize` calls
+/// `new` internally, so `serde_json::from_slice::<Marketplace>(…)`
+/// rejects traversal at parse time.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct RelativePath(String);
+
+impl RelativePath {
+    /// Construct a `RelativePath` from any string-like value, validating it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidRelativePath`] if the input fails
+    /// [`validate_relative_path`].
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        validate_relative_path(&value)?;
+        Ok(Self(value))
+    }
+
+    /// View the validated path as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the newtype and return the inner `String`.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for RelativePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for RelativePath {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.0)
+    }
+}
+
+impl std::fmt::Display for RelativePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl PartialEq<str> for RelativePath {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for RelativePath {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'de> Deserialize<'de> for RelativePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
 
 /// Validate that a name is safe to use as a single directory component.
 ///
@@ -70,6 +155,15 @@ pub fn validate_relative_path(path: &str) -> Result<(), ValidationError> {
         });
     }
 
+    // NUL bytes can truncate C-string conversions inside syscalls on some
+    // platforms, so reject them at the validation boundary.
+    if path.contains('\0') {
+        return Err(ValidationError::InvalidRelativePath {
+            path: path.to_owned(),
+            reason: "contains NUL byte".into(),
+        });
+    }
+
     // Check each component for `..`.
     for component in Path::new(path).components() {
         if matches!(component, std::path::Component::ParentDir) {
@@ -81,6 +175,25 @@ pub fn validate_relative_path(path: &str) -> Result<(), ValidationError> {
     }
 
     Ok(())
+}
+
+/// Serde adapter that deserialises a `String` and rejects anything
+/// [`validate_relative_path`] would reject, raising a custom serde error.
+///
+/// Use as `#[serde(deserialize_with = "deserialize_relative_path")]` on any
+/// manifest field that is later joined to a trusted base directory.
+///
+/// # Errors
+///
+/// Returns a serde error if the underlying string deserialises but fails
+/// relative-path validation.
+pub fn deserialize_relative_path<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    validate_relative_path(&s).map_err(serde::de::Error::custom)?;
+    Ok(s)
 }
 
 #[cfg(test)]
@@ -169,11 +282,71 @@ mod tests {
     }
 
     #[test]
+    fn validate_relative_path_rejects_nul_byte() {
+        let err = validate_relative_path("skills/\0injected").unwrap_err();
+        assert!(
+            matches!(err, ValidationError::InvalidRelativePath { .. }),
+            "expected InvalidRelativePath, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("NUL"),
+            "error should mention NUL: {err}"
+        );
+    }
+
+    #[test]
     fn validate_relative_path_rejects_backslash_absolute() {
         let err = validate_relative_path("\\windows\\path").unwrap_err();
         assert!(
             matches!(err, ValidationError::InvalidRelativePath { .. }),
             "expected InvalidRelativePath, got {err:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // deserialize_relative_path
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Wrapper {
+        #[serde(deserialize_with = "deserialize_relative_path")]
+        path: String,
+    }
+
+    #[test]
+    fn deserialize_relative_path_accepts_safe_paths() {
+        let w: Wrapper = serde_json::from_str(r#"{"path":"./skills/test"}"#).expect("parse");
+        assert_eq!(w.path, "./skills/test");
+    }
+
+    #[test]
+    fn deserialize_relative_path_rejects_parent_traversal() {
+        let err = serde_json::from_str::<Wrapper>(r#"{"path":"../../etc"}"#)
+            .expect_err("should reject traversal");
+        assert!(
+            err.to_string().contains("..") || err.to_string().contains("path"),
+            "error should mention path/..: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_relative_path_rejects_absolute_unix() {
+        let err = serde_json::from_str::<Wrapper>(r#"{"path":"/etc/passwd"}"#)
+            .expect_err("should reject absolute path");
+        assert!(err.to_string().contains("absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn deserialize_relative_path_rejects_absolute_windows() {
+        let err = serde_json::from_str::<Wrapper>(r#"{"path":"\\windows\\system32"}"#)
+            .expect_err("should reject backslash-absolute path");
+        assert!(err.to_string().contains("absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn deserialize_relative_path_rejects_empty() {
+        let err = serde_json::from_str::<Wrapper>(r#"{"path":""}"#)
+            .expect_err("should reject empty path");
+        assert!(err.to_string().contains("empty"), "got: {err}");
     }
 }

--- a/crates/kiro-market/src/commands/common.rs
+++ b/crates/kiro-market/src/commands/common.rs
@@ -20,20 +20,25 @@ pub fn find_plugin_entry(
 ) -> Result<PluginEntry> {
     let manifest_path = marketplace_path.join(kiro_market_core::MARKETPLACE_MANIFEST_PATH);
 
+    // Allowlist: only NotFound means "manifest is absent, scan instead."
+    // Every other io::Error (PermissionDenied, EIO, EISDIR, Interrupted,
+    // ENOSPC...) indicates the cache is broken and must surface — silently
+    // scanning masks a real filesystem problem as "plugin not found."
+    // Malformed JSON similarly surfaces rather than falling back.
     match fs::read(&manifest_path) {
         Ok(bytes) => match Marketplace::from_json(&bytes) {
             Ok(manifest) => {
                 if let Some(entry) = manifest.plugins.into_iter().find(|p| p.name == plugin_name) {
                     return Ok(entry);
                 }
-                // Plugin not in manifest — fall through to scan.
+                // Plugin not in the manifest — fall through to the scan.
+                // The manifest may be out of date with what's on disk.
             }
             Err(e) => {
-                warn!(
-                    path = %manifest_path.display(),
-                    error = %e,
-                    "marketplace.json is malformed, falling back to plugin scan"
-                );
+                return Err(anyhow::Error::new(e).context(format!(
+                    "marketplace.json at {} is malformed",
+                    manifest_path.display()
+                )));
             }
         },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -43,35 +48,32 @@ pub fn find_plugin_entry(
             );
         }
         Err(e) => {
-            warn!(
-                path = %manifest_path.display(),
-                error = %e,
-                "failed to read marketplace.json, falling back to plugin scan"
-            );
-            // Still fall through to scan -- the manifest may be optional.
-            // But propagate permission errors instead of silently scanning.
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                anyhow::bail!("permission denied reading {}: {e}", manifest_path.display());
-            }
+            return Err(anyhow::Error::new(e).context(format!(
+                "failed to read marketplace.json at {}",
+                manifest_path.display()
+            )));
         }
     }
 
     // Fall back to scanning for plugin.json. Surface a read failure as an
     // error rather than masking it as "plugin not found".
-    let discovered =
-        kiro_market_core::plugin::discover_plugins(marketplace_path, 3).with_context(|| {
-            format!(
-                "failed to scan marketplace at {}",
-                marketplace_path.display()
-            )
-        })?;
+    let discovered = kiro_market_core::plugin::discover_plugins(
+        marketplace_path,
+        kiro_market_core::plugin::DEFAULT_DISCOVERY_MAX_DEPTH,
+    )
+    .with_context(|| {
+        format!(
+            "failed to scan marketplace at {}",
+            marketplace_path.display()
+        )
+    })?;
     if let Some(dp) = discovered.into_iter().find(|dp| dp.name() == plugin_name) {
+        let rel = kiro_market_core::validation::RelativePath::new(dp.as_relative_path_string())
+            .expect("discovered plugin paths are always valid relative paths");
         return Ok(PluginEntry {
             name: dp.name().to_owned(),
             description: dp.description().map(String::from),
-            source: kiro_market_core::marketplace::PluginSource::RelativePath(
-                dp.as_relative_path_string(),
-            ),
+            source: kiro_market_core::marketplace::PluginSource::RelativePath(rel),
         });
     }
 
@@ -191,7 +193,7 @@ mod tests {
         assert!(
             matches!(
                 &entry.source,
-                kiro_market_core::marketplace::PluginSource::RelativePath(p) if p.contains("discovered")
+                kiro_market_core::marketplace::PluginSource::RelativePath(p) if p.as_str().contains("discovered")
             ),
             "source should be a RelativePath: {:?}",
             entry.source
@@ -210,6 +212,28 @@ mod tests {
             .expect("should find unlisted via scan");
 
         assert_eq!(entry.name, "unlisted");
+    }
+
+    #[test]
+    fn find_plugin_entry_errors_on_malformed_manifest() {
+        // Regression: previously a malformed marketplace.json would warn!
+        // and silently fall through to a scan, conflating "cache broken"
+        // with "plugin not found." Allowlist-style handling requires
+        // malformed JSON to surface as an error.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let mp_dir = root.join(".claude-plugin");
+        fs::create_dir_all(&mp_dir).expect("create .claude-plugin");
+        fs::write(mp_dir.join("marketplace.json"), b"{ not valid json")
+            .expect("write bad manifest");
+
+        let err = find_plugin_entry(root, "anything", "test-market")
+            .expect_err("malformed manifest should error, not fall through");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("malformed") || msg.contains("marketplace.json"),
+            "error chain should mention the manifest: {msg}"
+        );
     }
 
     #[test]

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -6,12 +6,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use kiro_market_core::cache::CacheDir;
-use kiro_market_core::git::{self, CloneOptions, GitBackend, GitProtocol, GitRef, GixCliBackend};
-use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
+use kiro_market_core::git::{GitProtocol, GixCliBackend};
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
-    FailedAgent, FailedSkill, InstallAgentsResult, InstallFilter, InstallSkillsResult,
+    FailedAgent, FailedSkill, InstallAgentsResult, InstallFilter, InstallMode, InstallSkillsResult,
     MarketplaceService,
 };
 use tracing::{debug, warn};
@@ -22,8 +21,8 @@ use crate::cli;
 ///
 /// Resolves `plugin_ref` to a plugin, discovers skills, copies skill
 /// directories, and installs into the current Kiro project.
-#[allow(clippy::too_many_lines)]
 pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<()> {
+    let mode = InstallMode::from(force);
     let (plugin_name, marketplace_name) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
         format!("invalid plugin reference '{plugin_ref}': expected plugin@marketplace")
     })?;
@@ -39,8 +38,62 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
         );
     }
 
-    // Look up the stored protocol preference for this marketplace.
-    let protocol = match cache.load_known_marketplaces() {
+    let protocol = load_protocol(&cache, marketplace_name);
+    let plugin_entry =
+        super::common::find_plugin_entry(&marketplace_path, plugin_name, marketplace_name)?;
+
+    // One service instance drives plugin-dir resolution plus the install
+    // loops; no second `GixCliBackend` needed.
+    let svc = MarketplaceService::new(cache.clone(), GixCliBackend::default());
+    let plugin_dir = fetch_plugin_dir(
+        &svc,
+        &plugin_entry,
+        &marketplace_path,
+        marketplace_name,
+        plugin_name,
+        protocol,
+    )?;
+
+    let plugin_manifest = load_plugin_manifest(&plugin_dir)?;
+    let skill_dirs = discover_plugin_skills(&plugin_dir, plugin_manifest.as_ref());
+    let agent_scan_paths = agent_scan_paths(plugin_manifest.as_ref());
+
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let project = KiroProject::new(cwd);
+    let version = plugin_manifest.as_ref().and_then(|m| m.version.clone());
+
+    let skill_result = run_skill_install(
+        &svc,
+        &project,
+        &skill_dirs,
+        skill_filter,
+        mode,
+        marketplace_name,
+        plugin_name,
+        version.as_deref(),
+    );
+    print_install_outcome(plugin_ref, &skill_result);
+
+    let agent_result = run_agent_install(
+        &svc,
+        &project,
+        &plugin_dir,
+        &agent_scan_paths,
+        skill_filter,
+        mode,
+        marketplace_name,
+        plugin_name,
+        version.as_deref(),
+    );
+    print_agent_outcome(&agent_result);
+
+    summarize_outcome(plugin_ref, skill_filter, &skill_result, &agent_result)
+}
+
+/// Look up the stored git protocol preference for a marketplace, falling back
+/// to the default if the registry is unreadable.
+fn load_protocol(cache: &CacheDir, marketplace_name: &str) -> GitProtocol {
+    match cache.load_known_marketplaces() {
         Ok(entries) => entries
             .into_iter()
             .find(|e| e.name == marketplace_name)
@@ -54,69 +107,95 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
             );
             GitProtocol::default()
         }
+    }
+}
+
+/// Resolve the plugin's on-disk directory, printing a progress message so the
+/// user sees something during the clone (which can block on network I/O).
+fn fetch_plugin_dir(
+    svc: &MarketplaceService,
+    entry: &kiro_market_core::marketplace::PluginEntry,
+    marketplace_path: &Path,
+    marketplace_name: &str,
+    plugin_name: &str,
+    protocol: GitProtocol,
+) -> Result<PathBuf> {
+    print!("  Fetching plugin '{plugin_name}'...");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    let dir = svc
+        .resolve_plugin_dir(entry, marketplace_path, marketplace_name, protocol)
+        .with_context(|| format!("failed to resolve plugin directory for '{plugin_name}'"))?;
+    println!(" done");
+    debug!(plugin_dir = %dir.display(), "resolved plugin directory");
+    Ok(dir)
+}
+
+#[allow(clippy::too_many_arguments)] // each arg is an independent piece of upstream context
+fn run_skill_install(
+    svc: &MarketplaceService,
+    project: &KiroProject,
+    skill_dirs: &[PathBuf],
+    skill_filter: Option<&str>,
+    mode: InstallMode,
+    marketplace_name: &str,
+    plugin_name: &str,
+    version: Option<&str>,
+) -> InstallSkillsResult {
+    if skill_dirs.is_empty() {
+        return InstallSkillsResult::default();
+    }
+    let filter = match skill_filter {
+        Some(name) => InstallFilter::SingleName(name),
+        None => InstallFilter::All,
     };
-
-    let plugin_entry =
-        super::common::find_plugin_entry(&marketplace_path, plugin_name, marketplace_name)?;
-
-    let plugin_dir = resolve_plugin_dir(
-        &plugin_entry,
-        &marketplace_path,
-        &cache,
+    svc.install_skills(
+        project,
+        skill_dirs,
+        &filter,
+        mode,
         marketplace_name,
-        protocol,
+        plugin_name,
+        version,
     )
-    .with_context(|| format!("failed to resolve plugin directory for '{plugin_name}'"))?;
+}
 
-    debug!(plugin_dir = %plugin_dir.display(), "resolved plugin directory");
+#[allow(clippy::too_many_arguments)] // each arg is an independent piece of upstream context
+fn run_agent_install(
+    svc: &MarketplaceService,
+    project: &KiroProject,
+    plugin_dir: &Path,
+    agent_scan_paths: &[String],
+    skill_filter: Option<&str>,
+    mode: InstallMode,
+    marketplace_name: &str,
+    plugin_name: &str,
+    version: Option<&str>,
+) -> InstallAgentsResult {
+    // A `--skill <name>` filter narrows the install to one skill and never
+    // includes agents.
+    if skill_filter.is_some() {
+        return InstallAgentsResult::default();
+    }
+    svc.install_plugin_agents(
+        project,
+        plugin_dir,
+        agent_scan_paths,
+        mode,
+        marketplace_name,
+        plugin_name,
+        version,
+    )
+}
 
-    let plugin_manifest = load_plugin_manifest(&plugin_dir);
-    let skill_dirs = discover_plugin_skills(&plugin_dir, plugin_manifest.as_ref());
-    let agent_scan_paths = agent_scan_paths(plugin_manifest.as_ref());
-
-    let cwd = std::env::current_dir().context("failed to determine current directory")?;
-    let project = KiroProject::new(cwd);
-    let version = plugin_manifest.as_ref().and_then(|m| m.version.clone());
-
-    // Build a one-off service just to drive the install loops — the CLI only
-    // needs the install calls here, not the full add/update lifecycle.
-    let svc = MarketplaceService::new(cache.clone(), GixCliBackend::default());
-
-    let skill_result = if skill_dirs.is_empty() {
-        InstallSkillsResult::default()
-    } else {
-        let filter = match skill_filter {
-            Some(name) => InstallFilter::SingleName(name),
-            None => InstallFilter::All,
-        };
-        svc.install_skills(
-            &project,
-            &skill_dirs,
-            &filter,
-            force,
-            marketplace_name,
-            plugin_name,
-            version.as_deref(),
-        )
-    };
-    print_install_outcome(plugin_ref, &skill_result);
-
-    // Agents: only run when the user did NOT pass `--skill <name>`. A skill
-    // filter narrows the install to one skill and never includes agents.
-    let agent_result = if skill_filter.is_none() {
-        svc.install_plugin_agents(
-            &project,
-            &plugin_dir,
-            &agent_scan_paths,
-            marketplace_name,
-            plugin_name,
-            version.as_deref(),
-        )
-    } else {
-        InstallAgentsResult::default()
-    };
-    print_agent_outcome(&agent_result);
-
+/// Decide whether the command exits zero or non-zero based on the accumulated
+/// skill + agent results. Any per-item failure becomes a non-zero exit so CI
+/// catches partial-success regressions.
+fn summarize_outcome(
+    plugin_ref: &str,
+    skill_filter: Option<&str>,
+    skill_result: &InstallSkillsResult,
+    agent_result: &InstallAgentsResult,
+) -> Result<()> {
     let nothing_installed = skill_result.installed.is_empty()
         && skill_result.skipped.is_empty()
         && agent_result.installed.is_empty()
@@ -129,21 +208,13 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
         };
         bail!("no {kind} were installed from '{plugin_ref}'");
     }
-
-    // Any per-agent or per-skill failure surfaces as a non-zero exit so CI
-    // catches partial-success regressions.
     if !agent_result.failed.is_empty() || !skill_result.failed.is_empty() {
+        let fail_count = agent_result.failed.len() + skill_result.failed.len();
         bail!(
-            "{} item{} failed during install from '{plugin_ref}'",
-            agent_result.failed.len() + skill_result.failed.len(),
-            if agent_result.failed.len() + skill_result.failed.len() == 1 {
-                ""
-            } else {
-                "s"
-            }
+            "{fail_count} item{s} failed during install from '{plugin_ref}'",
+            s = if fail_count == 1 { "" } else { "s" }
         );
     }
-
     Ok(())
 }
 
@@ -251,154 +322,111 @@ fn print_install_outcome(plugin_ref: &str, result: &InstallSkillsResult) {
     }
 }
 
-/// Resolve the on-disk directory for a plugin based on its source.
-fn resolve_plugin_dir(
-    entry: &PluginEntry,
-    marketplace_path: &Path,
-    cache: &CacheDir,
-    marketplace_name: &str,
-    protocol: GitProtocol,
-) -> Result<PathBuf> {
-    match &entry.source {
-        PluginSource::RelativePath(rel) => {
-            let resolved = marketplace_path.join(rel);
-            if !resolved.exists() {
-                bail!("plugin directory does not exist: {}", resolved.display());
-            }
-            Ok(resolved)
-        }
-        PluginSource::Structured(structured) => {
-            resolve_structured_source(structured, cache, marketplace_name, &entry.name, protocol)
-        }
-    }
-}
-
-/// Clone a structured source into the cache plugins directory and return the path.
-fn resolve_structured_source(
-    source: &StructuredSource,
-    cache: &CacheDir,
-    marketplace_name: &str,
-    plugin_name: &str,
-    protocol: GitProtocol,
-) -> Result<PathBuf> {
-    cache
-        .ensure_dirs()
-        .context("failed to create cache directories")?;
-
-    let dest = cache.plugin_path(marketplace_name, plugin_name);
-
-    // Extract the varying parts from each source variant.
-    let (url, subdir, git_ref, sha, label) = match source {
-        StructuredSource::GitHub { repo, git_ref, sha } => (
-            git::github_repo_to_url(repo, protocol),
-            None,
-            git_ref.as_deref(),
-            sha.as_deref(),
-            repo.as_str(),
-        ),
-        StructuredSource::GitUrl { url, git_ref, sha } => (
-            url.clone(),
-            None,
-            git_ref.as_deref(),
-            sha.as_deref(),
-            url.as_str(),
-        ),
-        StructuredSource::GitSubdir {
-            url,
-            path,
-            git_ref,
-            sha,
-        } => (
-            url.clone(),
-            Some(path.as_str()),
-            git_ref.as_deref(),
-            sha.as_deref(),
-            url.as_str(),
-        ),
-    };
-
-    let backend = GixCliBackend::default();
-
-    // If already cloned, reuse — but re-verify SHA so a corrupt or stale
-    // cache (e.g. the manifest's pinned SHA changed) cannot pass silently.
-    if dest.exists() {
-        debug!(dest = %dest.display(), "plugin already cached, reusing");
-        if let Some(expected) = sha {
-            backend.verify_sha(&dest, expected).with_context(|| {
-                format!(
-                    "cached plugin at {} fails SHA verification for '{label}' \
-                     (expected {expected}); delete the cache directory and retry",
-                    dest.display()
-                )
-            })?;
-        }
-        return Ok(match subdir {
-            Some(path) => dest.join(path),
-            None => dest,
-        });
-    }
-
-    debug!(url = %url, dest = %dest.display(), "cloning plugin");
-    print!("  Cloning {label}...");
-    // Validate the manifest-supplied git ref shape before passing to the
-    // backend. Treat failure as a clone-time error since this comes from
-    // untrusted manifest data.
-    let validated_ref = git_ref
-        .map(GitRef::new)
-        .transpose()
-        .with_context(|| format!("invalid git ref in manifest for '{label}'"))?;
-    let opts = CloneOptions {
-        git_ref: validated_ref,
-    };
-    backend
-        .clone_repo(&url, &dest, &opts)
-        .with_context(|| format!("failed to clone plugin from '{label}'"))?;
-    println!(" done");
-
-    if let Some(expected) = sha {
-        backend
-            .verify_sha(&dest, expected)
-            .with_context(|| format!("SHA verification failed for '{label}'"))?;
-    }
-
-    Ok(match subdir {
-        Some(path) => dest.join(path),
-        None => dest,
-    })
-}
-
-/// Load a `plugin.json` from the given directory, returning `None` if missing.
-fn load_plugin_manifest(plugin_dir: &Path) -> Option<PluginManifest> {
+/// Load a `plugin.json` from the given directory.
+///
+/// Returns:
+/// - `Ok(Some(manifest))` on success.
+/// - `Ok(None)` when the file is genuinely absent (`NotFound`) or when it is
+///   a symlink — a symlinked `plugin.json` inside a cloned repo could point
+///   at arbitrary host files, so it is treated as absent with a `warn!`.
+/// - `Err` for every other condition: permission denied, EIO, interrupted,
+///   malformed JSON, etc. Matches the allowlist-style error handling in
+///   `find_plugin_entry` — never mask a broken cache as "missing manifest."
+fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>> {
     let manifest_path = plugin_dir.join("plugin.json");
-    match fs::read(&manifest_path) {
-        Ok(bytes) => match PluginManifest::from_json(&bytes) {
-            Ok(manifest) => {
-                debug!(name = %manifest.name, "loaded plugin manifest");
-                Some(manifest)
-            }
-            Err(e) => {
-                warn!(
-                    path = %manifest_path.display(),
-                    error = %e,
-                    "plugin.json is malformed, falling back to defaults"
-                );
-                None
-            }
-        },
+
+    // Refuse to follow symlinks. plugin_dir lives inside a cloned (untrusted)
+    // repository; matches project::copy_dir_recursive and
+    // agent::discover_agents_in_dirs.
+    match fs::symlink_metadata(&manifest_path) {
+        Ok(m) if m.file_type().is_symlink() => {
+            warn!(
+                path = %manifest_path.display(),
+                "plugin.json is a symlink, refusing to follow; treating as missing"
+            );
+            return Ok(None);
+        }
+        Ok(_) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             debug!(
                 path = %manifest_path.display(),
                 "plugin.json not found, using defaults"
             );
-            None
+            return Ok(None);
         }
         Err(e) => {
-            warn!(
-                path = %manifest_path.display(),
-                error = %e,
-                "failed to read plugin.json, falling back to defaults"
-            );
-            None
+            return Err(anyhow::Error::new(e).context(format!(
+                "failed to stat plugin.json at {}",
+                manifest_path.display()
+            )));
         }
+    }
+
+    let bytes = fs::read(&manifest_path)
+        .with_context(|| format!("failed to read plugin.json at {}", manifest_path.display()))?;
+    let manifest = PluginManifest::from_json(&bytes)
+        .with_context(|| format!("plugin.json at {} is malformed", manifest_path.display()))?;
+    debug!(name = %manifest.name, "loaded plugin manifest");
+    Ok(Some(manifest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_plugin_manifest_reads_regular_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("plugin.json"),
+            r#"{"name":"ok","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        let m = load_plugin_manifest(tmp.path())
+            .expect("ok result")
+            .expect("some manifest");
+        assert_eq!(m.name, "ok");
+    }
+
+    #[test]
+    fn load_plugin_manifest_returns_ok_none_when_absent() {
+        // Genuine absence is expected — NotFound is part of the contract,
+        // not an error. Regression guard for the allowlist split.
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_plugin_manifest(tmp.path()).expect("NotFound must be Ok(None)");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_plugin_manifest_errors_on_malformed_json() {
+        // Regression: previously malformed plugin.json silently fell back
+        // to defaults. Allowlist-style handling requires it to surface.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("plugin.json"), b"{ not json").unwrap();
+        let err = load_plugin_manifest(tmp.path()).expect_err("malformed must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("malformed") || msg.contains("plugin.json"),
+            "error chain should mention the manifest: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_plugin_manifest_refuses_symlinked_manifest() {
+        // A malicious cloned repo could include a symlink
+        // `plugin.json -> /etc/passwd`. We must not follow it. Symlink is
+        // treated as absent (Ok(None)) with a warn!, not as an error —
+        // the install degrades to "no skills" rather than aborting.
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("elsewhere.json");
+        fs::write(&target, r#"{"name":"smuggled"}"#).unwrap();
+        std::os::unix::fs::symlink(&target, tmp.path().join("plugin.json")).unwrap();
+
+        let result = load_plugin_manifest(tmp.path()).expect("symlink should not error");
+        assert!(
+            result.is_none(),
+            "symlinked plugin.json must be treated as absent, got: {result:?}"
+        );
     }
 }

--- a/crates/kiro-market/src/commands/marketplace.rs
+++ b/crates/kiro-market/src/commands/marketplace.rs
@@ -1,5 +1,7 @@
 //! `marketplace` subcommand: add, list, update, and remove marketplace sources.
 
+use std::io::Write;
+
 use anyhow::{Context, Result};
 use colored::Colorize;
 use kiro_market_core::cache::CacheDir;
@@ -29,6 +31,9 @@ fn add(
     protocol: kiro_market_core::git::GitProtocol,
 ) -> Result<()> {
     print!("  Adding marketplace...");
+    // stdout is line-buffered when attached to a terminal; without flush
+    // the "..." appears only after the clone completes.
+    let _ = std::io::stdout().flush();
     let result = svc
         .add(source, protocol)
         .context("failed to add marketplace")?;

--- a/crates/kiro-market/src/commands/search.rs
+++ b/crates/kiro-market/src/commands/search.rs
@@ -9,7 +9,7 @@ use kiro_market_core::cache::CacheDir;
 use kiro_market_core::marketplace::{Marketplace, PluginSource};
 use kiro_market_core::plugin::discover_skill_dirs;
 use kiro_market_core::skill::{SkillFrontmatter, parse_frontmatter};
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Run the search command.
 ///
@@ -32,6 +32,7 @@ pub fn run(query: Option<&str>) -> Result<()> {
 
     let query_lower = query.map(str::to_lowercase);
     let mut match_count = 0u32;
+    let mut skipped_marketplaces: Vec<String> = Vec::new();
 
     for entry in &entries {
         let marketplace_path = cache.marketplace_path(&entry.name);
@@ -39,12 +40,24 @@ pub fn run(query: Option<&str>) -> Result<()> {
 
         let manifest_bytes = match fs::read(&manifest_path) {
             Ok(bytes) => bytes,
-            Err(e) => {
+            // Missing manifest is quiet — a newly added marketplace may
+            // legitimately not have one yet. Other io errors are upgraded
+            // to warn and surface to the user so "no results" doesn't
+            // silently mask a broken cache.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 debug!(
+                    marketplace = %entry.name,
+                    "no marketplace manifest; skipping"
+                );
+                continue;
+            }
+            Err(e) => {
+                warn!(
                     marketplace = %entry.name,
                     error = %e,
                     "failed to read marketplace manifest, skipping"
                 );
+                skipped_marketplaces.push(entry.name.clone());
                 continue;
             }
         };
@@ -52,11 +65,12 @@ pub fn run(query: Option<&str>) -> Result<()> {
         let manifest = match Marketplace::from_json(&manifest_bytes) {
             Ok(m) => m,
             Err(e) => {
-                debug!(
+                warn!(
                     marketplace = %entry.name,
                     error = %e,
                     "failed to parse marketplace manifest, skipping"
                 );
+                skipped_marketplaces.push(entry.name.clone());
                 continue;
             }
         };
@@ -70,6 +84,14 @@ pub fn run(query: Option<&str>) -> Result<()> {
                 match_count,
             );
         }
+    }
+
+    for name in &skipped_marketplaces {
+        eprintln!(
+            "  {} search coverage incomplete: could not read marketplace '{}'",
+            "!".yellow().bold(),
+            name
+        );
     }
 
     if match_count == 0 {

--- a/crates/kiro-market/src/commands/update.rs
+++ b/crates/kiro-market/src/commands/update.rs
@@ -1,31 +1,34 @@
 //! `update` command: update installed plugins.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use colored::Colorize;
 
 /// Run the update command.
 ///
 /// Currently advises users to use `remove` + `install --force` as a workaround.
 /// A proper in-place update mechanism can be added later.
-#[allow(clippy::unnecessary_wraps)]
+///
+/// Returns a non-zero exit code (via `Err`) so CI pipelines that invoke
+/// `kiro-market update` can distinguish "updated successfully" from
+/// "updating is not implemented yet."
 pub fn run(plugin_ref: Option<&str>) -> Result<()> {
     let target = plugin_ref.map_or_else(|| "all plugins".to_owned(), |r| format!("'{r}'"));
 
-    println!(
+    eprintln!(
         "{} In-place update for {} is not yet supported.",
         "!".yellow().bold(),
         target
     );
-    println!();
-    println!("To update, use:");
-    println!(
+    eprintln!();
+    eprintln!("To update, use:");
+    eprintln!(
         "  1. {} to remove the skill",
         "kiro-market remove <skill-name>".bold()
     );
-    println!(
+    eprintln!(
         "  2. {} to reinstall",
         "kiro-market install <plugin@marketplace> --force".bold()
     );
 
-    Ok(())
+    bail!("update command is not yet implemented");
 }

--- a/crates/kiro-market/src/main.rs
+++ b/crates/kiro-market/src/main.rs
@@ -3,12 +3,24 @@
 mod cli;
 mod commands;
 
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
 fn main() -> Result<()> {
     let cli = cli::Cli::parse();
+
+    // Disable ANSI color codes when stdout is redirected to a file/pipe
+    // (ls > out.log, kiro-market list | less) or when the user has set
+    // NO_COLOR (https://no-color.org/). The `colored` crate does a best
+    // effort itself, but setting this explicitly is less fragile than
+    // relying on auto-detection and keeps behaviour testable.
+    let force_no_color = std::env::var_os("NO_COLOR").is_some() || !std::io::stdout().is_terminal();
+    if force_no_color {
+        colored::control::set_override(false);
+    }
 
     let default_filter = match cli.verbose {
         0 => "kiro_market=info",

--- a/crates/kiro-market/tests/cli_tests.rs
+++ b/crates/kiro-market/tests/cli_tests.rs
@@ -68,6 +68,49 @@ fn marketplace_list_empty() {
 }
 
 #[test]
+fn stdout_has_no_ansi_escapes_when_piped() {
+    // IsTerminal gate must disable colored output when stdout is not a tty.
+    // `marketplace list` on an empty registry normally includes a `.bold()`
+    // hint, which would emit ANSI escapes if colour were on.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["marketplace", "list"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let out = stdout(&output);
+    assert!(
+        !out.contains('\x1b'),
+        "stdout must not contain ANSI escapes when piped:\n{out:?}"
+    );
+}
+
+#[test]
+fn no_color_env_suppresses_ansi_escapes() {
+    // Even if the user has a TTY, NO_COLOR=1 must disable colour per
+    // https://no-color.org. Integration tests always pipe output, so this
+    // primarily regresses the env-var branch of `force_no_color`.
+    use std::process::Command;
+    let dir = TempDir::new().expect("temp dir");
+    let output = Command::new(common::get_binary())
+        .args(["marketplace", "list"])
+        .current_dir(dir.path())
+        .env("KIRO_MARKET_DATA_DIR", dir.path().join(".data"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run kiro-market");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !out.contains('\x1b'),
+        "NO_COLOR=1 must suppress ANSI escapes:\n{out:?}"
+    );
+}
+
+#[test]
 fn list_no_installed_skills() {
     let dir = TempDir::new().expect("temp dir");
     let output = run_in_dir(dir.path(), &["list"]);
@@ -96,6 +139,27 @@ fn install_missing_marketplace_fails() {
     assert!(
         err.contains("not found"),
         "expected 'not found' in stderr:\n{err}"
+    );
+}
+
+#[test]
+fn update_command_exits_nonzero_while_unimplemented() {
+    // Regression: the top-level `update` command is a documented stub
+    // that previously returned Ok(()), so CI couldn't distinguish
+    // "update succeeded" from "update is not implemented." It must now
+    // exit non-zero so automation notices.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["update"]);
+    assert!(
+        !output.status.success(),
+        "unimplemented update must exit non-zero: stdout={} stderr={}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("not yet") || err.contains("not implemented"),
+        "stderr should explain the command is unimplemented: {err}"
     );
 }
 

--- a/crates/kiro-market/tests/common/fixtures.rs
+++ b/crates/kiro-market/tests/common/fixtures.rs
@@ -1,6 +1,26 @@
 use std::path::Path;
 use std::process::Command;
 
+/// Run `git <args>` in `dir` with deterministic author identity, asserting
+/// success. Shared between fixture setup and update helpers so we only have
+/// one place that understands the test-git environment.
+fn git_run(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Create a local git repository containing a valid marketplace manifest
 /// with one plugin that has one skill.
 pub fn create_marketplace_repo(dir: &Path) {
@@ -42,31 +62,18 @@ pub fn create_marketplace_repo(dir: &Path) {
     )
     .expect("write SKILL.md");
 
-    let run = |args: &[&str]| {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .env("GIT_AUTHOR_NAME", "Test")
-            .env("GIT_AUTHOR_EMAIL", "test@example.com")
-            .env("GIT_COMMITTER_NAME", "Test")
-            .env("GIT_COMMITTER_EMAIL", "test@example.com")
-            .output()
-            .expect("git command should run");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    };
-    run(&["init"]);
-    run(&["add", "."]);
-    run(&[
-        "-c",
-        "commit.gpgsign=false",
-        "commit",
-        "-m",
-        "initial marketplace",
-    ]);
+    git_run(dir, &["init"]);
+    git_run(dir, &["add", "."]);
+    git_run(
+        dir,
+        &[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "initial marketplace",
+        ],
+    );
 }
 
 /// Add a second commit to an existing marketplace repo to simulate an update.
@@ -78,28 +85,15 @@ pub fn add_marketplace_update(dir: &Path) {
     )
     .expect("write updated SKILL.md");
 
-    let run = |args: &[&str]| {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .env("GIT_AUTHOR_NAME", "Test")
-            .env("GIT_AUTHOR_EMAIL", "test@example.com")
-            .env("GIT_COMMITTER_NAME", "Test")
-            .env("GIT_COMMITTER_EMAIL", "test@example.com")
-            .output()
-            .expect("git command should run");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    };
-    run(&["add", "."]);
-    run(&[
-        "-c",
-        "commit.gpgsign=false",
-        "commit",
-        "-m",
-        "update marketplace",
-    ]);
+    git_run(dir, &["add", "."]);
+    git_run(
+        dir,
+        &[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "update marketplace",
+        ],
+    );
 }


### PR DESCRIPTION
## Summary

Six batches of hardening in response to the `/dg` adversarial review. **450 tests pass; clippy workspace clean with `-D warnings`.**

- Closes a path-traversal vector in `marketplace.json` deserialization. `RelativePath` newtype + manual `Deserialize` Visitor make malicious paths uninstantiable and preserve specific serde error messages.
- Closes a symlink-follow vector in agent discovery and `plugin.json` loading, matching the existing `copy_dir_recursive` precedent.
- Repairs the `--force` contract: previously `kiro-market install foo@bar --force` silently routed *agents* to `skipped`. New `InstallMode { New, Force }` threads through `install_skills` and `install_plugin_agents` uniformly.
- Error/UX polish: allowlist IO errors in `find_plugin_entry` and `load_plugin_manifest`; `warn!` + stderr notice in `search`; `stdout().flush()` before network prints; `update` returns `Err` so CI exit code is meaningful; `IsTerminal` + `NO_COLOR` gate colored output.
- Structural: `MarketplaceService::resolve_plugin_dir` absorbs the CLI-local resolver (one source of truth for both frontends); `install::run` split into named pipeline stages; `DEFAULT_DISCOVERY_MAX_DEPTH` replaces three magic `3`s.

## Key type changes

- `pub struct RelativePath(String)` with validating `new` / `Deserialize`
- `pub enum InstallMode { New, Force }` with `From<bool>` for the CLI boundary
- `PluginError::DirectoryMissing { path: PathBuf }` for missing `RelativePath` sources

## Test plan

- [x] `cargo test --workspace` — 450 tests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo-audit` against `Cargo.lock` — 0 advisories in the CLI dependency tree (21 warnings remain in `kiro-control-center` / Tauri transitives; unchanged by this PR)
- [ ] Manual smoke: `kiro-market marketplace add owner/repo`, `kiro-market install plugin@marketplace`, `kiro-market install plugin@marketplace --force` (exercises the `--force` fix), `kiro-market list | cat` (exercises the `IsTerminal` gate)
- [ ] Manual smoke on Windows: symlink guards are `#[cfg(unix)]`-tested; the production code uses `fs::symlink_metadata` which is cross-platform. Windows junction handling worth a follow-up PR.

## Out of scope (follow-ups)

- Windows equivalent of the symlink regression tests (junctions)
- `InstallContext<'a>` struct to collapse the three `#[allow(clippy::too_many_arguments)]` sites (one at `install_plugin_agents` in core, two in CLI helpers)
- Wire Tauri's install command to `MarketplaceService::resolve_plugin_dir` once the Tauri-side install flow lands

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>