### PR TITLE
refactor(browse): structural error/type design for browse + install (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,15 @@ cargo build
 
 ## Test
 ```bash
-cargo test                          # all tests
-cargo test -p kiro-market-core      # core library tests
-cargo test -p kiro-market           # CLI + integration tests
+cargo test                                             # all tests
+cargo test -p kiro-market-core                         # core library tests
+cargo test -p kiro-market                              # CLI + integration tests
+cargo test -p kiro-control-center --lib -- --ignored   # regenerate bindings.ts
 ```
+
+## Frontend (Tauri crate)
+From `crates/kiro-control-center/`:
+- `npm run check` — Svelte + TypeScript typecheck via `svelte-check`. Run after any core type change that flows through `bindings.ts`.
 
 ## Lint
 ```bash
@@ -30,9 +35,11 @@ Run all three before committing — CI enforces each:
 ## Code Style
 - Edition 2024, rust-version 1.85.0
 - `thiserror` for typed errors in kiro-market-core
-- Error chain: `#[source]` on inner variants (e.g. `PluginError::ManifestReadFailed { #[source] source: io::Error }`), `#[error(transparent)]` on top-level `Error` variants so `.source()` walks through. At Tauri/log boundaries call `error_full_chain(&err)` from `kiro_market_core::error` — `err.to_string()` only prints outer Display and loses source detail.
+- Error chain: `#[source]` on inner variants (e.g. `PluginError::ManifestReadFailed { #[source] source: io::Error }`), `#[error(transparent)]` on top-level `Error` variants so `.source()` walks through. At Tauri/log boundaries, AND in any wire-format `reason`/`error: String` field that crosses the FFI, use `error_full_chain(&err)` — not `err.to_string()`, which drops the source chain. See `SkippedPlugin::from_plugin_error` and `FailedSkill::install_failed` as the canonical constructors.
+- Don't name a non-`Error` payload field `source` on a `thiserror`-derived variant — the name is reserved for the `Error::source()` impl and requires the type to implement `Error`. Rename (e.g. `plugin_source: StructuredSource`) and keep the wire-format name via the projection to `SkippedReason`.
 - Prefer dedicated enum variants over `reason: String` sentinels when callers might branch on the semantic (e.g. `NotADirectory` / `SymlinkRefused` vs. a shared `DirectoryUnreadable { reason }`). `io::Error` goes directly in `#[source]` — no `Box` needed, it's `Send + Sync + 'static`.
 - **Parse, don't validate, at deserialization boundaries.** Untrusted string fields from manifests (`marketplace.json`, `plugin.json`, agent frontmatter) get wrapped in a newtype with a private inner field and a fallible `new` — see `RelativePath` (`validation.rs:28`) and `GitRef` (`git.rs:34`) as templates. Implement `Deserialize` to route through `new` so `serde_json::from_slice` rejects bad input at parse time, not later. A free `validate_xyz(&Thing) -> Result<()>` that nothing constructs is usually a missed newtype.
+- **Classifier functions over error enums enumerate every variant.** `SkippedReason::from_plugin_error`, `PluginError::remediation_hint`, and any similar "project a `PluginError` into a narrower type or pick a branch per variant" function must match every variant explicitly — no `_ => None` / `_ => default`. A new `PluginError` variant should then force a compile-time classification decision rather than silently defaulting. Two classifiers that share the same input enum drift one `_` apart otherwise.
 - `anyhow` for error propagation in kiro-market binary
 - `rstest` for parameterized tests, `tempfile` for test fixtures
 - `clippy::all` and `clippy::pedantic` enabled as warnings

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -13,7 +13,8 @@ use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource}
 use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
 use kiro_market_core::project::{InstalledSkills, KiroProject};
 use kiro_market_core::service::{
-    BulkSkillsResult, InstallFilter, InstallMode, MarketplaceService, SkillInfo,
+    BulkSkillsResult, InstallFilter, InstallMode, InstallSkillsResult, MarketplaceService,
+    PluginSkillsResult,
 };
 
 use crate::error::{CommandError, ErrorType};
@@ -58,21 +59,6 @@ pub struct PluginInfo {
     pub description: Option<String>,
     pub skill_count: u32,
     pub source_type: SourceType,
-}
-
-/// Result of an install operation across multiple skills.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct InstallResult {
-    pub installed: Vec<String>,
-    pub skipped: Vec<String>,
-    pub failed: Vec<FailedSkill>,
-}
-
-/// A skill that failed to install, with the reason.
-#[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct FailedSkill {
-    pub name: String,
-    pub error: String,
 }
 
 /// Summary information about a Kiro project directory.
@@ -160,13 +146,20 @@ pub async fn list_plugins(marketplace: String) -> Result<Vec<PluginInfo>, Comman
 }
 
 /// List all available skills for a plugin, cross-referenced with installed state.
+///
+/// Returns a [`PluginSkillsResult`] carrying both the happy-path skill list
+/// and any per-skill read failures (unreadable `SKILL.md`, malformed
+/// frontmatter) as [`PluginSkillsResult::skipped_skills`]. Previously these
+/// per-skill failures vanished into `warn!` logs, leaving the frontend to
+/// wonder why the count shrank; surfacing them structurally lets the UI
+/// show "N skills failed to load" with a drill-down.
 #[tauri::command]
 #[specta::specta]
 pub async fn list_available_skills(
     marketplace: String,
     plugin: String,
     project_path: String,
-) -> Result<Vec<SkillInfo>, CommandError> {
+) -> Result<PluginSkillsResult, CommandError> {
     let svc = make_service()?;
     let project = KiroProject::new(PathBuf::from(&project_path));
     let installed = load_installed_or_error(&project, &project_path)?;
@@ -195,6 +188,13 @@ pub async fn list_all_skills_for_marketplace(
 }
 
 /// Install specific skills from a plugin into a Kiro project.
+///
+/// Returns the core [`InstallSkillsResult`] directly rather than through a
+/// Tauri-local wrapper — the previous wrapper was a field-by-field copy
+/// and risked drifting away from the core shape (e.g. losing the
+/// `FailedSkill::kind` and `skipped_skills` fields introduced in #30).
+/// Using the core type keeps the wire format lockstep with what the
+/// service emits.
 #[tauri::command]
 #[specta::specta]
 pub async fn install_skills(
@@ -203,7 +203,7 @@ pub async fn install_skills(
     skills: Vec<String>,
     force: bool,
     project_path: String,
-) -> Result<InstallResult, CommandError> {
+) -> Result<InstallSkillsResult, CommandError> {
     let svc = make_service()?;
     let marketplace_path = svc.marketplace_path(&marketplace);
     let plugin_entries = svc
@@ -229,7 +229,7 @@ pub async fn install_skills(
     let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
 
     let project = KiroProject::new(PathBuf::from(&project_path));
-    let svc_result = svc.install_skills(
+    Ok(svc.install_skills(
         &project,
         &skill_dirs,
         &InstallFilter::Names(&skills),
@@ -237,20 +237,7 @@ pub async fn install_skills(
         &marketplace,
         &plugin,
         version.as_deref(),
-    );
-
-    Ok(InstallResult {
-        installed: svc_result.installed,
-        skipped: svc_result.skipped,
-        failed: svc_result
-            .failed
-            .into_iter()
-            .map(|f| FailedSkill {
-                name: f.name,
-                error: f.error,
-            })
-            .collect(),
-    })
+    ))
 }
 
 /// Get summary information about a Kiro project directory.

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -194,7 +194,10 @@ mod tests {
         ErrorType::ParseError
     )]
     #[case::plugin_no_skills(
-        CoreError::Plugin(PluginError::NoSkills { name: "empty".into() }),
+        CoreError::Plugin(PluginError::NoSkills {
+            name: "empty".into(),
+            path: PathBuf::from("/tmp/plugins/empty"),
+        }),
         ErrorType::Validation
     )]
     #[case::plugin_directory_missing(
@@ -232,6 +235,11 @@ mod tests {
     #[case::plugin_remote_source_not_local(
         CoreError::Plugin(PluginError::RemoteSourceNotLocal {
             plugin: "acme".into(),
+            plugin_source: kiro_market_core::marketplace::StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            },
         }),
         ErrorType::Validation
     )]

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -136,6 +136,17 @@ export type ErrorType = "not_found" | "already_exists" | "validation" | "git_err
  *  frontends should `match` on when deciding how to render the failure.
  *  The two are deliberately redundant — `error` can rephrase freely over
  *  time, while `kind` stays stable.
+ * 
+ *  Fields are `pub(crate)` so external callers cannot desync the two —
+ *  construction routes exclusively through [`Self::install_failed`] and
+ *  [`Self::requested_but_not_found`], each of which derives `error` and
+ *  `kind` together from a single source. Read access from outside the
+ *  crate happens via the [`Self::name`] / [`Self::error`] / [`Self::kind`]
+ *  accessors, and via the Serde/specta boundary (the generated
+ *  TypeScript type still exposes all three fields, because Serde ignores
+ *  Rust visibility). This mirrors the [`crate::service::browse::SkippedPlugin`]
+ *  enforcement pattern so the two redundant-by-design types stay
+ *  symmetric.
  */
 export type FailedSkill = {
 	name: string,
@@ -418,7 +429,18 @@ export type SkippedPlugin = {
  *  a single place so the projection stays consistent with the error
  *  classifier.
  */
-export type SkippedReason = { kind: "directory_missing"; path: string } | { kind: "not_a_directory"; path: string } | { kind: "symlink_refused"; path: string } | { kind: "directory_unreadable"; path: string; reason: string } | { kind: "invalid_manifest"; path: string; reason: string } | { kind: "manifest_read_failed"; path: string; reason: string } | { kind: "remote_source_not_local"; plugin: string; source: StructuredSource };
+export type SkippedReason = { kind: "directory_missing"; path: string } | { kind: "not_a_directory"; path: string } | { kind: "symlink_refused"; path: string } | { kind: "directory_unreadable"; path: string; reason: string } | { kind: "invalid_manifest"; path: string; reason: string } | { kind: "manifest_read_failed"; path: string; reason: string } | { kind: "remote_source_not_local"; plugin: string; source: StructuredSource } | 
+/**
+ *  The plugin exists and its manifest is well-formed, but it
+ *  declares no skills. Defensive classification — today no producer
+ *  in the bulk/listing path returns [`PluginError::NoSkills`], but
+ *  folding it into `skipped` means a future caller that DOES surface
+ *  it can't accidentally abort the bulk listing. The plugin name
+ *  lives on the wrapping [`SkippedPlugin`]; this variant carries
+ *  only `path` for UI remediation (the directory the user might
+ *  populate).
+ */
+{ kind: "no_skills"; path: string };
 
 /**
  *  A skill that was excluded from a listing because its `SKILL.md` or

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -8,8 +8,17 @@ export const commands = {
 	listMarketplaces: () => typedError<MarketplaceInfo[], CommandError>(__TAURI_INVOKE("list_marketplaces")),
 	// List all plugins in a given marketplace.
 	listPlugins: (marketplace: string) => typedError<PluginInfo[], CommandError>(__TAURI_INVOKE("list_plugins", { marketplace })),
-	// List all available skills for a plugin, cross-referenced with installed state.
-	listAvailableSkills: (marketplace: string, plugin: string, projectPath: string) => typedError<SkillInfo[], CommandError>(__TAURI_INVOKE("list_available_skills", { marketplace, plugin, projectPath })),
+	/**
+	 *  List all available skills for a plugin, cross-referenced with installed state.
+	 * 
+	 *  Returns a [`PluginSkillsResult`] carrying both the happy-path skill list
+	 *  and any per-skill read failures (unreadable `SKILL.md`, malformed
+	 *  frontmatter) as [`PluginSkillsResult::skipped_skills`]. Previously these
+	 *  per-skill failures vanished into `warn!` logs, leaving the frontend to
+	 *  wonder why the count shrank; surfacing them structurally lets the UI
+	 *  show "N skills failed to load" with a drill-down.
+	 */
+	listAvailableSkills: (marketplace: string, plugin: string, projectPath: string) => typedError<PluginSkillsResult, CommandError>(__TAURI_INVOKE("list_available_skills", { marketplace, plugin, projectPath })),
 	/**
 	 *  List all skills across every plugin in a marketplace, cross-referenced
 	 *  with installed state.
@@ -20,8 +29,17 @@ export const commands = {
 	 *  remote source) so the frontend can surface a partial-listing warning.
 	 */
 	listAllSkillsForMarketplace: (marketplace: string, projectPath: string) => typedError<BulkSkillsResult, CommandError>(__TAURI_INVOKE("list_all_skills_for_marketplace", { marketplace, projectPath })),
-	// Install specific skills from a plugin into a Kiro project.
-	installSkills: (marketplace: string, plugin: string, skills: string[], force: boolean, projectPath: string) => typedError<InstallResult, CommandError>(__TAURI_INVOKE("install_skills", { marketplace, plugin, skills, force, projectPath })),
+	/**
+	 *  Install specific skills from a plugin into a Kiro project.
+	 * 
+	 *  Returns the core [`InstallSkillsResult`] directly rather than through a
+	 *  Tauri-local wrapper — the previous wrapper was a field-by-field copy
+	 *  and risked drifting away from the core shape (e.g. losing the
+	 *  `FailedSkill::kind` and `skipped_skills` fields introduced in #30).
+	 *  Using the core type keeps the wire format lockstep with what the
+	 *  service emits.
+	 */
+	installSkills: (marketplace: string, plugin: string, skills: string[], force: boolean, projectPath: string) => typedError<InstallSkillsResult, CommandError>(__TAURI_INVOKE("install_skills", { marketplace, plugin, skills, force, projectPath })),
 	// Get summary information about a Kiro project directory.
 	getProjectInfo: (projectPath: string) => typedError<ProjectInfo, CommandError>(__TAURI_INVOKE("get_project_info", { projectPath })),
 	// List all skills installed in a Kiro project, sorted by name.
@@ -72,12 +90,15 @@ export const commands = {
 /**
  *  Result of a marketplace-wide skill listing. The bulk path continues
  *  past per-plugin errors (missing directory, malformed manifest) to
- *  preserve the partial listing; `skipped` records those errors so the
- *  frontend can show a warning rather than silently dropping plugins.
+ *  preserve the partial listing; `skipped` records plugin-level drops
+ *  and `skipped_skills` records per-skill drops inside otherwise-working
+ *  plugins, so the frontend can show a warning rather than silently
+ *  shrinking the count.
  */
 export type BulkSkillsResult = {
 	skills: SkillInfo[],
 	skipped: SkippedPlugin[],
+	skipped_skills: SkippedSkill[],
 };
 
 /**
@@ -107,11 +128,48 @@ export type DiscoveredProject = {
  */
 export type ErrorType = "not_found" | "already_exists" | "validation" | "git_error" | "io_error" | "parse_error" | "unknown";
 
-// A skill that failed to install, with the reason.
+/**
+ *  A skill that failed to install, with the reason.
+ * 
+ *  `error` is the human-readable Display (suitable for log lines or UI
+ *  direct rendering); `kind` is the stable programmatic contract that
+ *  frontends should `match` on when deciding how to render the failure.
+ *  The two are deliberately redundant — `error` can rephrase freely over
+ *  time, while `kind` stays stable.
+ */
 export type FailedSkill = {
 	name: string,
 	error: string,
+	kind: FailedSkillReason,
 };
+
+/**
+ *  Why a skill install failed. Separates "we tried to install and it
+ *  went wrong" ([`Self::InstallFailed`]) from "the caller named a skill
+ *  that isn't in this plugin" ([`Self::RequestedButNotFound`]) so
+ *  frontends can render a typo banner distinct from an install error
+ *  without substring-matching `FailedSkill::error`.
+ * 
+ *  [`Self::InstallFailed`] is unit-shaped: the human-readable error
+ *  message lives on [`FailedSkill::error`] and the typed `kind` here
+ *  exists to tell the typo case apart from every other failure mode.
+ *  Duplicating the error string into this variant would be redundant
+ *  since `FailedSkill.error` is always populated.
+ */
+export type FailedSkillReason = 
+/**
+ *  The install was attempted (`SKILL.md` read and frontmatter
+ *  parsed) but the filesystem copy / metadata write failed. See
+ *  [`FailedSkill::error`] for the human-readable reason.
+ */
+{ kind: "install_failed" } | 
+/**
+ *  The caller's `Names(_)` filter included a name that no skill in
+ *  the plugin's discovered list produced — typically a typo or a
+ *  stale reference. The `plugin` field carries the plugin context
+ *  so a flat UI list can attribute the miss.
+ */
+{ kind: "requested_but_not_found"; plugin: string };
 
 // A marketplace that failed to update, with the reason.
 export type FailedUpdate = {
@@ -129,11 +187,26 @@ export type GitProtocol =
 // Clone via SSH (uses SSH agent / keys).
 "ssh";
 
-// Result of an install operation across multiple skills.
-export type InstallResult = {
+// Outcome of installing a list of skill directories from one plugin.
+export type InstallSkillsResult = {
+	// Skill names successfully installed.
 	installed: string[],
+	// Skill names already installed and skipped (only when `force = false`).
 	skipped: string[],
+	/**
+	 *  Skill names whose install attempt failed (install error, or — for
+	 *  `Names(_)` filter — names requested but not found). Distinct from
+	 *  [`Self::skipped_skills`], which tracks entries we couldn't even
+	 *  read / parse before attempting to install them.
+	 */
 	failed: FailedSkill[],
+	/**
+	 *  Skill-source entries that could not be read or parsed, so no
+	 *  install was attempted. Surfaces what previously vanished into
+	 *  `warn!`-then-`continue`; mirrors
+	 *  [`crate::service::browse::BulkSkillsResult::skipped_skills`].
+	 */
+	skipped_skills: SkippedSkill[],
 };
 
 // Information about a single installed skill.
@@ -201,12 +274,38 @@ export type PluginInfo = {
 	source_type: SourceType,
 };
 
+/**
+ *  Result of [`MarketplaceService::list_skills_for_plugin`]. Mirrors
+ *  [`BulkSkillsResult`] for the single-plugin case so per-skill read
+ *  failures surface structurally rather than only via `warn!` logs.
+ */
+export type PluginSkillsResult = {
+	skills: SkillInfo[],
+	skipped_skills: SkippedSkill[],
+};
+
 // Summary information about a Kiro project directory.
 export type ProjectInfo = {
 	path: string,
 	kiro_initialized: boolean,
 	installed_skill_count: number,
 };
+
+/**
+ *  A string that has been validated as a safe relative path.
+ * 
+ *  Construction goes through [`RelativePath::new`], which applies
+ *  [`validate_relative_path`] — so holding a `RelativePath` is a static
+ *  guarantee that the inner string is non-empty, contains no `..`
+ *  components, no NUL bytes, and is not an absolute path.
+ * 
+ *  The newtype replaces a plain `String` in the manifest data model
+ *  (`PluginSource::RelativePath`, `StructuredSource::GitSubdir.path`) so
+ *  downstream code never needs to re-validate. `Deserialize` calls
+ *  `new` internally, so `serde_json::from_slice::<Marketplace>(…)`
+ *  rejects traversal at parse time.
+ */
+export type RelativePath = string;
 
 // Top-level category for a Kiro CLI setting.
 export type SettingCategory = "telemetry" | "chat" | "knowledge" | "key_bindings" | "features" | "api" | "mcp" | "environment";
@@ -281,11 +380,98 @@ export type SkillInfo = {
 	installed: boolean,
 };
 
-// A plugin that was excluded from a bulk listing, with the reason.
+/**
+ *  A plugin that was excluded from a bulk listing. Carries both a
+ *  human-readable `reason` (the error's rendered Display, suitable for
+ *  direct UI rendering or log lines) and a structured `kind` that
+ *  frontends match on for variant-specific affordances (e.g. a "clone"
+ *  button for [`SkippedReason::RemoteSourceNotLocal`]). The two are
+ *  deliberately redundant: `reason` is free-form text that may rephrase
+ *  over time, while `kind` is the stable programmatic contract.
+ * 
+ *  Fields are `pub(crate)` so external callers cannot desync the two
+ *  — construction routes exclusively through
+ *  [`SkippedPlugin::from_plugin_error`], which derives both from a
+ *  single source error. Read access from outside the crate happens via
+ *  the Serde/specta boundary (the generated TypeScript type still
+ *  exposes all three fields, because Serde ignores Rust visibility).
+ */
 export type SkippedPlugin = {
 	name: string,
 	reason: string,
+	kind: SkippedReason,
 };
+
+/**
+ *  Why a plugin was excluded from a bulk listing. Structured counterpart
+ *  to [`SkippedPlugin::reason`] so frontends can match on the cause
+ *  (rendering variant-specific UI like a "clone" button for
+ *  [`Self::RemoteSourceNotLocal`]) instead of substring-matching a
+ *  rendered error message.
+ * 
+ *  Mirrors the plugin-level subset of [`PluginError`] — exactly the
+ *  variants the bulk path folds into `skipped` rather than propagating.
+ *  Kept as a distinct type because [`PluginError`] is a Display-oriented
+ *  error carrying non-`Clone` `io::Error` chains, while `SkippedReason`
+ *  is `Serialize + specta::Type` data that crosses the FFI boundary.
+ *  Translating one to the other is the service layer's job, performed in
+ *  a single place so the projection stays consistent with the error
+ *  classifier.
+ */
+export type SkippedReason = { kind: "directory_missing"; path: string } | { kind: "not_a_directory"; path: string } | { kind: "symlink_refused"; path: string } | { kind: "directory_unreadable"; path: string; reason: string } | { kind: "invalid_manifest"; path: string; reason: string } | { kind: "manifest_read_failed"; path: string; reason: string } | { kind: "remote_source_not_local"; plugin: string; source: StructuredSource };
+
+/**
+ *  A skill that was excluded from a listing because its `SKILL.md` or
+ *  frontmatter could not be read. Surfaces what previously vanished
+ *  into `warn!`-then-`continue` so the frontend can render "N skills
+ *  failed to load" with a drill-down rather than silently shrinking the
+ *  listed count.
+ */
+export type SkippedSkill = {
+	/**
+	 *  Name of the plugin this skill was being enumerated under. The
+	 *  bulk path [`MarketplaceService::list_all_skills`] accumulates
+	 *  `SkippedSkill`s across every plugin in a marketplace, so without
+	 *  this attribution the frontend would have no way to group "N
+	 *  skills failed to load in plugin X" — making the structured
+	 *  surface strictly less useful than the per-plugin `warn!` it
+	 *  replaced. Per-plugin callers already have the plugin context
+	 *  but carry it anyway so both code paths produce identical shapes.
+	 */
+	plugin: string,
+	/**
+	 *  Directory name of the skill as a best-effort label. Not a
+	 *  guarantee the skill *would* have had this name — the frontmatter
+	 *  `name` is authoritative, and parsing it is precisely what failed.
+	 *  `None` when `Path::file_name()` cannot extract a component
+	 *  (empty path, root, or a path terminating in `..`). Encoded as
+	 *  `Option<String>` rather than a sentinel empty string so the
+	 *  frontend's type system forces the "no label available" branch
+	 *  to be handled explicitly — specta renders it as `string | null`.
+	 */
+	name_hint: string | null,
+	// Path to the `SKILL.md` file that could not be consumed.
+	path: string,
+	reason: SkippedSkillReason,
+};
+
+/**
+ *  Why an individual skill was excluded from a listing. Both variants
+ *  describe a working plugin with a single broken skill file — a
+ *  plugin-level failure surfaces as [`SkippedPlugin`] / [`SkippedReason`]
+ *  instead.
+ */
+export type SkippedSkillReason = 
+/**
+ *  Reading `SKILL.md` failed (permission denied, I/O error, invalid
+ *  UTF-8, etc.). `reason` carries the underlying error's Display.
+ */
+{ kind: "read_failed"; reason: string } | 
+/**
+ *  `SKILL.md` read successfully but the frontmatter could not be
+ *  parsed (missing fences, malformed YAML, missing `name`, etc.).
+ */
+{ kind: "frontmatter_invalid"; reason: string };
 
 /**
  *  Source type classification for marketplaces and plugins.
@@ -294,6 +480,28 @@ export type SkippedPlugin = {
  *  type like `"github" | "git" | "local" | "relative" | "git_subdir"`.
  */
 export type SourceType = "github" | "git" | "local" | "relative" | "git-subdir";
+
+/**
+ *  Provider-specific structured source descriptor, internally tagged on `"source"`.
+ * 
+ *  Carries `specta::Type` because `SkippedReason::RemoteSourceNotLocal`
+ *  embeds a `StructuredSource` payload in the browse service's
+ *  frontend-bound response. The `RelativePath` inside `GitSubdir.path`
+ *  already carries specta via its own newtype, so the whole tree exports
+ *  cleanly without further changes.
+ */
+export type StructuredSource = 
+// A GitHub repository.
+{ source: "github"; repo: string; ref: string | null; sha: string | null } | 
+// A plain Git URL.
+{ source: "url"; url: string; ref: string | null; sha: string | null } | 
+// A subdirectory within a Git repository.
+{ source: "git-subdir"; url: string; 
+/**
+ *  The subdir is typed as [`RelativePath`] so traversal cannot even
+ *  exist in-memory — `RelativePath::new` is the only way in.
+ */
+path: RelativePath; ref: string | null; sha: string | null };
 
 // Result of updating one or more marketplaces.
 export type UpdateResult = {

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -2,8 +2,54 @@
   import { onMount } from "svelte";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
-  import type { MarketplaceInfo, PluginInfo, SkillInfo } from "$lib/bindings";
+  import type {
+    MarketplaceInfo,
+    PluginInfo,
+    SkillInfo,
+    SkippedSkill,
+  } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
+
+  // Render a structured SkippedSkill as a one-line label for warning
+  // banners. Uses name_hint (Option<String> in core → string | null on
+  // the wire) with "<unnamed>" fallback so a skill whose directory name
+  // could not be extracted still shows up in the UI rather than being
+  // silently dropped — that silent drop is exactly the class of bug #30
+  // is fighting across all three call sites that consume SkippedSkill.
+  function formatSkippedSkill(s: SkippedSkill): string {
+    const label = s.name_hint ?? "<unnamed>";
+    // SkippedSkillReason is a discriminated union on `kind`. A future
+    // variant would land here as an unknown kind with a generic
+    // "unreadable" label rather than a compile error — consistent with
+    // the Rust #[non_exhaustive] attribute on the enum.
+    let reason: string;
+    switch (s.reason.kind) {
+      case "read_failed":
+        reason = `could not read SKILL.md: ${s.reason.reason}`;
+        break;
+      case "frontmatter_invalid":
+        reason = `malformed frontmatter: ${s.reason.reason}`;
+        break;
+      default:
+        reason = "unreadable";
+    }
+    return `${label}: ${reason}`;
+  }
+
+  function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): string {
+    // Caller already filtered to entries for one plugin; compose a
+    // compact single-line banner body. Truncate at MAX entries and
+    // surface the remainder as a "+N more" count — a plugin with
+    // dozens of malformed SKILL.md files is a real failure mode, but
+    // the banner isn't the right place to dump the whole list.
+    const MAX = 5;
+    const parts = list.slice(0, MAX).map(formatSkippedSkill);
+    const overflow = list.length - parts.length;
+    const joined = parts.join("; ");
+    return overflow > 0
+      ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
+      : `${list.length} skill(s) failed to load — ${joined}`;
+  }
 
   let { projectPath }: { projectPath: string } = $props();
 
@@ -216,7 +262,21 @@
       `${mp}/${plugin}`,
       () => commands.listAvailableSkills(mp, plugin, projectPath),
       (data) => {
-        skillsByPluginPair[cacheKey] = data;
+        // data is PluginSkillsResult (#30): { skills, skipped_skills }.
+        // Happy-path skills populate the card grid; per-skill read
+        // failures surface via the same per-plugin fetchErrors banner
+        // stream used by plugin-level skips (from the bulk path), so a
+        // user who sees "plugin X" in the warning list can also see
+        // "plugin Y has 2 skills that failed to load" on the same
+        // panel. Dropping skipped_skills on the floor was the silent
+        // regression flagged in the review.
+        skillsByPluginPair[cacheKey] = data.skills;
+        if (data.skipped_skills.length > 0) {
+          fetchErrors.set(
+            skillsErrKey(mp, plugin),
+            `${mp}/${plugin}: ${formatSkippedSkillsForPlugin(data.skipped_skills)}`
+          );
+        }
       }
     );
   }
@@ -244,7 +304,7 @@
       key,
       mp,
       () => commands.listAllSkillsForMarketplace(mp, projectPath),
-      ({ skills: skillList, skipped }) => {
+      ({ skills: skillList, skipped, skipped_skills }) => {
         const byPlugin = new Map<string, SkillInfo[]>();
         for (const s of skillList) {
           const arr = byPlugin.get(s.plugin);
@@ -252,6 +312,19 @@
           else byPlugin.set(s.plugin, [s]);
         }
         const skippedNames = new Set(skipped.map((s) => s.name));
+
+        // Group per-skill skips by plugin so each plugin gets one
+        // warning banner regardless of how many of its skills failed.
+        // Per-skill and plugin-level skips are disjoint (a plugin whose
+        // directory fails to resolve never reaches the per-skill loop),
+        // so the two banner streams don't collide on the same key.
+        const skippedSkillsByPlugin = new Map<string, SkippedSkill[]>();
+        for (const s of skipped_skills) {
+          const arr = skippedSkillsByPlugin.get(s.plugin);
+          if (arr) arr.push(s);
+          else skippedSkillsByPlugin.set(s.plugin, [s]);
+        }
+
         for (const p of plugins) {
           // Skipped plugins get NO cache entry so the per-plugin path can
           // still be tried if the user narrows to them — a retry might
@@ -264,17 +337,29 @@
         for (const s of skipped) {
           fetchErrors.set(skillsErrKey(mp, s.name), `${mp}/${s.name}: ${s.reason}`);
         }
+        // Record per-plugin error banners for plugins with per-skill
+        // read/parse failures — previously dropped silently (the exact
+        // regression the code-review called out for the bulk path).
+        for (const [plugin, list] of skippedSkillsByPlugin) {
+          fetchErrors.set(
+            skillsErrKey(mp, plugin),
+            `${mp}/${plugin}: ${formatSkippedSkillsForPlugin(list)}`
+          );
+        }
 
         // The bulk response is authoritative for working plugins — clear
         // stale per-plugin skill errors for THIS mp EXCEPT for pairs whose
         // fetch is still in flight (racing write could clobber us) and
-        // EXCEPT entries we just set above for skipped plugins.
+        // EXCEPT entries we just set above for skipped plugins OR plugins
+        // with surfaced per-skill failures (both populate the same
+        // banner key and must survive the post-bulk cleanup).
         const stale: ErrorSource[] = [];
         for (const k of fetchErrors.keys()) {
           if (!k.startsWith(SKILLS_ERR_PREFIX)) continue;
           const { marketplace, plugin } = parsePluginKey(k.slice(SKILLS_ERR_PREFIX.length));
           if (marketplace !== mp) continue;
           if (skippedNames.has(plugin)) continue;
+          if (skippedSkillsByPlugin.has(plugin)) continue;
           if (pendingFetches.has(skillsErrKey(marketplace, plugin))) continue;
           stale.push(k);
         }
@@ -408,6 +493,7 @@
     const installedAll: string[] = [];
     const skippedAll: string[] = [];
     const failedAll: { name: string; error: string }[] = [];
+    const unreadableAll: SkippedSkill[] = [];
     const notAttempted: string[] = [];
 
     try {
@@ -424,6 +510,11 @@
             installedAll.push(...result.data.installed);
             skippedAll.push(...result.data.skipped);
             failedAll.push(...result.data.failed);
+            // Per-skill read/parse failures surface separately from
+            // `failed` (which is install-time errors only). Previously
+            // these vanished into `warn!` logs and the user saw a
+            // shorter "installed N" count with no explanation.
+            unreadableAll.push(...result.data.skipped_skills);
           } else {
             notAttempted.push(`${group.marketplace}/${group.plugin} (${result.error.message})`);
           }
@@ -439,6 +530,11 @@
       if (skippedAll.length > 0) parts.push(`Skipped: ${skippedAll.join(", ")}`);
       if (failedAll.length > 0) {
         parts.push(`Failed: ${failedAll.map((f) => `${f.name} (${f.error})`).join(", ")}`);
+      }
+      if (unreadableAll.length > 0) {
+        parts.push(
+          `Unreadable: ${unreadableAll.map(formatSkippedSkill).join(", ")}`
+        );
       }
       if (notAttempted.length > 0) {
         parts.push(`Not attempted: ${notAttempted.join("; ")}`);

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::agent::ParseFailure;
+use crate::marketplace::StructuredSource;
 
 // ---------------------------------------------------------------------------
 // Marketplace errors
@@ -74,9 +75,12 @@ pub enum PluginError {
     #[error("plugin manifest not found at {path}")]
     ManifestNotFound { path: PathBuf },
 
-    /// The plugin declares no skills.
-    #[error("plugin `{name}` has no skills")]
-    NoSkills { name: String },
+    /// The plugin declares no skills. Carries `path` for parity with
+    /// [`Self::InvalidManifest`] and [`Self::ManifestReadFailed`] so
+    /// bulk-listing callers that surface the error alongside a plugin
+    /// name can also point at the plugin directory in the message.
+    #[error("plugin `{name}` at {path} has no skills")]
+    NoSkills { name: String, path: PathBuf },
 
     /// The plugin directory referenced by a `RelativePath` source does not
     /// exist on disk. Typically means the marketplace manifest points at a
@@ -140,11 +144,93 @@ pub enum PluginError {
     /// Distinct from [`Self::DirectoryMissing`] so the UI can offer the
     /// right remediation ("clone this remote plugin" vs "the local copy
     /// is broken").
-    #[error(
-        "plugin `{plugin}` uses a remote source and is not available \
-         locally; use the CLI to clone it first"
-    )]
-    RemoteSourceNotLocal { plugin: String },
+    ///
+    /// `plugin_source` carries the [`StructuredSource`] so callers that
+    /// surface this error to a user can render provider-specific
+    /// remediation (e.g. a GitHub-clone hint vs a plain git-URL hint)
+    /// without having to refetch the plugin entry. The field is named
+    /// `plugin_source` rather than `source` because thiserror treats a
+    /// field literally named `source` as the `std::error::Error::source()`
+    /// implementation and requires its type to implement `Error` — which
+    /// [`StructuredSource`] deliberately does not. The wire-format
+    /// projection in [`crate::service::browse::SkippedReason::RemoteSourceNotLocal`]
+    /// uses the natural name `source` on the frontend-facing side.
+    ///
+    /// The Display intentionally does NOT embed remediation text —
+    /// remediation is surface-dependent (CLI vs UI) and is exposed via
+    /// [`PluginError::remediation_hint`] so each frontend picks its own
+    /// phrasing.
+    #[error("plugin `{plugin}` uses a remote source and is not available locally")]
+    RemoteSourceNotLocal {
+        plugin: String,
+        plugin_source: StructuredSource,
+    },
+}
+
+/// Which user-facing surface is rendering an error. Used by
+/// [`PluginError::remediation_hint`] to pick surface-appropriate
+/// remediation text — CLI hints reference CLI commands, UI hints
+/// reference UI affordances. Kept in core so error variants and their
+/// remediation stay colocated; consumer crates pick the variant that
+/// matches where the error is about to be shown.
+///
+/// Closed two-variant semantic (no `#[non_exhaustive]`): these are
+/// every rendering surface in this workspace. If a new surface ever
+/// lands (e.g. a web UI), adding a variant is an intentional breaking
+/// change that should force every `match Surface { ... }` to decide
+/// what the new surface's remediation text is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Surface {
+    /// Terminal / CLI output. Remediation may reference CLI flags or
+    /// commands.
+    Cli,
+    /// Tauri desktop UI. Remediation may reference UI navigation or
+    /// buttons.
+    Ui,
+}
+
+impl PluginError {
+    /// A surface-appropriate remediation hint for this error, or `None`
+    /// if the variant is self-explanatory / no actionable next step
+    /// exists at this layer.
+    ///
+    /// The hint is deliberately NOT embedded in [`Display`] — a CLI
+    /// sentence ("use `kiro-market add` to clone it") renders as
+    /// misleading noise in the Tauri UI (which has no CLI), and a UI
+    /// sentence ("open the marketplace detail page") renders as
+    /// misleading noise in the CLI. Returning `Option<String>` also
+    /// lets callers decide how to compose the hint with the error
+    /// message (a trailing paragraph in the CLI, an inline badge in the
+    /// UI, etc.) rather than baking the composition into `Display`.
+    #[must_use]
+    pub fn remediation_hint(&self, surface: Surface) -> Option<String> {
+        // Every variant is enumerated explicitly (no `_ => None`) so a
+        // new `PluginError` variant that *should* have a remediation
+        // forces a compile error here rather than silently defaulting
+        // to `None`. This mirrors the sibling classifier
+        // [`crate::service::browse::SkippedReason::from_plugin_error`],
+        // which enumerates for the same reason — the two classifications
+        // cannot drift.
+        match self {
+            Self::RemoteSourceNotLocal { .. } => Some(match surface {
+                Surface::Cli => {
+                    "clone it first with `kiro-market add` before listing or installing".to_owned()
+                }
+                Surface::Ui => {
+                    "open the plugin's detail page in the marketplace to clone it".to_owned()
+                }
+            }),
+            Self::NotFound { .. }
+            | Self::InvalidManifest { .. }
+            | Self::ManifestNotFound { .. }
+            | Self::NoSkills { .. }
+            | Self::DirectoryMissing { .. }
+            | Self::NotADirectory { .. }
+            | Self::SymlinkRefused { .. }
+            | Self::DirectoryUnreadable { .. }
+            | Self::ManifestReadFailed { .. } => None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -455,8 +541,11 @@ mod tests {
         "plugin manifest not found at /tmp/plugin.json"
     )]
     #[case::plugin_no_skills(
-        PluginError::NoSkills { name: "empty".into() },
-        "plugin `empty` has no skills"
+        PluginError::NoSkills {
+            name: "empty".into(),
+            path: PathBuf::from("/tmp/plugins/empty"),
+        },
+        "plugin `empty` at /tmp/plugins/empty has no skills"
     )]
     #[case::plugin_directory_missing(
         PluginError::DirectoryMissing { path: PathBuf::from("/tmp/plugins/x") },
@@ -485,12 +574,113 @@ mod tests {
         "could not read plugin manifest at /tmp/plugins/x/plugin.json"
     )]
     #[case::plugin_remote_source_not_local(
-        PluginError::RemoteSourceNotLocal { plugin: "acme".into() },
-        "plugin `acme` uses a remote source and is not available \
-         locally; use the CLI to clone it first"
+        PluginError::RemoteSourceNotLocal {
+            plugin: "acme".into(),
+            plugin_source: StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            },
+        },
+        "plugin `acme` uses a remote source and is not available locally"
     )]
     fn plugin_error_display(#[case] err: PluginError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);
+    }
+
+    /// Regression guard: the Display of `RemoteSourceNotLocal` must NOT
+    /// embed the "use the CLI to clone it first" remediation any longer.
+    /// That sentence renders as misleading noise in the Tauri UI (which
+    /// has no CLI). Surface-appropriate remediation now lives on
+    /// [`PluginError::remediation_hint`]. If this test fails, somebody
+    /// put the CLI hint back in the format string — break out
+    /// `remediation_hint` instead.
+    #[test]
+    fn remote_source_not_local_display_has_no_cli_hint() {
+        let err = PluginError::RemoteSourceNotLocal {
+            plugin: "acme".into(),
+            plugin_source: StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            },
+        };
+        let display = err.to_string();
+        assert!(
+            !display.to_lowercase().contains("cli"),
+            "Display must be surface-neutral, got: {display}"
+        );
+        assert!(
+            !display.to_lowercase().contains("clone"),
+            "remediation verbs belong in remediation_hint, not Display: {display}"
+        );
+    }
+
+    #[test]
+    fn remediation_hint_remote_source_distinguishes_surfaces() {
+        let err = PluginError::RemoteSourceNotLocal {
+            plugin: "acme".into(),
+            plugin_source: StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            },
+        };
+        let cli = err
+            .remediation_hint(Surface::Cli)
+            .expect("CLI hint must be present for RemoteSourceNotLocal");
+        let ui = err
+            .remediation_hint(Surface::Ui)
+            .expect("UI hint must be present for RemoteSourceNotLocal");
+        assert_ne!(cli, ui, "CLI and UI hints must differ");
+        // Each hint must only reference its own surface's vocabulary —
+        // swapping them would be the whole point of bug.
+        assert!(
+            cli.to_lowercase().contains("cli") || cli.to_lowercase().contains("kiro-market"),
+            "CLI hint should reference CLI vocabulary, got: {cli}"
+        );
+        assert!(
+            !ui.to_lowercase().contains("cli") && !ui.contains("kiro-market"),
+            "UI hint must not reference CLI commands, got: {ui}"
+        );
+    }
+
+    /// Remediation hints are only defined for variants where the caller
+    /// can take an actionable next step. Every other plugin-level variant
+    /// returns `None` so consumers don't render empty trailing hints.
+    #[rstest]
+    #[case::not_found(PluginError::NotFound {
+        plugin: "p".into(),
+        marketplace: "m".into(),
+    })]
+    #[case::invalid_manifest(PluginError::InvalidManifest {
+        path: PathBuf::from("/tmp/plugin.json"),
+        reason: "bad json".into(),
+    })]
+    #[case::directory_missing(PluginError::DirectoryMissing {
+        path: PathBuf::from("/tmp/plugins/ghost"),
+    })]
+    #[case::not_a_directory(PluginError::NotADirectory {
+        path: PathBuf::from("/tmp/plugins/file"),
+    })]
+    #[case::symlink_refused(PluginError::SymlinkRefused {
+        path: PathBuf::from("/tmp/plugins/link"),
+    })]
+    #[case::no_skills(PluginError::NoSkills {
+        name: "empty".into(),
+        path: PathBuf::from("/tmp/plugins/empty"),
+    })]
+    fn remediation_hint_returns_none_for_variants_without_actionable_step(
+        #[case] err: PluginError,
+    ) {
+        assert!(
+            err.remediation_hint(Surface::Cli).is_none(),
+            "CLI hint must be None for variant without remediation"
+        );
+        assert!(
+            err.remediation_hint(Surface::Ui).is_none(),
+            "UI hint must be None for variant without remediation"
+        );
     }
 
     #[rstest]
@@ -645,6 +835,7 @@ mod tests {
     fn from_plugin_error() {
         let inner = PluginError::NoSkills {
             name: "test".into(),
+            path: PathBuf::from("/tmp/plugins/test"),
         };
         let err: Error = inner.into();
         assert!(matches!(err, Error::Plugin(_)));

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -212,9 +212,14 @@ impl PluginError {
         // which enumerates for the same reason — the two classifications
         // cannot drift.
         match self {
-            Self::RemoteSourceNotLocal { .. } => Some(match surface {
+            Self::RemoteSourceNotLocal { plugin, .. } => Some(match surface {
+                // `kiro-market install` uses the cloning resolver
+                // (`resolve_plugin_dir`), whereas `list`/`info`/`search`
+                // use `resolve_local_plugin_dir` — the non-cloning
+                // variant that produces this error. Installing is the
+                // user-facing remediation that triggers the clone.
                 Surface::Cli => {
-                    "clone it first with `kiro-market add` before listing or installing".to_owned()
+                    format!("run `kiro-market install {plugin}@<marketplace>` to clone it locally")
                 }
                 Surface::Ui => {
                     "open the plugin's detail page in the marketplace to clone it".to_owned()
@@ -638,6 +643,25 @@ mod tests {
         assert!(
             cli.to_lowercase().contains("cli") || cli.to_lowercase().contains("kiro-market"),
             "CLI hint should reference CLI vocabulary, got: {cli}"
+        );
+        // Pin the specific CLI subcommand. `kiro-market install` is the
+        // remediation because it uses the cloning resolver; previously
+        // this hint said `kiro-market add` which does not exist as a
+        // subcommand (flagged by gemini-code-assist on PR #35). The
+        // `install` substring catches a regression back to any
+        // non-existent command.
+        assert!(
+            cli.contains("kiro-market install"),
+            "CLI hint must reference `kiro-market install` (the cloning \
+             remediation), got: {cli}"
+        );
+        // The hint must interpolate the plugin name so the user can
+        // copy-paste it verbatim. "acme" is the plugin name seeded in
+        // the fixture above.
+        assert!(
+            cli.contains("acme"),
+            "CLI hint must interpolate the plugin name from the error \
+             payload, got: {cli}"
         );
         assert!(
             !ui.to_lowercase().contains("cli") && !ui.contains("kiro-market"),

--- a/crates/kiro-market-core/src/marketplace.rs
+++ b/crates/kiro-market-core/src/marketplace.rs
@@ -103,7 +103,14 @@ impl<'de> Deserialize<'de> for PluginSource {
 }
 
 /// Provider-specific structured source descriptor, internally tagged on `"source"`.
+///
+/// Carries `specta::Type` because `SkippedReason::RemoteSourceNotLocal`
+/// embeds a `StructuredSource` payload in the browse service's
+/// frontend-bound response. The `RelativePath` inside `GitSubdir.path`
+/// already carries specta via its own newtype, so the whole tree exports
+/// cleanly without further changes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 #[serde(tag = "source")]
 pub enum StructuredSource {
     /// A GitHub repository.

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use tracing::{debug, warn};
 
 use crate::error::{Error, PluginError};
-use crate::marketplace::{PluginEntry, PluginSource};
+use crate::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use crate::plugin::{PluginManifest, discover_skill_dirs};
 use crate::project::InstalledSkills;
 use crate::service::MarketplaceService;
@@ -41,21 +41,246 @@ pub struct SkillInfo {
 
 /// Result of a marketplace-wide skill listing. The bulk path continues
 /// past per-plugin errors (missing directory, malformed manifest) to
-/// preserve the partial listing; `skipped` records those errors so the
-/// frontend can show a warning rather than silently dropping plugins.
+/// preserve the partial listing; `skipped` records plugin-level drops
+/// and `skipped_skills` records per-skill drops inside otherwise-working
+/// plugins, so the frontend can show a warning rather than silently
+/// shrinking the count.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct BulkSkillsResult {
     pub skills: Vec<SkillInfo>,
     pub skipped: Vec<SkippedPlugin>,
+    pub skipped_skills: Vec<SkippedSkill>,
 }
 
-/// A plugin that was excluded from a bulk listing, with the reason.
+/// A plugin that was excluded from a bulk listing. Carries both a
+/// human-readable `reason` (the error's rendered Display, suitable for
+/// direct UI rendering or log lines) and a structured `kind` that
+/// frontends match on for variant-specific affordances (e.g. a "clone"
+/// button for [`SkippedReason::RemoteSourceNotLocal`]). The two are
+/// deliberately redundant: `reason` is free-form text that may rephrase
+/// over time, while `kind` is the stable programmatic contract.
+///
+/// Fields are `pub(crate)` so external callers cannot desync the two
+/// — construction routes exclusively through
+/// [`SkippedPlugin::from_plugin_error`], which derives both from a
+/// single source error. Read access from outside the crate happens via
+/// the Serde/specta boundary (the generated TypeScript type still
+/// exposes all three fields, because Serde ignores Rust visibility).
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct SkippedPlugin {
-    pub name: String,
-    pub reason: String,
+    pub(crate) name: String,
+    pub(crate) reason: String,
+    pub(crate) kind: SkippedReason,
+}
+
+impl SkippedPlugin {
+    /// Construct a [`SkippedPlugin`] from the plugin's name and the
+    /// [`Error`] that caused it to be skipped, keeping `reason` (the
+    /// error's rendered Display) and `kind` (the programmatic
+    /// projection) in lockstep. Returns `None` when the error is not a
+    /// plugin-level skip — callers must propagate such errors instead
+    /// of folding them into the response.
+    ///
+    /// This is the ONLY way to build a [`SkippedPlugin`] outside the
+    /// service module (fields are `pub(crate)`), so `reason` and `kind`
+    /// cannot drift from the underlying error. Subsumes the previous
+    /// free helper `plugin_skip_reason(&Error) -> Option<SkippedReason>`
+    /// — callers that only need the kind still have
+    /// [`SkippedReason::from_plugin_error`].
+    #[must_use]
+    pub(crate) fn from_plugin_error(name: String, err: &Error) -> Option<Self> {
+        let Error::Plugin(pe) = err else { return None };
+        let kind = SkippedReason::from_plugin_error(pe)?;
+        Some(Self {
+            name,
+            reason: err.to_string(),
+            kind,
+        })
+    }
+
+    /// Name of the plugin that was skipped. Public accessor so tests
+    /// and (future) crate-external code that only reads the value can
+    /// stay out of the wire-format derivation. The equivalent read via
+    /// the Serde-generated TypeScript type is `SkippedPlugin.name`.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Human-readable failure message (the source error's rendered
+    /// Display). Use [`Self::kind`] for programmatic matching; use
+    /// this for log lines and simple UI labels.
+    #[must_use]
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// Structured classification of the skip reason. Stable contract
+    /// for frontends that render variant-specific affordances.
+    #[must_use]
+    pub fn kind(&self) -> &SkippedReason {
+        &self.kind
+    }
+}
+
+impl SkippedReason {
+    /// Project a [`PluginError`] into its [`SkippedReason`] counterpart
+    /// if — and only if — the variant represents a plugin-level skip
+    /// that the bulk/listing paths should fold into the response rather
+    /// than propagate as an `Err`. Returns `None` for non-plugin-level
+    /// variants (e.g. [`PluginError::NotFound`], which is a "caller
+    /// asked for the wrong thing" bug, not a damaged plugin).
+    ///
+    /// This is the single source of truth for both the classification
+    /// (which variants skip vs. propagate) and the wire-format projection
+    /// (how each variant maps to a frontend-serializable shape). Keeping
+    /// them in one function means a new plugin-level variant on
+    /// [`PluginError`] either lands here (and is automatically surfaced
+    /// to the frontend) or does not (and will propagate as an error) —
+    /// the two classifications cannot drift.
+    #[must_use]
+    pub fn from_plugin_error(err: &PluginError) -> Option<Self> {
+        match err {
+            PluginError::DirectoryMissing { path } => {
+                Some(Self::DirectoryMissing { path: path.clone() })
+            }
+            PluginError::NotADirectory { path } => Some(Self::NotADirectory { path: path.clone() }),
+            PluginError::SymlinkRefused { path } => {
+                Some(Self::SymlinkRefused { path: path.clone() })
+            }
+            PluginError::DirectoryUnreadable { path, source } => Some(Self::DirectoryUnreadable {
+                path: path.clone(),
+                reason: source.to_string(),
+            }),
+            PluginError::InvalidManifest { path, reason } => Some(Self::InvalidManifest {
+                path: path.clone(),
+                reason: reason.clone(),
+            }),
+            PluginError::ManifestReadFailed { path, source } => Some(Self::ManifestReadFailed {
+                path: path.clone(),
+                reason: source.to_string(),
+            }),
+            PluginError::RemoteSourceNotLocal {
+                plugin,
+                plugin_source,
+            } => Some(Self::RemoteSourceNotLocal {
+                plugin: plugin.clone(),
+                source: plugin_source.clone(),
+            }),
+            // Explicit match on non-skip variants rather than `_ => None`
+            // so adding a new PluginError variant triggers a compiler
+            // error until the author decides whether it's plugin-level.
+            PluginError::NotFound { .. }
+            | PluginError::ManifestNotFound { .. }
+            | PluginError::NoSkills { .. } => None,
+        }
+    }
+}
+
+/// Why a plugin was excluded from a bulk listing. Structured counterpart
+/// to [`SkippedPlugin::reason`] so frontends can match on the cause
+/// (rendering variant-specific UI like a "clone" button for
+/// [`Self::RemoteSourceNotLocal`]) instead of substring-matching a
+/// rendered error message.
+///
+/// Mirrors the plugin-level subset of [`PluginError`] — exactly the
+/// variants the bulk path folds into `skipped` rather than propagating.
+/// Kept as a distinct type because [`PluginError`] is a Display-oriented
+/// error carrying non-`Clone` `io::Error` chains, while `SkippedReason`
+/// is `Serialize + specta::Type` data that crosses the FFI boundary.
+/// Translating one to the other is the service layer's job, performed in
+/// a single place so the projection stays consistent with the error
+/// classifier.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkippedReason {
+    DirectoryMissing {
+        path: PathBuf,
+    },
+    NotADirectory {
+        path: PathBuf,
+    },
+    SymlinkRefused {
+        path: PathBuf,
+    },
+    DirectoryUnreadable {
+        path: PathBuf,
+        reason: String,
+    },
+    InvalidManifest {
+        path: PathBuf,
+        reason: String,
+    },
+    ManifestReadFailed {
+        path: PathBuf,
+        reason: String,
+    },
+    RemoteSourceNotLocal {
+        plugin: String,
+        source: StructuredSource,
+    },
+}
+
+/// A skill that was excluded from a listing because its `SKILL.md` or
+/// frontmatter could not be read. Surfaces what previously vanished
+/// into `warn!`-then-`continue` so the frontend can render "N skills
+/// failed to load" with a drill-down rather than silently shrinking the
+/// listed count.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct SkippedSkill {
+    /// Name of the plugin this skill was being enumerated under. The
+    /// bulk path [`MarketplaceService::list_all_skills`] accumulates
+    /// `SkippedSkill`s across every plugin in a marketplace, so without
+    /// this attribution the frontend would have no way to group "N
+    /// skills failed to load in plugin X" — making the structured
+    /// surface strictly less useful than the per-plugin `warn!` it
+    /// replaced. Per-plugin callers already have the plugin context
+    /// but carry it anyway so both code paths produce identical shapes.
+    pub plugin: String,
+    /// Directory name of the skill as a best-effort label. Not a
+    /// guarantee the skill *would* have had this name — the frontmatter
+    /// `name` is authoritative, and parsing it is precisely what failed.
+    /// `None` when `Path::file_name()` cannot extract a component
+    /// (empty path, root, or a path terminating in `..`). Encoded as
+    /// `Option<String>` rather than a sentinel empty string so the
+    /// frontend's type system forces the "no label available" branch
+    /// to be handled explicitly — specta renders it as `string | null`.
+    pub name_hint: Option<String>,
+    /// Path to the `SKILL.md` file that could not be consumed.
+    pub path: PathBuf,
+    pub reason: SkippedSkillReason,
+}
+
+/// Why an individual skill was excluded from a listing. Both variants
+/// describe a working plugin with a single broken skill file — a
+/// plugin-level failure surfaces as [`SkippedPlugin`] / [`SkippedReason`]
+/// instead.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkippedSkillReason {
+    /// Reading `SKILL.md` failed (permission denied, I/O error, invalid
+    /// UTF-8, etc.). `reason` carries the underlying error's Display.
+    ReadFailed { reason: String },
+    /// `SKILL.md` read successfully but the frontmatter could not be
+    /// parsed (missing fences, malformed YAML, missing `name`, etc.).
+    FrontmatterInvalid { reason: String },
+}
+
+/// Result of [`MarketplaceService::list_skills_for_plugin`]. Mirrors
+/// [`BulkSkillsResult`] for the single-plugin case so per-skill read
+/// failures surface structurally rather than only via `warn!` logs.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginSkillsResult {
+    pub skills: Vec<SkillInfo>,
+    pub skipped_skills: Vec<SkippedSkill>,
 }
 
 // ---------------------------------------------------------------------------
@@ -124,8 +349,9 @@ impl MarketplaceService {
                     .into()),
                 }
             }
-            PluginSource::Structured(_) => Err(PluginError::RemoteSourceNotLocal {
+            PluginSource::Structured(s) => Err(PluginError::RemoteSourceNotLocal {
                 plugin: entry.name.clone(),
+                plugin_source: s.clone(),
             }
             .into()),
         }
@@ -135,10 +361,12 @@ impl MarketplaceService {
     /// with the project's installed set.
     ///
     /// Per-skill errors inside a working plugin (unreadable `SKILL.md`,
-    /// malformed frontmatter) are skipped silently with a `warn`. A
-    /// plugin-level error (missing directory, malformed manifest,
-    /// remote source) propagates — callers who selected this plugin
-    /// explicitly should see a real error rather than an empty list.
+    /// malformed frontmatter) land in [`PluginSkillsResult::skipped_skills`]
+    /// so they surface structurally rather than vanishing into a `warn!`.
+    /// A plugin-level error (missing directory, malformed manifest,
+    /// remote source) propagates as `Err` — callers who selected this
+    /// plugin explicitly should see a real error rather than an empty
+    /// list.
     ///
     /// # Errors
     ///
@@ -158,7 +386,7 @@ impl MarketplaceService {
         marketplace: &str,
         plugin: &str,
         installed: &InstalledSkills,
-    ) -> Result<Vec<SkillInfo>, Error> {
+    ) -> Result<PluginSkillsResult, Error> {
         let marketplace_path = self.marketplace_path(marketplace);
         let plugin_entries = self.list_plugin_entries(marketplace)?;
 
@@ -172,16 +400,21 @@ impl MarketplaceService {
                 })
             })?;
 
-        let mut out: Vec<SkillInfo> = Vec::new();
+        let mut skills: Vec<SkillInfo> = Vec::new();
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
         collect_skills_for_plugin_into(
             self,
             plugin_entry,
             &marketplace_path,
             marketplace,
             installed,
-            &mut out,
+            &mut skills,
+            &mut skipped_skills,
         )?;
-        Ok(out)
+        Ok(PluginSkillsResult {
+            skills,
+            skipped_skills,
+        })
     }
 
     /// List every skill across every plugin in a marketplace,
@@ -190,14 +423,17 @@ impl MarketplaceService {
     /// Plugin-level errors (missing directory, malformed manifest,
     /// remote source) are folded into [`BulkSkillsResult::skipped`]
     /// so a single bad plugin doesn't hide its siblings. Per-skill
-    /// errors inside a working plugin are still warned-and-skipped,
-    /// matching [`Self::list_skills_for_plugin`].
+    /// errors inside a working plugin go to
+    /// [`BulkSkillsResult::skipped_skills`], matching
+    /// [`Self::list_skills_for_plugin`]'s contract.
     ///
     /// The `skills` and `skipped` vectors are pre-allocated with the
     /// plugin count as a baseline — `skills` usually grows past it
     /// (multiple skills per plugin) and `skipped` is bounded above
     /// by it, so this avoids the first few reallocations in the
-    /// common case.
+    /// common case. `skipped_skills` stays at default capacity because
+    /// the common case is zero per-skill failures; paying for an
+    /// allocation that usually goes unused is the wrong default.
     ///
     /// # Errors
     ///
@@ -205,8 +441,8 @@ impl MarketplaceService {
     /// [`Error::Io`] / [`Error::Json`] from
     /// [`Self::list_plugin_entries`] when the marketplace is unknown
     /// or its registry is corrupt / unreadable. Non-plugin-level
-    /// errors during iteration propagate; plugin-level errors (see
-    /// [`is_plugin_level_skip`]) go to `skipped`.
+    /// errors during iteration propagate; plugin-level errors
+    /// (see [`SkippedReason::from_plugin_error`]) go to `skipped`.
     pub fn list_all_skills(
         &self,
         marketplace: &str,
@@ -217,6 +453,7 @@ impl MarketplaceService {
 
         let mut skills: Vec<SkillInfo> = Vec::with_capacity(plugin_entries.len());
         let mut skipped: Vec<SkippedPlugin> = Vec::with_capacity(plugin_entries.len());
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
 
         for plugin_entry in &plugin_entries {
             match collect_skills_for_plugin_into(
@@ -226,58 +463,43 @@ impl MarketplaceService {
                 marketplace,
                 installed,
                 &mut skills,
+                &mut skipped_skills,
             ) {
                 Ok(()) => {}
-                Err(err) if is_plugin_level_skip(&err) => {
-                    let reason = err.to_string();
-                    warn!(
-                        plugin = %plugin_entry.name,
-                        error = %reason,
-                        "skipping plugin in bulk skill listing"
-                    );
-                    skipped.push(SkippedPlugin {
-                        name: plugin_entry.name.clone(),
-                        reason,
-                    });
+                Err(err) => {
+                    match SkippedPlugin::from_plugin_error(plugin_entry.name.clone(), &err) {
+                        Some(sp) => {
+                            warn!(
+                                plugin = %plugin_entry.name,
+                                error = %sp.reason,
+                                "skipping plugin in bulk skill listing"
+                            );
+                            skipped.push(sp);
+                        }
+                        None => return Err(err),
+                    }
                 }
-                Err(other) => return Err(other),
             }
         }
 
-        Ok(BulkSkillsResult { skills, skipped })
+        Ok(BulkSkillsResult {
+            skills,
+            skipped,
+            skipped_skills,
+        })
     }
-}
-
-/// Is this error one that the bulk path should fold into `skipped`
-/// rather than propagate? `true` for plugin-level resolution failures
-/// (missing, not-a-directory, symlinked, or unreadable directory;
-/// malformed or unreadable manifest; remote source); `false` for
-/// anything else — corrupt marketplace state, unexpected I/O errors
-/// outside the per-plugin scope, etc., which must surface so callers
-/// see them.
-fn is_plugin_level_skip(err: &Error) -> bool {
-    matches!(
-        err,
-        Error::Plugin(
-            PluginError::DirectoryMissing { .. }
-                | PluginError::NotADirectory { .. }
-                | PluginError::SymlinkRefused { .. }
-                | PluginError::DirectoryUnreadable { .. }
-                | PluginError::InvalidManifest { .. }
-                | PluginError::ManifestReadFailed { .. }
-                | PluginError::RemoteSourceNotLocal { .. }
-        )
-    )
 }
 
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
 
-/// Append every skill defined by `plugin_entry` to `out`, cross-referenced
-/// against `installed`. Plugin-level errors (missing dir, malformed
-/// manifest, remote source) propagate as `Err`; per-skill errors
-/// (unreadable `SKILL.md`, malformed frontmatter) are logged and skipped.
+/// Append every readable skill defined by `plugin_entry` to `out`,
+/// cross-referenced against `installed`. Plugin-level errors (missing
+/// dir, malformed manifest, remote source) propagate as `Err`; per-skill
+/// errors (unreadable `SKILL.md`, malformed frontmatter) are appended to
+/// `skipped_skills` as structured [`SkippedSkill`] entries so the bulk
+/// and per-plugin public entry points both surface them to the caller.
 ///
 /// Shared between the per-plugin and bulk public entry points so the
 /// per-skill skip philosophy and plugin-level error classification live
@@ -289,6 +511,7 @@ fn collect_skills_for_plugin_into(
     marketplace_name: &str,
     installed: &InstalledSkills,
     out: &mut Vec<SkillInfo>,
+    skipped_skills: &mut Vec<SkippedSkill>,
 ) -> Result<(), Error> {
     let plugin_dir = service.resolve_local_plugin_dir(plugin_entry, marketplace_path)?;
     let plugin_manifest = load_plugin_manifest(&plugin_dir)?;
@@ -307,6 +530,14 @@ fn collect_skills_for_plugin_into(
                     error = %e,
                     "failed to read SKILL.md, skipping"
                 );
+                skipped_skills.push(SkippedSkill {
+                    plugin: plugin_entry.name.clone(),
+                    name_hint: name_hint_from_skill_dir(skill_dir),
+                    path: skill_md_path,
+                    reason: SkippedSkillReason::ReadFailed {
+                        reason: e.to_string(),
+                    },
+                });
                 continue;
             }
         };
@@ -321,6 +552,14 @@ fn collect_skills_for_plugin_into(
                     error = %e,
                     "failed to parse SKILL.md frontmatter, skipping"
                 );
+                skipped_skills.push(SkippedSkill {
+                    plugin: plugin_entry.name.clone(),
+                    name_hint: name_hint_from_skill_dir(skill_dir),
+                    path: skill_md_path,
+                    reason: SkippedSkillReason::FrontmatterInvalid {
+                        reason: e.to_string(),
+                    },
+                });
                 continue;
             }
         };
@@ -336,6 +575,24 @@ fn collect_skills_for_plugin_into(
     }
 
     Ok(())
+}
+
+/// Best-effort label for a skill whose real (frontmatter) name is
+/// unreachable — used as [`SkippedSkill::name_hint`]. Returns `None`
+/// when [`Path::file_name`] cannot extract a final component (degenerate
+/// inputs: empty path, root `/`, or a path terminating in `..`); in
+/// practice `skill_dir` always comes from [`discover_skill_dirs`] so
+/// the `None` arm is defensive rather than expected.
+///
+/// `pub(crate)` so the install path in [`super::MarketplaceService::install_skills`]
+/// can populate [`SkippedSkill::name_hint`] consistently with the
+/// listing path — the two codepaths used to both reach for
+/// `skill_dir.file_name()` inline; sharing the helper means a future
+/// tweak (e.g. normalising Unicode) lands once.
+pub(crate) fn name_hint_from_skill_dir(skill_dir: &Path) -> Option<String> {
+    skill_dir
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
 }
 
 /// Resolve the skill-discovery paths for a plugin. Uses
@@ -590,9 +847,18 @@ mod tests {
         let entry = relative_path_entry("good", "plugins/good");
 
         let mut out: Vec<SkillInfo> = Vec::new();
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
         let installed = InstalledSkills::default();
-        collect_skills_for_plugin_into(&svc, &entry, dir.path(), "mp1", &installed, &mut out)
-            .expect("happy path");
+        collect_skills_for_plugin_into(
+            &svc,
+            &entry,
+            dir.path(),
+            "mp1",
+            &installed,
+            &mut out,
+            &mut skipped_skills,
+        )
+        .expect("happy path");
 
         assert_eq!(out.len(), 2);
         assert!(out.iter().any(|s| s.name == "alpha"));
@@ -602,6 +868,10 @@ mod tests {
                 .all(|s| s.plugin == "good" && s.marketplace == "mp1")
         );
         assert!(out.iter().all(|s| !s.installed));
+        assert!(
+            skipped_skills.is_empty(),
+            "happy path must not skip any skills, got: {skipped_skills:?}"
+        );
     }
 
     #[test]
@@ -610,16 +880,25 @@ mod tests {
         let entry = relative_path_entry("ghost", "plugins/ghost");
 
         let mut out: Vec<SkillInfo> = Vec::new();
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
         let installed = InstalledSkills::default();
-        let err =
-            collect_skills_for_plugin_into(&svc, &entry, dir.path(), "mp1", &installed, &mut out)
-                .expect_err("missing dir must propagate");
+        let err = collect_skills_for_plugin_into(
+            &svc,
+            &entry,
+            dir.path(),
+            "mp1",
+            &installed,
+            &mut out,
+            &mut skipped_skills,
+        )
+        .expect_err("missing dir must propagate");
 
         assert!(
             matches!(err, Error::Plugin(PluginError::DirectoryMissing { .. })),
             "expected DirectoryMissing, got: {err:?}"
         );
         assert!(out.is_empty());
+        assert!(skipped_skills.is_empty());
     }
 
     #[test]
@@ -631,20 +910,29 @@ mod tests {
         let entry = relative_path_entry("broken", "plugins/broken");
 
         let mut out: Vec<SkillInfo> = Vec::new();
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
         let installed = InstalledSkills::default();
-        let err =
-            collect_skills_for_plugin_into(&svc, &entry, dir.path(), "mp1", &installed, &mut out)
-                .expect_err("malformed manifest must propagate");
+        let err = collect_skills_for_plugin_into(
+            &svc,
+            &entry,
+            dir.path(),
+            "mp1",
+            &installed,
+            &mut out,
+            &mut skipped_skills,
+        )
+        .expect_err("malformed manifest must propagate");
 
         assert!(
             matches!(err, Error::Plugin(PluginError::InvalidManifest { .. })),
             "expected InvalidManifest, got: {err:?}"
         );
         assert!(out.is_empty());
+        assert!(skipped_skills.is_empty());
     }
 
     #[test]
-    fn collect_skills_for_plugin_into_skips_bad_frontmatter_and_continues() {
+    fn collect_skills_for_plugin_into_surfaces_bad_frontmatter_as_skipped_skill() {
         let (dir, svc) = temp_service();
         let skills_dir = dir.path().join("plugins").join("mixed").join("skills");
         fs::create_dir_all(skills_dir.join("good-skill")).expect("create skill dir");
@@ -663,12 +951,38 @@ mod tests {
         let entry = relative_path_entry("mixed", "plugins/mixed");
 
         let mut out: Vec<SkillInfo> = Vec::new();
+        let mut skipped_skills: Vec<SkippedSkill> = Vec::new();
         let installed = InstalledSkills::default();
-        collect_skills_for_plugin_into(&svc, &entry, dir.path(), "mp1", &installed, &mut out)
-            .expect("per-skill errors should not propagate");
+        collect_skills_for_plugin_into(
+            &svc,
+            &entry,
+            dir.path(),
+            "mp1",
+            &installed,
+            &mut out,
+            &mut skipped_skills,
+        )
+        .expect("per-skill errors should not propagate");
 
-        assert_eq!(out.len(), 1, "bad frontmatter should be skipped, good kept");
+        // Regression for #30: previously the bad frontmatter vanished into
+        // a warn! log. Now it must surface as a structured SkippedSkill.
+        assert_eq!(out.len(), 1, "bad frontmatter should not be in skills");
         assert_eq!(out[0].name, "good-skill");
+        assert_eq!(skipped_skills.len(), 1, "bad frontmatter must be skipped");
+        assert_eq!(skipped_skills[0].name_hint.as_deref(), Some("bad-skill"));
+        assert_eq!(
+            skipped_skills[0].plugin, "mixed",
+            "per-skill skips must carry plugin attribution so bulk callers \
+             can group failures by plugin"
+        );
+        assert!(
+            matches!(
+                skipped_skills[0].reason,
+                SkippedSkillReason::FrontmatterInvalid { .. }
+            ),
+            "expected FrontmatterInvalid, got: {:?}",
+            skipped_skills[0].reason
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -868,7 +1182,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // is_plugin_level_skip covers the new plugin-level variants
+    // SkippedPlugin::from_plugin_error covers the new plugin-level variants
     // -----------------------------------------------------------------------
 
     /// Regression guard: the bulk path relies on this classifier to
@@ -899,20 +1213,51 @@ mod tests {
     }))]
     #[case::remote_source_not_local(Error::Plugin(PluginError::RemoteSourceNotLocal {
         plugin: "remote-plug".into(),
+        plugin_source: StructuredSource::GitHub {
+            repo: "owner/repo".into(),
+            git_ref: None,
+            sha: None,
+        },
     }))]
-    fn is_plugin_level_skip_accepts_plugin_level_variants(#[case] err: Error) {
-        assert!(
-            is_plugin_level_skip(&err),
-            "expected bulk-path skip for: {err:?}"
+    fn skipped_plugin_from_plugin_error_accepts_plugin_level_variants(#[case] err: Error) {
+        let sp = SkippedPlugin::from_plugin_error("test-plug".into(), &err);
+        assert!(sp.is_some(), "expected bulk-path skip for: {err:?}");
+        let sp = sp.expect("just checked");
+        assert_eq!(
+            sp.name, "test-plug",
+            "constructor must preserve the name argument"
+        );
+        assert_eq!(
+            sp.reason,
+            err.to_string(),
+            "reason must equal the source error's Display so it stays in \
+             lockstep with kind"
         );
     }
 
     #[test]
-    fn is_plugin_level_skip_rejects_non_plugin_errors() {
+    fn skipped_plugin_from_plugin_error_rejects_non_plugin_errors() {
         let io_err = Error::Io(std::io::Error::other("disk full"));
         assert!(
-            !is_plugin_level_skip(&io_err),
+            SkippedPlugin::from_plugin_error("x".into(), &io_err).is_none(),
             "generic I/O errors must propagate, not skip"
+        );
+    }
+
+    /// Regression guard: [`PluginError::NotFound`] represents a caller
+    /// asking for a plugin the marketplace doesn't list — a user-input
+    /// bug, not a damaged plugin. It must propagate rather than fold
+    /// into `skipped`, or bulk listings would silently hide lookup
+    /// errors too.
+    #[test]
+    fn skipped_plugin_from_plugin_error_rejects_plugin_not_found() {
+        let err = Error::Plugin(PluginError::NotFound {
+            plugin: "ghost".into(),
+            marketplace: "mp1".into(),
+        });
+        assert!(
+            SkippedPlugin::from_plugin_error("x".into(), &err).is_none(),
+            "NotFound must propagate, not skip (it's a caller bug, not a broken plugin)"
         );
     }
 
@@ -954,15 +1299,16 @@ mod tests {
         make_plugin_with_skills(&marketplace_path, "alpha", &["skill-a"]);
 
         let installed = InstalledSkills::default();
-        let skills = svc
+        let result = svc
             .list_skills_for_plugin("mp1", "alpha", &installed)
             .expect("happy path");
 
-        assert_eq!(skills.len(), 1);
-        assert_eq!(skills[0].name, "skill-a");
-        assert_eq!(skills[0].plugin, "alpha");
-        assert_eq!(skills[0].marketplace, "mp1");
-        assert!(!skills[0].installed);
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].name, "skill-a");
+        assert_eq!(result.skills[0].plugin, "alpha");
+        assert_eq!(result.skills[0].marketplace, "mp1");
+        assert!(!result.skills[0].installed);
+        assert!(result.skipped_skills.is_empty());
     }
 
     #[test]
@@ -995,15 +1341,18 @@ mod tests {
         make_plugin_with_skills(&marketplace_path, "alpha", &["already-installed", "fresh"]);
 
         let installed = installed_with("already-installed", "alpha", "mp1");
-        let skills = svc
+        let result = svc
             .list_skills_for_plugin("mp1", "alpha", &installed)
             .expect("happy path");
 
-        let marked_installed: Vec<_> = skills.iter().filter(|s| s.installed).collect();
+        let marked_installed: Vec<_> = result.skills.iter().filter(|s| s.installed).collect();
         assert_eq!(marked_installed.len(), 1);
         assert_eq!(marked_installed[0].name, "already-installed");
         assert!(
-            skills.iter().any(|s| s.name == "fresh" && !s.installed),
+            result
+                .skills
+                .iter()
+                .any(|s| s.name == "fresh" && !s.installed),
             "fresh skill should not be marked installed"
         );
     }
@@ -1039,13 +1388,18 @@ mod tests {
         assert_eq!(result.skills[0].name, "alpha");
         assert_eq!(result.skipped.len(), 1);
         assert_eq!(result.skipped[0].name, "broken");
-        // TODO(#30): replace substring match with a pattern match on a
-        // typed SkippedPlugin.reason enum once that refactor lands. The
-        // current Display-string assertion is fragile to rewording.
+        // The structured `kind` is the programmatic contract; the
+        // `reason` Display-string is a human-readable convenience and
+        // may rephrase freely. Previously this test substring-matched
+        // on `reason` (the TODO(#30) it replaced); the `matches!` below
+        // survives any Display rewording.
         assert!(
-            result.skipped[0].reason.contains("invalid plugin manifest"),
-            "skipped reason should name the manifest failure, got: {}",
-            result.skipped[0].reason
+            matches!(
+                result.skipped[0].kind,
+                SkippedReason::InvalidManifest { .. }
+            ),
+            "skipped kind should be InvalidManifest, got: {:?}",
+            result.skipped[0].kind
         );
     }
 
@@ -1079,13 +1433,260 @@ mod tests {
         assert_eq!(result.skills[0].name, "local-skill");
         assert_eq!(result.skipped.len(), 1);
         assert_eq!(result.skipped[0].name, "remote");
-        // TODO(#30): replace substring match with a pattern match on a
-        // typed SkippedPlugin.reason enum once that refactor lands. The
-        // current Display-string assertion is fragile to rewording.
+        // Structured `kind` doubles as a guard that the embedded
+        // `StructuredSource` payload made it through the Error →
+        // SkippedReason projection. If `plugin_source` ever got dropped
+        // from the projection, the `source: StructuredSource::GitHub`
+        // arm below would fail to match.
+        match &result.skipped[0].kind {
+            SkippedReason::RemoteSourceNotLocal { plugin, source } => {
+                assert_eq!(plugin, "remote");
+                assert!(
+                    matches!(
+                        source,
+                        StructuredSource::GitHub { repo, .. } if repo == "owner/repo"
+                    ),
+                    "expected GitHub source round-tripped through projection, got: {source:?}"
+                );
+            }
+            other => panic!("expected SkippedReason::RemoteSourceNotLocal, got: {other:?}"),
+        }
+    }
+
+    /// Regression guard: a regular file sitting at the plugin path must
+    /// fold into `skipped` with `kind = NotADirectory`, not propagate
+    /// or mis-classify as `DirectoryMissing`. Pre-#30 this class was
+    /// only covered at the `resolve_local_plugin_dir` unit layer; the
+    /// e2e assertion catches a regression where the bulk loop gets
+    /// narrowed to a subset of plugin-level variants.
+    #[test]
+    fn list_all_skills_skips_plugin_with_regular_file_at_path() {
+        let (dir, svc) = temp_service();
+        let entries = vec![
+            relative_path_entry("good", "plugins/good"),
+            relative_path_entry("not-a-dir", "plugins/not-a-dir"),
+        ];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "good", &["alpha"]);
+        // A regular file where the plugin directory should be.
+        fs::create_dir_all(marketplace_path.join("plugins")).expect("plugins dir");
+        fs::write(
+            marketplace_path.join("plugins").join("not-a-dir"),
+            b"file, not a directory",
+        )
+        .expect("write blocker file");
+
+        let installed = InstalledSkills::default();
+        let result = svc
+            .list_all_skills("mp1", &installed)
+            .expect("bulk call must succeed past the misshapen plugin path");
+
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].name, "not-a-dir");
         assert!(
-            result.skipped[0].reason.contains("remote source"),
-            "skipped reason should name the remote-source failure, got: {}",
-            result.skipped[0].reason
+            matches!(result.skipped[0].kind, SkippedReason::NotADirectory { .. }),
+            "expected NotADirectory, got: {:?}",
+            result.skipped[0].kind
+        );
+    }
+
+    /// Regression guard: a symlink at the plugin path must classify as
+    /// `SymlinkRefused` end-to-end. Before #30 only the
+    /// `resolve_local_plugin_dir` unit test covered this; the bulk
+    /// classifier could regress silently (symlink falls through to a
+    /// different variant).
+    #[cfg(unix)]
+    #[test]
+    fn list_all_skills_skips_plugin_with_symlinked_path() {
+        let (dir, svc) = temp_service();
+        let entries = vec![
+            relative_path_entry("good", "plugins/good"),
+            relative_path_entry("escape", "plugins/escape"),
+        ];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "good", &["alpha"]);
+        // Create a symlink at plugins/escape pointing outside the
+        // marketplace tree. The service must refuse to follow it.
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&outside).expect("create outside");
+        fs::create_dir_all(marketplace_path.join("plugins")).expect("plugins dir");
+        std::os::unix::fs::symlink(&outside, marketplace_path.join("plugins").join("escape"))
+            .expect("create symlink");
+
+        let installed = InstalledSkills::default();
+        let result = svc
+            .list_all_skills("mp1", &installed)
+            .expect("bulk call must succeed past the symlinked plugin path");
+
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].name, "escape");
+        assert!(
+            matches!(result.skipped[0].kind, SkippedReason::SymlinkRefused { .. }),
+            "expected SymlinkRefused, got: {:?}",
+            result.skipped[0].kind
+        );
+    }
+
+    /// Regression guard: a plugin directory whose stat fails (e.g.
+    /// chmod 000 on the parent) must classify as `DirectoryUnreadable`
+    /// rather than `DirectoryMissing`. The distinction matters for UI
+    /// remediation: "permission denied" is a different user action
+    /// from "directory deleted."
+    #[cfg(unix)]
+    #[test]
+    fn list_all_skills_skips_plugin_with_unreadable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![
+            relative_path_entry("good", "plugins/good"),
+            relative_path_entry("locked", "plugins/locked"),
+        ];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "good", &["alpha"]);
+        // Create `plugins/locked/` as a directory, then chmod its
+        // PARENT (`plugins/`) so stat'ing `plugins/locked` fails with
+        // EACCES rather than ENOENT. Chmodding the leaf itself would
+        // let stat succeed (read-bit on parent is what syscalls need).
+        let plugins_dir = marketplace_path.join("plugins");
+        fs::create_dir_all(plugins_dir.join("locked")).expect("create locked plugin");
+        fs::set_permissions(&plugins_dir, fs::Permissions::from_mode(0o000))
+            .expect("chmod 000 on plugins dir");
+
+        let installed = InstalledSkills::default();
+        let result = svc.list_all_skills("mp1", &installed);
+        // Restore permissions BEFORE assertions so tempdir cleanup can
+        // delete the directory even if an assertion panics.
+        fs::set_permissions(&plugins_dir, fs::Permissions::from_mode(0o755))
+            .expect("restore perms");
+
+        let result = result.expect("bulk call must succeed past the unreadable plugin path");
+
+        // With the plugins/ directory chmod-0'd, the "good" plugin
+        // ALSO becomes unstat-able — both plugins land in `skipped`
+        // with DirectoryUnreadable. That's the correct behavior: the
+        // classifier preserves semantics over every plugin-level arm,
+        // not just the one we're targeting.
+        assert_eq!(
+            result.skipped.len(),
+            2,
+            "both plugins should be unreadable when their parent is chmod-0"
+        );
+        for sp in &result.skipped {
+            assert!(
+                matches!(sp.kind, SkippedReason::DirectoryUnreadable { .. }),
+                "expected DirectoryUnreadable for plugin `{}`, got: {:?}",
+                sp.name,
+                sp.kind
+            );
+        }
+    }
+
+    /// Before #30, a single malformed `SKILL.md` inside an otherwise-
+    /// working plugin vanished into `warn!` + `continue`, leaving the
+    /// frontend to guess why the skill count shrank. The bulk path now
+    /// folds it into [`BulkSkillsResult::skipped_skills`] as a
+    /// structured entry.
+    #[test]
+    fn list_all_skills_surfaces_malformed_skill_as_skipped_skill() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("mixed", "plugins/mixed")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let skills_dir = marketplace_path
+            .join("plugins")
+            .join("mixed")
+            .join("skills");
+        fs::create_dir_all(skills_dir.join("ok")).expect("create ok skill dir");
+        fs::create_dir_all(skills_dir.join("malformed")).expect("create malformed skill dir");
+        fs::write(
+            skills_dir.join("ok").join("SKILL.md"),
+            "---\nname: ok\ndescription: works\n---\n",
+        )
+        .expect("write ok skill");
+        // Missing closing `---`: frontmatter parser fails.
+        fs::write(
+            skills_dir.join("malformed").join("SKILL.md"),
+            "---\nname: malformed\n",
+        )
+        .expect("write malformed skill");
+
+        let installed = InstalledSkills::default();
+        let result = svc.list_all_skills("mp1", &installed).expect("bulk ok");
+
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].name, "ok");
+        assert!(
+            result.skipped.is_empty(),
+            "plugin-level skipped must be empty when only a skill is bad"
+        );
+        assert_eq!(result.skipped_skills.len(), 1);
+        assert_eq!(
+            result.skipped_skills[0].name_hint.as_deref(),
+            Some("malformed")
+        );
+        assert_eq!(
+            result.skipped_skills[0].plugin, "mixed",
+            "bulk-path per-skill skips must carry plugin attribution so \
+             the frontend can group by plugin"
+        );
+        assert!(
+            matches!(
+                result.skipped_skills[0].reason,
+                SkippedSkillReason::FrontmatterInvalid { .. }
+            ),
+            "expected FrontmatterInvalid, got: {:?}",
+            result.skipped_skills[0].reason
+        );
+    }
+
+    /// Regression guard (Unix-only because chmod is the tool): an
+    /// unreadable `SKILL.md` must surface via
+    /// [`SkippedSkillReason::ReadFailed`] rather than vanish. On Windows
+    /// the equivalent case (access-denied via ACLs) exists but isn't
+    /// exercised here — we have UNIX coverage for the classification.
+    #[cfg(unix)]
+    #[test]
+    fn list_all_skills_surfaces_unreadable_skill_md_as_skipped_skill() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("locked", "plugins/locked")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let skill_dir = marketplace_path
+            .join("plugins")
+            .join("locked")
+            .join("skills")
+            .join("vault");
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
+        let skill_md = skill_dir.join("SKILL.md");
+        fs::write(&skill_md, "---\nname: vault\ndescription: locked\n---\n")
+            .expect("write SKILL.md");
+        // Remove all permissions so read_to_string fails with EACCES.
+        fs::set_permissions(&skill_md, fs::Permissions::from_mode(0o000))
+            .expect("chmod 000 SKILL.md");
+
+        let installed = InstalledSkills::default();
+        let result = svc.list_all_skills("mp1", &installed).expect("bulk ok");
+        // Restore permissions so tempdir cleanup can delete the file.
+        // Placed before assertions so a panic still cleans up.
+        fs::set_permissions(&skill_md, fs::Permissions::from_mode(0o644)).expect("restore perms");
+
+        assert!(
+            result.skills.is_empty(),
+            "no skills should land in happy path, got: {:?}",
+            result.skills
+        );
+        assert_eq!(result.skipped_skills.len(), 1);
+        assert_eq!(result.skipped_skills[0].name_hint.as_deref(), Some("vault"));
+        assert!(
+            matches!(
+                result.skipped_skills[0].reason,
+                SkippedSkillReason::ReadFailed { .. }
+            ),
+            "expected ReadFailed, got: {:?}",
+            result.skipped_skills[0].reason
         );
     }
 
@@ -1102,5 +1703,147 @@ mod tests {
         let marked: Vec<_> = result.skills.iter().filter(|s| s.installed).collect();
         assert_eq!(marked.len(), 1);
         assert_eq!(marked[0].name, "installed");
+    }
+
+    // -----------------------------------------------------------------------
+    // SkippedReason / SkippedSkillReason wire-format regression guards
+    // -----------------------------------------------------------------------
+    //
+    // These types cross the Tauri FFI and land in TypeScript via specta, so
+    // their JSON shape is a public contract — a silent serde-tag rename or
+    // variant-casing change would ripple into a frontend parse error that
+    // fires at runtime, not compile time. Pin the exact wire representation
+    // here so any such change surfaces as a failing unit test in this crate
+    // before a bindings.ts regeneration ever reaches the UI.
+
+    /// Regression guard: `name_hint_from_skill_dir` must return `None`
+    /// (not an empty string) for degenerate paths so the
+    /// `SkippedSkill.name_hint: Option<String>` contract is honored end
+    /// to end. Before this was an `Option` it was a sentinel empty
+    /// string and the two cases were indistinguishable at the wire.
+    #[test]
+    fn name_hint_from_skill_dir_returns_none_for_degenerate_paths() {
+        assert_eq!(name_hint_from_skill_dir(Path::new("")), None);
+        assert_eq!(name_hint_from_skill_dir(Path::new("foo/..")), None);
+        // A normal skill directory yields Some(file_name).
+        assert_eq!(
+            name_hint_from_skill_dir(Path::new("/plugins/acme/skills/alpha")).as_deref(),
+            Some("alpha")
+        );
+    }
+
+    /// Wire-format pin for every path-shaped `SkippedReason` variant
+    /// (the five that carry only `path`, plus the three that add a
+    /// `reason` string). `RemoteSourceNotLocal` is covered by a
+    /// dedicated test because it embeds a `StructuredSource` payload
+    /// that needs its own round-trip guard.
+    ///
+    /// Parametric to keep the cost of adding a future path-shaped
+    /// variant low — one new `#[case]` line pins its JSON shape.
+    #[rstest::rstest]
+    #[case::directory_missing(
+        SkippedReason::DirectoryMissing { path: PathBuf::from("/tmp/plugins/ghost") },
+        serde_json::json!({ "kind": "directory_missing", "path": "/tmp/plugins/ghost" })
+    )]
+    #[case::not_a_directory(
+        SkippedReason::NotADirectory { path: PathBuf::from("/tmp/plugins/file") },
+        serde_json::json!({ "kind": "not_a_directory", "path": "/tmp/plugins/file" })
+    )]
+    #[case::symlink_refused(
+        SkippedReason::SymlinkRefused { path: PathBuf::from("/tmp/plugins/link") },
+        serde_json::json!({ "kind": "symlink_refused", "path": "/tmp/plugins/link" })
+    )]
+    #[case::directory_unreadable(
+        SkippedReason::DirectoryUnreadable {
+            path: PathBuf::from("/tmp/plugins/noaccess"),
+            reason: "permission denied".into(),
+        },
+        serde_json::json!({
+            "kind": "directory_unreadable",
+            "path": "/tmp/plugins/noaccess",
+            "reason": "permission denied",
+        })
+    )]
+    #[case::invalid_manifest(
+        SkippedReason::InvalidManifest {
+            path: PathBuf::from("/tmp/plugins/x/plugin.json"),
+            reason: "missing name".into(),
+        },
+        serde_json::json!({
+            "kind": "invalid_manifest",
+            "path": "/tmp/plugins/x/plugin.json",
+            "reason": "missing name",
+        })
+    )]
+    #[case::manifest_read_failed(
+        SkippedReason::ManifestReadFailed {
+            path: PathBuf::from("/tmp/plugins/x/plugin.json"),
+            reason: "permission denied".into(),
+        },
+        serde_json::json!({
+            "kind": "manifest_read_failed",
+            "path": "/tmp/plugins/x/plugin.json",
+            "reason": "permission denied",
+        })
+    )]
+    fn skipped_reason_path_variants_json_shape(
+        #[case] reason: SkippedReason,
+        #[case] expected: serde_json::Value,
+    ) {
+        let json = serde_json::to_value(&reason).expect("serialize");
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn skipped_reason_remote_source_not_local_embeds_structured_source() {
+        let reason = SkippedReason::RemoteSourceNotLocal {
+            plugin: "acme".into(),
+            source: StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: Some("main".into()),
+                sha: None,
+            },
+        };
+        let json = serde_json::to_value(&reason).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "remote_source_not_local",
+                "plugin": "acme",
+                "source": {
+                    "source": "github",
+                    "repo": "owner/repo",
+                    "ref": "main",
+                    "sha": null,
+                },
+            }),
+            "StructuredSource must round-trip via its existing serde tag \
+             (`source`) inside the SkippedReason envelope"
+        );
+    }
+
+    #[test]
+    fn skipped_skill_reason_json_shapes() {
+        let read_failed = SkippedSkillReason::ReadFailed {
+            reason: "permission denied".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&read_failed).expect("serialize"),
+            serde_json::json!({
+                "kind": "read_failed",
+                "reason": "permission denied",
+            })
+        );
+
+        let frontmatter_invalid = SkippedSkillReason::FrontmatterInvalid {
+            reason: "missing closing ---".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&frontmatter_invalid).expect("serialize"),
+            serde_json::json!({
+                "kind": "frontmatter_invalid",
+                "reason": "missing closing ---",
+            })
+        );
     }
 }

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use tracing::{debug, warn};
 
-use crate::error::{Error, PluginError};
+use crate::error::{Error, PluginError, error_full_chain};
 use crate::marketplace::{PluginEntry, PluginSource, StructuredSource};
 use crate::plugin::{PluginManifest, discover_skill_dirs};
 use crate::project::InstalledSkills;
@@ -95,7 +95,17 @@ impl SkippedPlugin {
         let kind = SkippedReason::from_plugin_error(pe)?;
         Some(Self {
             name,
-            reason: err.to_string(),
+            // `error_full_chain`, not `err.to_string()` — variants like
+            // `PluginError::DirectoryUnreadable` and `ManifestReadFailed`
+            // carry an `io::Error` via `#[source]`, and their Display
+            // deliberately omits the source's detail ("could not access
+            // plugin directory at {path}" with no "permission denied"
+            // suffix). `err.to_string()` would drop that detail at the
+            // Tauri FFI boundary where it becomes `SkippedPlugin.reason`.
+            // CLAUDE.md mandates `error_full_chain` at such boundaries.
+            // The sibling constructor `FailedSkill::install_failed`
+            // already uses this; keep the two lockstep.
+            reason: error_full_chain(err),
             kind,
         })
     }
@@ -1246,9 +1256,45 @@ mod tests {
         );
         assert_eq!(
             sp.reason,
-            err.to_string(),
-            "reason must equal the source error's Display so it stays in \
-             lockstep with kind"
+            error_full_chain(&err),
+            "reason must equal the full source chain so `io::Error` \
+             details behind `#[source]` survive the Tauri FFI boundary — \
+             `err.to_string()` would strip them"
+        );
+    }
+
+    /// Regression guard for the `err.to_string()` → `error_full_chain(err)`
+    /// fix on `SkippedPlugin::from_plugin_error`. Before the fix, this
+    /// field lost `io::Error` detail at the Tauri FFI boundary for any
+    /// `PluginError` variant that carried `#[source]`. Using
+    /// `DirectoryUnreadable` here because it's the simplest variant with
+    /// a non-trivial source chain — the Display says only "could not
+    /// access plugin directory at {path}" with no mention of the
+    /// underlying `io::ErrorKind`, so the chain walk is load-bearing.
+    ///
+    /// Explicitly asserts the source detail appears in `reason`;
+    /// `err.to_string()` would fail this assertion because its output
+    /// stops at the top-level Display.
+    #[test]
+    fn skipped_plugin_reason_preserves_io_source_detail_from_chain() {
+        let err = Error::Plugin(PluginError::DirectoryUnreadable {
+            path: PathBuf::from("/tmp/plugins/locked"),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "forbidden zone"),
+        });
+        let sp = SkippedPlugin::from_plugin_error("locked-plug".into(), &err)
+            .expect("DirectoryUnreadable is plugin-level, must construct");
+
+        assert!(
+            sp.reason.contains("could not access plugin directory"),
+            "reason must include the variant's Display text, got: {}",
+            sp.reason
+        );
+        assert!(
+            sp.reason.contains("forbidden zone"),
+            "reason must include the io::Error's message from the \
+             source chain (regression guard against `err.to_string()`), \
+             got: {}",
+            sp.reason
         );
     }
 

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -169,12 +169,14 @@ impl SkippedReason {
                 plugin: plugin.clone(),
                 source: plugin_source.clone(),
             }),
+            PluginError::NoSkills { path, .. } => Some(Self::NoSkills { path: path.clone() }),
             // Explicit match on non-skip variants rather than `_ => None`
             // so adding a new PluginError variant triggers a compiler
             // error until the author decides whether it's plugin-level.
-            PluginError::NotFound { .. }
-            | PluginError::ManifestNotFound { .. }
-            | PluginError::NoSkills { .. } => None,
+            // `NotFound` and `ManifestNotFound` stay here because they
+            // represent "caller asked for the wrong thing" — a user-input
+            // bug, not a damaged plugin to fold into `skipped`.
+            PluginError::NotFound { .. } | PluginError::ManifestNotFound { .. } => None,
         }
     }
 }
@@ -222,6 +224,17 @@ pub enum SkippedReason {
     RemoteSourceNotLocal {
         plugin: String,
         source: StructuredSource,
+    },
+    /// The plugin exists and its manifest is well-formed, but it
+    /// declares no skills. Defensive classification — today no producer
+    /// in the bulk/listing path returns [`PluginError::NoSkills`], but
+    /// folding it into `skipped` means a future caller that DOES surface
+    /// it can't accidentally abort the bulk listing. The plugin name
+    /// lives on the wrapping [`SkippedPlugin`]; this variant carries
+    /// only `path` for UI remediation (the directory the user might
+    /// populate).
+    NoSkills {
+        path: PathBuf,
     },
 }
 
@@ -1219,6 +1232,10 @@ mod tests {
             sha: None,
         },
     }))]
+    #[case::no_skills(Error::Plugin(PluginError::NoSkills {
+        name: "empty-plug".into(),
+        path: "/tmp/x".into(),
+    }))]
     fn skipped_plugin_from_plugin_error_accepts_plugin_level_variants(#[case] err: Error) {
         let sp = SkippedPlugin::from_plugin_error("test-plug".into(), &err);
         assert!(sp.is_some(), "expected bulk-path skip for: {err:?}");
@@ -1785,6 +1802,10 @@ mod tests {
             "path": "/tmp/plugins/x/plugin.json",
             "reason": "permission denied",
         })
+    )]
+    #[case::no_skills(
+        SkippedReason::NoSkills { path: PathBuf::from("/tmp/plugins/empty") },
+        serde_json::json!({ "kind": "no_skills", "path": "/tmp/plugins/empty" })
     )]
     fn skipped_reason_path_variants_json_shape(
         #[case] reason: SkippedReason,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -5,7 +5,10 @@
 
 pub mod browse;
 
-pub use browse::{BulkSkillsResult, SkillInfo, SkippedPlugin};
+pub use browse::{
+    BulkSkillsResult, PluginSkillsResult, SkillInfo, SkippedPlugin, SkippedReason, SkippedSkill,
+    SkippedSkillReason,
+};
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -228,17 +231,126 @@ pub struct InstallSkillsResult {
     pub installed: Vec<String>,
     /// Skill names already installed and skipped (only when `force = false`).
     pub skipped: Vec<String>,
-    /// Skill names whose install attempt failed (read/parse/install error,
-    /// or — for `Names(_)` filter — names requested but not found).
+    /// Skill names whose install attempt failed (install error, or — for
+    /// `Names(_)` filter — names requested but not found). Distinct from
+    /// [`Self::skipped_skills`], which tracks entries we couldn't even
+    /// read / parse before attempting to install them.
     pub failed: Vec<FailedSkill>,
+    /// Skill-source entries that could not be read or parsed, so no
+    /// install was attempted. Surfaces what previously vanished into
+    /// `warn!`-then-`continue`; mirrors
+    /// [`crate::service::browse::BulkSkillsResult::skipped_skills`].
+    pub skipped_skills: Vec<browse::SkippedSkill>,
 }
 
 /// A skill that failed to install, with the reason.
+///
+/// `error` is the human-readable Display (suitable for log lines or UI
+/// direct rendering); `kind` is the stable programmatic contract that
+/// frontends should `match` on when deciding how to render the failure.
+/// The two are deliberately redundant — `error` can rephrase freely over
+/// time, while `kind` stays stable.
+///
+/// Fields are `pub(crate)` so external callers cannot desync the two —
+/// construction routes exclusively through [`Self::install_failed`] and
+/// [`Self::requested_but_not_found`], each of which derives `error` and
+/// `kind` together from a single source. Read access from outside the
+/// crate happens via the [`Self::name`] / [`Self::error`] / [`Self::kind`]
+/// accessors, and via the Serde/specta boundary (the generated
+/// TypeScript type still exposes all three fields, because Serde ignores
+/// Rust visibility). This mirrors the [`crate::service::browse::SkippedPlugin`]
+/// enforcement pattern so the two redundant-by-design types stay
+/// symmetric.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct FailedSkill {
-    pub name: String,
-    pub error: String,
+    pub(crate) name: String,
+    pub(crate) error: String,
+    pub(crate) kind: FailedSkillReason,
+}
+
+impl FailedSkill {
+    /// Build a [`FailedSkill`] for an install-time failure (filesystem
+    /// copy error, tracking-file write error, etc.). Derives the
+    /// human-readable `error` from [`crate::error::error_full_chain`]
+    /// and sets `kind = InstallFailed` in lockstep.
+    ///
+    /// This is one of exactly two constructors (the other is
+    /// [`Self::requested_but_not_found`]); fields being `pub(crate)`
+    /// guarantees no external caller can produce a `FailedSkill` with
+    /// a mismatched `kind` and `error`.
+    #[must_use]
+    pub(crate) fn install_failed(name: String, err: &Error) -> Self {
+        Self {
+            name,
+            error: error_full_chain(err),
+            kind: FailedSkillReason::InstallFailed,
+        }
+    }
+
+    /// Build a [`FailedSkill`] for a `Names(_)` filter miss — the
+    /// caller asked for a skill name that no discovered `SKILL.md`
+    /// produced. Composes the user-facing error string and pins
+    /// `kind = RequestedButNotFound { plugin }` so the frontend can
+    /// render a typo banner distinct from an install error.
+    #[must_use]
+    pub(crate) fn requested_but_not_found(name: String, plugin: String) -> Self {
+        Self {
+            error: format!("skill '{name}' not found in plugin '{plugin}'"),
+            name,
+            kind: FailedSkillReason::RequestedButNotFound { plugin },
+        }
+    }
+
+    /// Name of the skill that failed. The equivalent read via the
+    /// Serde-generated TypeScript type is `FailedSkill.name`.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Human-readable failure message (rendered source-error chain or
+    /// a user-facing composition, depending on `kind`). Use
+    /// [`Self::kind`] for programmatic matching; use this for log
+    /// lines and simple UI labels.
+    #[must_use]
+    pub fn error(&self) -> &str {
+        &self.error
+    }
+
+    /// Structured classification of the failure. Stable contract for
+    /// frontends that render variant-specific affordances.
+    #[must_use]
+    pub fn kind(&self) -> &FailedSkillReason {
+        &self.kind
+    }
+}
+
+/// Why a skill install failed. Separates "we tried to install and it
+/// went wrong" ([`Self::InstallFailed`]) from "the caller named a skill
+/// that isn't in this plugin" ([`Self::RequestedButNotFound`]) so
+/// frontends can render a typo banner distinct from an install error
+/// without substring-matching `FailedSkill::error`.
+///
+/// [`Self::InstallFailed`] is unit-shaped: the human-readable error
+/// message lives on [`FailedSkill::error`] and the typed `kind` here
+/// exists to tell the typo case apart from every other failure mode.
+/// Duplicating the error string into this variant would be redundant
+/// since `FailedSkill.error` is always populated.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum FailedSkillReason {
+    /// The install was attempted (`SKILL.md` read and frontmatter
+    /// parsed) but the filesystem copy / metadata write failed. See
+    /// [`FailedSkill::error`] for the human-readable reason.
+    InstallFailed,
+    /// The caller's `Names(_)` filter included a name that no skill in
+    /// the plugin's discovered list produced — typically a typo or a
+    /// stale reference. The `plugin` field carries the plugin context
+    /// so a flat UI list can attribute the miss.
+    RequestedButNotFound { plugin: String },
 }
 
 /// Outcome of installing the agents from one plugin.
@@ -787,6 +899,14 @@ impl MarketplaceService {
                         error = %e,
                         "failed to read SKILL.md, skipping"
                     );
+                    result.skipped_skills.push(browse::SkippedSkill {
+                        plugin: plugin.to_owned(),
+                        name_hint: browse::name_hint_from_skill_dir(skill_dir),
+                        path: skill_md_path,
+                        reason: browse::SkippedSkillReason::ReadFailed {
+                            reason: e.to_string(),
+                        },
+                    });
                     continue;
                 }
             };
@@ -799,6 +919,14 @@ impl MarketplaceService {
                         error = %e,
                         "failed to parse SKILL.md frontmatter, skipping"
                     );
+                    result.skipped_skills.push(browse::SkippedSkill {
+                        plugin: plugin.to_owned(),
+                        name_hint: browse::name_hint_from_skill_dir(skill_dir),
+                        path: skill_md_path,
+                        reason: browse::SkippedSkillReason::FrontmatterInvalid {
+                            reason: e.to_string(),
+                        },
+                    });
                     continue;
                 }
             };
@@ -831,11 +959,14 @@ impl MarketplaceService {
                     result.skipped.push(frontmatter.name);
                 }
                 Err(e) => {
-                    warn!(skill = %frontmatter.name, error = %e, "skill install failed");
-                    result.failed.push(FailedSkill {
-                        name: frontmatter.name,
-                        error: error_full_chain(&e),
-                    });
+                    warn!(
+                        skill = %frontmatter.name,
+                        error = %error_full_chain(&e),
+                        "skill install failed"
+                    );
+                    result
+                        .failed
+                        .push(FailedSkill::install_failed(frontmatter.name, &e));
                 }
             }
         }
@@ -846,10 +977,10 @@ impl MarketplaceService {
             for name in requested {
                 if !processed.contains(name) {
                     warn!(skill = %name, plugin = %plugin, "requested skill not found in plugin");
-                    result.failed.push(FailedSkill {
-                        name: name.clone(),
-                        error: format!("skill '{name}' not found in plugin '{plugin}'"),
-                    });
+                    result.failed.push(FailedSkill::requested_but_not_found(
+                        name.clone(),
+                        plugin.to_owned(),
+                    ));
                 }
             }
         }
@@ -3285,5 +3416,281 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "solo");
+    }
+
+    // -------------------------------------------------------------------
+    // install_skills: per-skill surfacing + FailedSkillReason (audit #30)
+    // -------------------------------------------------------------------
+    //
+    // These tests pin the behavior introduced by the issue-#30 audit fold-in:
+    // install_skills used to vanish per-skill read/parse failures into
+    // `warn!` + `continue`. They now surface as structured `skipped_skills`
+    // entries, and requested-but-missing names carry the typed
+    // `FailedSkillReason::RequestedButNotFound` variant so frontends can
+    // distinguish a typo from an install error.
+
+    /// Per-skill frontmatter parse failures inside `install_skills` used
+    /// to silently drop. They now land in `skipped_skills` as structured
+    /// entries — the install count stays accurate even when some skill
+    /// directories have broken `SKILL.md` files.
+    #[test]
+    fn install_skills_surfaces_malformed_skill_md_as_skipped_skill() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let ok_dir = plugin_tmp.path().join("ok");
+        fs::create_dir_all(&ok_dir).unwrap();
+        fs::write(
+            ok_dir.join("SKILL.md"),
+            "---\nname: ok\ndescription: works\n---\nbody\n",
+        )
+        .unwrap();
+        let broken_dir = plugin_tmp.path().join("broken");
+        fs::create_dir_all(&broken_dir).unwrap();
+        // Missing closing `---` breaks the frontmatter parse.
+        fs::write(broken_dir.join("SKILL.md"), "---\nname: broken\n").unwrap();
+
+        let skill_dirs = vec![ok_dir, broken_dir];
+        let result = svc.install_skills(
+            &project,
+            &skill_dirs,
+            &InstallFilter::All,
+            InstallMode::New,
+            "mp1",
+            "plug1",
+            None,
+        );
+
+        assert_eq!(result.installed, vec!["ok".to_string()]);
+        assert_eq!(result.skipped_skills.len(), 1);
+        assert_eq!(
+            result.skipped_skills[0].name_hint.as_deref(),
+            Some("broken")
+        );
+        assert!(
+            matches!(
+                result.skipped_skills[0].reason,
+                browse::SkippedSkillReason::FrontmatterInvalid { .. }
+            ),
+            "expected FrontmatterInvalid, got: {:?}",
+            result.skipped_skills[0].reason
+        );
+    }
+
+    /// A `Names(_)` filter requesting a skill that no discovered
+    /// SKILL.md produces must surface as
+    /// `FailedSkillReason::RequestedButNotFound` — distinguishable from
+    /// an install error so the frontend can render typo UX separately
+    /// from an I/O or filesystem failure.
+    #[test]
+    fn install_skills_requested_but_not_found_uses_typed_reason() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let only_dir = plugin_tmp.path().join("present");
+        fs::create_dir_all(&only_dir).unwrap();
+        fs::write(
+            only_dir.join("SKILL.md"),
+            "---\nname: present\ndescription: here\n---\nbody\n",
+        )
+        .unwrap();
+
+        let requested = vec!["absent".to_string()];
+        let result = svc.install_skills(
+            &project,
+            &[only_dir],
+            &InstallFilter::Names(&requested),
+            InstallMode::New,
+            "mp1",
+            "plug1",
+            None,
+        );
+
+        assert!(result.installed.is_empty(), "nothing should install");
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "absent");
+        match &result.failed[0].kind {
+            FailedSkillReason::RequestedButNotFound { plugin } => {
+                assert_eq!(plugin, "plug1");
+            }
+            other => panic!("expected RequestedButNotFound, got: {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // FailedSkillReason wire-format regression guards
+    // -------------------------------------------------------------------
+    //
+    // `FailedSkillReason` crosses the Tauri FFI via `InstallSkillsResult`,
+    // so its JSON shape is a public contract with the frontend. Pin the
+    // exact representation here so a silent serde-tag rename or casing
+    // flip surfaces as a failing unit test in this crate BEFORE a
+    // bindings.ts regeneration ever reaches the UI.
+
+    #[test]
+    fn failed_skill_reason_install_failed_json_shape() {
+        let reason = FailedSkillReason::InstallFailed;
+        let json = serde_json::to_value(&reason).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({ "kind": "install_failed" }),
+            "InstallFailed is unit-shaped; the wire carries only the \
+             discriminant (no payload). FailedSkill.error holds the \
+             human-readable detail."
+        );
+    }
+
+    #[test]
+    fn failed_skill_reason_requested_but_not_found_json_shape() {
+        let reason = FailedSkillReason::RequestedButNotFound {
+            plugin: "plug1".into(),
+        };
+        let json = serde_json::to_value(&reason).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "requested_but_not_found",
+                "plugin": "plug1",
+            })
+        );
+    }
+
+    /// Regression guard for the `install_skills` per-skill
+    /// `read_to_string` failure path. Before the #30 audit fold-in,
+    /// this vanished into `warn!` + `continue`; now it must surface as
+    /// a structured `SkippedSkill` with `ReadFailed`. The sibling
+    /// `list_all_skills_surfaces_unreadable_skill_md_as_skipped_skill`
+    /// exists in the browse module and covers the identical branch in
+    /// `collect_skills_for_plugin_into` — this test catches a
+    /// divergence where the two structurally-identical codepaths gain
+    /// different error-wrapping over time.
+    #[cfg(unix)]
+    #[test]
+    fn install_skills_surfaces_unreadable_skill_md_as_skipped_skill() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let skill_dir = plugin_tmp.path().join("vault");
+        fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        fs::write(
+            &skill_md,
+            "---\nname: vault\ndescription: locked\n---\nbody\n",
+        )
+        .expect("write SKILL.md");
+        // Remove all permissions so read_to_string fails with EACCES.
+        fs::set_permissions(&skill_md, fs::Permissions::from_mode(0o000))
+            .expect("chmod 000 SKILL.md");
+
+        let result = svc.install_skills(
+            &project,
+            std::slice::from_ref(&skill_dir),
+            &InstallFilter::All,
+            InstallMode::New,
+            "mp1",
+            "plug1",
+            None,
+        );
+        // Restore permissions BEFORE assertions so tempdir cleanup can
+        // delete the file even if an assertion panics.
+        fs::set_permissions(&skill_md, fs::Permissions::from_mode(0o644)).expect("restore perms");
+
+        assert!(
+            result.installed.is_empty(),
+            "unreadable skill must not install"
+        );
+        assert_eq!(result.skipped_skills.len(), 1);
+        assert_eq!(result.skipped_skills[0].name_hint.as_deref(), Some("vault"));
+        assert_eq!(result.skipped_skills[0].plugin, "plug1");
+        assert!(
+            matches!(
+                result.skipped_skills[0].reason,
+                browse::SkippedSkillReason::ReadFailed { .. }
+            ),
+            "expected ReadFailed, got: {:?}",
+            result.skipped_skills[0].reason
+        );
+    }
+
+    /// Regression guard for `FailedSkillReason::InstallFailed`. Induces
+    /// an install failure (a regular file where `.kiro/skills` would
+    /// need to be a directory) and pins that the error routes to
+    /// `failed` with `kind = InstallFailed`, not to `skipped_skills`
+    /// or anywhere else.
+    ///
+    /// Cross-platform (no chmod needed): a file sitting at the skills
+    /// directory path causes `fs::create_dir_all` to fail on every
+    /// OS we support. Install-time errors used to only carry a string;
+    /// the typed `kind` here is the programmatic contract that
+    /// survives Display rewording.
+    #[test]
+    fn install_skills_surfaces_typed_install_failed_on_fs_error() {
+        use crate::project::KiroProject;
+
+        let (_dir, svc) = temp_service();
+        let project_tmp = tempfile::tempdir().unwrap();
+        // Seed `.kiro/skills` as a regular file so create_dir_all fails.
+        let kiro = project_tmp.path().join(".kiro");
+        fs::create_dir_all(&kiro).unwrap();
+        fs::write(kiro.join("skills"), b"not a directory").expect("write blocker");
+
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let plugin_tmp = tempfile::tempdir().unwrap();
+        let skill_dir = plugin_tmp.path().join("target");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: target\ndescription: will-fail-install\n---\nbody\n",
+        )
+        .unwrap();
+
+        let result = svc.install_skills(
+            &project,
+            &[skill_dir],
+            &InstallFilter::All,
+            InstallMode::New,
+            "mp1",
+            "plug1",
+            None,
+        );
+
+        assert!(
+            result.installed.is_empty(),
+            "install must fail, got installed: {:?}",
+            result.installed
+        );
+        assert!(
+            result.skipped_skills.is_empty(),
+            "per-skill read/parse succeeded; failure belongs to `failed`, \
+             not `skipped_skills`: {:?}",
+            result.skipped_skills
+        );
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "target");
+        assert!(
+            !result.failed[0].error.is_empty(),
+            "FailedSkill.error must carry the human-readable chain, \
+             got empty string"
+        );
+        assert!(
+            matches!(result.failed[0].kind, FailedSkillReason::InstallFailed),
+            "expected InstallFailed, got: {:?}",
+            result.failed[0].kind
+        );
     }
 }

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -10,7 +10,7 @@ use kiro_market_core::git::{GitProtocol, GixCliBackend};
 use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
-    FailedAgent, FailedSkill, InstallAgentsResult, InstallFilter, InstallMode, InstallSkillsResult,
+    FailedAgent, InstallAgentsResult, InstallFilter, InstallMode, InstallSkillsResult,
     MarketplaceService,
 };
 use tracing::{debug, warn};
@@ -298,11 +298,46 @@ fn print_install_outcome(plugin_ref: &str, result: &InstallSkillsResult) {
             name.bold()
         );
     }
-    for FailedSkill { name, error } in &result.failed {
+    for failure in &result.failed {
+        // `FailedSkill`'s fields are `pub(crate)` — go through the
+        // accessors so the `error`/`kind` invariant (populated together
+        // via `FailedSkill::install_failed` or ::requested_but_not_found)
+        // stays enforced at the type boundary.
         eprintln!(
-            "  {} Failed to install skill '{}': {error}",
+            "  {} Failed to install skill '{}': {}",
             "✗".red().bold(),
-            name
+            failure.name(),
+            failure.error()
+        );
+    }
+    // Per-skill read/parse failures used to vanish into `warn!` logs;
+    // the service now surfaces them as structured SkippedSkill entries.
+    // Render them so users see *why* the install count is smaller than
+    // the skill directory count.
+    for sk in &result.skipped_skills {
+        // SkippedSkillReason is #[non_exhaustive]; a wildcard arm is
+        // required. Future variants render via their Debug form until
+        // an explicit arm lands — better than a bare "unreadable"
+        // label because it at least surfaces the variant payload in
+        // terminal output. Safer than a compile error in the downstream
+        // binary every time core gains a variant.
+        let reason = match &sk.reason {
+            kiro_market_core::service::SkippedSkillReason::ReadFailed { reason } => {
+                format!("could not read SKILL.md: {reason}")
+            }
+            kiro_market_core::service::SkippedSkillReason::FrontmatterInvalid { reason } => {
+                format!("malformed frontmatter: {reason}")
+            }
+            other => format!("unreadable: {other:?}"),
+        };
+        // `name_hint` is None when the skill directory's file_name()
+        // can't be extracted (degenerate path) — fall back to the
+        // directory path itself so the user still has a locator.
+        let label = sk.name_hint.as_deref().unwrap_or("<unnamed>");
+        eprintln!(
+            "  {} Skipped unreadable skill '{label}' ({}): {reason}",
+            "⚠".yellow().bold(),
+            sk.path.display()
         );
     }
 
@@ -330,6 +365,18 @@ fn print_install_outcome(plugin_ref: &str, result: &InstallSkillsResult) {
             "✗".red().bold(),
             result.failed.len(),
             if result.failed.len() == 1 { "" } else { "s" }
+        );
+    }
+    if !result.skipped_skills.is_empty() {
+        println!(
+            "{} {} skill{} could not be read",
+            "⚠".yellow().bold(),
+            result.skipped_skills.len(),
+            if result.skipped_skills.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
         );
     }
 }

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -331,8 +331,10 @@ fn print_install_outcome(plugin_ref: &str, result: &InstallSkillsResult) {
             other => format!("unreadable: {other:?}"),
         };
         // `name_hint` is None when the skill directory's file_name()
-        // can't be extracted (degenerate path) — fall back to the
-        // directory path itself so the user still has a locator.
+        // can't be extracted (degenerate path — empty, root, or `..`-
+        // terminated). Fall back to a `<unnamed>` placeholder; the
+        // skill's file path is still printed on the same line below,
+        // so the user retains a locator even when the label is empty.
         let label = sk.name_hint.as_deref().unwrap_or("<unnamed>");
         eprintln!(
             "  {} Skipped unreadable skill '{label}' ({}): {reason}",


### PR DESCRIPTION
## Summary

Phase 3 structural type design for the browse service layer. Resolves #30.

- **Plugin-level and per-skill skip reasons become structured enums** that cross the Tauri FFI as discriminated unions (`SkippedReason`, `SkippedSkillReason`, `FailedSkillReason`). Previously the frontend only saw a `reason: String` and had to substring-match the Display text to tell "missing directory" from "remote source"; now it can `match` on `kind`.
- **Per-skill silent drops are gone.** `collect_skills_for_plugin_into` and `install_skills` used to emit `warn!` + `continue` on unreadable `SKILL.md` / malformed frontmatter; they now populate `skipped_skills: Vec<SkippedSkill>` with plugin attribution, the file path, and a typed reason. The frontend (`BrowseTab.svelte`) renders these as per-plugin banners on all three call sites (per-plugin fetch, bulk fetch, install).
- **`SkippedPlugin` and `FailedSkill` are constructor-only.** Fields are `pub(crate)`; construction routes through `SkippedPlugin::from_plugin_error(name, &err)` and `FailedSkill::{install_failed, requested_but_not_found}`, each deriving the free-form `reason`/`error` string and the typed `kind` together from a single source. Drift between the two is no longer representable.
- **`PluginError::RemoteSourceNotLocal`** gained a `plugin_source: StructuredSource` payload; its `Display` was stripped of the CLI-specific "use the CLI to clone it" hint. A new `Surface { Cli, Ui }` enum plus `PluginError::remediation_hint(surface) -> Option<String>` method lets each frontend pick its own phrasing. Both `remediation_hint` and `SkippedReason::from_plugin_error` enumerate every `PluginError` variant explicitly (no `_ => None`) so a new variant forces a compile decision.
- **Tauri crate: duplicate `InstallResult`/`FailedSkill` wrappers deleted.** `#[tauri::command]` handlers now return core types (`InstallSkillsResult`, `PluginSkillsResult`) directly, eliminating the drift hazard the first-pass review flagged.

### Breaking API changes

- `list_skills_for_plugin`: `Result<Vec<SkillInfo>, Error>` → `Result<PluginSkillsResult, Error>`. The CLI and Tauri handler were the only consumers; both updated.
- `PluginError::NoSkills` gained a `path: PathBuf` field (had no production callers — only three test fixtures needed updating).
- `PluginError::RemoteSourceNotLocal` field addition.
- `FailedSkill` / `SkippedPlugin` fields are `pub(crate)` — external reads go through accessors or the Serde/specta boundary.

### Tests

+30 new cases, test suite at **506 core + 89 workspace**:

- Parametric wire-format pins for all 7 `SkippedReason` variants + both `FailedSkillReason` variants (`skipped_reason_path_variants_json_shape`, `failed_skill_reason_*_json_shape`). Guards the TypeScript union in `bindings.ts`.
- Bulk-path e2e for the three variants that previously only had unit coverage: `NotADirectory`, `SymlinkRefused` (Unix), `DirectoryUnreadable` (Unix, via chmod-0 on parent so `stat` hits EACCES).
- `install_skills` read-failure regression guard (Unix, chmod 000 on SKILL.md), install-failure regression guard (cross-platform, regular file blocking `.kiro/skills`), typo-detection guard (`RequestedButNotFound`).
- `SkippedPlugin::from_plugin_error` lockstep assertions: `reason == err.to_string()`, `name == supplied name`, projection covers every plugin-level variant.
- `name_hint_from_skill_dir` empty-path / `..`-terminated path unit test.
- Classification negative tests: `NotFound`, `Io`, `Json` must propagate (not fold into `skipped`).

### Follow-ups (filed, not in this PR)

- **#32** — `count_plugin_skills` silent-zero migration (blocks #33).
- **#33** — Tauri `load_plugin_manifest` dedup (depends on #32).
- **#34** — pre-existing `#[allow(...)]` cleanup triggered by the zero-tolerance rule added in #31.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --tests -- -D warnings` passes
- [x] `cargo test --workspace` passes (506 core tests)
- [x] `npm run check` (svelte-check) passes — 0 errors, 0 warnings
- [x] Manual: Tauri bindings regenerated via `cargo test -p kiro-control-center --lib -- --ignored`; all new TypeScript types appear in `bindings.ts`
- [x] Code review passes: two rounds of `pr-review-toolkit:review-pr` against all five reviewer agents; 20 findings across both rounds resolved (14 fixed in-PR, 3 filed as follow-up issues, 3 confirmed as non-issues)

## Related

- Closes #30
- Follow-ups: #32, #33, #34
- Preceded by: #29 (service-layer extraction), #31 (CLAUDE.md quality rules this PR operates under)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
