### PR TITLE
fix(browse): replace count_plugin_skills silent-zero with SkillCount

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -9,12 +9,12 @@ use tracing::{debug, warn};
 use kiro_market_core::cache::{CacheDir, MarketplaceSource};
 use kiro_market_core::error::error_full_chain;
 use kiro_market_core::git::GixCliBackend;
-use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
+use kiro_market_core::marketplace::{PluginSource, StructuredSource};
 use kiro_market_core::plugin::{discover_skill_dirs, PluginManifest};
 use kiro_market_core::project::{InstalledSkills, KiroProject};
 use kiro_market_core::service::{
     BulkSkillsResult, InstallFilter, InstallMode, InstallSkillsResult, MarketplaceService,
-    PluginSkillsResult,
+    PluginSkillsResult, SkillCount,
 };
 
 use crate::error::{CommandError, ErrorType};
@@ -57,7 +57,7 @@ pub struct MarketplaceInfo {
 pub struct PluginInfo {
     pub name: String,
     pub description: Option<String>,
-    pub skill_count: u32,
+    pub skill_count: SkillCount,
     pub source_type: SourceType,
 }
 
@@ -133,11 +133,10 @@ pub async fn list_plugins(marketplace: String) -> Result<Vec<PluginInfo>, Comman
     let mut results = Vec::with_capacity(plugin_entries.len());
     for plugin in &plugin_entries {
         let source_type = plugin_source_type(&plugin.source);
-        let skill_count = count_plugin_skills(plugin, &marketplace_path);
         results.push(PluginInfo {
             name: plugin.name.clone(),
             description: plugin.description.clone(),
-            skill_count: saturate_to_u32(skill_count, "skill_count"),
+            skill_count: svc.count_skills_for_plugin(plugin, &marketplace_path),
             source_type,
         });
     }
@@ -429,35 +428,6 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Com
                 ErrorType::ParseError,
             ))
         }
-    }
-}
-
-/// Count skills within a plugin entry. Only counts for local (relative path)
-/// plugins; remote plugins report 0.
-///
-/// A malformed `plugin.json` is logged at `warn` rather than collapsed into
-/// "use defaults" so the listing count agrees with `list_available_skills`,
-/// which surfaces the parse error to the user. A genuinely missing manifest
-/// (the common case) falls back to default skill paths silently.
-fn count_plugin_skills(entry: &PluginEntry, marketplace_path: &Path) -> usize {
-    match &entry.source {
-        PluginSource::RelativePath(rel) => {
-            let plugin_dir = marketplace_path.join(rel);
-            let manifest = match load_plugin_manifest(&plugin_dir) {
-                Ok(opt) => opt,
-                Err(e) => {
-                    warn!(
-                        plugin = %entry.name,
-                        path = %plugin_dir.display(),
-                        error = %e.message,
-                        "could not load plugin.json for skill count; reporting 0"
-                    );
-                    return 0;
-                }
-            };
-            discover_skills_for_plugin(&plugin_dir, manifest.as_ref()).len()
-        }
-        PluginSource::Structured(_) => 0,
     }
 }
 

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -191,7 +191,7 @@ pub async fn list_all_skills_for_marketplace(
 /// Returns the core [`InstallSkillsResult`] directly rather than through a
 /// Tauri-local wrapper — the previous wrapper was a field-by-field copy
 /// and risked drifting away from the core shape (e.g. losing the
-/// `FailedSkill::kind` and `skipped_skills` fields introduced in #30).
+/// structured `FailedSkill::kind` and `skipped_skills` fields).
 /// Using the core type keeps the wire format lockstep with what the
 /// service emits.
 #[tauri::command]

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -281,7 +281,7 @@ export type PluginBasicInfo = {
 export type PluginInfo = {
 	name: string,
 	description: string | null,
-	skill_count: number,
+	skill_count: SkillCount,
 	source_type: SourceType,
 };
 
@@ -374,6 +374,57 @@ export type Settings = {
 	// Last active project path (restored on launch).
 	last_project?: string | null,
 };
+
+/**
+ *  Result of [`MarketplaceService::count_skills_for_plugin`].
+ *  Distinguishes the three cases the frontend must render differently:
+ *  a known count, a remote plugin (not locally countable), and a local
+ *  plugin whose directory or manifest could not be loaded. Replaces the
+ *  prior `usize` that collapsed failures into a silent `0`.
+ */
+export type SkillCount = 
+/**
+ *  The plugin directory was readable; `count` is the number of
+ *  discovered skill directories (including the legitimate zero case).
+ */
+{ state: "known"; count: number } | 
+/**
+ *  Plugin source is remote (GitHub / git URL). Skills cannot be
+ *  enumerated without cloning, which the listing path never does.
+ *  Distinct from `ManifestFailed { reason: RemoteSourceNotLocal }`:
+ *  here we know the plugin is remote by construction and never
+ *  attempt the local resolution.
+ */
+{ state: "remote_not_counted" } | 
+/**
+ *  The plugin is local but something about its directory or
+ *  `plugin.json` prevented a skill count.
+ * 
+ *  `SkippedReason` is reused as the error payload to share the #30
+ *  projection [`SkippedReason::from_plugin_error`]. Reachable from
+ *  this path:
+ * 
+ *  From the `MarketplaceService::resolve_local_plugin_dir` pre-check:
+ *  - [`SkippedReason::DirectoryMissing`] — `plugin_dir` not found.
+ *  - [`SkippedReason::NotADirectory`] — `plugin_dir` is a file.
+ *  - [`SkippedReason::SymlinkRefused`] — `plugin_dir` is a symlink.
+ *  - [`SkippedReason::DirectoryUnreadable`] — stat failed for any
+ *    other reason (permission denied, transient I/O, etc.).
+ * 
+ *  From [`load_plugin_manifest`]:
+ *  - [`SkippedReason::InvalidManifest`] — `plugin.json` malformed.
+ *  - [`SkippedReason::ManifestReadFailed`] — `plugin.json` read
+ *    failed after a successful stat.
+ * 
+ *  [`SkippedReason::NoSkills`] is not produced anywhere in this
+ *  path; [`SkippedReason::RemoteSourceNotLocal`] is pre-empted by
+ *  [`Self::RemoteNotCounted`] before resolution is attempted.
+ *  Frontends typed against `SkippedReason` will not get
+ *  compile-time narrowing for those two — accepted because
+ *  consolidating the projection is more valuable than a narrower
+ *  wire type.
+ */
+{ state: "manifest_failed"; reason: SkippedReason };
 
 /**
  *  Information about a single skill, cross-referenced with the target

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -35,7 +35,7 @@ export const commands = {
 	 *  Returns the core [`InstallSkillsResult`] directly rather than through a
 	 *  Tauri-local wrapper — the previous wrapper was a field-by-field copy
 	 *  and risked drifting away from the core shape (e.g. losing the
-	 *  `FailedSkill::kind` and `skipped_skills` fields introduced in #30).
+	 *  structured `FailedSkill::kind` and `skipped_skills` fields).
 	 *  Using the core type keeps the wire format lockstep with what the
 	 *  service emits.
 	 */
@@ -400,8 +400,8 @@ export type SkillCount =
  *  The plugin is local but something about its directory or
  *  `plugin.json` prevented a skill count.
  * 
- *  `SkippedReason` is reused as the error payload to share the #30
- *  projection [`SkippedReason::from_plugin_error`]. Reachable from
+ *  `SkippedReason` is reused as the error payload to share the
+ *  [`SkippedReason::from_plugin_error`] classifier. Reachable from
  *  this path:
  * 
  *  From the `MarketplaceService::resolve_local_plugin_dir` pre-check:

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -6,16 +6,64 @@
     MarketplaceInfo,
     PluginInfo,
     SkillInfo,
+    SkillCount,
+    SkippedReason,
     SkippedSkill,
   } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
+
+  // Render a structured SkippedReason as a one-line string. Total over
+  // all eight variants (not just the six reachable via SkillCount) —
+  // TypeScript's exhaustiveness check forces full coverage. The two
+  // currently-unreachable variants (remote_source_not_local, no_skills)
+  // are reserved for future reuse with SkippedPlugin banners.
+  function formatSkippedReason(r: SkippedReason): string {
+    switch (r.kind) {
+      case "directory_missing":
+        return `plugin directory not found: ${r.path}`;
+      case "not_a_directory":
+        return `plugin path is not a directory: ${r.path}`;
+      case "symlink_refused":
+        return `plugin path is a symlink (refused): ${r.path}`;
+      case "directory_unreadable":
+        return `could not read ${r.path}: ${r.reason}`;
+      case "invalid_manifest":
+        return `malformed plugin.json at ${r.path}: ${r.reason}`;
+      case "manifest_read_failed":
+        return `could not read plugin.json at ${r.path}: ${r.reason}`;
+      case "remote_source_not_local":
+        return `plugin source is remote: ${r.plugin}`;
+      case "no_skills":
+        return `plugin declares no skills: ${r.path}`;
+    }
+  }
+
+  function skillCountLabel(sc: SkillCount): string {
+    switch (sc.state) {
+      case "known": return String(sc.count);
+      case "remote_not_counted": return "–";
+      case "manifest_failed": return "!";
+    }
+  }
+
+  function skillCountTitle(sc: SkillCount): string | undefined {
+    switch (sc.state) {
+      case "known":
+        return undefined;
+      case "remote_not_counted":
+        return "Remote plugin — skills cannot be counted without cloning";
+      case "manifest_failed":
+        return formatSkippedReason(sc.reason);
+    }
+  }
 
   // Render a structured SkippedSkill as a one-line label for warning
   // banners. Uses name_hint (Option<String> in core → string | null on
   // the wire) with "<unnamed>" fallback so a skill whose directory name
   // could not be extracted still shows up in the UI rather than being
-  // silently dropped — that silent drop is exactly the class of bug #30
-  // is fighting across all three call sites that consume SkippedSkill.
+  // silently dropped — that silent drop is exactly the class of bug the
+  // SkippedSkill surfacing pattern is fighting across all three call
+  // sites that consume SkippedSkill.
   function formatSkippedSkill(s: SkippedSkill): string {
     const label = s.name_hint ?? "<unnamed>";
     // SkippedSkillReason is a discriminated union on `kind`. A future
@@ -274,7 +322,7 @@
       () => commands.listAvailableSkills(mp, plugin, projectPath),
       {
         onSuccess: (data) => {
-          // data is PluginSkillsResult (#30): { skills, skipped_skills }.
+          // data is PluginSkillsResult: { skills, skipped_skills }.
           // Happy-path skills populate the card grid; per-skill read
           // failures surface via the same per-plugin fetchErrors banner
           // stream used by plugin-level skips (from the bulk path), so a
@@ -701,7 +749,11 @@
                     class="h-3.5 w-3.5 rounded border-kiro-muted text-kiro-accent-500"
                   />
                   <span class="flex-1 truncate">{ap.plugin.name}</span>
-                  <span class="text-[11px] text-kiro-subtle">{ap.plugin.skill_count}</span>
+                  <span
+                    class="text-[11px] {ap.plugin.skill_count.state === 'manifest_failed' ? 'text-kiro-warning' : 'text-kiro-subtle'}"
+                    title={skillCountTitle(ap.plugin.skill_count)}
+                    aria-label={skillCountTitle(ap.plugin.skill_count)}
+                  >{skillCountLabel(ap.plugin.skill_count)}</span>
                 </label>
               {/each}
             </div>

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::error::{Error, PluginError, error_full_chain};
 use crate::marketplace::{PluginEntry, PluginSource, StructuredSource};
@@ -330,8 +330,8 @@ pub enum SkillCount {
     /// The plugin is local but something about its directory or
     /// `plugin.json` prevented a skill count.
     ///
-    /// `SkippedReason` is reused as the error payload to share the #30
-    /// projection [`SkippedReason::from_plugin_error`]. Reachable from
+    /// `SkippedReason` is reused as the error payload to share the
+    /// [`SkippedReason::from_plugin_error`] classifier. Reachable from
     /// this path:
     ///
     /// From the `MarketplaceService::resolve_local_plugin_dir` pre-check:
@@ -598,8 +598,17 @@ impl MarketplaceService {
         let plugin_dir = match self.resolve_local_plugin_dir(plugin, marketplace_path) {
             Ok(p) => p,
             Err(err) => {
+                // Compute the intended path for defensive fallback logging;
+                // `resolve_local_plugin_dir`'s success path would have
+                // returned this value. For `Structured` sources we'd
+                // never reach here (the remote short-circuit above
+                // caught it), so the `rel` branch is the only case.
+                let plugin_dir_hint = match &plugin.source {
+                    PluginSource::RelativePath(rel) => marketplace_path.join(rel),
+                    PluginSource::Structured(_) => marketplace_path.to_path_buf(),
+                };
                 return SkillCount::ManifestFailed {
-                    reason: skipped_reason_from_resolve_error(&plugin.name, err),
+                    reason: skipped_reason_from_resolve_error(&plugin.name, &plugin_dir_hint, err),
                 };
             }
         };
@@ -607,9 +616,16 @@ impl MarketplaceService {
         match load_plugin_manifest(&plugin_dir) {
             Ok(manifest) => {
                 let count = discover_skills_for_plugin(&plugin_dir, manifest.as_ref()).len();
-                SkillCount::Known {
-                    count: u32::try_from(count).unwrap_or(u32::MAX),
-                }
+                let saturated = u32::try_from(count).unwrap_or_else(|_| {
+                    warn!(
+                        plugin = %plugin.name,
+                        path = %plugin_dir.display(),
+                        original = count,
+                        "skill count exceeds u32::MAX; saturating"
+                    );
+                    u32::MAX
+                });
+                SkillCount::Known { count: saturated }
             }
             Err(err) => SkillCount::ManifestFailed {
                 reason: skipped_reason_from_manifest_error(&plugin.name, &plugin_dir, err),
@@ -749,10 +765,20 @@ fn discover_skills_for_plugin(
 /// `SymlinkRefused`, `DirectoryUnreadable`, plus
 /// `RemoteSourceNotLocal` — pre-empted at the caller). The defensive
 /// `unwrap_or_else` branch exists for forward-compatibility: if a
-/// future `PluginError` variant lands and the classifier chooses to
-/// propagate rather than skip, we fold it into `DirectoryUnreadable`
-/// with a `warn!` rather than regress to a silent `0`.
-fn skipped_reason_from_resolve_error(plugin_name: &str, err: Error) -> SkippedReason {
+/// future `PluginError` variant lands and the classifier returns
+/// `None`, we fold it into `DirectoryUnreadable` with an `error!`
+/// (a missing classification is a code defect, not a runtime warning)
+/// rather than regress to a silent `0`.
+///
+/// `plugin_dir_hint` is the intended plugin directory the caller would
+/// have resolved on the success path; it is used to populate the
+/// `DirectoryUnreadable.path` field in the defensive fallbacks so the
+/// UI can render something more informative than an empty path.
+fn skipped_reason_from_resolve_error(
+    plugin_name: &str,
+    plugin_dir_hint: &Path,
+    err: Error,
+) -> SkippedReason {
     let Error::Plugin(pe) = err else {
         // `resolve_local_plugin_dir` only returns `Error::Plugin` today,
         // but `Error` is `#[non_exhaustive]` — defensive.
@@ -762,18 +788,18 @@ fn skipped_reason_from_resolve_error(plugin_name: &str, err: Error) -> SkippedRe
             "unexpected non-plugin error resolving plugin_dir; reporting as DirectoryUnreadable"
         );
         return SkippedReason::DirectoryUnreadable {
-            path: PathBuf::new(),
+            path: plugin_dir_hint.to_path_buf(),
             reason: error_full_chain(&err),
         };
     };
     SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
-        warn!(
+        error!(
             plugin = %plugin_name,
             error = ?pe,
             "unclassified PluginError from resolve_local_plugin_dir; reporting as DirectoryUnreadable"
         );
         SkippedReason::DirectoryUnreadable {
-            path: PathBuf::new(),
+            path: plugin_dir_hint.to_path_buf(),
             reason: error_full_chain(&pe),
         }
     })
@@ -784,7 +810,9 @@ fn skipped_reason_from_resolve_error(plugin_name: &str, err: Error) -> SkippedRe
 /// `load_plugin_manifest` returns [`PluginError::InvalidManifest`] or
 /// [`PluginError::ManifestReadFailed`] today. Same defensive pattern
 /// as [`skipped_reason_from_resolve_error`]: an unclassified variant
-/// folds into `ManifestReadFailed` with a `warn!`.
+/// folds into `ManifestReadFailed` with an `error!` — a missing
+/// classification indicates a new `PluginError` variant was added
+/// without a corresponding branch in `SkippedReason::from_plugin_error`.
 fn skipped_reason_from_manifest_error(
     plugin_name: &str,
     plugin_dir: &Path,
@@ -802,7 +830,7 @@ fn skipped_reason_from_manifest_error(
         };
     };
     SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
-        warn!(
+        error!(
             plugin = %plugin_name,
             error = ?pe,
             "unclassified PluginError from load_plugin_manifest; reporting as ManifestReadFailed"
@@ -1165,7 +1193,7 @@ mod tests {
         )
         .expect("per-skill errors should not propagate");
 
-        // Regression for #30: previously the bad frontmatter vanished into
+        // Regression guard: previously the bad frontmatter vanished into
         // a warn! log. Now it must surface as a structured SkippedSkill.
         assert_eq!(out.len(), 1, "bad frontmatter should not be in skills");
         assert_eq!(out[0].name, "good-skill");
@@ -1632,8 +1660,8 @@ mod tests {
         // The structured `kind` is the programmatic contract; the
         // `reason` Display-string is a human-readable convenience and
         // may rephrase freely. Previously this test substring-matched
-        // on `reason` (the TODO(#30) it replaced); the `matches!` below
-        // survives any Display rewording.
+        // on `reason` before the structured SkippedReason existed; the
+        // `matches!` below survives any Display rewording.
         assert!(
             matches!(
                 result.skipped[0].kind,
@@ -1696,7 +1724,7 @@ mod tests {
 
     /// Regression guard: a regular file sitting at the plugin path must
     /// fold into `skipped` with `kind = NotADirectory`, not propagate
-    /// or mis-classify as `DirectoryMissing`. Pre-#30 this class was
+    /// or mis-classify as `DirectoryMissing`. Previously this class was
     /// only covered at the `resolve_local_plugin_dir` unit layer; the
     /// e2e assertion catches a regression where the bulk loop gets
     /// narrowed to a subset of plugin-level variants.
@@ -1733,7 +1761,7 @@ mod tests {
     }
 
     /// Regression guard: a symlink at the plugin path must classify as
-    /// `SymlinkRefused` end-to-end. Before #30 only the
+    /// `SymlinkRefused` end-to-end. Previously only the
     /// `resolve_local_plugin_dir` unit test covered this; the bulk
     /// classifier could regress silently (symlink falls through to a
     /// different variant).
@@ -1825,7 +1853,7 @@ mod tests {
         }
     }
 
-    /// Before #30, a single malformed `SKILL.md` inside an otherwise-
+    /// Previously, a single malformed `SKILL.md` inside an otherwise-
     /// working plugin vanished into `warn!` + `continue`, leaving the
     /// frontend to guess why the skill count shrank. The bulk path now
     /// folds it into [`BulkSkillsResult::skipped_skills`] as a
@@ -2289,6 +2317,32 @@ mod tests {
                 }
             ),
             "expected ManifestFailed/InvalidManifest, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_when_plugin_json_is_a_directory() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/json-is-a-dir");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // Create `plugin.json` as a directory (not a regular file). stat
+        // succeeds (not a symlink, not NotFound), so load_plugin_manifest
+        // proceeds to fs::read which fails with ErrorKind::IsADirectory →
+        // PluginError::ManifestReadFailed. Pins the ManifestReadFailed
+        // branch portably without requiring chmod or root-awareness.
+        fs::create_dir(plugin_dir.join("plugin.json")).expect("create plugin.json as dir");
+
+        let entry = relative_path_entry("json-is-a-dir", "plugins/json-is-a-dir");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::ManifestReadFailed { .. }
+                }
+            ),
+            "expected ManifestFailed/ManifestReadFailed, got: {result:?}"
         );
     }
 

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -306,6 +306,56 @@ pub struct PluginSkillsResult {
     pub skipped_skills: Vec<SkippedSkill>,
 }
 
+/// Result of `MarketplaceService::count_skills_for_plugin`.
+/// Distinguishes the three cases the frontend must render differently:
+/// a known count, a remote plugin (not locally countable), and a local
+/// plugin whose directory or manifest could not be loaded. Replaces the
+/// prior `usize` that collapsed failures into a silent `0`.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "state", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkillCount {
+    /// The plugin directory was readable; `count` is the number of
+    /// discovered skill directories (including the legitimate zero case).
+    Known { count: u32 },
+
+    /// Plugin source is remote (GitHub / git URL). Skills cannot be
+    /// enumerated without cloning, which the listing path never does.
+    /// Distinct from `ManifestFailed { reason: RemoteSourceNotLocal }`:
+    /// here we know the plugin is remote by construction and never
+    /// attempt the local resolution.
+    RemoteNotCounted,
+
+    /// The plugin is local but something about its directory or
+    /// `plugin.json` prevented a skill count.
+    ///
+    /// `SkippedReason` is reused as the error payload to share the #30
+    /// projection [`SkippedReason::from_plugin_error`]. Reachable from
+    /// this path:
+    ///
+    /// From the `MarketplaceService::resolve_local_plugin_dir` pre-check:
+    /// - [`SkippedReason::DirectoryMissing`] — `plugin_dir` not found.
+    /// - [`SkippedReason::NotADirectory`] — `plugin_dir` is a file.
+    /// - [`SkippedReason::SymlinkRefused`] — `plugin_dir` is a symlink.
+    /// - [`SkippedReason::DirectoryUnreadable`] — stat failed for any
+    ///   other reason (permission denied, transient I/O, etc.).
+    ///
+    /// From [`load_plugin_manifest`]:
+    /// - [`SkippedReason::InvalidManifest`] — `plugin.json` malformed.
+    /// - [`SkippedReason::ManifestReadFailed`] — `plugin.json` read
+    ///   failed after a successful stat.
+    ///
+    /// [`SkippedReason::NoSkills`] is not produced anywhere in this
+    /// path; [`SkippedReason::RemoteSourceNotLocal`] is pre-empted by
+    /// [`Self::RemoteNotCounted`] before resolution is attempted.
+    /// Frontends typed against `SkippedReason` will not get
+    /// compile-time narrowing for those two — accepted because
+    /// consolidating the projection is more valuable than a narrower
+    /// wire type.
+    ManifestFailed { reason: SkippedReason },
+}
+
 // ---------------------------------------------------------------------------
 // Service methods
 // ---------------------------------------------------------------------------
@@ -1912,5 +1962,36 @@ mod tests {
                 "reason": "missing closing ---",
             })
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // SkillCount wire-format pins
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn skill_count_serde_known_wire_format() {
+        let json = serde_json::to_value(SkillCount::Known { count: 7 }).expect("serialize");
+        assert_eq!(json, serde_json::json!({"state": "known", "count": 7}));
+    }
+
+    #[test]
+    fn skill_count_serde_remote_not_counted_wire_format() {
+        let json = serde_json::to_value(SkillCount::RemoteNotCounted).expect("serialize");
+        assert_eq!(json, serde_json::json!({"state": "remote_not_counted"}));
+    }
+
+    #[test]
+    fn skill_count_serde_manifest_failed_wire_format() {
+        let sc = SkillCount::ManifestFailed {
+            reason: SkippedReason::InvalidManifest {
+                path: std::path::PathBuf::from("/tmp/plug/plugin.json"),
+                reason: "expected `}`".into(),
+            },
+        };
+        let json = serde_json::to_value(sc).expect("serialize");
+        assert_eq!(json["state"], "manifest_failed");
+        assert_eq!(json["reason"]["kind"], "invalid_manifest");
+        assert_eq!(json["reason"]["path"], "/tmp/plug/plugin.json");
+        assert_eq!(json["reason"]["reason"], "expected `}`");
     }
 }

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -306,7 +306,7 @@ pub struct PluginSkillsResult {
     pub skipped_skills: Vec<SkippedSkill>,
 }
 
-/// Result of `MarketplaceService::count_skills_for_plugin`.
+/// Result of [`MarketplaceService::count_skills_for_plugin`].
 /// Distinguishes the three cases the frontend must render differently:
 /// a known count, a remote plugin (not locally countable), and a local
 /// plugin whose directory or manifest could not be loaded. Replaces the
@@ -561,6 +561,61 @@ impl MarketplaceService {
             skipped_skills,
         })
     }
+
+    /// Count skills for a single plugin entry without loading skill bodies.
+    ///
+    /// Returns [`SkillCount::RemoteNotCounted`] for remote sources,
+    /// [`SkillCount::ManifestFailed`] if the plugin directory or its
+    /// `plugin.json` cannot be read or parsed, and [`SkillCount::Known`]
+    /// otherwise (including the legitimate zero case where the manifest
+    /// is absent or declares no skills).
+    ///
+    /// Takes the pre-resolved [`PluginEntry`] and `marketplace_path` so
+    /// the batch caller in `list_plugins` pays the registry-parse cost
+    /// once per marketplace rather than once per plugin. Errors are
+    /// never propagated as `Err` — every outcome fits the three-way
+    /// union.
+    ///
+    /// The plugin-directory pre-check delegates to
+    /// [`Self::resolve_local_plugin_dir`] so the hardening (symlink
+    /// refusal, `is_dir` check, `NotFound` / other-I/O classification) stays
+    /// consistent with the bulk-listing path and does not duplicate.
+    #[must_use]
+    pub fn count_skills_for_plugin(
+        &self,
+        plugin: &PluginEntry,
+        marketplace_path: &Path,
+    ) -> SkillCount {
+        // Short-circuit remote sources before `resolve_local_plugin_dir`
+        // is called — it would return `PluginError::RemoteSourceNotLocal`
+        // which we would then translate to `ManifestFailed`, conflating
+        // "remote by design" with "should have been local but resolved
+        // remote." The two need distinct UI states.
+        if matches!(plugin.source, PluginSource::Structured(_)) {
+            return SkillCount::RemoteNotCounted;
+        }
+
+        let plugin_dir = match self.resolve_local_plugin_dir(plugin, marketplace_path) {
+            Ok(p) => p,
+            Err(err) => {
+                return SkillCount::ManifestFailed {
+                    reason: skipped_reason_from_resolve_error(&plugin.name, err),
+                };
+            }
+        };
+
+        match load_plugin_manifest(&plugin_dir) {
+            Ok(manifest) => {
+                let count = discover_skills_for_plugin(&plugin_dir, manifest.as_ref()).len();
+                SkillCount::Known {
+                    count: u32::try_from(count).unwrap_or(u32::MAX),
+                }
+            }
+            Err(err) => SkillCount::ManifestFailed {
+                reason: skipped_reason_from_manifest_error(&plugin.name, &plugin_dir, err),
+            },
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -684,6 +739,79 @@ fn discover_skills_for_plugin(
     };
 
     discover_skill_dirs(plugin_dir, &skill_paths)
+}
+
+/// Project a `resolve_local_plugin_dir` error into a [`SkippedReason`].
+///
+/// `resolve_local_plugin_dir` only returns [`PluginError`] variants
+/// that [`SkippedReason::from_plugin_error`] classifies as
+/// plugin-level skips (`DirectoryMissing`, `NotADirectory`,
+/// `SymlinkRefused`, `DirectoryUnreadable`, plus
+/// `RemoteSourceNotLocal` — pre-empted at the caller). The defensive
+/// `unwrap_or_else` branch exists for forward-compatibility: if a
+/// future `PluginError` variant lands and the classifier chooses to
+/// propagate rather than skip, we fold it into `DirectoryUnreadable`
+/// with a `warn!` rather than regress to a silent `0`.
+fn skipped_reason_from_resolve_error(plugin_name: &str, err: Error) -> SkippedReason {
+    let Error::Plugin(pe) = err else {
+        // `resolve_local_plugin_dir` only returns `Error::Plugin` today,
+        // but `Error` is `#[non_exhaustive]` — defensive.
+        warn!(
+            plugin = %plugin_name,
+            error = %error_full_chain(&err),
+            "unexpected non-plugin error resolving plugin_dir; reporting as DirectoryUnreadable"
+        );
+        return SkippedReason::DirectoryUnreadable {
+            path: PathBuf::new(),
+            reason: error_full_chain(&err),
+        };
+    };
+    SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
+        warn!(
+            plugin = %plugin_name,
+            error = ?pe,
+            "unclassified PluginError from resolve_local_plugin_dir; reporting as DirectoryUnreadable"
+        );
+        SkippedReason::DirectoryUnreadable {
+            path: PathBuf::new(),
+            reason: error_full_chain(&pe),
+        }
+    })
+}
+
+/// Project a `load_plugin_manifest` error into a [`SkippedReason`].
+///
+/// `load_plugin_manifest` returns [`PluginError::InvalidManifest`] or
+/// [`PluginError::ManifestReadFailed`] today. Same defensive pattern
+/// as [`skipped_reason_from_resolve_error`]: an unclassified variant
+/// folds into `ManifestReadFailed` with a `warn!`.
+fn skipped_reason_from_manifest_error(
+    plugin_name: &str,
+    plugin_dir: &Path,
+    err: Error,
+) -> SkippedReason {
+    let Error::Plugin(pe) = err else {
+        warn!(
+            plugin = %plugin_name,
+            error = %error_full_chain(&err),
+            "unexpected non-plugin error loading plugin.json; reporting as ManifestReadFailed"
+        );
+        return SkippedReason::ManifestReadFailed {
+            path: plugin_dir.join("plugin.json"),
+            reason: error_full_chain(&err),
+        };
+    };
+    SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
+        warn!(
+            plugin = %plugin_name,
+            error = ?pe,
+            "unclassified PluginError from load_plugin_manifest; reporting as ManifestReadFailed"
+        );
+        SkippedReason::ManifestReadFailed {
+            path: plugin_dir.join("plugin.json"),
+            reason: error_full_chain(&pe),
+        }
+    })
 }
 
 /// Load a `plugin.json` from the given directory.
@@ -1993,5 +2121,199 @@ mod tests {
         assert_eq!(json["reason"]["kind"], "invalid_manifest");
         assert_eq!(json["reason"]["path"], "/tmp/plug/plugin.json");
         assert_eq!(json["reason"]["reason"], "expected `}`");
+    }
+
+    // -----------------------------------------------------------------------
+    // count_skills_for_plugin
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn count_skills_for_plugin_returns_known_for_local_plugin() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        make_plugin_with_skills(&marketplace_path, "my-plugin", &["alpha", "beta", "gamma"]);
+
+        let entry = relative_path_entry("my-plugin", "plugins/my-plugin");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 3 }),
+            "expected Known {{ count: 3 }}, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_known_with_zero_when_no_skills() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/lonely");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // A plugin.json with no custom skill paths → default paths apply,
+        // but no skills/ directory exists, so count is 0.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{"name": "lonely", "version": "0.0.0"}"#,
+        )
+        .expect("write plugin.json");
+
+        let entry = relative_path_entry("lonely", "plugins/lonely");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 0 }),
+            "expected Known {{ count: 0 }}, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_known_when_manifest_absent() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        // No plugin.json → defaults kick in. make_plugin_with_skills creates
+        // skills/ subdirs (not plugin.json), so the count comes from those
+        // subdirs alone.
+        make_plugin_with_skills(&marketplace_path, "defaults", &["alpha", "beta"]);
+
+        let entry = relative_path_entry("defaults", "plugins/defaults");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 2 }),
+            "expected Known {{ count: 2 }}, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_remote_for_structured_source() {
+        let (_dir, svc) = temp_service();
+        let marketplace_path = Path::new("/tmp/nonexistent-marketplace");
+
+        let entry = PluginEntry {
+            name: "remote".into(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            }),
+        };
+
+        let result = svc.count_skills_for_plugin(&entry, marketplace_path);
+        assert!(
+            matches!(result, SkillCount::RemoteNotCounted),
+            "expected RemoteNotCounted, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_on_missing_plugin_dir() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        fs::create_dir_all(&marketplace_path).expect("create marketplace root");
+
+        let entry = relative_path_entry("ghost", "plugins/ghost");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::DirectoryMissing { .. }
+                }
+            ),
+            "expected ManifestFailed/DirectoryMissing, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_when_plugin_dir_is_a_file() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugins_root = marketplace_path.join("plugins");
+        fs::create_dir_all(&plugins_root).expect("create plugins root");
+        // Create a regular file where the plugin dir should be.
+        fs::write(plugins_root.join("not-a-dir"), b"i am a file").expect("write file");
+
+        let entry = relative_path_entry("not-a-dir", "plugins/not-a-dir");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::NotADirectory { .. }
+                }
+            ),
+            "expected ManifestFailed/NotADirectory, got: {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_skills_for_plugin_returns_manifest_failed_on_symlinked_plugin_dir() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugins_root = marketplace_path.join("plugins");
+        fs::create_dir_all(&plugins_root).expect("create plugins root");
+        // Symlink target must exist so the symlink itself is what triggers
+        // the refusal, not a broken-symlink variant.
+        let real_target = dir.path().join("real-plugin");
+        fs::create_dir_all(&real_target).expect("create real target");
+        symlink(&real_target, plugins_root.join("symlinked")).expect("create symlink");
+
+        let entry = relative_path_entry("symlinked", "plugins/symlinked");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::SymlinkRefused { .. }
+                }
+            ),
+            "expected ManifestFailed/SymlinkRefused, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_on_malformed_json() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/broken");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(plugin_dir.join("plugin.json"), b"{not json").expect("write plugin.json");
+
+        let entry = relative_path_entry("broken", "plugins/broken");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::InvalidManifest { .. }
+                }
+            ),
+            "expected ManifestFailed/InvalidManifest, got: {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_skills_for_plugin_treats_symlinked_plugin_json_as_missing() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/symjson");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // Symlinked plugin.json is treated as absent by load_plugin_manifest
+        // (security hardening; see its symlink_metadata branch). That means
+        // we fall back to default skill paths — no skills/ dir exists here,
+        // so count is 0. Regression pin for this specific interaction.
+        let real_manifest = dir.path().join("real-plugin.json");
+        fs::write(&real_manifest, b"{\"name\":\"irrelevant\"}").expect("write real manifest");
+        symlink(&real_manifest, plugin_dir.join("plugin.json")).expect("create symlink");
+
+        let entry = relative_path_entry("symjson", "plugins/symjson");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 0 }),
+            "expected Known {{ count: 0 }}, got: {result:?}"
+        );
     }
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -6,8 +6,8 @@
 pub mod browse;
 
 pub use browse::{
-    BulkSkillsResult, PluginSkillsResult, SkillInfo, SkippedPlugin, SkippedReason, SkippedSkill,
-    SkippedSkillReason,
+    BulkSkillsResult, PluginSkillsResult, SkillCount, SkillInfo, SkippedPlugin, SkippedReason,
+    SkippedSkill, SkippedSkillReason,
 };
 
 use std::fs;

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -3419,10 +3419,10 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // install_skills: per-skill surfacing + FailedSkillReason (audit #30)
+    // install_skills: per-skill surfacing + FailedSkillReason
     // -------------------------------------------------------------------
     //
-    // These tests pin the behavior introduced by the issue-#30 audit fold-in:
+    // These tests pin the behavior introduced by the silent-drop audit:
     // install_skills used to vanish per-skill read/parse failures into
     // `warn!` + `continue`. They now surface as structured `skipped_skills`
     // entries, and requested-but-missing names carry the typed
@@ -3564,9 +3564,9 @@ mod tests {
     }
 
     /// Regression guard for the `install_skills` per-skill
-    /// `read_to_string` failure path. Before the #30 audit fold-in,
-    /// this vanished into `warn!` + `continue`; now it must surface as
-    /// a structured `SkippedSkill` with `ReadFailed`. The sibling
+    /// `read_to_string` failure path. Previously, this vanished into
+    /// `warn!` + `continue`; now it must surface as a structured
+    /// `SkippedSkill` with `ReadFailed`. The sibling
     /// `list_all_skills_surfaces_unreadable_skill_md_as_skipped_skill`
     /// exists in the browse module and covers the identical branch in
     /// `collect_skills_for_plugin_into` — this test catches a

--- a/docs/superpowers/plans/2026-04-21-count-plugin-skills-silent-zero.md
+++ b/docs/superpowers/plans/2026-04-21-count-plugin-skills-silent-zero.md
@@ -1,0 +1,997 @@
+# count_plugin_skills Silent-Zero Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `count_plugin_skills` silent-zero antipattern (which collapses remote plugins and manifest-load failures into the same `0` a legitimately empty plugin reports) with a discriminated `SkillCount` enum carried through the service, Tauri FFI, and Svelte UI.
+
+**Architecture:** Add a new `MarketplaceService::count_skills_for_plugin` in `kiro-market-core` returning a three-way `SkillCount` union (`Known { count }` / `RemoteNotCounted` / `ManifestFailed { reason }`). The directory pre-check the spec proposed as a new `check_plugin_dir` helper is satisfied by reusing the existing `MarketplaceService::resolve_local_plugin_dir` — it already performs the identical five-branch stat (symlink / non-dir / OK / NotFound / other-I/O) and is test-pinned. Tauri's `PluginInfo.skill_count` field type changes from `u32` to `SkillCount`, specta regenerates `bindings.ts`, and `BrowseTab.svelte` renders the three states with minimal labels (number / `"–"` / `"!"` + tooltip).
+
+**Tech Stack:** Rust 2024 (edition), `serde`, `specta` (feature-gated), `tempfile` (test fixtures), SvelteKit 5, TypeScript, Tauri IPC via specta-generated bindings.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-count-plugin-skills-silent-zero-design.md` (committed as `ffd8300`).
+
+**Branch:** `fix/count-plugin-skills-silent-zero`.
+
+**Out of scope (per spec):** Deleting Tauri-local `load_plugin_manifest` / `discover_skills_for_plugin` — both still called by `install_skills` in the Tauri crate; their removal is #33's job.
+
+**Spec → plan refinement (note to reviewers):** The spec proposed a new `check_plugin_dir` helper. During plan writing I discovered `MarketplaceService::resolve_local_plugin_dir` at `crates/kiro-market-core/src/service/browse.rs:338` already performs an identical five-branch directory stat (`SymlinkRefused` / `NotADirectory` / `Ok` / `DirectoryMissing` / `DirectoryUnreadable`) with full test coverage. Reusing it satisfies the spec's intent (plugin-directory hardening that prevents silent-zero for missing plugin_dir) with zero new helper code and zero new duplication. The spec's alignment note explicitly flagged extraction as the preferred outcome. No behavior change vs. the spec; only the implementation path differs.
+
+---
+
+## File structure
+
+Files touched by this plan, with one-line responsibility:
+
+| File | Responsibility |
+|---|---|
+| `crates/kiro-market-core/src/service/browse.rs` | Add `SkillCount` enum (response types section) and `MarketplaceService::count_skills_for_plugin` method. Add behavior + wire-format tests inside existing `#[cfg(test)] mod tests` block. |
+| `crates/kiro-control-center/src-tauri/src/commands/browse.rs` | Change `PluginInfo.skill_count` field type `u32` → `SkillCount`. Replace call site in `list_plugins` with `svc.count_skills_for_plugin(...)`. Delete local `count_plugin_skills`. Add Layer 3 integration test. |
+| `crates/kiro-control-center/src-tauri/src/lib.rs` (or wherever specta re-exports are declared) | Re-export `SkillCount` so specta picks it up for `bindings.ts`. |
+| `crates/kiro-control-center/src/lib/bindings.ts` | **Auto-regenerated** by `cargo test -p kiro-control-center --lib -- --ignored`. Do not edit by hand. |
+| `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` | Add `formatSkippedReason`, `skillCountLabel`, `skillCountTitle` helpers at top of `<script>`. Replace the `{ap.plugin.skill_count}` rendering at line 704 with the new labeled span. |
+
+No new files created. Tauri-local `count_plugin_skills` is deleted; the Tauri-local `load_plugin_manifest` / `discover_skills_for_plugin` stay (used by `install_skills`, future #33 concern).
+
+---
+
+## Preflight
+
+Before starting Task 1, verify the branch and starting commit match the plan.
+
+- [ ] **Step 0.1: Verify branch**
+
+Run: `git branch --show-current`
+Expected output: `fix/count-plugin-skills-silent-zero`
+
+- [ ] **Step 0.2: Verify starting commit**
+
+Run: `git log -1 --oneline`
+Expected output starts with: `ffd8300 docs(spec): design for #32`
+
+- [ ] **Step 0.3: Verify clean working tree (tracked files)**
+
+Run: `git status --porcelain | grep -v '^??' || true`
+Expected output: empty (no modified or staged tracked files).
+
+---
+
+## Task 1: Add `SkillCount` enum and serde wire-format pin
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/browse.rs` — add enum at line 308 (between `PluginSkillsResult` and the `// Service methods` divider), add test at the end of the `#[cfg(test)] mod tests` block (around line 1915, before the closing `}` of the module).
+
+- [ ] **Step 1.1: Write the failing wire-format pin test**
+
+Open `crates/kiro-market-core/src/service/browse.rs`. Find the end of the `#[cfg(test)] mod tests` block (closing `}` at line 1916). Insert the following test immediately before that closing `}`, indented one level:
+
+```rust
+    // -----------------------------------------------------------------------
+    // SkillCount wire-format pins
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn skill_count_serde_known_wire_format() {
+        let json = serde_json::to_value(SkillCount::Known { count: 7 }).unwrap();
+        assert_eq!(json, serde_json::json!({"state": "known", "count": 7}));
+    }
+
+    #[test]
+    fn skill_count_serde_remote_not_counted_wire_format() {
+        let json = serde_json::to_value(SkillCount::RemoteNotCounted).unwrap();
+        assert_eq!(json, serde_json::json!({"state": "remote_not_counted"}));
+    }
+
+    #[test]
+    fn skill_count_serde_manifest_failed_wire_format() {
+        let sc = SkillCount::ManifestFailed {
+            reason: SkippedReason::InvalidManifest {
+                path: std::path::PathBuf::from("/tmp/plug/plugin.json"),
+                reason: "expected `}`".into(),
+            },
+        };
+        let json = serde_json::to_value(sc).unwrap();
+        assert_eq!(json["state"], "manifest_failed");
+        assert_eq!(json["reason"]["kind"], "invalid_manifest");
+        assert_eq!(json["reason"]["path"], "/tmp/plug/plugin.json");
+        assert_eq!(json["reason"]["reason"], "expected `}`");
+    }
+```
+
+- [ ] **Step 1.2: Run the tests to verify they fail**
+
+Run: `cargo test -p kiro-market-core --lib service::browse::tests::skill_count 2>&1 | tail -20`
+Expected: compilation error (`cannot find type SkillCount in this scope` or similar).
+
+- [ ] **Step 1.3: Add the `SkillCount` enum**
+
+Open `crates/kiro-market-core/src/service/browse.rs`. Insert the following immediately after the closing `}` of `PluginSkillsResult` (line 307) and before the `// ---------------------------------------------------------------------------` divider that precedes `// Service methods`:
+
+```rust
+/// Result of [`MarketplaceService::count_skills_for_plugin`].
+/// Distinguishes the three cases the frontend must render differently:
+/// a known count, a remote plugin (not locally countable), and a local
+/// plugin whose directory or manifest could not be loaded. Replaces the
+/// prior `usize` that collapsed failures into a silent `0`.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "state", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkillCount {
+    /// The plugin directory was readable; `count` is the number of
+    /// discovered skill directories (including the legitimate zero case).
+    Known { count: u32 },
+
+    /// Plugin source is remote (GitHub / git URL). Skills cannot be
+    /// enumerated without cloning, which the listing path never does.
+    /// Distinct from `ManifestFailed { reason: RemoteSourceNotLocal }`:
+    /// here we know the plugin is remote by construction and never
+    /// attempt the local resolution.
+    RemoteNotCounted,
+
+    /// The plugin is local but something about its directory or
+    /// `plugin.json` prevented a skill count.
+    ///
+    /// `SkippedReason` is reused as the error payload to share the #30
+    /// projection [`SkippedReason::from_plugin_error`]. Reachable from
+    /// this path:
+    ///
+    /// From the `MarketplaceService::resolve_local_plugin_dir` pre-check:
+    /// - [`SkippedReason::DirectoryMissing`] — `plugin_dir` not found.
+    /// - [`SkippedReason::NotADirectory`] — `plugin_dir` is a file.
+    /// - [`SkippedReason::SymlinkRefused`] — `plugin_dir` is a symlink.
+    /// - [`SkippedReason::DirectoryUnreadable`] — stat failed for any
+    ///   other reason (permission denied, transient I/O, etc.).
+    ///
+    /// From [`load_plugin_manifest`]:
+    /// - [`SkippedReason::InvalidManifest`] — `plugin.json` malformed.
+    /// - [`SkippedReason::ManifestReadFailed`] — `plugin.json` read
+    ///   failed after a successful stat.
+    ///
+    /// [`SkippedReason::NoSkills`] is not produced anywhere in this
+    /// path; [`SkippedReason::RemoteSourceNotLocal`] is pre-empted by
+    /// [`Self::RemoteNotCounted`] before resolution is attempted.
+    /// Frontends typed against `SkippedReason` will not get
+    /// compile-time narrowing for those two — accepted because
+    /// consolidating the projection is more valuable than a narrower
+    /// wire type.
+    ManifestFailed { reason: SkippedReason },
+}
+```
+
+- [ ] **Step 1.4: Run the tests to verify they pass**
+
+Run: `cargo test -p kiro-market-core --lib service::browse::tests::skill_count 2>&1 | tail -20`
+Expected: `test result: ok. 3 passed`.
+
+- [ ] **Step 1.5: Run clippy to catch lints early**
+
+Run: `cargo clippy -p kiro-market-core --tests -- -D warnings 2>&1 | tail -10`
+Expected: no warnings or errors.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service/browse.rs
+git commit -m "$(cat <<'EOF'
+feat(core): add SkillCount enum
+
+Three-way discriminated union for plugin skill-count reporting:
+Known { count }, RemoteNotCounted, ManifestFailed { reason }. Reuses
+the existing SkippedReason type (via #[cfg_attr(feature = "specta", derive(specta::Type))])
+so the #30 projection `SkippedReason::from_plugin_error` stays the
+single source of truth.
+
+Part of #32.
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `count_skills_for_plugin` service method + Layer 1 behavior tests
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/browse.rs` — add method inside `impl MarketplaceService` block (insert before line 514, which is the closing `}` of the impl; after `list_all_skills`). Add tests at the end of the `#[cfg(test)] mod tests` block (after the Task 1 wire-format tests).
+
+- [ ] **Step 2.1: Write a single failing happy-path test**
+
+Open `crates/kiro-market-core/src/service/browse.rs`. At the end of the `#[cfg(test)] mod tests` block (after the Task 1 wire-format tests, before the module closing `}`), insert:
+
+```rust
+    // -----------------------------------------------------------------------
+    // count_skills_for_plugin
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn count_skills_for_plugin_returns_known_for_local_plugin() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        make_plugin_with_skills(&marketplace_path, "my-plugin", &["alpha", "beta", "gamma"]);
+
+        let entry = relative_path_entry("my-plugin", "plugins/my-plugin");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 3 }),
+            "expected Known {{ count: 3 }}, got: {result:?}"
+        );
+    }
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+Run: `cargo test -p kiro-market-core --lib service::browse::tests::count_skills_for_plugin_returns_known_for_local_plugin 2>&1 | tail -10`
+Expected: compile error (`no method named count_skills_for_plugin`).
+
+- [ ] **Step 2.3: Implement `count_skills_for_plugin`**
+
+Open `crates/kiro-market-core/src/service/browse.rs`. Find the closing `}` of the `impl MarketplaceService` block at line 514. Insert the following **before** that closing `}`, after the `list_all_skills` method:
+
+```rust
+    /// Count skills for a single plugin entry without loading skill bodies.
+    ///
+    /// Returns [`SkillCount::RemoteNotCounted`] for remote sources,
+    /// [`SkillCount::ManifestFailed`] if the plugin directory or its
+    /// `plugin.json` cannot be read or parsed, and [`SkillCount::Known`]
+    /// otherwise (including the legitimate zero case where the manifest
+    /// is absent or declares no skills).
+    ///
+    /// Takes the pre-resolved [`PluginEntry`] and `marketplace_path` so
+    /// the batch caller in `list_plugins` pays the registry-parse cost
+    /// once per marketplace rather than once per plugin. Errors are
+    /// never propagated as `Err` — every outcome fits the three-way
+    /// union.
+    ///
+    /// The plugin-directory pre-check delegates to
+    /// [`Self::resolve_local_plugin_dir`] so the hardening (symlink
+    /// refusal, is_dir check, NotFound / other-I/O classification) stays
+    /// consistent with the bulk-listing path and does not duplicate.
+    #[must_use]
+    pub fn count_skills_for_plugin(
+        &self,
+        plugin: &PluginEntry,
+        marketplace_path: &Path,
+    ) -> SkillCount {
+        // Short-circuit remote sources before `resolve_local_plugin_dir`
+        // is called — it would return `PluginError::RemoteSourceNotLocal`
+        // which we would then translate to `ManifestFailed`, conflating
+        // "remote by design" with "should have been local but resolved
+        // remote." The two need distinct UI states.
+        if matches!(plugin.source, PluginSource::Structured(_)) {
+            return SkillCount::RemoteNotCounted;
+        }
+
+        let plugin_dir = match self.resolve_local_plugin_dir(plugin, marketplace_path) {
+            Ok(p) => p,
+            Err(err) => {
+                return SkillCount::ManifestFailed {
+                    reason: skipped_reason_from_resolve_error(&plugin.name, err),
+                };
+            }
+        };
+
+        match load_plugin_manifest(&plugin_dir) {
+            Ok(manifest) => {
+                let count = discover_skills_for_plugin(&plugin_dir, manifest.as_ref()).len();
+                SkillCount::Known {
+                    count: u32::try_from(count).unwrap_or(u32::MAX),
+                }
+            }
+            Err(err) => SkillCount::ManifestFailed {
+                reason: skipped_reason_from_manifest_error(&plugin.name, &plugin_dir, err),
+            },
+        }
+    }
+```
+
+Next, add two small private helpers to centralize the `Error` → `SkippedReason` projection (kept out of the method body so the defensive-fallback logging paths don't clutter the reading path). Add them in the "Private helpers" section, immediately after `discover_skills_for_plugin` (which ends at line 637):
+
+```rust
+/// Project a `resolve_local_plugin_dir` error into a [`SkippedReason`].
+///
+/// `resolve_local_plugin_dir` only returns [`PluginError`] variants
+/// that [`SkippedReason::from_plugin_error`] classifies as
+/// plugin-level skips (`DirectoryMissing`, `NotADirectory`,
+/// `SymlinkRefused`, `DirectoryUnreadable`, plus
+/// `RemoteSourceNotLocal` — pre-empted at the caller). The defensive
+/// `unwrap_or_else` branch exists for forward-compatibility: if a
+/// future `PluginError` variant lands and the classifier chooses to
+/// propagate rather than skip, we fold it into `DirectoryUnreadable`
+/// with a `warn!` rather than regress to a silent `0`.
+fn skipped_reason_from_resolve_error(plugin_name: &str, err: Error) -> SkippedReason {
+    let Error::Plugin(pe) = err else {
+        // `resolve_local_plugin_dir` only returns `Error::Plugin` today,
+        // but `Error` is `#[non_exhaustive]` — defensive.
+        warn!(
+            plugin = %plugin_name,
+            error = %error_full_chain(&err),
+            "unexpected non-plugin error resolving plugin_dir; reporting as DirectoryUnreadable"
+        );
+        return SkippedReason::DirectoryUnreadable {
+            path: PathBuf::new(),
+            reason: error_full_chain(&err),
+        };
+    };
+    SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
+        warn!(
+            plugin = %plugin_name,
+            error = ?pe,
+            "unclassified PluginError from resolve_local_plugin_dir; reporting as DirectoryUnreadable"
+        );
+        SkippedReason::DirectoryUnreadable {
+            path: PathBuf::new(),
+            reason: pe.to_string(),
+        }
+    })
+}
+
+/// Project a `load_plugin_manifest` error into a [`SkippedReason`].
+///
+/// `load_plugin_manifest` returns [`PluginError::InvalidManifest`] or
+/// [`PluginError::ManifestReadFailed`] today. Same defensive pattern
+/// as [`skipped_reason_from_resolve_error`]: an unclassified variant
+/// folds into `ManifestReadFailed` with a `warn!`.
+fn skipped_reason_from_manifest_error(
+    plugin_name: &str,
+    plugin_dir: &Path,
+    err: Error,
+) -> SkippedReason {
+    let Error::Plugin(pe) = err else {
+        warn!(
+            plugin = %plugin_name,
+            error = %error_full_chain(&err),
+            "unexpected non-plugin error loading plugin.json; reporting as ManifestReadFailed"
+        );
+        return SkippedReason::ManifestReadFailed {
+            path: plugin_dir.join("plugin.json"),
+            reason: error_full_chain(&err),
+        };
+    };
+    SkippedReason::from_plugin_error(&pe).unwrap_or_else(|| {
+        warn!(
+            plugin = %plugin_name,
+            error = ?pe,
+            "unclassified PluginError from load_plugin_manifest; reporting as ManifestReadFailed"
+        );
+        SkippedReason::ManifestReadFailed {
+            path: plugin_dir.join("plugin.json"),
+            reason: pe.to_string(),
+        }
+    })
+}
+```
+
+- [ ] **Step 2.4: Run the first test to verify it passes**
+
+Run: `cargo test -p kiro-market-core --lib service::browse::tests::count_skills_for_plugin_returns_known_for_local_plugin 2>&1 | tail -10`
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 2.5: Add the remaining Layer 1 tests**
+
+Back in the `#[cfg(test)] mod tests` block, under the `// count_skills_for_plugin` heading you added in Step 2.1, append the following tests (in the same module, after the existing happy-path test):
+
+```rust
+    #[test]
+    fn count_skills_for_plugin_returns_known_with_zero_when_no_skills() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/lonely");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // A plugin.json with no custom skill paths → default paths apply,
+        // but no skills/ directory exists, so count is 0.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{"name": "lonely", "version": "0.0.0"}"#,
+        )
+        .expect("write plugin.json");
+
+        let entry = relative_path_entry("lonely", "plugins/lonely");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 0 }),
+            "expected Known {{ count: 0 }}, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_known_when_manifest_absent() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        // No plugin.json → defaults kick in. Create the default skills/
+        // layout so the count is nonzero.
+        make_plugin_with_skills(&marketplace_path, "defaults", &["alpha", "beta"]);
+        // Remove the default plugin.json we didn't ask for (make_plugin_with_skills
+        // only creates skill dirs, not plugin.json).
+
+        let entry = relative_path_entry("defaults", "plugins/defaults");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 2 }),
+            "expected Known {{ count: 2 }}, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_remote_for_structured_source() {
+        let (_dir, svc) = temp_service();
+        let marketplace_path = Path::new("/tmp/nonexistent-marketplace");
+
+        let entry = PluginEntry {
+            name: "remote".into(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            }),
+        };
+
+        let result = svc.count_skills_for_plugin(&entry, marketplace_path);
+        assert!(
+            matches!(result, SkillCount::RemoteNotCounted),
+            "expected RemoteNotCounted, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_on_missing_plugin_dir() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        fs::create_dir_all(&marketplace_path).expect("create marketplace root");
+
+        let entry = relative_path_entry("ghost", "plugins/ghost");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::DirectoryMissing { .. }
+                }
+            ),
+            "expected ManifestFailed/DirectoryMissing, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_when_plugin_dir_is_a_file() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugins_root = marketplace_path.join("plugins");
+        fs::create_dir_all(&plugins_root).expect("create plugins root");
+        // Create a regular file where the plugin dir should be.
+        fs::write(plugins_root.join("not-a-dir"), b"i am a file").expect("write file");
+
+        let entry = relative_path_entry("not-a-dir", "plugins/not-a-dir");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::NotADirectory { .. }
+                }
+            ),
+            "expected ManifestFailed/NotADirectory, got: {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_skills_for_plugin_returns_manifest_failed_on_symlinked_plugin_dir() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugins_root = marketplace_path.join("plugins");
+        fs::create_dir_all(&plugins_root).expect("create plugins root");
+        // Symlink target must exist so the symlink itself is what triggers
+        // the refusal, not a broken-symlink variant.
+        let real_target = dir.path().join("real-plugin");
+        fs::create_dir_all(&real_target).expect("create real target");
+        symlink(&real_target, plugins_root.join("symlinked")).expect("create symlink");
+
+        let entry = relative_path_entry("symlinked", "plugins/symlinked");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::SymlinkRefused { .. }
+                }
+            ),
+            "expected ManifestFailed/SymlinkRefused, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn count_skills_for_plugin_returns_manifest_failed_on_malformed_json() {
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/broken");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(plugin_dir.join("plugin.json"), b"{not json").expect("write plugin.json");
+
+        let entry = relative_path_entry("broken", "plugins/broken");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(
+                result,
+                SkillCount::ManifestFailed {
+                    reason: SkippedReason::InvalidManifest { .. }
+                }
+            ),
+            "expected ManifestFailed/InvalidManifest, got: {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_skills_for_plugin_treats_symlinked_plugin_json_as_missing() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, svc) = temp_service();
+        let marketplace_path = dir.path().join("marketplace");
+        let plugin_dir = marketplace_path.join("plugins/symjson");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // Symlinked plugin.json is treated as absent by load_plugin_manifest
+        // (security hardening, see service/browse.rs:656). That means we
+        // fall back to default skill paths — no skills/ dir exists here,
+        // so count is 0. Regression pin for this specific interaction.
+        let real_manifest = dir.path().join("real-plugin.json");
+        fs::write(&real_manifest, b"{\"name\":\"irrelevant\"}").expect("write real manifest");
+        symlink(&real_manifest, plugin_dir.join("plugin.json")).expect("create symlink");
+
+        let entry = relative_path_entry("symjson", "plugins/symjson");
+        let result = svc.count_skills_for_plugin(&entry, &marketplace_path);
+        assert!(
+            matches!(result, SkillCount::Known { count: 0 }),
+            "expected Known {{ count: 0 }}, got: {result:?}"
+        );
+    }
+```
+
+- [ ] **Step 2.6: Run all `count_skills_for_plugin` tests**
+
+Run: `cargo test -p kiro-market-core --lib service::browse::tests::count_skills_for_plugin 2>&1 | tail -15`
+Expected: `test result: ok. 8 passed` (7 for the 7 non-cfg-gated + 1 cfg(unix) + 1 cfg(unix) = 8 on Linux/macOS; 6 on Windows where the two `#[cfg(unix)]` tests are skipped).
+
+- [ ] **Step 2.7: Run the full browse test module to check for regressions**
+
+Run: `cargo test -p kiro-market-core --lib service::browse 2>&1 | tail -10`
+Expected: all tests pass. No existing tests broken.
+
+- [ ] **Step 2.8: Run clippy**
+
+Run: `cargo clippy -p kiro-market-core --tests -- -D warnings 2>&1 | tail -10`
+Expected: no warnings or errors.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service/browse.rs
+git commit -m "$(cat <<'EOF'
+feat(core): add MarketplaceService::count_skills_for_plugin
+
+Replaces the Tauri-side `count_plugin_skills` silent-zero behavior
+with a three-way SkillCount result. Plugin-directory pre-check reuses
+`resolve_local_plugin_dir` rather than duplicating the stat logic,
+then falls through to `load_plugin_manifest` for plugin.json-specific
+failures. Two private helpers
+(`skipped_reason_from_resolve_error` / `skipped_reason_from_manifest_error`)
+centralize the Error → SkippedReason projection so the method body
+stays readable.
+
+Part of #32.
+EOF
+)"
+```
+
+---
+
+## Task 3: Tauri FFI wiring + bindings regeneration + Layer 3 integration test
+
+**Files:**
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/browse.rs` — change `PluginInfo.skill_count` type (line 60), replace `list_plugins` call site (line 136), delete `count_plugin_skills` (lines ~435–462).
+- Possibly modify: `crates/kiro-control-center/src-tauri/src/lib.rs` (specta re-exports, if needed).
+- Auto-regenerate: `crates/kiro-control-center/src/lib/bindings.ts`.
+
+- [ ] **Step 3.1: Update `PluginInfo.skill_count` field type**
+
+In `crates/kiro-control-center/src-tauri/src/commands/browse.rs`, find the `PluginInfo` struct (line ~56). Change the field type:
+
+```rust
+// Before (around line 56–62):
+pub struct PluginInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub skill_count: u32,
+    pub source_type: SourceType,
+}
+
+// After:
+pub struct PluginInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub skill_count: kiro_market_core::service::browse::SkillCount,
+    pub source_type: SourceType,
+}
+```
+
+If the file already has a `use` import that would make a shorter path idiomatic (e.g. `use kiro_market_core::service::browse::*`), use the shorter path. Otherwise import `SkillCount`:
+
+```rust
+// Near the top of the file, in the imports block:
+use kiro_market_core::service::browse::{BulkSkillsResult, PluginSkillsResult, SkillCount};
+```
+
+(Add `SkillCount` to whichever `use kiro_market_core::service::browse::{...}` line already exists; if there's no such line, add one.)
+
+- [ ] **Step 3.2: Replace the `list_plugins` call site**
+
+In the same file, find `list_plugins` around line 126. Locate the loop body at line ~134–143:
+
+```rust
+// Before:
+for plugin in &plugin_entries {
+    let source_type = plugin_source_type(&plugin.source);
+    let skill_count = count_plugin_skills(plugin, &marketplace_path);
+    results.push(PluginInfo {
+        name: plugin.name.clone(),
+        description: plugin.description.clone(),
+        skill_count: saturate_to_u32(skill_count, "skill_count"),
+        source_type,
+    });
+}
+
+// After:
+for plugin in &plugin_entries {
+    let source_type = plugin_source_type(&plugin.source);
+    results.push(PluginInfo {
+        name: plugin.name.clone(),
+        description: plugin.description.clone(),
+        skill_count: svc.count_skills_for_plugin(plugin, &marketplace_path),
+        source_type,
+    });
+}
+```
+
+- [ ] **Step 3.3: Delete the local `count_plugin_skills` function**
+
+In the same file, delete the entire `count_plugin_skills` function (roughly lines 435–462 — the doc comment block starting `/// Count skills within a plugin entry...` through the closing `}` of the function). Do **not** delete `load_plugin_manifest` or `discover_skills_for_plugin` (both still used by `install_skills` at lines 227/229).
+
+- [ ] **Step 3.4: Run the Rust side to confirm it compiles**
+
+Run: `cargo check -p kiro-control-center 2>&1 | tail -20`
+Expected: builds clean. If clippy complains about unused imports (e.g. `saturate_to_u32` if no longer used in the file), remove them. Verify by re-running `cargo check`.
+
+- [ ] **Step 3.5: Regenerate specta bindings**
+
+Run: `cargo test -p kiro-control-center --lib -- --ignored 2>&1 | tail -15`
+Expected: runs the bindings-regeneration test and updates `crates/kiro-control-center/src/lib/bindings.ts`.
+
+Verify the `SkillCount` type appears in the regenerated bindings:
+
+Run: `grep -n "export type SkillCount" crates/kiro-control-center/src/lib/bindings.ts`
+Expected output (path and exact text may vary slightly with specta version):
+```
+export type SkillCount = { state: "known"; count: number } | { state: "remote_not_counted" } | { state: "manifest_failed"; reason: SkippedReason };
+```
+
+And verify `PluginInfo.skill_count` now references `SkillCount`:
+
+Run: `grep -nA 4 "export type PluginInfo" crates/kiro-control-center/src/lib/bindings.ts`
+Expected: the `skill_count` field is typed `SkillCount`, not `number`.
+
+If the bindings regenerated but the `SkillCount` export is missing, add a specta re-export in the Tauri crate's `lib.rs`. Open `crates/kiro-control-center/src-tauri/src/lib.rs` and search for the existing `collect_types!` / `Builder::new().commands(...)` call. If `SkippedReason` is listed as an exported type there, add `SkillCount` alongside it. If the file re-exports types implicitly via the struct fields (the common specta pattern), no change is needed — the struct-field reference already triggered the export.
+
+- [ ] **Step 3.6: Write the Layer 3 integration test**
+
+In `crates/kiro-control-center/src-tauri/src/commands/browse.rs`, at the end of the `#[cfg(test)] mod tests` block (line 564 or so), add a test that exercises the batch `list_plugins` path end-to-end. Look for the nearest existing `list_plugins` integration test to match its style; if no such test exists, add this one as the first:
+
+```rust
+    #[tokio::test]
+    async fn list_plugins_surfaces_three_skill_count_states() {
+        use kiro_market_core::marketplace::{PluginEntry, PluginSource, StructuredSource};
+        use kiro_market_core::validation::RelativePath;
+        use std::fs;
+        use tempfile::tempdir;
+
+        // Integration-test harness setup mirrors other tests in this module.
+        // If a richer helper exists (e.g. `with_marketplace`), prefer that
+        // and adapt the body accordingly. Pattern below uses direct writes
+        // to a tempdir cache.
+        let cache_dir = tempdir().expect("tempdir");
+        // Instead of spinning up the full Tauri test harness (heavy), call
+        // the core method directly against a service configured to use
+        // this cache — matching the existing integration-test pattern in
+        // this file. If no such pattern exists yet, make this a unit test
+        // on the core crate instead and delete this integration case.
+        // (Implementation note: add the full setup wiring matching nearest
+        // existing test harness; do NOT cargo-cult from this template.)
+        //
+        // Three plugins:
+        //   - "local-ok" with 2 skills → Known { count: 2 }
+        //   - "local-broken" with malformed plugin.json → ManifestFailed
+        //   - "remote" with GitHub source → RemoteNotCounted
+        //
+        // After invoking `list_plugins(marketplace)`, assert each variant
+        // appears in the returned Vec<PluginInfo>.
+
+        // Gap: this test is a placeholder skeleton because the Tauri-crate
+        // test harness pattern for `list_plugins` doesn't yet exist in
+        // this file (the Tauri command wraps `MarketplaceService` whose
+        // tests are in the core crate). If implementation reveals there
+        // IS a pattern to follow, fill this in. If there isn't, delete
+        // this test and rely on the Task 2 core-crate tests plus a brief
+        // manual smoke test via `cargo tauri dev` + the Browse tab.
+        //
+        // Either outcome is acceptable — the core coverage from Task 2
+        // is the authoritative pin for the behavior.
+        let _ = cache_dir;
+    }
+```
+
+**Important:** If upon writing this test you find the Tauri crate already has a `list_plugins` test harness (e.g., one that constructs `MarketplaceService` with a fake cache and calls `list_plugins(mp_name).await`), delete the placeholder and follow that pattern to make the three-plugin assertion real. If it doesn't, delete the placeholder and document in the commit message that Layer 3 coverage deferred to manual smoke-test (the spec explicitly permits this fallback).
+
+- [ ] **Step 3.7: Decide integration-test fate and run the test suite**
+
+Run: `cargo test -p kiro-control-center 2>&1 | tail -15`
+Expected: if the real integration test was written in Step 3.6, it passes. If the placeholder remained and was deleted per the "Important" note, nothing new runs but nothing breaks either.
+
+- [ ] **Step 3.8: Run clippy on the Tauri crate**
+
+Run: `cargo clippy -p kiro-control-center --tests -- -D warnings 2>&1 | tail -10`
+Expected: no warnings or errors. If `saturate_to_u32` is now unused in the file, confirm its import / definition was cleaned up in Step 3.4.
+
+- [ ] **Step 3.9: Run TypeScript check**
+
+Run: `cd crates/kiro-control-center && npm run check 2>&1 | tail -20; cd -`
+Expected: `svelte-check` currently fails on `BrowseTab.svelte` because the `skill_count` field is now a `SkillCount` object but the template still renders it as a number. That's the expected state heading into Task 4. Note the failure but do not fix it yet.
+
+- [ ] **Step 3.10: Commit**
+
+```bash
+git add crates/kiro-control-center/src-tauri/src/commands/browse.rs crates/kiro-control-center/src/lib/bindings.ts
+# Add lib.rs too ONLY if Step 3.5 required a re-export edit:
+# git add crates/kiro-control-center/src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(tauri): wire PluginInfo.skill_count to core SkillCount
+
+PluginInfo.skill_count changes from u32 to SkillCount, list_plugins
+now calls MarketplaceService::count_skills_for_plugin, and the
+Tauri-local count_plugin_skills helper is deleted. bindings.ts
+regenerated. load_plugin_manifest / discover_skills_for_plugin stay
+(still called by install_skills; removal is #33's scope).
+
+Frontend rendering is intentionally broken at this commit — fixed in
+the next commit. Part of #32.
+EOF
+)"
+```
+
+---
+
+## Task 4: Svelte `BrowseTab.svelte` rendering update
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` — add three helpers at the top of `<script>` block, update the rendering span at line 704.
+
+- [ ] **Step 4.1: Import `SkillCount` from bindings**
+
+Open `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`. Find the existing import from `'$lib/bindings'` (around line 7–10). It currently includes `SkippedSkill`. Add `SkillCount` and `SkippedReason`:
+
+```typescript
+// Before (approx.):
+import {
+  commands,
+  SkippedSkill,
+  // ... other imports ...
+} from '$lib/bindings';
+
+// After:
+import {
+  commands,
+  SkippedSkill,
+  SkippedReason,
+  SkillCount,
+  // ... other imports ...
+} from '$lib/bindings';
+```
+
+(If `SkippedReason` is already imported, just add `SkillCount`. Confirm by reading lines 1–30 of the file before editing.)
+
+- [ ] **Step 4.2: Add `formatSkippedReason` helper**
+
+Still in the `<script>` block, find the existing `formatSkippedSkill` helper (around line 19). Immediately before it, add:
+
+```typescript
+  // Render a structured SkippedReason as a one-line string. Total over
+  // all eight variants (not just the six reachable via SkillCount) —
+  // TypeScript's exhaustiveness check forces full coverage since
+  // SkippedReason is used in multiple contexts.
+  function formatSkippedReason(r: SkippedReason): string {
+    switch (r.kind) {
+      case "directory_missing":
+        return `plugin directory not found: ${r.path}`;
+      case "not_a_directory":
+        return `plugin path is not a directory: ${r.path}`;
+      case "symlink_refused":
+        return `plugin path is a symlink (refused): ${r.path}`;
+      case "directory_unreadable":
+        return `could not read plugin directory: ${r.reason}`;
+      case "invalid_manifest":
+        return `plugin.json is malformed: ${r.reason}`;
+      case "manifest_read_failed":
+        return `could not read plugin.json: ${r.reason}`;
+      case "remote_source_not_local":
+        return `plugin source is remote: ${r.plugin}`;
+      case "no_skills":
+        return `plugin declares no skills: ${r.path}`;
+    }
+  }
+```
+
+- [ ] **Step 4.3: Add `skillCountLabel` and `skillCountTitle` helpers**
+
+Immediately after `formatSkippedReason`, add:
+
+```typescript
+  function skillCountLabel(sc: SkillCount): string {
+    switch (sc.state) {
+      case "known": return String(sc.count);
+      case "remote_not_counted": return "–";
+      case "manifest_failed": return "!";
+    }
+  }
+
+  function skillCountTitle(sc: SkillCount): string | undefined {
+    switch (sc.state) {
+      case "known":
+        return undefined;
+      case "remote_not_counted":
+        return "Remote plugin — skills cannot be counted without cloning";
+      case "manifest_failed":
+        return `plugin.json failed to load: ${formatSkippedReason(sc.reason)}`;
+    }
+  }
+```
+
+- [ ] **Step 4.4: Update the rendering span**
+
+Find line 704 (`<span class="text-[11px] text-kiro-subtle">{ap.plugin.skill_count}</span>`). Replace it with:
+
+```svelte
+                  <span
+                    class="text-[11px] {ap.plugin.skill_count.state === 'manifest_failed' ? 'text-kiro-warning' : 'text-kiro-subtle'}"
+                    title={skillCountTitle(ap.plugin.skill_count)}
+                  >{skillCountLabel(ap.plugin.skill_count)}</span>
+```
+
+Preserve the surrounding `<label>` structure exactly. The class string is a Svelte class directive — the template syntax above is valid Svelte 5.
+
+- [ ] **Step 4.5: Verify `text-kiro-warning` token exists; substitute if not**
+
+Run: `grep -rn "kiro-warning" crates/kiro-control-center/src/ crates/kiro-control-center/tailwind.config.* 2>/dev/null | head -5`
+
+- If matches are found (token exists), no change needed.
+- If no matches are found, the token is undefined. Grep for how `MarketplaceInfo.load_error` is rendered and reuse its color class:
+
+  Run: `grep -n "load_error" crates/kiro-control-center/src/lib/components/BrowseTab.svelte`
+
+  Look at the `class=` on the span rendering the warning badge for marketplace load errors; use the same token (commonly `text-yellow-500` or `text-kiro-accent-400` depending on the project's theme). Replace `text-kiro-warning` in Step 4.4's span with that token.
+
+- [ ] **Step 4.6: Run `npm run check`**
+
+Run: `cd crates/kiro-control-center && npm run check 2>&1 | tail -25; cd -`
+Expected: zero errors. The exhaustive switches over `SkillCount.state` and `SkippedReason.kind` confirm all variants are handled.
+
+- [ ] **Step 4.7: Smoke-test in a browser**
+
+Per CLAUDE.md's UI-testing rule, verify the feature in a browser before marking this task complete.
+
+Run: `cd crates/kiro-control-center && npm run tauri dev 2>&1 &`
+(Wait ~30 seconds for Tauri to spin up.)
+
+Manual check in the app window:
+- Open the Browse tab.
+- Verify the plugin sidebar: local plugins with skills show numeric counts, remote plugins show `"–"`, and any plugin with a deliberately-malformed `plugin.json` in your cache shows `"!"` with a tooltip on hover.
+- To force a `ManifestFailed` row without doctoring real state, you can temporarily point a marketplace at a directory containing a plugin whose `plugin.json` is malformed — or skip this step if you don't have such a marketplace handy and rely on the automated tests.
+
+Stop the dev server (`kill %1` or Ctrl-C).
+
+If the three states render correctly (or cannot be tested live without significant fixture construction — common), note that explicitly in the commit message rather than claiming full UI verification.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+git commit -m "$(cat <<'EOF'
+feat(browse): render SkillCount three-way state in sidebar
+
+Plugin sidebar now renders a number for Known, em-dash for
+RemoteNotCounted, and `!` with a tooltip for ManifestFailed. Adds
+formatSkippedReason, skillCountLabel, and skillCountTitle helpers.
+TypeScript exhaustiveness checks pin all SkillCount / SkippedReason
+variants.
+
+Part of #32.
+EOF
+)"
+```
+
+---
+
+## Task 5: Workspace-wide pre-commit verification
+
+**Files:** no edits expected unless formatter or linter surfaces an issue.
+
+- [ ] **Step 5.1: Run `cargo fmt` check**
+
+Run: `cargo fmt --all --check 2>&1 | tail -10`
+Expected: no output, exit 0. If formatting issues surface:
+- Run `cargo fmt --all` to fix.
+- `git add` the changed files.
+- `git commit -m "chore: cargo fmt"`.
+
+- [ ] **Step 5.2: Run full workspace test suite**
+
+Run: `cargo test --workspace 2>&1 | tail -15`
+Expected: all tests pass. No regressions anywhere.
+
+- [ ] **Step 5.3: Run full workspace clippy**
+
+Run: `cargo clippy --workspace --tests -- -D warnings 2>&1 | tail -15`
+Expected: no warnings or errors.
+
+- [ ] **Step 5.4: Run TypeScript check one more time**
+
+Run: `cd crates/kiro-control-center && npm run check 2>&1 | tail -10; cd -`
+Expected: zero errors.
+
+- [ ] **Step 5.5: Confirm no new `#[allow(...)]` directives were introduced**
+
+Run: `git diff main -- 'crates/**/*.rs' | grep -E '^\+.*#\[allow\(' || echo "clean"`
+Expected output: `clean` (no new `#[allow]` added per CLAUDE.md zero-tolerance rule).
+
+If any `#[allow]` snuck in, revisit the code and fix the underlying issue rather than suppressing.
+
+- [ ] **Step 5.6: Review diff for spec coverage**
+
+Run: `git log --oneline main..HEAD`
+Expected: four feature commits (Task 1–4) plus optionally one `chore: cargo fmt` commit if Step 5.1 surfaced formatting.
+
+Scan the diff:
+- `git diff main -- crates/kiro-market-core/src/service/browse.rs` — confirm `SkillCount` enum + `count_skills_for_plugin` method + two helpers + 8 tests.
+- `git diff main -- crates/kiro-control-center/src-tauri/src/commands/browse.rs` — confirm `PluginInfo.skill_count` changed, `list_plugins` updated, `count_plugin_skills` deleted.
+- `git diff main -- crates/kiro-control-center/src/lib/bindings.ts` — confirm `SkillCount` and updated `PluginInfo` present.
+- `git diff main -- crates/kiro-control-center/src/lib/components/BrowseTab.svelte` — confirm three helpers added and rendering updated.
+
+---
+
+## Acceptance criteria (from spec)
+
+Tick these off after Task 5 passes. Re-run verification if any fails.
+
+- [ ] `MarketplaceService::count_skills_for_plugin(&PluginEntry, &Path) -> SkillCount` added in `kiro-market-core::service::browse` with doc comment, `#[must_use]`, three-outcome contract.
+- [ ] Plugin-directory hardening pre-check performed (via delegation to `resolve_local_plugin_dir`; spec note: no new `check_plugin_dir` helper needed — `resolve_local_plugin_dir` covers all four failure variants).
+- [ ] `SkillCount` enum added as `Serialize + specta::Type` (feature-gated) with `#[serde(tag = "state", rename_all = "snake_case")]` and `#[non_exhaustive]`.
+- [ ] `PluginInfo.skill_count` changes from `u32` to `SkillCount`. `bindings.ts` regenerated.
+- [ ] `list_plugins` Tauri handler calls the core method; Tauri-local `count_plugin_skills` deleted. `load_plugin_manifest` / `discover_skills_for_plugin` left in place (still used by `install_skills`; #33 scope).
+- [ ] Svelte `BrowseTab.svelte` renders three states: number for `Known`, `"–"` for `RemoteNotCounted`, `"!"` with warning color + tooltip for `ManifestFailed`.
+- [ ] Unit tests cover Layer 1 table from spec. Wire-format pins added. Layer 3 integration test added or explicitly deferred per Task 3.
+- [ ] `cargo test --workspace`, `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --all --check`, `npm run check` all pass.
+- [ ] No new `#[allow(...)]` directives (CLAUDE.md zero-tolerance).
+
+---
+
+## Notes for the implementing engineer
+
+1. **The spec is the contract; this plan is the how.** If a task step contradicts the spec, the spec wins. Raise the discrepancy in a PR comment.
+
+2. **Do not skip the "run and watch it fail" steps.** They confirm the test is actually exercising the code under test and not passing trivially (e.g. through a typo that matches a constant).
+
+3. **Commit at the end of each task, not each step.** The task boundaries are designed so each commit leaves the workspace in a reasonable state (tests pass for completed tasks; TypeScript may transiently fail between Task 3 and Task 4 — that's acceptable and flagged in the Task 3 commit message).
+
+4. **When a step says "Expected output" and the actual output differs,** investigate before proceeding. Silent skips here compound.
+
+5. **The `resolve_local_plugin_dir` delegation is the spec-to-plan refinement.** If you find it doesn't cover a spec-listed failure variant, stop and raise it rather than adding a new helper — the five existing tests on `resolve_local_plugin_dir` are your safety net.
+
+6. **Remote-source short-circuit must come before `resolve_local_plugin_dir`.** Otherwise the remote case returns `ManifestFailed { reason: RemoteSourceNotLocal }` instead of the `RemoteNotCounted` variant the frontend wants — a subtle but user-visible miscategorization.

--- a/docs/superpowers/specs/2026-04-21-count-plugin-skills-silent-zero-design.md
+++ b/docs/superpowers/specs/2026-04-21-count-plugin-skills-silent-zero-design.md
@@ -1,0 +1,484 @@
+# Design: `count_plugin_skills` silent-zero fix (#32)
+
+**Date:** 2026-04-21
+**Issue:** [#32 — count_plugin_skills returns silent 0 when plugin.json fails to load](https://github.com/dwalleck/kiro-control-center/issues/32)
+**Branch:** `fix/count-plugin-skills-silent-zero`
+**Follow-ups unblocked:** #33 (dedup Tauri-local `load_plugin_manifest`)
+
+---
+
+## Problem
+
+`count_plugin_skills` at `crates/kiro-control-center/src-tauri/src/commands/browse.rs:442` returns `0` in two distinct cases that the UI cannot distinguish:
+
+1. **Remote plugin** — `PluginSource::Structured(_)`. Skills are not locally countable without cloning.
+2. **Local plugin, manifest load failed** — `load_plugin_manifest` returned `Err`. Currently swallowed by a `warn!` log and `return 0`.
+
+A plugin with a legitimately zero skill count renders the same way in the filter sidebar as a plugin whose `plugin.json` is malformed, which is the same antipattern #30 fixed across `list_skills_for_plugin` / `list_all_skills` / `install_skills` (silent drops replaced by structured `SkippedPlugin` / `SkippedReason` projections).
+
+---
+
+## Approved design decisions (from brainstorm)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Where does the function live? | **Move to core.** New method `MarketplaceService::count_skills_for_plugin` in `kiro-market-core::service::browse`. Tauri's `list_plugins` calls it. |
+| 2 | Error payload type for `ManifestFailed`? | **Reuse `SkippedReason`** with an inline doc comment naming the unreachable variants (`NoSkills`, `RemoteSourceNotLocal`). One projection function (`SkippedReason::from_plugin_error`) stays the single source of truth. |
+| 3 | How does `PluginInfo` carry the new shape? | **In-place type change** — `skill_count: u32` becomes `skill_count: SkillCount`. Same field name, new type. |
+| 4 | Service method signature? | **Entry-plus-path** — `count_skills_for_plugin(&self, plugin: &PluginEntry, marketplace_path: &Path) -> SkillCount`. Plain return (no `Result`). Avoids N² registry parsing in the batch caller. |
+| 5 | Svelte rendering? | **Minimal text labels** — `Known` → number, `RemoteNotCounted` → `"–"`, `ManifestFailed` → `"!"` in a warning color with a `title` tooltip containing the `SkippedReason` detail. Plugin name unchanged across all states. |
+
+---
+
+## Rust core
+
+### New type: `SkillCount`
+
+Location: `crates/kiro-market-core/src/service/browse.rs`, co-located with `SkippedReason`.
+
+```rust
+/// Result of counting skills for a single plugin in a marketplace listing.
+/// Distinguishes the three cases the frontend must render differently:
+/// a known count, a remote plugin (not locally countable), and a local
+/// plugin whose manifest could not be loaded. Replaces the prior
+/// `usize` that collapsed failures into a silent 0.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "state", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkillCount {
+    /// The plugin directory was readable; `count` is the number of
+    /// discovered skill directories (including the legitimate zero case).
+    Known { count: u32 },
+
+    /// Plugin source is remote (GitHub / git URL). Skills cannot be
+    /// enumerated without cloning, which the listing path never does.
+    /// Distinct from `ManifestFailed { reason: RemoteSourceNotLocal }`
+    /// (which is reachable from the bulk-listing path when a plugin
+    /// that should have been local resolves remote) — here we know
+    /// the plugin is remote by construction and never attempt the load.
+    RemoteNotCounted,
+
+    /// The plugin is local but something about its directory or
+    /// manifest prevented a skill count.
+    ///
+    /// `SkippedReason` is reused as the error payload to share the #30
+    /// projection `SkippedReason::from_plugin_error`. Six of its
+    /// variants are reachable from this path:
+    ///
+    /// From the pre-`load_plugin_manifest` plugin-directory check:
+    /// - `DirectoryMissing` — `plugin_dir` does not exist.
+    /// - `NotADirectory` — `plugin_dir` exists but is a file or other
+    ///   non-directory node.
+    /// - `SymlinkRefused` — `plugin_dir` is a symlink; refused for the
+    ///   same reason `list_all_skills` refuses them (untrusted
+    ///   clone path could redirect at arbitrary host files).
+    /// - `DirectoryUnreadable` — stat'ing `plugin_dir` failed for any
+    ///   other reason (permission denied, transient I/O, etc.).
+    ///
+    /// From `load_plugin_manifest` (`plugin.json`-specific):
+    /// - `InvalidManifest` — `plugin.json` exists but is malformed.
+    /// - `ManifestReadFailed` — `plugin.json` exists and was stat'd
+    ///   successfully but the subsequent read failed.
+    ///
+    /// `NoSkills` is not produced anywhere in this path;
+    /// `RemoteSourceNotLocal` is pre-empted by `RemoteNotCounted`.
+    /// Frontends typed against `SkippedReason` will not get
+    /// compile-time narrowing for those two — accepted because
+    /// consolidating the projection is more valuable than a narrower
+    /// wire type.
+    ManifestFailed { reason: SkippedReason },
+}
+```
+
+### New method: `MarketplaceService::count_skills_for_plugin`
+
+Location: same `impl MarketplaceService` block as `list_skills_for_plugin` in `service/browse.rs` (so the existing private `load_plugin_manifest` and `discover_skills_for_plugin` are in scope without visibility changes).
+
+```rust
+/// Count skills for a single plugin entry without loading skill bodies.
+///
+/// Returns `SkillCount::RemoteNotCounted` for remote sources,
+/// `SkillCount::ManifestFailed` if the plugin directory or its
+/// `plugin.json` cannot be read or parsed, and `SkillCount::Known { count }`
+/// otherwise (including the legitimate zero case where the manifest is
+/// absent or declares no skills).
+///
+/// Takes the pre-resolved `PluginEntry` and `marketplace_path` so the
+/// batch caller in `list_plugins` pays for the registry parse once per
+/// marketplace rather than once per plugin. Errors are never propagated
+/// as `Err` — every outcome fits the three-way union.
+#[must_use]
+pub fn count_skills_for_plugin(
+    &self,
+    plugin: &PluginEntry,
+    marketplace_path: &Path,
+) -> SkillCount {
+    match &plugin.source {
+        PluginSource::Structured(_) => SkillCount::RemoteNotCounted,
+        PluginSource::RelativePath(rel) => {
+            let plugin_dir = marketplace_path.join(rel);
+
+            // Plugin-directory pre-check. Mirrors the hardening
+            // `list_all_skills` already applies: missing /
+            // non-directory / symlinked / unreadable `plugin_dir`
+            // all surface structurally rather than silently
+            // collapsing into a zero-skill count. Without this,
+            // `load_plugin_manifest` would see NotFound when
+            // stat'ing `plugin_dir/plugin.json` inside a missing
+            // parent and return `Ok(None)` — preserving the silent-0
+            // bug one level up from the one #32 names directly.
+            match check_plugin_dir(&plugin_dir) {
+                Ok(()) => {}
+                Err(reason) => {
+                    warn!(
+                        plugin = %plugin.name,
+                        path = %plugin_dir.display(),
+                        ?reason,
+                        "plugin directory check failed; reporting as ManifestFailed"
+                    );
+                    return SkillCount::ManifestFailed { reason };
+                }
+            }
+
+            match load_plugin_manifest(&plugin_dir) {
+                Ok(manifest) => {
+                    let count = discover_skills_for_plugin(
+                        &plugin_dir,
+                        manifest.as_ref(),
+                    ).len();
+                    SkillCount::Known {
+                        count: u32::try_from(count).unwrap_or(u32::MAX),
+                    }
+                }
+                Err(Error::Plugin(pe)) => {
+                    // `SkippedReason::from_plugin_error` is the single
+                    // classifier; a new plugin-level variant there
+                    // lands here automatically.
+                    let reason = SkippedReason::from_plugin_error(&pe)
+                        .unwrap_or_else(|| {
+                            // `PluginError::NotFound` / `ManifestNotFound`
+                            // — the classifier deliberately returns None
+                            // ("caller asked for the wrong thing"). Not
+                            // reachable from `load_plugin_manifest`
+                            // today; defensive fallback logs and folds
+                            // into ManifestReadFailed so a future
+                            // producer cannot regress to a silent 0.
+                            warn!(
+                                plugin = %plugin.name,
+                                error = ?pe,
+                                "unclassified PluginError in count path"
+                            );
+                            SkippedReason::ManifestReadFailed {
+                                path: plugin_dir.join("plugin.json"),
+                                reason: pe.to_string(),
+                            }
+                        });
+                    warn!(
+                        plugin = %plugin.name,
+                        path = %plugin_dir.display(),
+                        ?reason,
+                        "plugin.json load failed; reporting as ManifestFailed"
+                    );
+                    SkillCount::ManifestFailed { reason }
+                }
+                Err(other) => {
+                    // `load_plugin_manifest` only returns `Error::Plugin`
+                    // today, but `Error` is `#[non_exhaustive]` —
+                    // defensive fallthrough so a new top-level variant
+                    // doesn't silently vanish here either.
+                    warn!(
+                        plugin = %plugin.name,
+                        error = %error_full_chain(&other),
+                        "unexpected non-plugin error in count path"
+                    );
+                    SkillCount::ManifestFailed {
+                        reason: SkippedReason::ManifestReadFailed {
+                            path: plugin_dir.join("plugin.json"),
+                            reason: error_full_chain(&other),
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**Notes:**
+- `u32::try_from(count).unwrap_or(u32::MAX)` replaces the current `saturate_to_u32` helper at the Tauri boundary. Saturation now lives in core since `SkillCount` is a core type.
+- Both defensive `warn!` branches log but never panic or return `Err` — the contract is "every outcome fits the three-way union."
+- `warn!` logging is preserved at the core level, matching the existing pattern in `load_plugin_manifest` itself.
+
+### New helper: `check_plugin_dir`
+
+Co-located with `count_skills_for_plugin` in `service/browse.rs`. Private to the module.
+
+```rust
+/// Validate a plugin directory before attempting manifest load.
+/// Returns `Ok(())` for a real, readable, non-symlinked directory;
+/// returns a `SkippedReason` describing the failure mode otherwise.
+///
+/// Mirrors the plugin-directory hardening in `collect_skills_for_plugin_into`
+/// (bulk listing path). Kept as a separate helper so the pre-check is one
+/// call and the reasoning is visible at the `count_skills_for_plugin` site.
+fn check_plugin_dir(plugin_dir: &Path) -> Result<(), SkippedReason> {
+    match fs::symlink_metadata(plugin_dir) {
+        Ok(m) if m.file_type().is_symlink() => {
+            Err(SkippedReason::SymlinkRefused {
+                path: plugin_dir.to_path_buf(),
+            })
+        }
+        Ok(m) if !m.is_dir() => {
+            Err(SkippedReason::NotADirectory {
+                path: plugin_dir.to_path_buf(),
+            })
+        }
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(SkippedReason::DirectoryMissing {
+                path: plugin_dir.to_path_buf(),
+            })
+        }
+        Err(e) => Err(SkippedReason::DirectoryUnreadable {
+            path: plugin_dir.to_path_buf(),
+            reason: e.to_string(),
+        }),
+    }
+}
+```
+
+**Alignment with bulk path:** `collect_skills_for_plugin_into` in the bulk listing path performs a similar plugin-directory check today (producing the same `SkippedReason` variants). Implementation step 1 verifies whether the bulk-path check is cleanly extractable into a shared `check_plugin_dir` helper usable from both sites; if so, do that and remove the duplication. If the bulk-path check carries extra logic around the stat (e.g., interleaved with manifest-load work) that makes extraction awkward, keep `check_plugin_dir` local to `count_skills_for_plugin` and file a follow-up issue to dedup later. Either outcome is acceptable for this PR.
+
+---
+
+## FFI boundary (Tauri)
+
+### `PluginInfo` field type change
+
+`crates/kiro-control-center/src-tauri/src/commands/browse.rs`:
+
+```rust
+pub struct PluginInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub skill_count: SkillCount,          // was: u32
+    pub source_type: SourceType,
+}
+```
+
+Re-export `SkillCount` (and confirm `SkippedReason` re-export) from the Tauri crate so specta picks them up for `bindings.ts`. `SkippedReason` already crosses the FFI via `SkippedPlugin` (#30), so the re-export plumbing exists.
+
+### `list_plugins` call site (line ~136) simplifies
+
+```rust
+// Before:
+let skill_count = count_plugin_skills(plugin, &marketplace_path);
+results.push(PluginInfo {
+    name: plugin.name.clone(),
+    description: plugin.description.clone(),
+    skill_count: saturate_to_u32(skill_count, "skill_count"),
+    source_type,
+});
+
+// After:
+results.push(PluginInfo {
+    name: plugin.name.clone(),
+    description: plugin.description.clone(),
+    skill_count: svc.count_skills_for_plugin(plugin, &marketplace_path),
+    source_type,
+});
+```
+
+### Deletions in `src-tauri/src/commands/browse.rs`
+
+- `fn count_plugin_skills` (lines 442–462) — fully replaced by the core method.
+- The `saturate_to_u32` call site for `skill_count` — saturation moves into core.
+
+### What stays behind for #33
+
+Both Tauri-local helpers **stay in place after this PR** because the `install_skills` Tauri command at `browse.rs:200` still calls them:
+
+- `load_plugin_manifest` (line 357) — called by `install_skills` at line 227. Last non-`count_plugin_skills` caller, stays.
+- `discover_skills_for_plugin` (line 334) — called by `install_skills` at line 229. Last non-`count_plugin_skills` caller, stays.
+
+This confirms the #32→#33 sequencing in the original issue: #33's work is replacing the `install_skills` call sites with core calls (likely by moving the `install_skills` manifest-load preamble into the core service, or by exposing the core `load_plugin_manifest` / `discover_skills_for_plugin` publicly for direct call-through). Out of scope here.
+
+### `bindings.ts` regeneration
+
+```bash
+cargo test -p kiro-control-center --lib -- --ignored
+```
+
+Produces (specta-generated):
+
+```typescript
+export type SkillCount =
+  | { state: "known"; count: number }
+  | { state: "remote_not_counted" }
+  | { state: "manifest_failed"; reason: SkippedReason };
+
+export type PluginInfo = {
+    name: string;
+    description: string | null;
+    skill_count: SkillCount;
+    source_type: SourceType;
+};
+```
+
+---
+
+## Frontend (Svelte)
+
+Current rendering at `crates/kiro-control-center/src/lib/components/BrowseTab.svelte:704`:
+
+```svelte
+<span class="text-[11px] text-kiro-subtle">{ap.plugin.skill_count}</span>
+```
+
+### Replacement
+
+Helpers in the `<script>` block:
+
+```typescript
+function skillCountLabel(sc: SkillCount): string {
+  switch (sc.state) {
+    case "known": return String(sc.count);
+    case "remote_not_counted": return "–";
+    case "manifest_failed": return "!";
+  }
+}
+
+function skillCountTitle(sc: SkillCount): string | undefined {
+  switch (sc.state) {
+    case "known":
+      return undefined;
+    case "remote_not_counted":
+      return "Remote plugin — skills cannot be counted without cloning";
+    case "manifest_failed":
+      return `plugin.json failed to load: ${formatSkippedReason(sc.reason)}`;
+  }
+}
+```
+
+Template:
+
+```svelte
+<span
+  class="text-[11px] {ap.plugin.skill_count.state === 'manifest_failed' ? 'text-kiro-warning' : 'text-kiro-subtle'}"
+  title={skillCountTitle(ap.plugin.skill_count)}
+>{skillCountLabel(ap.plugin.skill_count)}</span>
+```
+
+### Dependencies
+
+- `formatSkippedReason(r: SkippedReason): string` — **new helper**, added as part of this PR in `BrowseTab.svelte`'s `<script>` block (or a shared `$lib` module if a second consumer appears). No analog exists today: `SkippedPlugin` carries a pre-rendered `reason: String` alongside its `kind: SkippedReason` (see `service/browse.rs:72–75`), so existing banner code (`BrowseTab.svelte:358`) uses the string directly. `SkillCount::ManifestFailed` deliberately does NOT duplicate the string field — that would create two representations of the same error and encourage substring-matching at the frontend. One small formatter replaces the need. Implementation: exhaustive `switch (r.kind)` over all eight `SkippedReason` variants (not just the six reachable from the count path — the formatter takes the full type and TypeScript's exhaustiveness check forces all cases), each returning a one-line sentence (e.g., `"plugin directory not found at {path}"`, `"plugin.json is malformed: {reason}"`).
+- `text-kiro-warning` — confirm the token exists in the Tailwind config. If not, reuse whatever token `MarketplaceInfo.load_error` currently renders with (grep `BrowseTab.svelte` and the theme config). Implementation-time decision with a clear fallback.
+
+### What does NOT change
+
+- Plugin row is not greyed out / struck-through / italicized when `ManifestFailed` — the row remains clickable because the user might want a richer error surface in the detail panel. The `"!"` + tooltip is the only visual signal in the sidebar.
+
+---
+
+## Tests
+
+All Rust tests in `crates/kiro-market-core/src/service/browse.rs` alongside existing bulk-listing tests. Frontend has no snapshot / component tests in this area today; TypeScript compilation via `npm run check` verifies the `SkillCount` switch is exhaustive.
+
+### Layer 1: `count_skills_for_plugin` behavior (uses `tempfile`)
+
+| Test | Setup | Expected outcome |
+|---|---|---|
+| `count_skills_for_plugin_returns_known_for_local_plugin` | tempdir w/ `plugin.json` + 3 skill dirs | `Known { count: 3 }` |
+| `count_skills_for_plugin_returns_known_with_zero_when_no_skills` | tempdir w/ `plugin.json`, no skill dirs | `Known { count: 0 }` — distinguishes legitimate zero from failure |
+| `count_skills_for_plugin_returns_known_when_manifest_absent` | tempdir, no `plugin.json`, default skill paths populated | `Known { count: N }` — absent manifest → defaults, not a failure |
+| `count_skills_for_plugin_returns_remote_for_structured_source` | `PluginEntry { source: PluginSource::Structured(...) }` | `RemoteNotCounted` |
+| `count_skills_for_plugin_returns_manifest_failed_on_missing_plugin_dir` | `PluginEntry` points at nonexistent path | `ManifestFailed { reason: DirectoryMissing { .. } }` |
+| `count_skills_for_plugin_returns_manifest_failed_when_plugin_dir_is_a_file` | `plugin_dir` is a regular file, not a directory | `ManifestFailed { reason: NotADirectory { .. } }` |
+| `count_skills_for_plugin_returns_manifest_failed_on_symlinked_plugin_dir` | `plugin_dir` is a symlink pointing at a real dir | `ManifestFailed { reason: SymlinkRefused { .. } }` |
+| `count_skills_for_plugin_returns_manifest_failed_on_malformed_json` | tempdir w/ `plugin.json` containing `"{not json"` | `ManifestFailed { reason: InvalidManifest { .. } }` |
+
+**Not tested** (reachable in principle, but not portably testable at this layer):
+
+- **`DirectoryUnreadable`** — requires a `stat` failure that isn't `NotFound`. Producing this portably in a unit test needs platform-specific permission manipulation (e.g., `chmod 000` the parent on Unix, harder on Windows) and root-aware handling (root bypasses the permission check). The branch exists, it's covered by the `stat`-returns-Err match arm, and the `SkippedReason::from_plugin_error` classifier pins its shape. Leave unpinned here.
+- **`ManifestReadFailed`** — requires `plugin.json` to stat successfully but fail on read. Same portability issue as `DirectoryUnreadable`. Branch exists and is structurally reachable; shape is pinned by the `from_plugin_error` classifier tests in `service/browse.rs:1772+`.
+
+**Symlinked `plugin.json` specifically** — still treated as `Ok(None)` by `load_plugin_manifest` (not changed by this PR). Reaches `Known { count: N_default }` when `plugin_dir` itself is not a symlink but `plugin_dir/plugin.json` is. Add one test pinning this behavior to guard against regression:
+
+```
+count_skills_for_plugin_treats_symlinked_plugin_json_as_missing  →  Known { count: N_default }
+```
+
+### Layer 2: Serde wire-format pin
+
+Following the existing `SkippedReason::from_plugin_error` pin pattern at `service/browse.rs:1772+`:
+
+```rust
+#[test]
+fn skill_count_serde_wire_format_pins() {
+    let json = serde_json::to_value(SkillCount::Known { count: 7 }).unwrap();
+    assert_eq!(json, json!({"state": "known", "count": 7}));
+
+    let json = serde_json::to_value(SkillCount::RemoteNotCounted).unwrap();
+    assert_eq!(json, json!({"state": "remote_not_counted"}));
+
+    let sc = SkillCount::ManifestFailed {
+        reason: SkippedReason::InvalidManifest {
+            path: PathBuf::from("/tmp/plug/plugin.json"),
+            reason: "expected `}`".into(),
+        },
+    };
+    let json = serde_json::to_value(sc).unwrap();
+    assert_eq!(json["state"], "manifest_failed");
+    assert_eq!(json["reason"]["kind"], "invalid_manifest");
+}
+```
+
+Pins the tag names the frontend `switch` depends on. Breaks if someone changes `rename_all` or the tag key.
+
+### Layer 3: Tauri `list_plugins` handler integration
+
+One test in `src-tauri/src/commands/browse.rs` tests module, mirroring existing `list_plugins` test structure. Setup: a marketplace with three plugins — one local-working, one local-malformed, one remote. Assert each `PluginInfo.skill_count` variant appears in the returned list and carries the expected state.
+
+### Branches NOT tested
+
+`PluginError::NotFound` / `ManifestNotFound` → "unclassified" fallback. Two reasons:
+1. `load_plugin_manifest` does not produce these variants, so the branch is unreachable in the real code path.
+2. Testing it would require injecting a mock that returns those variants; the current API does not allow this.
+
+The defensive fallback is belt-and-suspenders for future `PluginError` variants, not a testable branch today. A comment in the code records this.
+
+---
+
+## Out of scope
+
+Explicit non-goals for this PR:
+
+1. Moving `discover_skills_for_plugin` to core as a new public API — core already has its own copy. The Tauri-local one stays because `install_skills` still uses it; that's #33's job.
+2. Deleting Tauri-local `load_plugin_manifest` — `install_skills` still calls it. #33.
+3. Changing symlink handling for `plugin.json` — preserve current `Ok(None)` + `warn!` behavior.
+4. Enriching `ManifestFailed` with the raw `PluginError` chain — `SkippedReason`'s existing `reason: String` already carries chain-preserved context from #30.
+5. UI drill-down panel for failed plugins. The sidebar gets `"!"` + tooltip; a richer detail panel is separate UX work.
+
+---
+
+## Acceptance criteria
+
+Restated from the issue with design decisions baked in:
+
+- [ ] `MarketplaceService::count_skills_for_plugin(&PluginEntry, &Path) -> SkillCount` added in `kiro-market-core::service::browse` with doc comment, `#[must_use]`, and the three-outcome contract.
+- [ ] `check_plugin_dir` helper added (module-private) performing the plugin-directory hardening pre-check (`DirectoryMissing` / `NotADirectory` / `SymlinkRefused` / `DirectoryUnreadable`). Consider factoring out of `collect_skills_for_plugin_into` if the extraction is clean; otherwise keep local and defer dedup.
+- [ ] `SkillCount` enum added as `Serialize + specta::Type` (feature-gated) with `#[serde(tag = "state", rename_all = "snake_case")]` and `#[non_exhaustive]`. Inline doc comment lists reachable and unreachable `SkippedReason` variants.
+- [ ] `PluginInfo.skill_count` changes from `u32` to `SkillCount`. `bindings.ts` regenerated.
+- [ ] `list_plugins` Tauri handler calls the core method; Tauri-local `count_plugin_skills` deleted.
+- [ ] Svelte `BrowseTab.svelte` renders the three states: number for `Known`, `"–"` for `RemoteNotCounted`, `"!"` with warning color + tooltip for `ManifestFailed`. Plugin name unchanged across states.
+- [ ] Unit tests cover the Layer 1 table above. Serde wire-format pin added. One Tauri integration test covers the batch path end-to-end.
+- [ ] `cargo test --workspace`, `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --all --check`, and `npm run check` (from `crates/kiro-control-center/`) all pass.
+- [ ] No new `#[allow(...)]` directives introduced (per CLAUDE.md zero-tolerance rule).
+
+---
+
+## Related
+
+- #30 — Phase 3 structural error/type design (landed). Established `SkippedReason` / `SkippedPlugin` + `from_plugin_error` projection pattern reused here.
+- #33 — Tauri-side `load_plugin_manifest` dedup. Unblocked by this PR.


### PR DESCRIPTION
## Summary

- Replaces `count_plugin_skills -> usize` (which collapsed remote plugins and manifest-load failures into the same `0` a legitimately empty plugin reports) with a three-way `SkillCount` discriminated union: `Known { count }` / `RemoteNotCounted` / `ManifestFailed { reason: SkippedReason }`.
- New `MarketplaceService::count_skills_for_plugin` in `kiro-market-core` reuses the existing `resolve_local_plugin_dir` for plugin-directory hardening (symlink refusal, is-dir check, NotFound/other-I/O classification), falls through to `load_plugin_manifest` for `plugin.json`-specific errors, and routes both paths through the `SkippedReason::from_plugin_error` classifier so a new `PluginError` variant forces a compile-time decision.
- Frontend sidebar now renders a number for `Known`, an en-dash for `RemoteNotCounted`, and `"!"` (with `title` + `aria-label` tooltip via `formatSkippedReason`) for `ManifestFailed` — replacing a bare `{ap.plugin.skill_count}` mustache that rendered `[object Object]` for the new type.

Closes #32. Unblocks #33 (dedup Tauri-local `load_plugin_manifest`; `install_skills` is its only remaining caller).

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-21-count-plugin-skills-silent-zero-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-count-plugin-skills-silent-zero.md`

Both artifacts committed to the branch so the design rationale (including why `resolve_local_plugin_dir` reuse was chosen over a new `check_plugin_dir` helper) is reviewable alongside the code.

## Test plan

- [x] ` cargo test --workspace` — 610+ tests passing, 0 failed (58 in `service::browse` — 46 pre-existing + 12 new for `SkillCount` and `count_skills_for_plugin`)
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `npm run check` (from `crates/kiro-control-center/`) — 0 errors, 0 warnings (TypeScript exhaustiveness pins all `SkillCount.state` and `SkippedReason.kind` variants in the Svelte helpers)
- [x] `bindings.ts` regenerated via `cargo test -p kiro-control-center --lib -- --ignored`; `SkillCount` exported, `PluginInfo.skill_count: SkillCount`
- [x] No new `#[allow(...)]` directives (per CLAUDE.md zero-tolerance rule)
- [x] No new `.unwrap()` / `.expect()` in production code (only in `#[cfg(test)] mod tests`, which are exempt)
- [x] Wire-format `reason: String` fields routed through `error_full_chain(&err)` per CLAUDE.md
- [x] 13 stale `#30` references swept across the files this PR touched (sweep covered pre-existing comments too — "we fix things as we find them")
- [ ] Manual smoke-test in `npm run tauri dev`: filter sidebar shows numeric counts, `–` for remote plugins, `!` with tooltip for a plugin with a malformed `plugin.json` (deferred to reviewer; TypeScript exhaustiveness covers the "all three states handled" invariant)

## Review trail (for reviewer context)

This PR landed via an unusually thorough review process — noted here so the commit count / amend-heavy history makes sense:

- 4 per-task code-quality reviews (one per feature commit); issues from each applied as commit amends
- 1 final cross-commit review
- 1 comprehensive `pr-review-toolkit:review-pr` pass (6 parallel reviewers); 6 findings addressed in a final amend
- 1 `code-simplifier` pass (no changes — rejected 6 candidates with specific rationale)

## Out of scope

- Deleting Tauri-local `load_plugin_manifest` / `discover_skills_for_plugin` — both still called by `install_skills` at `src-tauri/src/commands/browse.rs:227,229`. That's #33's scope; this PR unblocks it.
- UI drill-down panel for failed plugins — sidebar gets `"!"` + tooltip only.
- Changing the existing `plugin.json` symlink-refusal semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)