### PR TITLE
perf(browse): bulk-fetch skills per marketplace

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -10,7 +10,7 @@ use kiro_market_core::cache::{CacheDir, MarketplaceSource};
 use kiro_market_core::git::GixCliBackend;
 use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
-use kiro_market_core::project::KiroProject;
+use kiro_market_core::project::{InstalledSkills, KiroProject};
 use kiro_market_core::service::{InstallFilter, InstallMode, MarketplaceService};
 use kiro_market_core::skill::parse_frontmatter;
 
@@ -81,6 +81,23 @@ pub struct InstallResult {
 pub struct FailedSkill {
     pub name: String,
     pub error: String,
+}
+
+/// Response for [`list_all_skills_for_marketplace`]. `skipped` carries the
+/// plugins whose directory or manifest errored — the bulk path continues past
+/// such errors to preserve the partial listing, but the frontend needs to
+/// know which plugins were silently dropped so it can surface a warning.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct BulkSkillsResult {
+    pub skills: Vec<SkillInfo>,
+    pub skipped: Vec<SkippedPlugin>,
+}
+
+/// A plugin that was excluded from a bulk skills listing, with the reason.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SkippedPlugin {
+    pub name: String,
+    pub reason: String,
 }
 
 /// Summary information about a Kiro project directory.
@@ -183,49 +200,22 @@ pub async fn list_available_skills(
             )
         })?;
 
-    let plugin_dir = resolve_local_plugin_dir(plugin_entry, &marketplace_path)?;
-    let plugin_manifest = load_plugin_manifest(&plugin_dir)?;
-    let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
-
     let project = KiroProject::new(PathBuf::from(&project_path));
-    let installed = project.load_installed().map_err(CommandError::from)?;
+    let installed = load_installed_or_error(&project, &project_path)?;
 
-    let mut results = Vec::with_capacity(skill_dirs.len());
-    for skill_dir in &skill_dirs {
-        let skill_md_path = skill_dir.join("SKILL.md");
-        let content = match fs::read_to_string(&skill_md_path) {
-            Ok(c) => c,
-            Err(e) => {
-                warn!(
-                    path = %skill_md_path.display(),
-                    error = %e,
-                    "failed to read SKILL.md, skipping"
-                );
-                continue;
-            }
-        };
-
-        let (frontmatter, _body_offset) = match parse_frontmatter(&content) {
-            Ok(result) => result,
-            Err(e) => {
-                warn!(
-                    path = %skill_md_path.display(),
-                    error = %e,
-                    "failed to parse SKILL.md frontmatter, skipping"
-                );
-                continue;
-            }
-        };
-
-        let is_installed = installed.skills.contains_key(&frontmatter.name);
-        results.push(SkillInfo {
-            name: frontmatter.name,
-            description: frontmatter.description,
-            plugin: plugin.clone(),
-            marketplace: marketplace.clone(),
-            installed: is_installed,
-        });
-    }
+    let mut results: Vec<SkillInfo> = Vec::new();
+    collect_skills_for_plugin(
+        plugin_entry,
+        &marketplace_path,
+        &marketplace,
+        &installed,
+        &mut results,
+    )
+    // Surface the original error — the user selected this plugin and
+    // deserves to know it's broken, not a silent partial result.
+    .map_err(|e| match e {
+        CollectSkillsError::MissingDir(err) | CollectSkillsError::MalformedManifest(err) => err,
+    })?;
 
     Ok(results)
 }
@@ -235,17 +225,18 @@ pub async fn list_available_skills(
 ///
 /// Bulk alternative to calling [`list_available_skills`] per plugin when no
 /// plugin filter is active. Does one `load_installed` up front instead of
-/// N (one per plugin), and folds plugin-level I/O errors (missing directory,
-/// malformed manifest, unreadable `SKILL.md`) into `warn` logs rather than
-/// failing the whole call — the worst case is a partial listing that mirrors
-/// what the per-plugin path would produce if the user walked the grid
-/// manually.
+/// N (one per plugin), and returns a [`BulkSkillsResult`] whose `skipped`
+/// field carries plugin-level errors (missing directory, malformed manifest)
+/// so the frontend can surface a partial-listing warning. Per-skill errors
+/// inside a working plugin (unreadable `SKILL.md`, bad frontmatter) are
+/// always skipped silently with a `warn` — same behavior as the per-plugin
+/// path.
 #[tauri::command]
 #[specta::specta]
 pub async fn list_all_skills_for_marketplace(
     marketplace: String,
     project_path: String,
-) -> Result<Vec<SkillInfo>, CommandError> {
+) -> Result<BulkSkillsResult, CommandError> {
     let svc = make_service()?;
     let marketplace_path = svc.marketplace_path(&marketplace);
     let plugin_entries = svc
@@ -253,75 +244,35 @@ pub async fn list_all_skills_for_marketplace(
         .map_err(CommandError::from)?;
 
     let project = KiroProject::new(PathBuf::from(&project_path));
-    let installed = project.load_installed().map_err(CommandError::from)?;
+    let installed = load_installed_or_error(&project, &project_path)?;
 
-    let mut results: Vec<SkillInfo> = Vec::new();
+    let mut skills: Vec<SkillInfo> = Vec::new();
+    let mut skipped: Vec<SkippedPlugin> = Vec::new();
 
     for plugin_entry in &plugin_entries {
-        let plugin_dir = match resolve_local_plugin_dir(plugin_entry, &marketplace_path) {
-            Ok(d) => d,
-            Err(e) => {
+        match collect_skills_for_plugin(
+            plugin_entry,
+            &marketplace_path,
+            &marketplace,
+            &installed,
+            &mut skills,
+        ) {
+            Ok(()) => {}
+            Err(CollectSkillsError::MissingDir(e) | CollectSkillsError::MalformedManifest(e)) => {
                 warn!(
                     plugin = %plugin_entry.name,
                     error = %e.message,
                     "skipping plugin in bulk skill listing"
                 );
-                continue;
+                skipped.push(SkippedPlugin {
+                    name: plugin_entry.name.clone(),
+                    reason: e.message,
+                });
             }
-        };
-
-        let plugin_manifest = match load_plugin_manifest(&plugin_dir) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(
-                    plugin = %plugin_entry.name,
-                    error = %e.message,
-                    "skipping plugin with malformed manifest in bulk skill listing"
-                );
-                continue;
-            }
-        };
-
-        let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
-
-        for skill_dir in &skill_dirs {
-            let skill_md_path = skill_dir.join("SKILL.md");
-            let content = match fs::read_to_string(&skill_md_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        path = %skill_md_path.display(),
-                        error = %e,
-                        "failed to read SKILL.md, skipping"
-                    );
-                    continue;
-                }
-            };
-
-            let (frontmatter, _body_offset) = match parse_frontmatter(&content) {
-                Ok(result) => result,
-                Err(e) => {
-                    warn!(
-                        path = %skill_md_path.display(),
-                        error = %e,
-                        "failed to parse SKILL.md frontmatter, skipping"
-                    );
-                    continue;
-                }
-            };
-
-            let is_installed = installed.skills.contains_key(&frontmatter.name);
-            results.push(SkillInfo {
-                name: frontmatter.name,
-                description: frontmatter.description,
-                plugin: plugin_entry.name.clone(),
-                marketplace: marketplace.clone(),
-                installed: is_installed,
-            });
         }
     }
 
-    Ok(results)
+    Ok(BulkSkillsResult { skills, skipped })
 }
 
 /// Install specific skills from a plugin into a Kiro project.
@@ -409,6 +360,109 @@ pub async fn get_project_info(project_path: String) -> Result<ProjectInfo, Comma
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Per-plugin failure modes surfaced by [`collect_skills_for_plugin`] so
+/// callers can decide whether to propagate or continue.
+///
+/// Per-plugin callers (user selected this plugin) propagate both variants;
+/// bulk callers (fanning out across a marketplace) fold both into the
+/// response's `skipped` list so a single bad plugin doesn't hide its 49
+/// siblings. Per-skill errors (unreadable `SKILL.md`, malformed frontmatter)
+/// are always skipped silently with a `warn` and don't surface here — they
+/// never suggest the containing plugin itself is broken.
+enum CollectSkillsError {
+    MissingDir(CommandError),
+    MalformedManifest(CommandError),
+}
+
+// Debug impl so test assertions can format CollectSkillsError in panic
+// messages. Defined alongside the enum (not behind `#[cfg(test)]`) to avoid
+// clippy's `items-after-test-module` lint.
+impl std::fmt::Debug for CollectSkillsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingDir(e) => write!(f, "MissingDir({})", e.message),
+            Self::MalformedManifest(e) => write!(f, "MalformedManifest({})", e.message),
+        }
+    }
+}
+
+/// Load the project's installed-skills tracking file, wrapping I/O errors
+/// with an actionable message that names the path and hints at the next
+/// step. Without this extra framing the frontend sees bare `serde_json` or
+/// filesystem error text that doesn't tell users where the problem lives.
+fn load_installed_or_error(
+    project: &KiroProject,
+    project_path: &str,
+) -> Result<InstalledSkills, CommandError> {
+    project.load_installed().map_err(|e| {
+        warn!(path = %project_path, error = %e, "failed to load installed skills");
+        CommandError::new(
+            format!(
+                "failed to read installed skills for project at '{project_path}': {e}. \
+                 Check that .kiro/installed.json exists and is readable."
+            ),
+            ErrorType::IoError,
+        )
+    })
+}
+
+/// Collect every skill defined by a single plugin, appending `SkillInfo`
+/// records to `out` as they're built. Pure function extracted from the two
+/// commands that previously duplicated this loop — keeps the per-skill skip
+/// philosophy in one place and exposes plugin-level errors as typed variants
+/// so callers can choose propagate-or-continue.
+fn collect_skills_for_plugin(
+    plugin_entry: &PluginEntry,
+    marketplace_path: &Path,
+    marketplace: &str,
+    installed: &InstalledSkills,
+    out: &mut Vec<SkillInfo>,
+) -> Result<(), CollectSkillsError> {
+    let plugin_dir = resolve_local_plugin_dir(plugin_entry, marketplace_path)
+        .map_err(CollectSkillsError::MissingDir)?;
+    let plugin_manifest =
+        load_plugin_manifest(&plugin_dir).map_err(CollectSkillsError::MalformedManifest)?;
+    let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
+
+    for skill_dir in &skill_dirs {
+        let skill_md_path = skill_dir.join("SKILL.md");
+        let content = match fs::read_to_string(&skill_md_path) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    path = %skill_md_path.display(),
+                    error = %e,
+                    "failed to read SKILL.md, skipping"
+                );
+                continue;
+            }
+        };
+
+        let (frontmatter, _body_offset) = match parse_frontmatter(&content) {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(
+                    path = %skill_md_path.display(),
+                    error = %e,
+                    "failed to parse SKILL.md frontmatter, skipping"
+                );
+                continue;
+            }
+        };
+
+        let is_installed = installed.skills.contains_key(&frontmatter.name);
+        out.push(SkillInfo {
+            name: frontmatter.name,
+            description: frontmatter.description,
+            plugin: plugin_entry.name.clone(),
+            marketplace: marketplace.to_owned(),
+            installed: is_installed,
+        });
+    }
+
+    Ok(())
+}
 
 /// Map a `MarketplaceSource` to a `SourceType`.
 fn marketplace_source_type(source: &MarketplaceSource) -> SourceType {
@@ -714,5 +768,122 @@ mod tests {
             "expected 'remote source' in message, got: {}",
             err.message
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_skills_for_plugin
+    // -----------------------------------------------------------------------
+
+    /// Build a plugin directory with skills under the default `skills/`
+    /// layout that `discover_skills_for_plugin` walks.
+    fn make_plugin_with_skills(root: &std::path::Path, plugin_name: &str, skill_names: &[&str]) {
+        let skills_root = root.join("plugins").join(plugin_name).join("skills");
+        fs::create_dir_all(&skills_root).expect("create skills dir");
+        for name in skill_names {
+            let dir = skills_root.join(name);
+            fs::create_dir_all(&dir).expect("create skill dir");
+            fs::write(
+                dir.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: test\n---\n"),
+            )
+            .expect("write SKILL.md");
+        }
+    }
+
+    fn relative_path_entry(name: &str, rel: &str) -> PluginEntry {
+        PluginEntry {
+            name: name.into(),
+            description: None,
+            source: PluginSource::RelativePath(
+                kiro_market_core::validation::RelativePath::new(rel).unwrap(),
+            ),
+        }
+    }
+
+    #[test]
+    fn collect_skills_for_plugin_happy_path() {
+        let tmp = tempdir().expect("tempdir");
+        make_plugin_with_skills(tmp.path(), "good", &["alpha", "beta"]);
+        let entry = relative_path_entry("good", "plugins/good");
+
+        let mut out: Vec<SkillInfo> = Vec::new();
+        let installed = InstalledSkills::default();
+        let result = collect_skills_for_plugin(&entry, tmp.path(), "mp1", &installed, &mut out);
+
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().any(|s| s.name == "alpha"));
+        assert!(out.iter().any(|s| s.name == "beta"));
+        assert!(out
+            .iter()
+            .all(|s| s.plugin == "good" && s.marketplace == "mp1"));
+        assert!(out.iter().all(|s| !s.installed));
+    }
+
+    #[test]
+    fn collect_skills_for_plugin_missing_dir_returns_missing_dir_variant() {
+        let tmp = tempdir().expect("tempdir");
+        let entry = relative_path_entry("ghost", "plugins/ghost");
+
+        let mut out: Vec<SkillInfo> = Vec::new();
+        let installed = InstalledSkills::default();
+        let result = collect_skills_for_plugin(&entry, tmp.path(), "mp1", &installed, &mut out);
+
+        match result {
+            Err(CollectSkillsError::MissingDir(e)) => {
+                assert_eq!(e.error_type, ErrorType::NotFound);
+            }
+            other => panic!("expected MissingDir, got {other:?}"),
+        }
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn collect_skills_for_plugin_malformed_manifest_returns_malformed_variant() {
+        let tmp = tempdir().expect("tempdir");
+        let plugin_dir = tmp.path().join("plugins").join("broken");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(plugin_dir.join("plugin.json"), "{ not valid json").expect("write manifest");
+        let entry = relative_path_entry("broken", "plugins/broken");
+
+        let mut out: Vec<SkillInfo> = Vec::new();
+        let installed = InstalledSkills::default();
+        let result = collect_skills_for_plugin(&entry, tmp.path(), "mp1", &installed, &mut out);
+
+        match result {
+            Err(CollectSkillsError::MalformedManifest(e)) => {
+                assert_eq!(e.error_type, ErrorType::ParseError);
+            }
+            other => panic!("expected MalformedManifest, got {other:?}"),
+        }
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn collect_skills_for_plugin_skips_bad_frontmatter_and_continues() {
+        let tmp = tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join("plugins").join("mixed").join("skills");
+        fs::create_dir_all(skills_dir.join("good-skill")).expect("create skill dir");
+        fs::create_dir_all(skills_dir.join("bad-skill")).expect("create skill dir");
+        fs::write(
+            skills_dir.join("good-skill").join("SKILL.md"),
+            "---\nname: good-skill\ndescription: works\n---\n",
+        )
+        .expect("write good skill");
+        // Missing closing `---` makes frontmatter parsing fail.
+        fs::write(
+            skills_dir.join("bad-skill").join("SKILL.md"),
+            "---\nname: bad\n",
+        )
+        .expect("write bad skill");
+        let entry = relative_path_entry("mixed", "plugins/mixed");
+
+        let mut out: Vec<SkillInfo> = Vec::new();
+        let installed = InstalledSkills::default();
+        let result = collect_skills_for_plugin(&entry, tmp.path(), "mp1", &installed, &mut out);
+
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+        assert_eq!(out.len(), 1, "bad frontmatter should be skipped, good kept");
+        assert_eq!(out[0].name, "good-skill");
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -246,8 +246,13 @@ pub async fn list_all_skills_for_marketplace(
     let project = KiroProject::new(PathBuf::from(&project_path));
     let installed = load_installed_or_error(&project, &project_path)?;
 
-    let mut skills: Vec<SkillInfo> = Vec::new();
-    let mut skipped: Vec<SkippedPlugin> = Vec::new();
+    // Pre-allocate with `plugin_entries.len()` as a baseline — `skills`
+    // typically grows well past that (multiple skills per plugin) and
+    // `skipped` is bounded above by it. A rough capacity avoids the first
+    // few reallocations in the common case; exact-fit isn't possible without
+    // a second pass.
+    let mut skills: Vec<SkillInfo> = Vec::with_capacity(plugin_entries.len());
+    let mut skipped: Vec<SkippedPlugin> = Vec::with_capacity(plugin_entries.len());
 
     for plugin_entry in &plugin_entries {
         match collect_skills_for_plugin(
@@ -424,6 +429,7 @@ fn collect_skills_for_plugin(
     let plugin_manifest =
         load_plugin_manifest(&plugin_dir).map_err(CollectSkillsError::MalformedManifest)?;
     let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
+    out.reserve(skill_dirs.len());
 
     for skill_dir in &skill_dirs {
         let skill_md_path = skill_dir.join("SKILL.md");

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -230,6 +230,100 @@ pub async fn list_available_skills(
     Ok(results)
 }
 
+/// List all skills across every plugin in a marketplace, cross-referenced
+/// with installed state.
+///
+/// Bulk alternative to calling [`list_available_skills`] per plugin when no
+/// plugin filter is active. Does one `load_installed` up front instead of
+/// N (one per plugin), and folds plugin-level I/O errors (missing directory,
+/// malformed manifest, unreadable `SKILL.md`) into `warn` logs rather than
+/// failing the whole call — the worst case is a partial listing that mirrors
+/// what the per-plugin path would produce if the user walked the grid
+/// manually.
+#[tauri::command]
+#[specta::specta]
+pub async fn list_all_skills_for_marketplace(
+    marketplace: String,
+    project_path: String,
+) -> Result<Vec<SkillInfo>, CommandError> {
+    let svc = make_service()?;
+    let marketplace_path = svc.marketplace_path(&marketplace);
+    let plugin_entries = svc
+        .list_plugin_entries(&marketplace)
+        .map_err(CommandError::from)?;
+
+    let project = KiroProject::new(PathBuf::from(&project_path));
+    let installed = project.load_installed().map_err(CommandError::from)?;
+
+    let mut results: Vec<SkillInfo> = Vec::new();
+
+    for plugin_entry in &plugin_entries {
+        let plugin_dir = match resolve_local_plugin_dir(plugin_entry, &marketplace_path) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(
+                    plugin = %plugin_entry.name,
+                    error = %e.message,
+                    "skipping plugin in bulk skill listing"
+                );
+                continue;
+            }
+        };
+
+        let plugin_manifest = match load_plugin_manifest(&plugin_dir) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    plugin = %plugin_entry.name,
+                    error = %e.message,
+                    "skipping plugin with malformed manifest in bulk skill listing"
+                );
+                continue;
+            }
+        };
+
+        let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
+
+        for skill_dir in &skill_dirs {
+            let skill_md_path = skill_dir.join("SKILL.md");
+            let content = match fs::read_to_string(&skill_md_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(
+                        path = %skill_md_path.display(),
+                        error = %e,
+                        "failed to read SKILL.md, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            let (frontmatter, _body_offset) = match parse_frontmatter(&content) {
+                Ok(result) => result,
+                Err(e) => {
+                    warn!(
+                        path = %skill_md_path.display(),
+                        error = %e,
+                        "failed to parse SKILL.md frontmatter, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            let is_installed = installed.skills.contains_key(&frontmatter.name);
+            results.push(SkillInfo {
+                name: frontmatter.name,
+                description: frontmatter.description,
+                plugin: plugin_entry.name.clone(),
+                marketplace: marketplace.clone(),
+                installed: is_installed,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
 /// Install specific skills from a plugin into a Kiro project.
 #[tauri::command]
 #[specta::specta]

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::browse::list_marketplaces,
         commands::browse::list_plugins,
         commands::browse::list_available_skills,
+        commands::browse::list_all_skills_for_marketplace,
         commands::browse::install_skills,
         commands::browse::get_project_info,
         commands::installed::list_installed_skills,

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -10,6 +10,19 @@ export const commands = {
 	listPlugins: (marketplace: string) => typedError<PluginInfo[], CommandError>(__TAURI_INVOKE("list_plugins", { marketplace })),
 	// List all available skills for a plugin, cross-referenced with installed state.
 	listAvailableSkills: (marketplace: string, plugin: string, projectPath: string) => typedError<SkillInfo[], CommandError>(__TAURI_INVOKE("list_available_skills", { marketplace, plugin, projectPath })),
+	/**
+	 *  List all skills across every plugin in a marketplace, cross-referenced
+	 *  with installed state.
+	 * 
+	 *  Bulk alternative to calling [`list_available_skills`] per plugin when no
+	 *  plugin filter is active. Does one `load_installed` up front instead of
+	 *  N (one per plugin), and folds plugin-level I/O errors (missing directory,
+	 *  malformed manifest, unreadable `SKILL.md`) into `warn` logs rather than
+	 *  failing the whole call — the worst case is a partial listing that mirrors
+	 *  what the per-plugin path would produce if the user walked the grid
+	 *  manually.
+	 */
+	listAllSkillsForMarketplace: (marketplace: string, projectPath: string) => typedError<SkillInfo[], CommandError>(__TAURI_INVOKE("list_all_skills_for_marketplace", { marketplace, projectPath })),
 	// Install specific skills from a plugin into a Kiro project.
 	installSkills: (marketplace: string, plugin: string, skills: string[], force: boolean, projectPath: string) => typedError<InstallResult, CommandError>(__TAURI_INVOKE("install_skills", { marketplace, plugin, skills, force, projectPath })),
 	// Get summary information about a Kiro project directory.

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -16,13 +16,14 @@ export const commands = {
 	 * 
 	 *  Bulk alternative to calling [`list_available_skills`] per plugin when no
 	 *  plugin filter is active. Does one `load_installed` up front instead of
-	 *  N (one per plugin), and folds plugin-level I/O errors (missing directory,
-	 *  malformed manifest, unreadable `SKILL.md`) into `warn` logs rather than
-	 *  failing the whole call — the worst case is a partial listing that mirrors
-	 *  what the per-plugin path would produce if the user walked the grid
-	 *  manually.
+	 *  N (one per plugin), and returns a [`BulkSkillsResult`] whose `skipped`
+	 *  field carries plugin-level errors (missing directory, malformed manifest)
+	 *  so the frontend can surface a partial-listing warning. Per-skill errors
+	 *  inside a working plugin (unreadable `SKILL.md`, bad frontmatter) are
+	 *  always skipped silently with a `warn` — same behavior as the per-plugin
+	 *  path.
 	 */
-	listAllSkillsForMarketplace: (marketplace: string, projectPath: string) => typedError<SkillInfo[], CommandError>(__TAURI_INVOKE("list_all_skills_for_marketplace", { marketplace, projectPath })),
+	listAllSkillsForMarketplace: (marketplace: string, projectPath: string) => typedError<BulkSkillsResult, CommandError>(__TAURI_INVOKE("list_all_skills_for_marketplace", { marketplace, projectPath })),
 	// Install specific skills from a plugin into a Kiro project.
 	installSkills: (marketplace: string, plugin: string, skills: string[], force: boolean, projectPath: string) => typedError<InstallResult, CommandError>(__TAURI_INVOKE("install_skills", { marketplace, plugin, skills, force, projectPath })),
 	// Get summary information about a Kiro project directory.
@@ -72,6 +73,17 @@ export const commands = {
 };
 
 /* Types */
+/**
+ *  Response for [`list_all_skills_for_marketplace`]. `skipped` carries the
+ *  plugins whose directory or manifest errored — the bulk path continues past
+ *  such errors to preserve the partial listing, but the frontend needs to
+ *  know which plugins were silently dropped so it can surface a warning.
+ */
+export type BulkSkillsResult = {
+	skills: SkillInfo[],
+	skipped: SkippedPlugin[],
+};
+
 /**
  *  Structured error response for Tauri commands.
  * 
@@ -264,6 +276,12 @@ export type SkillInfo = {
 	plugin: string,
 	marketplace: string,
 	installed: boolean,
+};
+
+// A plugin that was excluded from a bulk skills listing, with the reason.
+export type SkippedPlugin = {
+	name: string,
+	reason: string,
 };
 
 /**

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -23,16 +23,19 @@
     return { marketplace, plugin, name };
   };
 
-  // Error-source key family. The `plugins\u001f` / `skills\u001f` prefixes
-  // embed DELIM so a marketplace literally named `plugins` or `skills` still
-  // produces a distinct key from the namespace tag.
+  // Error-source key family. The `plugins\u001f` / `skills\u001f` /
+  // `bulk-skills\u001f` prefixes embed DELIM so a marketplace literally
+  // named `plugins` or `skills` still produces a distinct key from the
+  // namespace tag.
   const PLUGINS_ERR_PREFIX = `plugins${DELIM}` as const;
   const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
+  const BULK_SKILLS_ERR_PREFIX = `bulk-skills${DELIM}` as const;
   const ERR_MARKETPLACES = "marketplaces" as const;
   type ErrorSource =
     | typeof ERR_MARKETPLACES
     | `${typeof PLUGINS_ERR_PREFIX}${string}`
-    | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`;
+    | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`
+    | `${typeof BULK_SKILLS_ERR_PREFIX}${string}`;
   // Compile-time guard: fails if any `as const` above is removed and the
   // union silently widens back to `string` (which would defeat typo
   // protection on `fetchErrors.get/set/delete` with zero compile errors).
@@ -40,6 +43,7 @@
   const pluginsErrKey = (mp: string): ErrorSource => `${PLUGINS_ERR_PREFIX}${mp}`;
   const skillsErrKey = (mp: string, plugin: string): ErrorSource =>
     `${SKILLS_ERR_PREFIX}${mp}${DELIM}${plugin}`;
+  const bulkSkillsErrKey = (mp: string): ErrorSource => `${BULK_SKILLS_ERR_PREFIX}${mp}`;
 
   // Short source-label for screen-reader aria-label on dismiss buttons. The
   // banner body already holds the full message; the button label just needs
@@ -48,6 +52,9 @@
     if (key === ERR_MARKETPLACES) return "Dismiss marketplaces error";
     if (key.startsWith(PLUGINS_ERR_PREFIX)) {
       return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
+    }
+    if (key.startsWith(BULK_SKILLS_ERR_PREFIX)) {
+      return `Dismiss error for ${key.slice(BULK_SKILLS_ERR_PREFIX.length)}`;
     }
     const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
     return `Dismiss error for ${marketplace}/${plugin}`;
@@ -69,6 +76,7 @@
   let loadingMarketplaces: boolean = $state(false);
   let pendingPluginFetches = new SvelteSet<string>();
   let pendingSkillFetches = new SvelteSet<string>();
+  let pendingBulkSkillFetches = new SvelteSet<string>();
   let installing: boolean = $state(false);
 
   // Keyed per-source so a concurrent success for one fetch can't clear
@@ -121,7 +129,10 @@
   // while previously-fetched skills are still on screen.
   let showLoadingSpinner = $derived(
     skills.length === 0 &&
-      (loadingMarketplaces || pendingPluginFetches.size > 0 || pendingSkillFetches.size > 0)
+      (loadingMarketplaces ||
+        pendingPluginFetches.size > 0 ||
+        pendingSkillFetches.size > 0 ||
+        pendingBulkSkillFetches.size > 0)
   );
 
   // Only the initial-marketplaces fetch gates the grid's empty-state UI.
@@ -203,16 +214,77 @@
     }
   }
 
+  // Bulk path: one backend call populates per-plugin cache entries for an
+  // entire marketplace. Used when no plugin filter is active; a marketplace
+  // with 50 plugins would otherwise fire 50 concurrent `listAvailableSkills`
+  // calls on first paint. Plugins with zero skills get empty-array cache
+  // entries so the per-pair guard in `fetchSkillsFor` doesn't re-fetch them
+  // later if the user applies a plugin filter.
+  async function fetchAllSkillsForMarketplace(mp: string, plugins: PluginInfo[]) {
+    if (pendingBulkSkillFetches.has(mp)) return;
+    const allCached = plugins.every(
+      (p) => skillsByPluginPair[pluginKey(mp, p.name)] !== undefined
+    );
+    if (allCached) return;
+
+    pendingBulkSkillFetches.add(mp);
+    const errKey = bulkSkillsErrKey(mp);
+    try {
+      const result = await commands.listAllSkillsForMarketplace(mp, projectPath);
+      if (result.status === "ok") {
+        const byPlugin = new Map<string, SkillInfo[]>();
+        for (const s of result.data) {
+          const arr = byPlugin.get(s.plugin);
+          if (arr) arr.push(s);
+          else byPlugin.set(s.plugin, [s]);
+        }
+        for (const p of plugins) {
+          skillsByPluginPair[pluginKey(mp, p.name)] = byPlugin.get(p.name) ?? [];
+        }
+        fetchErrors.delete(errKey);
+        // The bulk response is authoritative for this marketplace — clear any
+        // stale per-plugin skill errors lingering from a prior filtered path.
+        const stale: ErrorSource[] = [];
+        for (const key of fetchErrors.keys()) {
+          if (key.startsWith(SKILLS_ERR_PREFIX)) {
+            const { marketplace } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
+            if (marketplace === mp) stale.push(key);
+          }
+        }
+        for (const key of stale) fetchErrors.delete(key);
+      } else {
+        console.error(`[BrowseTab] listAllSkillsForMarketplace(${mp}) returned error`, result.error);
+        fetchErrors.set(errKey, `${mp}: ${result.error.message}`);
+      }
+    } catch (e) {
+      console.error(`[BrowseTab] listAllSkillsForMarketplace(${mp}) threw`, e);
+      const reason = e instanceof Error ? e.message : String(e);
+      fetchErrors.set(errKey, `${mp}: ${reason}`);
+    } finally {
+      pendingBulkSkillFetches.delete(mp);
+    }
+  }
+
   $effect(() => {
     for (const mp of selectedMarketplaces) fetchPluginsFor(mp);
   });
 
+  // When no plugin filter is active, prefer the bulk path — one call per
+  // marketplace instead of one per (mp, plugin). Once a filter narrows the
+  // set, fall back to per-plugin calls which avoid over-fetching skills
+  // the user explicitly hid.
   $effect(() => {
     for (const mp of selectedMarketplaces) {
-      const list = pluginsByMarketplace[mp] ?? [];
-      for (const pl of list) {
-        if (selectedPlugins.size > 0 && !selectedPlugins.has(pluginKey(mp, pl.name))) continue;
-        fetchSkillsFor(mp, pl.name);
+      const plugins = pluginsByMarketplace[mp];
+      if (plugins === undefined) continue;
+
+      if (selectedPlugins.size === 0) {
+        fetchAllSkillsForMarketplace(mp, plugins);
+      } else {
+        for (const pl of plugins) {
+          if (!selectedPlugins.has(pluginKey(mp, pl.name))) continue;
+          fetchSkillsFor(mp, pl.name);
+        }
       }
     }
   });
@@ -230,7 +302,12 @@
       // would re-trigger the effect on each delete.
       const stale: ErrorSource[] = [];
       for (const key of fetchErrors.keys()) {
-        if (key.startsWith(SKILLS_ERR_PREFIX)) stale.push(key);
+        if (
+          key.startsWith(SKILLS_ERR_PREFIX) ||
+          key.startsWith(BULK_SKILLS_ERR_PREFIX)
+        ) {
+          stale.push(key);
+        }
       }
       for (const key of stale) fetchErrors.delete(key);
     }
@@ -251,6 +328,9 @@
       if (key === ERR_MARKETPLACES) continue;
       if (key.startsWith(PLUGINS_ERR_PREFIX)) {
         const mp = key.slice(PLUGINS_ERR_PREFIX.length);
+        if (!selectedMarketplaces.has(mp)) stale.push(key);
+      } else if (key.startsWith(BULK_SKILLS_ERR_PREFIX)) {
+        const mp = key.slice(BULK_SKILLS_ERR_PREFIX.length);
         if (!selectedMarketplaces.has(mp)) stale.push(key);
       } else if (key.startsWith(SKILLS_ERR_PREFIX)) {
         const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -25,8 +25,8 @@
 
   // Error-source key family. The `plugins\u001f` / `skills\u001f` /
   // `bulk-skills\u001f` prefixes embed DELIM so a marketplace literally
-  // named `plugins` or `skills` still produces a distinct key from the
-  // namespace tag.
+  // named `plugins`, `skills`, or `bulk-skills` still produces a distinct
+  // key from the namespace tag.
   const PLUGINS_ERR_PREFIX = `plugins${DELIM}` as const;
   const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
   const BULK_SKILLS_ERR_PREFIX = `bulk-skills${DELIM}` as const;
@@ -74,9 +74,12 @@
   let popRef: HTMLDivElement | undefined = $state();
 
   let loadingMarketplaces: boolean = $state(false);
-  let pendingPluginFetches = new SvelteSet<string>();
-  let pendingSkillFetches = new SvelteSet<string>();
-  let pendingBulkSkillFetches = new SvelteSet<string>();
+  // Single pending-fetch tracker keyed by ErrorSource — each in-flight fetch
+  // "owns" its error-source key until it completes. Unifying the three
+  // previous per-fetcher sets puts pending-tracking on the same typed
+  // taxonomy as the errors they mirror (every pending key is also a
+  // potential fetchErrors key).
+  let pendingFetches = new SvelteSet<ErrorSource>();
   let installing: boolean = $state(false);
 
   // Keyed per-source so a concurrent success for one fetch can't clear
@@ -128,11 +131,7 @@
   // Spinner only when no skills yet — avoids flicker when toggling filters
   // while previously-fetched skills are still on screen.
   let showLoadingSpinner = $derived(
-    skills.length === 0 &&
-      (loadingMarketplaces ||
-        pendingPluginFetches.size > 0 ||
-        pendingSkillFetches.size > 0 ||
-        pendingBulkSkillFetches.size > 0)
+    skills.length === 0 && (loadingMarketplaces || pendingFetches.size > 0)
   );
 
   // Only the initial-marketplaces fetch gates the grid's empty-state UI.
@@ -169,49 +168,57 @@
     }
   }
 
-  async function fetchPluginsFor(mp: string) {
-    if (pendingPluginFetches.has(mp) || pluginsByMarketplace[mp]) return;
-    pendingPluginFetches.add(mp);
-    const errKey = pluginsErrKey(mp);
+  // Shared scaffold for fetch helpers: manages `pendingFetches` membership,
+  // error-banner state on success/failure, and structured console logging.
+  // Each caller provides the result-producing op and the success-side cache
+  // update; cache-hit guards stay at the call site since each helper has
+  // its own cache shape.
+  async function withFetchGuard<T>(
+    key: ErrorSource,
+    label: string,
+    op: () => Promise<{ status: "ok"; data: T } | { status: "error"; error: { message: string } }>,
+    onSuccess: (data: T) => void
+  ): Promise<void> {
+    pendingFetches.add(key);
     try {
-      const result = await commands.listPlugins(mp);
+      const result = await op();
       if (result.status === "ok") {
-        pluginsByMarketplace[mp] = result.data;
-        fetchErrors.delete(errKey);
+        onSuccess(result.data);
+        fetchErrors.delete(key);
       } else {
-        console.error(`[BrowseTab] listPlugins(${mp}) returned error`, result.error);
-        fetchErrors.set(errKey, `${mp}: ${result.error.message}`);
+        console.error(`[BrowseTab] ${label} returned error`, result.error);
+        fetchErrors.set(key, `${label}: ${result.error.message}`);
       }
     } catch (e) {
-      console.error(`[BrowseTab] listPlugins(${mp}) threw`, e);
+      console.error(`[BrowseTab] ${label} threw`, e);
       const reason = e instanceof Error ? e.message : String(e);
-      fetchErrors.set(errKey, `${mp}: ${reason}`);
+      fetchErrors.set(key, `${label}: ${reason}`);
     } finally {
-      pendingPluginFetches.delete(mp);
+      pendingFetches.delete(key);
     }
   }
 
+  async function fetchPluginsFor(mp: string) {
+    const key = pluginsErrKey(mp);
+    if (pendingFetches.has(key) || pluginsByMarketplace[mp]) return;
+    await withFetchGuard(key, mp, () => commands.listPlugins(mp), (data) => {
+      pluginsByMarketplace[mp] = data;
+    });
+  }
+
   async function fetchSkillsFor(mp: string, plugin: string, force = false) {
-    const key = pluginKey(mp, plugin);
-    if (!force && (pendingSkillFetches.has(key) || skillsByPluginPair[key])) return;
-    pendingSkillFetches.add(key);
-    const errKey = skillsErrKey(mp, plugin);
-    try {
-      const result = await commands.listAvailableSkills(mp, plugin, projectPath);
-      if (result.status === "ok") {
-        skillsByPluginPair[key] = result.data;
-        fetchErrors.delete(errKey);
-      } else {
-        console.error(`[BrowseTab] listAvailableSkills(${mp}, ${plugin}) returned error`, result.error);
-        fetchErrors.set(errKey, `${mp}/${plugin}: ${result.error.message}`);
+    const cacheKey = pluginKey(mp, plugin);
+    const key = skillsErrKey(mp, plugin);
+    if (pendingFetches.has(key)) return;
+    if (!force && skillsByPluginPair[cacheKey]) return;
+    await withFetchGuard(
+      key,
+      `${mp}/${plugin}`,
+      () => commands.listAvailableSkills(mp, plugin, projectPath),
+      (data) => {
+        skillsByPluginPair[cacheKey] = data;
       }
-    } catch (e) {
-      console.error(`[BrowseTab] listAvailableSkills(${mp}, ${plugin}) threw`, e);
-      const reason = e instanceof Error ? e.message : String(e);
-      fetchErrors.set(errKey, `${mp}/${plugin}: ${reason}`);
-    } finally {
-      pendingSkillFetches.delete(key);
-    }
+    );
   }
 
   // Bulk path: one backend call populates per-plugin cache entries for an
@@ -219,50 +226,61 @@
   // with 50 plugins would otherwise fire 50 concurrent `listAvailableSkills`
   // calls on first paint. Plugins with zero skills get empty-array cache
   // entries so the per-pair guard in `fetchSkillsFor` doesn't re-fetch them
-  // later if the user applies a plugin filter.
-  async function fetchAllSkillsForMarketplace(mp: string, plugins: PluginInfo[]) {
-    if (pendingBulkSkillFetches.has(mp)) return;
+  // later if the user applies a plugin filter. Plugins the backend couldn't
+  // load (missing dir, malformed manifest) come back in `skipped` and get
+  // per-plugin error banners — avoids the silent-partial-listing footgun.
+  async function fetchAllSkillsForMarketplace(
+    mp: string,
+    plugins: readonly { name: string }[]
+  ) {
+    const key = bulkSkillsErrKey(mp);
+    if (plugins.length === 0 || pendingFetches.has(key)) return;
     const allCached = plugins.every(
       (p) => skillsByPluginPair[pluginKey(mp, p.name)] !== undefined
     );
     if (allCached) return;
 
-    pendingBulkSkillFetches.add(mp);
-    const errKey = bulkSkillsErrKey(mp);
-    try {
-      const result = await commands.listAllSkillsForMarketplace(mp, projectPath);
-      if (result.status === "ok") {
+    await withFetchGuard(
+      key,
+      mp,
+      () => commands.listAllSkillsForMarketplace(mp, projectPath),
+      ({ skills: skillList, skipped }) => {
         const byPlugin = new Map<string, SkillInfo[]>();
-        for (const s of result.data) {
+        for (const s of skillList) {
           const arr = byPlugin.get(s.plugin);
           if (arr) arr.push(s);
           else byPlugin.set(s.plugin, [s]);
         }
+        const skippedNames = new Set(skipped.map((s) => s.name));
         for (const p of plugins) {
+          // Skipped plugins get NO cache entry so the per-plugin path can
+          // still be tried if the user narrows to them — a retry might
+          // succeed (e.g. if the manifest was hand-edited).
+          if (skippedNames.has(p.name)) continue;
           skillsByPluginPair[pluginKey(mp, p.name)] = byPlugin.get(p.name) ?? [];
         }
-        fetchErrors.delete(errKey);
-        // The bulk response is authoritative for this marketplace — clear any
-        // stale per-plugin skill errors lingering from a prior filtered path.
-        const stale: ErrorSource[] = [];
-        for (const key of fetchErrors.keys()) {
-          if (key.startsWith(SKILLS_ERR_PREFIX)) {
-            const { marketplace } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
-            if (marketplace === mp) stale.push(key);
-          }
+
+        // Record per-plugin error banners for every skipped plugin.
+        for (const s of skipped) {
+          fetchErrors.set(skillsErrKey(mp, s.name), `${mp}/${s.name}: ${s.reason}`);
         }
-        for (const key of stale) fetchErrors.delete(key);
-      } else {
-        console.error(`[BrowseTab] listAllSkillsForMarketplace(${mp}) returned error`, result.error);
-        fetchErrors.set(errKey, `${mp}: ${result.error.message}`);
+
+        // The bulk response is authoritative for working plugins — clear
+        // stale per-plugin skill errors for THIS mp EXCEPT for pairs whose
+        // fetch is still in flight (racing write could clobber us) and
+        // EXCEPT entries we just set above for skipped plugins.
+        const stale: ErrorSource[] = [];
+        for (const k of fetchErrors.keys()) {
+          if (!k.startsWith(SKILLS_ERR_PREFIX)) continue;
+          const { marketplace, plugin } = parsePluginKey(k.slice(SKILLS_ERR_PREFIX.length));
+          if (marketplace !== mp) continue;
+          if (skippedNames.has(plugin)) continue;
+          if (pendingFetches.has(skillsErrKey(marketplace, plugin))) continue;
+          stale.push(k);
+        }
+        for (const k of stale) fetchErrors.delete(k);
       }
-    } catch (e) {
-      console.error(`[BrowseTab] listAllSkillsForMarketplace(${mp}) threw`, e);
-      const reason = e instanceof Error ? e.message : String(e);
-      fetchErrors.set(errKey, `${mp}: ${reason}`);
-    } finally {
-      pendingBulkSkillFetches.delete(mp);
-    }
+    );
   }
 
   $effect(() => {
@@ -289,7 +307,8 @@
     }
   });
 
-  // Skill caches and skill-fetch errors are both project-scoped — `installed`
+  // Skill caches and skill-fetch errors (both per-plugin `skills\u001f` and
+  // marketplace-level `bulk-skills\u001f`) are project-scoped — `installed`
   // flags flip and error messages cite paths under the previous project — so
   // invalidate the lot when projectPath changes. Plugin-fetch and marketplace
   // errors are project-agnostic and survive.


### PR DESCRIPTION
Closes #22.

## Summary

Replace the N-plugin fan-out in BrowseTab's first-paint skill-load path with a single bulk call per marketplace. A marketplace with 50 plugins now issues 1 Tauri IPC round-trip for skills instead of 50 concurrent calls.

## Backend: \`list_all_skills_for_marketplace\`

New Tauri command in \`crates/kiro-control-center/src-tauri/src/commands/browse.rs\` that:
- Walks every plugin entry in the marketplace
- Calls \`load_installed\` once up front (vs once per plugin)
- Returns a flat \`Vec<SkillInfo>\` (each entry tagged with its \`plugin\`)
- Folds per-plugin I/O errors (missing directory, malformed manifest, unreadable SKILL.md) into \`warn\` logs and continues — a broken plugin produces a partial listing rather than an empty one, mirroring what the per-plugin path would produce if the user walked the grid manually

The existing \`list_available_skills\` command is unchanged and used as the per-plugin fallback.

## Frontend: branched auto-fetch effect

\`BrowseTab.svelte\` auto-fetch effect now branches:

| Condition | Path | Round-trips per marketplace |
|---|---|---|
| \`selectedPlugins.size === 0\` | \`fetchAllSkillsForMarketplace(mp)\` | 1 |
| \`selectedPlugins.size > 0\` | per-plugin \`fetchSkillsFor(mp, plugin)\` | min(N, filter size) |

The bulk response populates \`skillsByPluginPair[pluginKey(mp, p)]\` for every plugin (empty arrays for plugins with zero skills) so:
- The existing cartesian-product \`skills\` derivation is unchanged
- Per-pair cache guards in \`fetchSkillsFor\` short-circuit correctly if the user later adds a plugin filter
- The post-install refetch via \`Promise.all(fetchSkillsFor(..., force=true))\` still works pair-by-pair

## Error handling

New \`bulk-skills\\u001f\${mp}\` arm of \`ErrorSource\`. A bulk failure surfaces as a **single** marketplace-level banner (not N per-plugin banners). Participates in the same sweep effects:
- Dropped on \`projectPath\` change (project-scoped)
- Dropped on marketplace deselection (source-scoped)
- User-dismissible via the existing \`errLabel\`-powered dismiss button (produces \"Dismiss error for mp1\" aria-label)

## Acceptance criteria (from #22)

- [x] **Initial render of a marketplace with >10 plugins fires at most 1 backend call for skill data** — \`fetchAllSkillsForMarketplace\` replaces N per-plugin calls when \`selectedPlugins.size === 0\`.
- [x] **The per-plugin filter path (\`selectedPlugins.size > 0\`) still uses the per-plugin command** — unchanged; the branch in the auto-fetch effect preserves it.
- [x] **Existing unit tests for the per-plugin path remain valid** — \`list_available_skills\` and its helpers are untouched; \`cargo test -p kiro-market-core\` reports 442 passing.

## Test plan

- [x] \`cargo test -p kiro-market-core\` — 442 passed
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`npx svelte-check --tsconfig ./tsconfig.json\` — 0 errors / 0 warnings
- [x] \`npm run build\` — ✓ built
- [ ] Manual: open Browse with a marketplace containing multiple plugins, confirm grid populates via one network call (devtools network tab)
- [ ] Manual: toggle a plugin filter, confirm per-plugin calls fire for only the selected plugins
- [ ] Manual: simulate a bulk-command failure (e.g. point at an invalid projectPath that breaks \`load_installed\`), confirm single bulk-skills banner appears, dismissible via X button
- [ ] Manual: switch projects, confirm bulk-skills errors clear (project-scoped sweep)

## Files changed

- \`crates/kiro-control-center/src-tauri/src/commands/browse.rs\` — new \`list_all_skills_for_marketplace\` command
- \`crates/kiro-control-center/src-tauri/src/lib.rs\` — register the command in \`collect_commands\`
- \`crates/kiro-control-center/src/lib/bindings.ts\` — regenerated; adds \`listAllSkillsForMarketplace\`
- \`crates/kiro-control-center/src/lib/components/BrowseTab.svelte\` — branched effect, \`fetchAllSkillsForMarketplace\`, new \`BULK_SKILLS_ERR_PREFIX\` arm + supporting logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)