### PR TITLE
chore(deps): bump rand + specta, migrate to serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -613,7 +613,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -931,7 +931,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3082,7 +3082,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3196,7 +3196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "specta",
  "tempfile",
  "thiserror 2.0.18",
@@ -3587,7 +3587,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3951,7 +3951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3961,7 +3961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4299,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4566,7 +4566,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4830,10 +4830,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -4993,7 +4993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5046,21 +5046,21 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.20"
+version = "2.0.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccbb212565d2dc177bc15ecb7b039d66c4490da892436a4eee5b394d620c9bc"
+checksum = "f320c7dd82008b6958f43f6257c95319c407d1c17ade43686e50ea520c28bb26"
 dependencies = [
  "paste",
+ "rustc_version",
  "serde_json",
  "specta-macros",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.17"
+version = "2.0.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68999d29816965eb9e5201f60aec02a76512139811661a7e8e653abc810b8f72"
+checksum = "153f185d0051a64d81977bab5012809d5c9d9db8792406a0997352e05494f711"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -5070,23 +5070,32 @@ dependencies = [
 
 [[package]]
 name = "specta-serde"
-version = "0.0.7"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12260cbb21abb2e83a0375b1521867910e3aed8a7afa782206150ce552cd2e5a"
+checksum = "b5a46349e2c3fb3f3de4b78daa19632c32813262e1ab0966896b64ca91e0926e"
 dependencies = [
  "specta",
- "thiserror 1.0.69",
+ "specta-macros",
+]
+
+[[package]]
+name = "specta-tags"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3026b7e2f8c76dcab90ec27b7f3e6a0b7d646501a3a8aa5d739d09cb9ee59871"
+dependencies = [
+ "serde",
+ "serde_json",
+ "specta",
 ]
 
 [[package]]
 name = "specta-typescript"
-version = "0.0.7"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4472229365ceb6395487e3a60d921ad8e21f9ad06eaecc396f098902c9adc"
+checksum = "ea586e1709619c9f4cb0c9115ff29c278f331c0450aff266c2913c639708b299"
 dependencies = [
  "specta",
- "specta-serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5526,17 +5535,19 @@ dependencies = [
 
 [[package]]
 name = "tauri-specta"
-version = "2.0.0-rc.20"
+version = "2.0.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d06336a2fa3ead0c8d08719e78cbc1fb73650845789605bd2ab908cbde72815"
+checksum = "9191951c8d3aefce8fb9818271545c61b441a3c1095d8443637b36572e0346e4"
 dependencies = [
  "heck 0.5.0",
  "serde",
  "serde_json",
  "specta",
+ "specta-serde",
+ "specta-tags",
  "specta-typescript",
  "tauri",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5598,7 +5609,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6025,7 +6036,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6491,7 +6502,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pedantic = "warn"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/kiro-control-center/src-tauri/Cargo.toml
+++ b/crates/kiro-control-center/src-tauri/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-tauri-specta = { version = "2.0.0-rc.20", features = ["typescript"] }
+tauri-specta = { version = "2.0.0-rc.24", features = ["typescript"] }
 
 [dependencies]
 kiro-market-core = { path = "../../kiro-market-core", features = ["specta"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
-tauri-specta = { version = "2.0.0-rc.20", features = ["typescript"] }
-specta = { version = "2.0.0-rc.20" }
-specta-typescript = "0.0.7"
+tauri-specta = { version = "2.0.0-rc.24", features = ["typescript"] }
+specta = { version = "2.0.0-rc.24" }
+specta-typescript = "0.0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -17,7 +17,7 @@ test-support = []
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 gix = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -25,7 +25,7 @@ dirs = { workspace = true }
 chrono = { workspace = true }
 fs4 = { workspace = true }
 clap = { workspace = true, optional = true }
-specta = { version = "2.0.0-rc.20", optional = true, features = ["derive", "serde_json"] }
+specta = { version = "2.0.0-rc.24", optional = true, features = ["derive", "serde_json"] }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -29,8 +29,8 @@ struct ClaudeFrontmatter {
 /// path and lifts into `AgentError::ParseFailed`.
 pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml_block, body) = split_frontmatter(content)?;
-    let fm: ClaudeFrontmatter =
-        serde_yaml::from_str(yaml_block).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
+    let fm: ClaudeFrontmatter = serde_yaml_ng::from_str(yaml_block)
+        .map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
     // Validate the name at parse time so downstream fs operations (and the

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -40,7 +40,7 @@ struct CopilotFrontmatter {
 pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml, body) = split_frontmatter(content)?;
     let fm: CopilotFrontmatter =
-        serde_yaml::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
+        serde_yaml_ng::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
     // Validate the name at parse time so downstream fs operations (and the

--- a/crates/kiro-market-core/src/skill.rs
+++ b/crates/kiro-market-core/src/skill.rs
@@ -63,7 +63,7 @@ pub fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, usize), Par
     let yaml_block = &after_open[..close_pos];
 
     let frontmatter: SkillFrontmatter =
-        serde_yaml::from_str(yaml_block).map_err(|e| ParseError::InvalidYaml(e.to_string()))?;
+        serde_yaml_ng::from_str(yaml_block).map_err(|e| ParseError::InvalidYaml(e.to_string()))?;
 
     // Calculate the byte offset where the body starts (after closing `---` and its newline).
     let close_fence_start =


### PR DESCRIPTION
## Summary
- Clears 2 of 22 `cargo audit` findings: `rand 0.8.5 → 0.8.6` (RUSTSEC-2026-0097 on the 0.8.x line) and `serde_yaml 0.9.34+deprecated` → `serde_yaml_ng 0.10` (actively-maintained fork, no advisories).
- Modernizes the specta stack by 4 RCs: `specta` + `tauri-specta` 2.0.0-rc.20 → rc.24; `specta-typescript` 0.0.7 → 0.0.11.
- Remaining 20 advisories all trace exclusively to `kiro-control-center`'s Tauri dep tree and are blocked on upstream Tauri migrating off gtk3-rs. The `kiro-market` CLI ship path is clean of RUSTSEC advisories.

## Notes
- Investigated `serde_yml` as the initial migration target but it has its own open advisory (RUSTSEC-2025-0068 unsound/unmaintained) plus `libyml` (RUSTSEC-2025-0067). Pivoted to `serde_yaml_ng`, a drop-in API-compatible fork that is actively maintained.
- Tried bumping `wry 0.54 → 0.55` but blocked by `tauri-runtime-wry 2.10.1` pinning `wry = "^0.54"`. Needs a Tauri release.
- No `.cargo/audit.toml` added — the 20 known-upstream advisories remain noisy on every `cargo audit` run by design, so regressions vs baseline are obvious.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test -p kiro-market-core` — 369 passed
- [x] `cargo test -p kiro-market` — 27 passed (15 + 12 across integration groups)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo audit` — 20 warnings (down from 22), 0 vulnerabilities
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)