### PR TITLE
fix(browse): per-source fetchErrors map prevents concurrent overwrite race

### DIFF
--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { SvelteSet } from "svelte/reactivity";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
   import type { MarketplaceInfo, PluginInfo, SkillInfo } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
@@ -23,6 +23,20 @@
     return { marketplace, plugin, name };
   };
 
+  // Error-source key family. Shares DELIM with the composite-key helpers so
+  // `plugins\u001f${mp}` and `skills\u001f${pluginKey(mp, p)}` can't collide
+  // with a marketplace literally named "plugins:foo".
+  const PLUGINS_ERR_PREFIX = `plugins${DELIM}` as const;
+  const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
+  const ERR_MARKETPLACES = "marketplaces" as const;
+  type ErrorSource =
+    | typeof ERR_MARKETPLACES
+    | `${typeof PLUGINS_ERR_PREFIX}${string}`
+    | `${typeof SKILLS_ERR_PREFIX}${string}`;
+  const pluginsErrKey = (mp: string): ErrorSource => `${PLUGINS_ERR_PREFIX}${mp}`;
+  const skillsErrKey = (mp: string, plugin: string): ErrorSource =>
+    `${SKILLS_ERR_PREFIX}${pluginKey(mp, plugin)}`;
+
   let marketplaces: MarketplaceInfo[] = $state([]);
   let pluginsByMarketplace: Record<string, PluginInfo[]> = $state({});
   let skillsByPluginPair: Record<string, SkillInfo[]> = $state({});
@@ -41,18 +55,11 @@
   let pendingSkillFetches = new SvelteSet<string>();
   let installing: boolean = $state(false);
 
-  // Per-source fetch errors, keyed by an origin-tagged string. Successful
-  // fetches only clear their own entry, so concurrent failures from
-  // independent sources don't overwrite each other in a race. Install
-  // failures use their own `installError` because they're user-initiated
-  // and deserve prominent, independent clearing semantics.
-  let fetchErrors: Record<string, string> = $state({});
+  // Keyed per-source so a concurrent success for one fetch can't clear
+  // another source's failure mid-race.
+  let fetchErrors = new SvelteMap<ErrorSource, string>();
   let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
-
-  const ERR_MARKETPLACES = "marketplaces";
-  const pluginsErrKey = (mp: string) => `plugins:${mp}`;
-  const skillsErrKey = (mp: string, plugin: string) => `skills:${pluginKey(mp, plugin)}`;
 
   let availablePlugins = $derived.by(() => {
     const out: { marketplace: string; plugin: PluginInfo }[] = [];
@@ -101,8 +108,12 @@
       (loadingMarketplaces || pendingPluginFetches.size > 0 || pendingSkillFetches.size > 0)
   );
 
+  // Only the initial-marketplaces fetch gates the grid's empty-state UI.
+  // Plugin and skill fetch errors surface as their own banners but don't
+  // imply an empty grid — a selected marketplace can have a mix of working
+  // and broken plugins and still render successful pairs' skills.
   let initialLoadFailed = $derived(
-    fetchErrors[ERR_MARKETPLACES] !== undefined &&
+    fetchErrors.has(ERR_MARKETPLACES) &&
       marketplaces.length === 0 &&
       !loadingMarketplaces
   );
@@ -118,12 +129,12 @@
         if (marketplaces.length > 0 && selectedMarketplaces.size === 0) {
           selectedMarketplaces.add(marketplaces[0].name);
         }
-        delete fetchErrors[ERR_MARKETPLACES];
+        fetchErrors.delete(ERR_MARKETPLACES);
       } else {
-        fetchErrors[ERR_MARKETPLACES] = result.error.message;
+        fetchErrors.set(ERR_MARKETPLACES, result.error.message);
       }
     } catch (e) {
-      fetchErrors[ERR_MARKETPLACES] = e instanceof Error ? e.message : String(e);
+      fetchErrors.set(ERR_MARKETPLACES, e instanceof Error ? e.message : String(e));
     } finally {
       loadingMarketplaces = false;
     }
@@ -137,13 +148,13 @@
       const result = await commands.listPlugins(mp);
       if (result.status === "ok") {
         pluginsByMarketplace[mp] = result.data;
-        delete fetchErrors[errKey];
+        fetchErrors.delete(errKey);
       } else {
-        fetchErrors[errKey] = `${mp}: ${result.error.message}`;
+        fetchErrors.set(errKey, `${mp}: ${result.error.message}`);
       }
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
-      fetchErrors[errKey] = `${mp}: ${reason}`;
+      fetchErrors.set(errKey, `${mp}: ${reason}`);
     } finally {
       pendingPluginFetches.delete(mp);
     }
@@ -158,13 +169,13 @@
       const result = await commands.listAvailableSkills(mp, plugin, projectPath);
       if (result.status === "ok") {
         skillsByPluginPair[key] = result.data;
-        delete fetchErrors[errKey];
+        fetchErrors.delete(errKey);
       } else {
-        fetchErrors[errKey] = `${mp}/${plugin}: ${result.error.message}`;
+        fetchErrors.set(errKey, `${mp}/${plugin}: ${result.error.message}`);
       }
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
-      fetchErrors[errKey] = `${mp}/${plugin}: ${reason}`;
+      fetchErrors.set(errKey, `${mp}/${plugin}: ${reason}`);
     } finally {
       pendingSkillFetches.delete(key);
     }
@@ -184,23 +195,46 @@
     }
   });
 
-  // Skill caches are project-scoped — `installed` flags flip meaning when
-  // projectPath changes, so invalidate everything and drop pending selections.
+  // Skill caches and skill-fetch errors are both project-scoped — `installed`
+  // flags flip and error messages cite paths under the previous project — so
+  // invalidate the lot when projectPath changes. Plugin-fetch and marketplace
+  // errors are project-agnostic and survive.
   let priorProjectPath: string | null = null;
   $effect(() => {
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
       skillsByPluginPair = {};
       selectedSkills.clear();
+      for (const key of fetchErrors.keys()) {
+        if (key.startsWith(SKILLS_ERR_PREFIX)) fetchErrors.delete(key);
+      }
     }
     priorProjectPath = projectPath;
   });
 
-  // Drop selected-skill keys that no longer refer to a visible skill — happens
-  // when the user deselects a marketplace that contained the selected skills.
+  // Drop stale selections and stale error banners when the underlying filter
+  // set narrows. A deselected marketplace (or a plugin filter that excludes a
+  // pair) means the user can no longer see or act on that source — leaving its
+  // banner up would misattribute responsibility to a filter the user set
+  // intentionally. Marketplace-listing errors are always kept: they gate the
+  // initial-load empty state and aren't scoped to any selection.
   $effect(() => {
     const valid = new Set(skills.map((s) => skillKey(s.marketplace, s.plugin, s.name)));
     for (const key of selectedSkills) {
       if (!valid.has(key)) selectedSkills.delete(key);
+    }
+
+    for (const key of fetchErrors.keys()) {
+      if (key === ERR_MARKETPLACES) continue;
+      if (key.startsWith(PLUGINS_ERR_PREFIX)) {
+        const mp = key.slice(PLUGINS_ERR_PREFIX.length);
+        if (!selectedMarketplaces.has(mp)) fetchErrors.delete(key);
+      } else if (key.startsWith(SKILLS_ERR_PREFIX)) {
+        const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
+        const stillSelected =
+          selectedMarketplaces.has(marketplace) &&
+          (selectedPlugins.size === 0 || selectedPlugins.has(pluginKey(marketplace, plugin)));
+        if (!stillSelected) fetchErrors.delete(key);
+      }
     }
   });
 
@@ -489,7 +523,7 @@
     </div>
   {/if}
 
-  {#each Object.entries(fetchErrors) as [key, message] (key)}
+  {#each fetchErrors as [key, message] (key)}
     <div
       data-testid="fetch-error"
       class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
@@ -497,10 +531,8 @@
       <p class="text-sm text-kiro-error flex-1">{message}</p>
       <button
         type="button"
-        onclick={() => {
-          delete fetchErrors[key];
-        }}
-        aria-label="Dismiss error"
+        onclick={() => fetchErrors.delete(key)}
+        aria-label={`Dismiss ${message}`}
         class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
       >
         ×
@@ -517,7 +549,7 @@
       <button
         type="button"
         onclick={() => (installError = null)}
-        aria-label="Dismiss error"
+        aria-label={`Dismiss ${installError}`}
         class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
       >
         ×

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -41,8 +41,18 @@
   let pendingSkillFetches = new SvelteSet<string>();
   let installing: boolean = $state(false);
 
-  let error: string | null = $state(null);
+  // Per-source fetch errors, keyed by an origin-tagged string. Successful
+  // fetches only clear their own entry, so concurrent failures from
+  // independent sources don't overwrite each other in a race. Install
+  // failures use their own `installError` because they're user-initiated
+  // and deserve prominent, independent clearing semantics.
+  let fetchErrors: Record<string, string> = $state({});
+  let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
+
+  const ERR_MARKETPLACES = "marketplaces";
+  const pluginsErrKey = (mp: string) => `plugins:${mp}`;
+  const skillsErrKey = (mp: string, plugin: string) => `skills:${pluginKey(mp, plugin)}`;
 
   let availablePlugins = $derived.by(() => {
     const out: { marketplace: string; plugin: PluginInfo }[] = [];
@@ -92,14 +102,15 @@
   );
 
   let initialLoadFailed = $derived(
-    error !== null && marketplaces.length === 0 && !loadingMarketplaces
+    fetchErrors[ERR_MARKETPLACES] !== undefined &&
+      marketplaces.length === 0 &&
+      !loadingMarketplaces
   );
 
   let selectedCount = $derived(selectedSkills.size);
 
   async function loadMarketplaces() {
     loadingMarketplaces = true;
-    error = null;
     try {
       const result = await commands.listMarketplaces();
       if (result.status === "ok") {
@@ -107,11 +118,12 @@
         if (marketplaces.length > 0 && selectedMarketplaces.size === 0) {
           selectedMarketplaces.add(marketplaces[0].name);
         }
+        delete fetchErrors[ERR_MARKETPLACES];
       } else {
-        error = result.error.message;
+        fetchErrors[ERR_MARKETPLACES] = result.error.message;
       }
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      fetchErrors[ERR_MARKETPLACES] = e instanceof Error ? e.message : String(e);
     } finally {
       loadingMarketplaces = false;
     }
@@ -120,16 +132,18 @@
   async function fetchPluginsFor(mp: string) {
     if (pendingPluginFetches.has(mp) || pluginsByMarketplace[mp]) return;
     pendingPluginFetches.add(mp);
-    error = null;
+    const errKey = pluginsErrKey(mp);
     try {
       const result = await commands.listPlugins(mp);
       if (result.status === "ok") {
         pluginsByMarketplace[mp] = result.data;
+        delete fetchErrors[errKey];
       } else {
-        error = result.error.message;
+        fetchErrors[errKey] = `${mp}: ${result.error.message}`;
       }
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      const reason = e instanceof Error ? e.message : String(e);
+      fetchErrors[errKey] = `${mp}: ${reason}`;
     } finally {
       pendingPluginFetches.delete(mp);
     }
@@ -139,16 +153,18 @@
     const key = pluginKey(mp, plugin);
     if (!force && (pendingSkillFetches.has(key) || skillsByPluginPair[key])) return;
     pendingSkillFetches.add(key);
-    error = null;
+    const errKey = skillsErrKey(mp, plugin);
     try {
       const result = await commands.listAvailableSkills(mp, plugin, projectPath);
       if (result.status === "ok") {
         skillsByPluginPair[key] = result.data;
+        delete fetchErrors[errKey];
       } else {
-        error = result.error.message;
+        fetchErrors[errKey] = `${mp}/${plugin}: ${result.error.message}`;
       }
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      const reason = e instanceof Error ? e.message : String(e);
+      fetchErrors[errKey] = `${mp}/${plugin}: ${reason}`;
     } finally {
       pendingSkillFetches.delete(key);
     }
@@ -215,7 +231,7 @@
   async function installSelected() {
     if (selectedSkills.size === 0) return;
     installing = true;
-    error = null;
+    installError = null;
     installMessage = null;
 
     type Group = { marketplace: string; plugin: string; names: string[] };
@@ -271,7 +287,7 @@
       }
 
       if (!hadSuccess && notAttempted.length > 0 && failedAll.length === 0) {
-        error = `Install failed: ${notAttempted.join("; ")}`;
+        installError = `Install failed: ${notAttempted.join("; ")}`;
       } else if (parts.length > 0) {
         installMessage = parts.join(" | ");
       }
@@ -473,9 +489,39 @@
     </div>
   {/if}
 
-  {#if error}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
-      <p class="text-sm text-kiro-error">{error}</p>
+  {#each Object.entries(fetchErrors) as [key, message] (key)}
+    <div
+      data-testid="fetch-error"
+      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+    >
+      <p class="text-sm text-kiro-error flex-1">{message}</p>
+      <button
+        type="button"
+        onclick={() => {
+          delete fetchErrors[key];
+        }}
+        aria-label="Dismiss error"
+        class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+
+  {#if installError}
+    <div
+      data-testid="install-error"
+      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+    >
+      <p class="text-sm text-kiro-error flex-1">{installError}</p>
+      <button
+        type="button"
+        onclick={() => (installError = null)}
+        aria-label="Dismiss error"
+        class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
     </div>
   {/if}
 

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -23,19 +23,35 @@
     return { marketplace, plugin, name };
   };
 
-  // Error-source key family. Shares DELIM with the composite-key helpers so
-  // `plugins\u001f${mp}` and `skills\u001f${pluginKey(mp, p)}` can't collide
-  // with a marketplace literally named "plugins:foo".
+  // Error-source key family. The `plugins\u001f` / `skills\u001f` prefixes
+  // embed DELIM so a marketplace literally named `plugins` or `skills` still
+  // produces a distinct key from the namespace tag.
   const PLUGINS_ERR_PREFIX = `plugins${DELIM}` as const;
   const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
   const ERR_MARKETPLACES = "marketplaces" as const;
   type ErrorSource =
     | typeof ERR_MARKETPLACES
     | `${typeof PLUGINS_ERR_PREFIX}${string}`
-    | `${typeof SKILLS_ERR_PREFIX}${string}`;
+    | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`;
+  // Compile-time guard: fails if any `as const` above is removed and the
+  // union silently widens back to `string` (which would defeat typo
+  // protection on `fetchErrors.get/set/delete` with zero compile errors).
+  type _AssertNarrow = string extends ErrorSource ? never : ErrorSource;
   const pluginsErrKey = (mp: string): ErrorSource => `${PLUGINS_ERR_PREFIX}${mp}`;
   const skillsErrKey = (mp: string, plugin: string): ErrorSource =>
-    `${SKILLS_ERR_PREFIX}${pluginKey(mp, plugin)}`;
+    `${SKILLS_ERR_PREFIX}${mp}${DELIM}${plugin}`;
+
+  // Short source-label for screen-reader aria-label on dismiss buttons. The
+  // banner body already holds the full message; the button label just needs
+  // enough context to disambiguate N stacked identical-looking controls.
+  function errLabel(key: ErrorSource): string {
+    if (key === ERR_MARKETPLACES) return "Dismiss marketplaces error";
+    if (key.startsWith(PLUGINS_ERR_PREFIX)) {
+      return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
+    }
+    const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
+    return `Dismiss error for ${marketplace}/${plugin}`;
+  }
 
   let marketplaces: MarketplaceInfo[] = $state([]);
   let pluginsByMarketplace: Record<string, PluginInfo[]> = $state({});
@@ -131,9 +147,11 @@
         }
         fetchErrors.delete(ERR_MARKETPLACES);
       } else {
+        console.error("[BrowseTab] listMarketplaces returned error", result.error);
         fetchErrors.set(ERR_MARKETPLACES, result.error.message);
       }
     } catch (e) {
+      console.error("[BrowseTab] listMarketplaces threw", e);
       fetchErrors.set(ERR_MARKETPLACES, e instanceof Error ? e.message : String(e));
     } finally {
       loadingMarketplaces = false;
@@ -150,9 +168,11 @@
         pluginsByMarketplace[mp] = result.data;
         fetchErrors.delete(errKey);
       } else {
+        console.error(`[BrowseTab] listPlugins(${mp}) returned error`, result.error);
         fetchErrors.set(errKey, `${mp}: ${result.error.message}`);
       }
     } catch (e) {
+      console.error(`[BrowseTab] listPlugins(${mp}) threw`, e);
       const reason = e instanceof Error ? e.message : String(e);
       fetchErrors.set(errKey, `${mp}: ${reason}`);
     } finally {
@@ -171,9 +191,11 @@
         skillsByPluginPair[key] = result.data;
         fetchErrors.delete(errKey);
       } else {
+        console.error(`[BrowseTab] listAvailableSkills(${mp}, ${plugin}) returned error`, result.error);
         fetchErrors.set(errKey, `${mp}/${plugin}: ${result.error.message}`);
       }
     } catch (e) {
+      console.error(`[BrowseTab] listAvailableSkills(${mp}, ${plugin}) threw`, e);
       const reason = e instanceof Error ? e.message : String(e);
       fetchErrors.set(errKey, `${mp}/${plugin}: ${reason}`);
     } finally {
@@ -204,38 +226,41 @@
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
       skillsByPluginPair = {};
       selectedSkills.clear();
+      // Snapshot first — deleting during `for (const key of fetchErrors.keys())`
+      // would re-trigger the effect on each delete.
+      const stale: ErrorSource[] = [];
       for (const key of fetchErrors.keys()) {
-        if (key.startsWith(SKILLS_ERR_PREFIX)) fetchErrors.delete(key);
+        if (key.startsWith(SKILLS_ERR_PREFIX)) stale.push(key);
       }
+      for (const key of stale) fetchErrors.delete(key);
     }
     priorProjectPath = projectPath;
   });
 
-  // Drop stale selections and stale error banners when the underlying filter
-  // set narrows. A deselected marketplace (or a plugin filter that excludes a
-  // pair) means the user can no longer see or act on that source — leaving its
-  // banner up would misattribute responsibility to a filter the user set
-  // intentionally. Marketplace-listing errors are always kept: they gate the
-  // initial-load empty state and aren't scoped to any selection.
+  // Drop stale selections and banners when the filter set narrows — leaving a
+  // banner for a deselected source misattributes responsibility to a filter
+  // the user set intentionally. Marketplace-listing errors always survive.
   $effect(() => {
     const valid = new Set(skills.map((s) => skillKey(s.marketplace, s.plugin, s.name)));
     for (const key of selectedSkills) {
       if (!valid.has(key)) selectedSkills.delete(key);
     }
 
+    const stale: ErrorSource[] = [];
     for (const key of fetchErrors.keys()) {
       if (key === ERR_MARKETPLACES) continue;
       if (key.startsWith(PLUGINS_ERR_PREFIX)) {
         const mp = key.slice(PLUGINS_ERR_PREFIX.length);
-        if (!selectedMarketplaces.has(mp)) fetchErrors.delete(key);
+        if (!selectedMarketplaces.has(mp)) stale.push(key);
       } else if (key.startsWith(SKILLS_ERR_PREFIX)) {
         const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
         const stillSelected =
           selectedMarketplaces.has(marketplace) &&
           (selectedPlugins.size === 0 || selectedPlugins.has(pluginKey(marketplace, plugin)));
-        if (!stillSelected) fetchErrors.delete(key);
+        if (!stillSelected) stale.push(key);
       }
     }
+    for (const key of stale) fetchErrors.delete(key);
   });
 
   function toggleMarketplace(name: string) {
@@ -331,11 +356,21 @@
       // Force-refresh so `installed` flags reflect new state. Fan out in
       // parallel — these reads are independent and serializing them delays
       // the grid refresh in proportion to the number of affected plugins.
-      await Promise.all(
-        Array.from(groups.values(), (group) =>
-          fetchSkillsFor(group.marketplace, group.plugin, true)
-        )
-      );
+      // fetchSkillsFor never rejects externally (its own try/catch surfaces
+      // failures via fetchErrors), so this Promise.all should resolve. The
+      // outer try/catch is defense-in-depth against a future regression in
+      // that invariant that would otherwise strand `installing = true`.
+      try {
+        await Promise.all(
+          Array.from(groups.values(), (group) =>
+            fetchSkillsFor(group.marketplace, group.plugin, true)
+          )
+        );
+      } catch (e) {
+        console.error("[BrowseTab] post-install refresh rejected unexpectedly", e);
+        const reason = e instanceof Error ? e.message : String(e);
+        installError = `Post-install refresh failed: ${reason}`;
+      }
     } finally {
       installing = false;
     }
@@ -523,7 +558,10 @@
     </div>
   {/if}
 
-  {#each fetchErrors as [key, message] (key)}
+  <!-- Banners render newest-first (reverse insertion order) and cap at 3 so
+       a storm of broken plugins doesn't push the grid off-screen. Dismissing
+       a banner or resolving its source surfaces the next-newest below. -->
+  {#each [...fetchErrors].reverse().slice(0, 3) as [key, message] (key)}
     <div
       data-testid="fetch-error"
       class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
@@ -532,13 +570,21 @@
       <button
         type="button"
         onclick={() => fetchErrors.delete(key)}
-        aria-label={`Dismiss ${message}`}
+        aria-label={errLabel(key)}
         class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
       >
         ×
       </button>
     </div>
   {/each}
+  {#if fetchErrors.size > 3}
+    <div
+      data-testid="fetch-error-overflow"
+      class="mx-4 mt-3 px-4 py-2 text-xs text-kiro-subtle text-center border border-kiro-muted/50 rounded-md bg-kiro-surface/30"
+    >
+      +{fetchErrors.size - 3} more {fetchErrors.size - 3 === 1 ? "error" : "errors"} — dismiss or resolve above to see the rest
+    </div>
+  {/if}
 
   {#if installError}
     <div
@@ -549,7 +595,7 @@
       <button
         type="button"
         onclick={() => (installError = null)}
-        aria-label={`Dismiss ${installError}`}
+        aria-label="Dismiss install error"
         class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
       >
         ×
@@ -587,7 +633,13 @@
             d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
         <p class="text-sm">
-          {filterText ? "No skills match the filter" : "No skills available"}
+          {#if filterText}
+            No skills match the filter
+          {:else if fetchErrors.size > 0}
+            Skills unavailable due to errors above
+          {:else}
+            No skills available
+          {/if}
         </p>
       </div>
     {:else}

--- a/crates/kiro-control-center/tests/e2e/app.spec.ts
+++ b/crates/kiro-control-center/tests/e2e/app.spec.ts
@@ -108,4 +108,28 @@ test.describe("Marketplace workflow", () => {
     await page.getByRole("button", { name: "Installed", exact: true }).click();
     await expect(page.getByText(/test-skill/i).first()).toBeVisible();
   });
+
+  test("broken marketplace surfaces dismissible banner that clears on deselect", async ({ page }) => {
+    const brokenPath = process.env.FIXTURE_BROKEN_MARKETPLACE_PATH;
+    if (!brokenPath) {
+      test.skip(true, "FIXTURE_BROKEN_MARKETPLACE_PATH not set");
+      return;
+    }
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Marketplaces", exact: true }).click();
+
+    await page.getByPlaceholder(/source|url|path/i).fill(brokenPath);
+    await page.getByRole("button", { name: /add/i }).click();
+
+    // Switch to Browse — the plugin-fetch error should surface as a banner.
+    await page.getByRole("button", { name: "Browse", exact: true }).click();
+
+    const errorBanner = page.locator('[data-testid="fetch-error"]').first();
+    await expect(errorBanner).toBeVisible({ timeout: 10_000 });
+
+    // Dismiss via the contextual aria-label (e.g. "Dismiss error for <mp>").
+    await errorBanner.getByRole("button", { name: /^Dismiss error for/ }).click();
+    await expect(errorBanner).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #21.

## Summary

Replace the single \`error\` state (which every fetch helper cleared at its start) with a keyed \`fetchErrors: Record<string, string>\`. Each source writes to its own origin-tagged key on failure and deletes that key on success, so concurrent fetches no longer clobber each other's error messages.

## Problem

Before this PR, every fetch fn called \`error = null\` at the start. When two marketplaces were selected simultaneously:

1. \`fetchPluginsFor(mp1)\` starts → \`error = null\`
2. \`fetchPluginsFor(mp2)\` starts → \`error = null\`
3. mp1 fails → \`error = \"mp1: connection refused\"\`
4. mp2 succeeds → \`error\` stays null from step 2
5. User sees… nothing. Failure vanished.

The \`Promise.all\` parallelization in PR #20 (commit \`3efbc71\`) amplified this because the post-install refresh issues N concurrent fetches, each racing on the same shared \`error\` state.

## Fix

### State split
- \`fetchErrors: Record<string, string>\` — keyed by origin-tagged strings (\`\"marketplaces\"\`, \`plugins:\${mp}\`, \`skills:\${mp}\u001f\${plugin}\`).
- \`installError: string | null\` — user-initiated install failures stay separate so they can be cleared independently on retry without touching background-fetch errors.
- \`installMessage\` unchanged (success summary).

### Fetch semantics
Each fetch fn now:
- **Success**: \`delete fetchErrors[errKey]\` — clears *only its own* entry. A concurrent failing fetch's entry is preserved.
- **Failure**: \`fetchErrors[errKey] = \`\${mp}: \${message}\`\` — prefixes the message with the source so stacked banners remain attributable.

No more optimistic \`error = null\` at fetch start; the clearing now happens atomically with the success outcome, so no window exists where a failing fetch's message can be wiped by an unrelated fetch.

### Render
Stacked banners with individual dismiss buttons (\`aria-label=\"Dismiss error\"\`, focus-visible ring). Each banner has \`data-testid=\"fetch-error\"\` for future integration tests.

## Acceptance criteria (from issue #21)

- [x] **Two concurrent failing fetches both surface their errors (no overwrite)** — distinct keys → both entries live in the map → both render.
- [x] **Failing fetch followed by a succeeding one does not hide the failure** — the succeeding fetch only clears its own key; unrelated failure entries persist.
- [x] **No regression in happy-path: error banner clears on successful retry** — retrying a failing source writes to the same key; on success it's deleted, so the banner disappears.

## Test plan

- [x] \`npx svelte-check --tsconfig ./tsconfig.json\` — 0 errors, 0 warnings across 289 files
- [x] \`npm run build\` — ✓ built, static site emitted
- [ ] Manual: run the app, force two marketplaces to fail concurrently (e.g., temp-rename their clone dirs), verify two banners stack and dismiss works
- [ ] Manual: fail mp1 → toggle mp1 off/on → verify banner clears after successful retry
- [ ] Manual: install failure + fetch failure coexist — verify both banners visible simultaneously

**Automated race-condition coverage is not added**: Playwright alone can't deterministically force a concurrent-fetch race without a backend-mocking harness, which this project doesn't have. The per-source code structure itself is the correctness proof here; a vitest + \`@testing-library/svelte\` setup would be the right follow-up for fine-grained component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)