### PR TITLE
feat(tauri): add command test harness for unit-testing Tauri handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ Marketplace operations (add/remove/update/list) live in `kiro-market-core::servi
 CLI and Tauri handlers are thin wrappers that construct the service, call it, and format output.
 Domain logic is never duplicated between frontends.
 
+### Tauri command handlers
+Each `#[tauri::command]` splits into a thin wrapper plus a private `fn <name>_impl(svc: &MarketplaceService, ...) -> Result<T, CommandError>`. The wrapper does the globals work (`make_service()?`) and calls the `_impl`; the `_impl` is pure Rust and takes the service + primitives by reference. Tests exercise `_impl` directly using fixtures from `kiro_market_core::service::test_support` (activated via a `dev-dependencies` feature override). See `install_skills_impl` in `crates/kiro-control-center/src-tauri/src/commands/browse.rs` and its `#[cfg(test)] mod tests` for the exemplar. New commands follow this shape so their bodies are testable without a Tauri runtime.
+
 ### Git Abstraction
 Git operations are abstracted behind the `GitBackend` trait (`kiro-market-core::git`).
 `GixCliBackend` implements the trait using `gix` for clone/open and the system `git` CLI

--- a/crates/kiro-control-center/src-tauri/Cargo.toml
+++ b/crates/kiro-control-center/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+kiro-market-core = { path = "../../kiro-market-core", features = ["test-support"] }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -202,17 +202,31 @@ pub async fn install_skills(
     project_path: String,
 ) -> Result<InstallSkillsResult, CommandError> {
     let svc = make_service()?;
+    install_skills_impl(&svc, &marketplace, &plugin, &skills, force, &project_path)
+}
+
+// Separated from the `#[tauri::command]` wrapper so the body is unit-testable
+// with a test-built `MarketplaceService` — the wrapper's only extra work is
+// constructing the service from process globals.
+fn install_skills_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    skills: &[String],
+    force: bool,
+    project_path: &str,
+) -> Result<InstallSkillsResult, CommandError> {
     let ctx = svc
-        .resolve_plugin_install_context(&marketplace, &plugin)
+        .resolve_plugin_install_context(marketplace, plugin)
         .map_err(CommandError::from)?;
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    let project = KiroProject::new(PathBuf::from(project_path));
     Ok(svc.install_skills(
         &project,
         &ctx.skill_dirs,
-        &InstallFilter::Names(&skills),
+        &InstallFilter::Names(skills),
         InstallMode::from(force),
-        &marketplace,
-        &plugin,
+        marketplace,
+        plugin,
         ctx.version.as_deref(),
     ))
 }
@@ -306,8 +320,21 @@ fn plugin_source_type(source: &PluginSource) -> SourceType {
 
 #[cfg(test)]
 mod tests {
+    //! Tauri command-body tests.
+    //!
+    //! Each `#[tauri::command]` splits into a wrapper + `_impl` fn;
+    //! these tests exercise the `_impl` bodies directly using
+    //! `MarketplaceService` fixtures from
+    //! `kiro_market_core::service::test_support`. The `#[tauri::command]`
+    //! attribute itself is a thin serde shim we don't re-test here.
+
+    use std::fs;
+
     use kiro_market_core::cache::MarketplaceSource;
     use kiro_market_core::marketplace::{PluginSource, StructuredSource};
+    use kiro_market_core::service::test_support::{
+        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry, temp_service,
+    };
 
     use super::*;
 
@@ -407,5 +434,89 @@ mod tests {
     fn saturate_to_u32_clamps_values_above_u32_max() {
         assert_eq!(saturate_to_u32((u32::MAX as usize) + 1, "test"), u32::MAX);
         assert_eq!(saturate_to_u32(usize::MAX, "test"), u32::MAX);
+    }
+
+    // -----------------------------------------------------------------------
+    // install_skills_impl
+    // -----------------------------------------------------------------------
+
+    fn make_kiro_project(dir: &std::path::Path) -> String {
+        let project_path = dir.join("kproj");
+        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
+        project_path.to_str().expect("utf-8 path").to_owned()
+    }
+
+    #[test]
+    fn install_skills_impl_threads_resolved_version_into_install_result() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        fs::write(
+            marketplace_path.join("plugins/myplugin/plugin.json"),
+            br#"{"name": "myplugin", "version": "2.0.0"}"#,
+        )
+        .expect("write plugin.json");
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_skills_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            &["alpha".to_string()],
+            false,
+            &project_path,
+        )
+        .expect("install happy path");
+
+        assert_eq!(result.installed, vec!["alpha".to_string()]);
+        assert!(
+            result.failed.is_empty(),
+            "no skills should fail, got: {:?}",
+            result.failed
+        );
+        let project = KiroProject::new(std::path::PathBuf::from(&project_path));
+        let installed = project.load_installed().expect("load installed-skills");
+        let meta = installed
+            .skills
+            .get("alpha")
+            .expect("alpha should be recorded in installed-skills.json");
+        assert_eq!(meta.version.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn install_skills_impl_returns_not_found_for_unknown_plugin() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("real-plugin", "plugins/real-plugin")];
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let project_path = make_kiro_project(dir.path());
+
+        let err = install_skills_impl(&svc, "mp1", "does-not-exist", &[], false, &project_path)
+            .expect_err("unknown plugin must error");
+
+        assert_eq!(err.error_type, ErrorType::NotFound);
+    }
+
+    #[test]
+    fn install_skills_impl_returns_validation_for_remote_source() {
+        use kiro_market_core::marketplace::PluginEntry;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![PluginEntry {
+            name: "remote-plugin".into(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "owner/repo".into(),
+                git_ref: None,
+                sha: None,
+            }),
+        }];
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let project_path = make_kiro_project(dir.path());
+
+        let err = install_skills_impl(&svc, "mp1", "remote-plugin", &[], false, &project_path)
+            .expect_err("remote source must refuse local install");
+
+        assert_eq!(err.error_type, ErrorType::Validation);
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -281,7 +281,7 @@ fn load_installed_or_error(
         CommandError::new(
             format!(
                 "failed to read installed skills for project at '{project_path}': {e}. \
-                 Check that .kiro/installed.json exists and is readable."
+                 Check that .kiro/installed-skills.json exists and is readable."
             ),
             ErrorType::IoError,
         )

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -202,18 +202,26 @@ pub async fn install_skills(
     project_path: String,
 ) -> Result<InstallSkillsResult, CommandError> {
     let svc = make_service()?;
-    install_skills_impl(&svc, &marketplace, &plugin, &skills, force, &project_path)
+    install_skills_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        &skills,
+        InstallMode::from(force),
+        &project_path,
+    )
 }
 
 // Separated from the `#[tauri::command]` wrapper so the body is unit-testable
 // with a test-built `MarketplaceService` — the wrapper's only extra work is
-// constructing the service from process globals.
+// constructing the service from process globals and translating the FFI
+// `force: bool` into an `InstallMode`.
 fn install_skills_impl(
     svc: &MarketplaceService,
     marketplace: &str,
     plugin: &str,
     skills: &[String],
-    force: bool,
+    mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSkillsResult, CommandError> {
     let ctx = svc
@@ -224,7 +232,7 @@ fn install_skills_impl(
         &project,
         &ctx.skill_dirs,
         &InstallFilter::Names(skills),
-        InstallMode::from(force),
+        mode,
         marketplace,
         plugin,
         ctx.version.as_deref(),
@@ -464,7 +472,7 @@ mod tests {
             "mp1",
             "myplugin",
             &["alpha".to_string()],
-            false,
+            InstallMode::New,
             &project_path,
         )
         .expect("install happy path");
@@ -482,6 +490,115 @@ mod tests {
             .get("alpha")
             .expect("alpha should be recorded in installed-skills.json");
         assert_eq!(meta.version.as_deref(), Some("2.0.0"));
+        assert!(
+            std::path::PathBuf::from(&project_path)
+                .join(".kiro/installed-skills.json")
+                .exists(),
+            "installed-skills.json must land under the requested project_path, not an unrelated directory"
+        );
+    }
+
+    #[test]
+    fn install_skills_impl_force_mode_overwrites_existing_install() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        fs::write(
+            marketplace_path.join("plugins/myplugin/plugin.json"),
+            br#"{"name": "myplugin", "version": "1.0.0"}"#,
+        )
+        .expect("write plugin.json");
+        let project_path = make_kiro_project(dir.path());
+
+        let first = install_skills_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            &["alpha".to_string()],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect("first install");
+        assert_eq!(first.installed, vec!["alpha".to_string()]);
+
+        // Re-installing with InstallMode::New must skip, not re-install.
+        let second_safe = install_skills_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            &["alpha".to_string()],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect("second install with InstallMode::New");
+        assert!(
+            second_safe.installed.is_empty(),
+            "InstallMode::New should not re-install an existing skill, got: {:?}",
+            second_safe.installed
+        );
+
+        // InstallMode::Force must re-install.
+        let third_force = install_skills_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            &["alpha".to_string()],
+            InstallMode::Force,
+            &project_path,
+        )
+        .expect("third install with InstallMode::Force");
+        assert_eq!(
+            third_force.installed,
+            vec!["alpha".to_string()],
+            "InstallMode::Force must re-install an existing skill, got: {:?}",
+            third_force.installed
+        );
+    }
+
+    #[test]
+    fn install_skills_impl_names_filter_installs_only_requested_subset() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha", "beta"]);
+        fs::write(
+            marketplace_path.join("plugins/myplugin/plugin.json"),
+            br#"{"name": "myplugin", "version": "1.0.0"}"#,
+        )
+        .expect("write plugin.json");
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_skills_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            &["alpha".to_string()],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect("install subset");
+
+        assert_eq!(result.installed, vec!["alpha".to_string()]);
+
+        // beta was not requested — it must not appear in the result or on disk.
+        let project = KiroProject::new(std::path::PathBuf::from(&project_path));
+        let installed = project.load_installed().expect("load installed-skills");
+        assert!(
+            !installed.skills.contains_key("beta"),
+            "beta was not requested; must not appear in installed-skills.json"
+        );
+        assert!(
+            !project_path_contains_skill_dir(&project_path, "beta"),
+            "beta was not requested; must not land on disk at .kiro/skills/beta/"
+        );
+    }
+
+    fn project_path_contains_skill_dir(project_path: &str, skill: &str) -> bool {
+        std::path::PathBuf::from(project_path)
+            .join(".kiro/skills")
+            .join(skill)
+            .exists()
     }
 
     #[test]
@@ -491,8 +608,15 @@ mod tests {
         let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
         let project_path = make_kiro_project(dir.path());
 
-        let err = install_skills_impl(&svc, "mp1", "does-not-exist", &[], false, &project_path)
-            .expect_err("unknown plugin must error");
+        let err = install_skills_impl(
+            &svc,
+            "mp1",
+            "does-not-exist",
+            &[],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("unknown plugin must error");
 
         assert_eq!(err.error_type, ErrorType::NotFound);
     }
@@ -514,8 +638,15 @@ mod tests {
         let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
         let project_path = make_kiro_project(dir.path());
 
-        let err = install_skills_impl(&svc, "mp1", "remote-plugin", &[], false, &project_path)
-            .expect_err("remote source must refuse local install");
+        let err = install_skills_impl(
+            &svc,
+            "mp1",
+            "remote-plugin",
+            &[],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("remote source must refuse local install");
 
         assert_eq!(err.error_type, ErrorType::Validation);
     }

--- a/crates/kiro-market-core/Cargo.toml
+++ b/crates/kiro-market-core/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 default = []
 cli = ["clap"]
 specta = ["dep:specta"]
-test-support = []
+test-support = ["dep:tempfile"]
 
 [dependencies]
 serde = { workspace = true }
@@ -36,6 +36,7 @@ specta = { version = "2.0.0-rc.24", optional = true, features = ["derive", "serd
 # the resolved feature list contains `ssl` so this regression cannot
 # return unnoticed.
 curl = { workspace = true }
+tempfile = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1007,72 +1007,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::cache::CacheDir;
-    use crate::error::GitError;
-    use crate::git::{CloneOptions, GitBackend};
     use crate::marketplace::{PluginSource, StructuredSource};
-    use crate::validation::RelativePath;
-
-    // -----------------------------------------------------------------------
-    // Test fixtures
-    // -----------------------------------------------------------------------
-
-    /// A `GitBackend` that panics on any network operation — browse-side
-    /// tests never clone, so any call means a bug in the code under test.
-    #[derive(Default)]
-    struct PanicOnNetworkBackend;
-
-    impl GitBackend for PanicOnNetworkBackend {
-        fn clone_repo(
-            &self,
-            _url: &str,
-            _dest: &Path,
-            _opts: &CloneOptions,
-        ) -> Result<(), GitError> {
-            panic!("browse-side tests must not clone");
-        }
-
-        fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
-            panic!("browse-side tests must not pull");
-        }
-
-        fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
-            Ok(())
-        }
-    }
-
-    fn temp_service() -> (tempfile::TempDir, MarketplaceService) {
-        let dir = tempdir().expect("tempdir");
-        let cache = CacheDir::with_root(dir.path().to_path_buf());
-        cache.ensure_dirs().expect("ensure_dirs");
-        let svc = MarketplaceService::new(cache, PanicOnNetworkBackend);
-        (dir, svc)
-    }
-
-    /// Build a plugin directory tree with `skills/<name>/SKILL.md` files
-    /// under `<root>/plugins/<plugin_name>/skills/`, matching the
-    /// default skill-discovery layout.
-    fn make_plugin_with_skills(root: &Path, plugin_name: &str, skill_names: &[&str]) {
-        let skills_root = root.join("plugins").join(plugin_name).join("skills");
-        fs::create_dir_all(&skills_root).expect("create skills dir");
-        for name in skill_names {
-            let dir = skills_root.join(name);
-            fs::create_dir_all(&dir).expect("create skill dir");
-            fs::write(
-                dir.join("SKILL.md"),
-                format!("---\nname: {name}\ndescription: test\n---\n"),
-            )
-            .expect("write SKILL.md");
-        }
-    }
-
-    fn relative_path_entry(name: &str, rel: &str) -> PluginEntry {
-        PluginEntry {
-            name: name.into(),
-            description: None,
-            source: PluginSource::RelativePath(RelativePath::new(rel).unwrap()),
-        }
-    }
+    use crate::service::test_support::{
+        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry, temp_service,
+    };
 
     // -----------------------------------------------------------------------
     // resolve_local_plugin_dir
@@ -1305,28 +1243,6 @@ mod tests {
     // -----------------------------------------------------------------------
     // list_all_skills (bulk public API)
     // -----------------------------------------------------------------------
-
-    /// Build a plugin-registry-backed marketplace so the bulk path can
-    /// enumerate entries without a real `marketplace.json`.
-    ///
-    /// Reconstructs a sibling `CacheDir` pointing at the same root the
-    /// service was built with — `CacheDir` is stateless, so this is a
-    /// safe end-run around the service's private cache field without
-    /// exposing it.
-    fn seed_marketplace_with_registry(
-        cache_root: &Path,
-        svc: &MarketplaceService,
-        marketplace_name: &str,
-        entries: &[PluginEntry],
-    ) -> PathBuf {
-        let marketplace_path = svc.marketplace_path(marketplace_name);
-        fs::create_dir_all(&marketplace_path).expect("create marketplace root");
-        let cache = CacheDir::with_root(cache_root.to_path_buf());
-        cache
-            .write_plugin_registry(marketplace_name, entries)
-            .expect("write plugin registry");
-        marketplace_path
-    }
 
     #[test]
     fn list_all_skills_happy_path_enumerates_across_plugins() {
@@ -2605,7 +2521,7 @@ mod tests {
     fn resolve_plugin_install_context_errors_on_plugin_not_found() {
         let (dir, svc) = temp_service();
         let entries = vec![relative_path_entry("alpha", "plugins/alpha")];
-        seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
             .resolve_plugin_install_context("mp1", "does-not-exist")
@@ -2627,7 +2543,7 @@ mod tests {
         // the directory is never created — the resolver must surface
         // DirectoryMissing rather than silently falling back to defaults.
         let entries = vec![relative_path_entry("ghost", "plugins/ghost")];
-        seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
             .resolve_plugin_install_context("mp1", "ghost")
@@ -2668,7 +2584,7 @@ mod tests {
                 sha: None,
             }),
         }];
-        seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
             .resolve_plugin_install_context("mp1", "remote-plugin")

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -5,6 +5,9 @@
 
 pub mod browse;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
 pub use browse::{
     BulkSkillsResult, PluginSkillsResult, SkillCount, SkillInfo, SkippedPlugin, SkippedReason,
     SkippedSkill, SkippedSkillReason,

--- a/crates/kiro-market-core/src/service/test_support.rs
+++ b/crates/kiro-market-core/src/service/test_support.rs
@@ -1,0 +1,125 @@
+//! Test fixtures for exercising [`MarketplaceService`] in downstream
+//! crates' unit tests.
+//!
+//! Available when the `test-support` feature is enabled or when
+//! running the crate's own tests. Downstream crates (Tauri, CLI)
+//! activate the feature via a `dev-dependencies` override on
+//! `kiro-market-core` so the fixtures land only in test builds.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::{TempDir, tempdir};
+
+use crate::cache::CacheDir;
+use crate::error::GitError;
+use crate::git::{CloneOptions, GitBackend};
+use crate::marketplace::{PluginEntry, PluginSource};
+use crate::service::MarketplaceService;
+use crate::validation::RelativePath;
+
+/// A [`GitBackend`] that panics on any network operation. Browse and
+/// listing tests never clone — reaching a network call means a bug in
+/// the code under test, not a missing fixture.
+#[derive(Default)]
+pub struct PanicOnNetworkBackend;
+
+impl GitBackend for PanicOnNetworkBackend {
+    fn clone_repo(&self, _url: &str, _dest: &Path, _opts: &CloneOptions) -> Result<(), GitError> {
+        panic!("browse-side tests must not clone");
+    }
+
+    fn pull_repo(&self, _path: &Path) -> Result<(), GitError> {
+        panic!("browse-side tests must not pull");
+    }
+
+    fn verify_sha(&self, _path: &Path, _expected: &str) -> Result<(), GitError> {
+        Ok(())
+    }
+}
+
+/// Build a [`MarketplaceService`] backed by a temporary cache directory
+/// and the panic-on-network git backend. The returned [`TempDir`] must
+/// outlive the service — drop it last.
+///
+/// # Panics
+///
+/// Panics if the temporary directory cannot be created or its cache
+/// subdirectories cannot be initialized. Test infrastructure only.
+#[must_use]
+pub fn temp_service() -> (TempDir, MarketplaceService) {
+    let dir = tempdir().expect("tempdir");
+    let cache = CacheDir::with_root(dir.path().to_path_buf());
+    cache.ensure_dirs().expect("ensure_dirs");
+    let svc = MarketplaceService::new(cache, PanicOnNetworkBackend);
+    (dir, svc)
+}
+
+/// Build a plugin directory tree with `skills/<name>/SKILL.md` files
+/// under `<root>/plugins/<plugin_name>/skills/`, matching the default
+/// skill-discovery layout. Does not write a `plugin.json` — callers
+/// that need one write it explicitly.
+///
+/// # Panics
+///
+/// Panics if any directory or file creation fails. Test infrastructure
+/// only — callers should pass a freshly created temp directory.
+pub fn make_plugin_with_skills(root: &Path, plugin_name: &str, skill_names: &[&str]) {
+    let skills_root = root.join("plugins").join(plugin_name).join("skills");
+    std::fs::create_dir_all(&skills_root).expect("create skills dir");
+    for name in skill_names {
+        let dir = skills_root.join(name);
+        std::fs::create_dir_all(&dir).expect("create skill dir");
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: test\n---\n"),
+        )
+        .expect("write SKILL.md");
+    }
+}
+
+/// Construct a [`PluginEntry`] with a [`PluginSource::RelativePath`]
+/// source. The relative path is validated through [`RelativePath::new`].
+///
+/// # Panics
+///
+/// Panics if `rel` is not a valid relative path. Callers are tests
+/// passing known-good literals.
+#[must_use]
+pub fn relative_path_entry(name: &str, rel: &str) -> PluginEntry {
+    PluginEntry {
+        name: name.into(),
+        description: None,
+        source: PluginSource::RelativePath(RelativePath::new(rel).expect("valid relative path")),
+    }
+}
+
+/// Seed a marketplace's plugin registry directly to disk, bypassing
+/// the real `marketplace.json` + fetch flow. Returns the marketplace
+/// root path as a convenience for tests that then place plugin
+/// directories under it; tests that only need the registry can bind
+/// the return to `_`.
+///
+/// Reconstructs a sibling [`CacheDir`] pointing at the same root the
+/// service was built with — [`CacheDir`] is stateless, so this is a
+/// safe end-run around the service's private cache field without
+/// exposing it.
+///
+/// # Panics
+///
+/// Panics if the marketplace directory cannot be created or the
+/// registry cannot be written. Test infrastructure only.
+#[must_use]
+pub fn seed_marketplace_with_registry(
+    cache_root: &Path,
+    svc: &MarketplaceService,
+    marketplace_name: &str,
+    entries: &[PluginEntry],
+) -> PathBuf {
+    let marketplace_path = svc.marketplace_path(marketplace_name);
+    std::fs::create_dir_all(&marketplace_path).expect("create marketplace root");
+    let cache = CacheDir::with_root(cache_root.to_path_buf());
+    cache
+        .write_plugin_registry(marketplace_name, entries)
+        .expect("write plugin registry");
+    marketplace_path
+}

--- a/crates/kiro-market-core/src/service/test_support.rs
+++ b/crates/kiro-market-core/src/service/test_support.rs
@@ -6,6 +6,21 @@
 //! activate the feature via a `dev-dependencies` override on
 //! `kiro-market-core` so the fixtures land only in test builds.
 
+// Fails the build if `test-support` is enabled in a release, non-test
+// context. Catches the specific misuse of adding
+// `kiro-market-core = { features = ["test-support"] }` under a downstream
+// crate's `[dependencies]` (not `[dev-dependencies]`), which would ship
+// `PanicOnNetworkBackend` into release binaries. `cargo test --release`
+// on downstream crates is the one false positive; those callers should
+// gate their release-test setup behind a local feature.
+#[cfg(all(feature = "test-support", not(any(test, debug_assertions))))]
+compile_error!(
+    "The `test-support` feature is for test dev-dependencies only. \
+     Enabling it from `[dependencies]` or the default feature list would ship \
+     `PanicOnNetworkBackend` into release binaries, where any browse-side \
+     git operation would panic."
+);
+
 use std::path::{Path, PathBuf};
 
 use tempfile::{TempDir, tempdir};
@@ -20,7 +35,7 @@ use crate::validation::RelativePath;
 /// A [`GitBackend`] that panics on any network operation. Browse and
 /// listing tests never clone — reaching a network call means a bug in
 /// the code under test, not a missing fixture.
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PanicOnNetworkBackend;
 
 impl GitBackend for PanicOnNetworkBackend {


### PR DESCRIPTION
## Summary

- Establishes a **walking skeleton** for unit-testing Tauri command handlers below the Playwright/UI layer. The `#[tauri::command]` attribute is a thin serde shim; testing it per-command at unit level adds no value, but the Rust body (arg threading, error mapping, service-call composition) is where real regressions live. This PR introduces the pattern: each `#[tauri::command]` splits into a thin wrapper that builds the service from process globals + a private `_impl` function that takes `&MarketplaceService` and primitives by reference.
- Extracts 5 service-layer test fixtures (`PanicOnNetworkBackend`, `temp_service`, `make_plugin_with_skills`, `relative_path_entry`, `seed_marketplace_with_registry`) from `crates/kiro-market-core/src/service/browse.rs`'s test module into a feature-gated `pub mod test_support`. The `test-support` feature was already declared (used by `test_utils` for a path-URL helper); this extends its scope. Downstream crates activate the feature via a `[dev-dependencies]` override so fixtures land only in test builds. A `compile_error!` guard fails the release build if the feature is mis-enabled in `[dependencies]`.
- Converts `install_skills` as the **first exemplar**. 5 tests pin the wrapper's threading: version → `installed-skills.json`, unknown plugin → `NotFound`, remote source → `Validation`, `InstallMode` semantics (New skips / Force overwrites), filter subset isolation (requesting skill `alpha` must not silently install skills `alpha+beta`), and `project_path` routing (result lands under the requested path, not a stray directory).
- Documents the pattern in `CLAUDE.md` so future command authors follow it by default.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — core: 531 pass, Tauri: 61 pass (+2 new, +1 strengthened over baseline)
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo build -p kiro-market-core --features test-support` — succeeds (debug)
- [x] `cargo build -p kiro-market-core --features test-support --release` — **fails with `compile_error!`** (guard correctly prevents shipping test fixtures into release binaries)
- [x] No new `.unwrap()` / `.expect()` / `let _ = ...` on `Result` / `#[allow(...)]` in production code (tests exempt)
- [x] `install_skills` Tauri signature byte-identical pre/post — `bindings.ts` regeneration not needed
- [x] Comprehensive 5-reviewer PR review (code / tests / comments / errors / type-design) addressed — all Critical and Important findings closed; deferred Minor items flagged

## Scope

### In scope

- `crates/kiro-market-core/src/service/test_support.rs` — new feature-gated fixture module
- `crates/kiro-market-core/Cargo.toml` — `tempfile` promoted from dev-deps-only to optional dep activated by `test-support`
- `crates/kiro-control-center/src-tauri/Cargo.toml` — dev-dep override enabling `test-support` for test builds only
- `crates/kiro-control-center/src-tauri/src/commands/browse.rs` — `install_skills` split into wrapper + `install_skills_impl(svc, ..., mode: InstallMode, ...)`; 5 tests
- `CLAUDE.md` — new "Tauri command handlers" subsection

### Out of scope (follow-ups)

- Converting other Tauri commands to `_impl` — done incrementally as they're touched.
- #42's CLI `load_plugin_manifest` dedup — will be the second consumer of `test_support`, validating the fixtures are reusable.
- Pre-existing silent behaviors that the harness makes easy to pin but didn't change: `skills: &[]` → success-shaped empty result (Rule 36 candidate); `project_path: ""` → silently resolves to CWD. Both pre-date this PR.
- Tauri command-level tests for browse/list/etc. handlers — one exemplar proves the pattern; bulk conversion is its own PR.

## Design notes

- **`install_skills_impl` takes `InstallMode`, not `bool`.** The wrapper does `InstallMode::from(force)` at the FFI boundary (Tauri/JS needs a primitive); the `_impl` reads declaratively as `InstallMode::New` / `InstallMode::Force`. Removes the boolean trap flagged in review.
- **Fixtures panic on I/O failure.** Test infrastructure; every public fixture carries a `# Panics` doc section. `PanicOnNetworkBackend`'s panic messages explicitly name the failure mode ("browse-side tests must not clone") so a misuse surfaces loudly.
- **`compile_error!` guard covers the specific misuse scenario** (enabling `test-support` in `[dependencies]` instead of `[dev-dependencies]`, which would ship `PanicOnNetworkBackend` into release binaries). Release builds of downstream crates with the feature now fail at compile time with a pointed message, rather than crashing at the first git operation.

Closes #43.