### PR TITLE
fix(ci): unblock Claude review action with Bash allow + direct file reads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           show_full_output: true
-          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          prompt: |
+            /code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+
+            Use `gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path'` to discover changed files, and read them directly from the checked-out tree instead of `gh pr diff`.
+          claude_args: --allowedTools "Bash"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Broadens the Claude Code review workflow sandbox to allow all Bash (`--allowedTools "Bash"`). The default sandbox was splitting compound commands (`&&`, `|`) and rejecting `gh api`, which caused subagents spawned by `/code-review:code-review` to loop on blocked tool calls and time out without posting a comment — see run [24700839492](https://github.com/dwalleck/kiro-control-center/actions/runs/24700839492) (12m58s, no comment landed).
- Extends the prompt to tell Claude to use `gh pr view --json files --jq '.files[].path'` and read files directly from the checked-out tree (already on disk from `actions/checkout@v4`) instead of parsing `gh pr diff` output. This sidesteps the 25k-token Read cap that large PRs hit.
- Blast radius bounded by the existing `permissions:` block (`contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`) — the `GITHUB_TOKEN` can't reach anything outside this PR regardless of what Bash commands Claude runs.

## Test plan
- [ ] This PR triggers the workflow on `opened`.
- [ ] Run log contains no `"requires approval"` lines.
- [ ] `claude[bot]` posts a review comment on this PR within ~2 minutes.
- [ ] If any of the above fails, investigate and iterate on the branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)