### PR TITLE
refactor(cli+core): dedupe CLI load_plugin_manifest via resolve_plugin_install_context_from_dir

### DIFF
--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -359,7 +359,8 @@ pub enum SkillCount {
 /// Inputs that [`MarketplaceService::install_skills`] needs for a
 /// single-plugin install, resolved from a `(marketplace, plugin)` pair.
 ///
-/// Constructed by [`MarketplaceService::resolve_plugin_install_context`].
+/// Constructed by [`MarketplaceService::resolve_plugin_install_context`]
+/// or [`MarketplaceService::resolve_plugin_install_context_from_dir`].
 /// Rust-internal only — never crosses the FFI boundary, so no `Serialize`
 /// or `specta::Type` derive. The type is `pub` so frontend handlers can
 /// hold onto the resolved inputs between the context-resolution call and
@@ -369,6 +370,12 @@ pub enum SkillCount {
 pub struct PluginInstallContext {
     pub version: Option<String>,
     pub skill_dirs: Vec<PathBuf>,
+    /// Directories to scan for agent `.md` files inside the plugin.
+    /// Derived from `plugin.json`'s `agents` field, or
+    /// [`crate::DEFAULT_AGENT_PATHS`] when the manifest is absent or
+    /// declares no agents. Consumed by
+    /// [`MarketplaceService::install_plugin_agents`].
+    pub agent_scan_paths: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -691,12 +698,38 @@ impl MarketplaceService {
                 })
             })?;
         let plugin_dir = self.resolve_local_plugin_dir(plugin_entry, &marketplace_path)?;
-        let manifest = load_plugin_manifest(&plugin_dir)?;
+        self.resolve_plugin_install_context_from_dir(&plugin_dir)
+    }
+
+    /// Build a [`PluginInstallContext`] from an already-resolved plugin
+    /// directory. Loads `plugin.json` (refusing symlinked manifests),
+    /// enumerates skill directories, and derives agent-scan paths.
+    ///
+    /// Companion to [`Self::resolve_plugin_install_context`], which
+    /// starts from a `(marketplace, plugin)` reference and drives a
+    /// local-only resolution. This variant takes the directory as input,
+    /// so callers that have already resolved `plugin_dir` by other means
+    /// — including fetch-aware CLI callers that cloned a remote source
+    /// first — can share the manifest-loading and path-discovery logic
+    /// without re-entering the registry lookup.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::Plugin`] ([`PluginError::InvalidManifest`] /
+    ///   [`PluginError::ManifestReadFailed`]) if `plugin.json` is
+    ///   present but malformed or unreadable.
+    pub fn resolve_plugin_install_context_from_dir(
+        &self,
+        plugin_dir: &Path,
+    ) -> Result<PluginInstallContext, Error> {
+        let manifest = load_plugin_manifest(plugin_dir)?;
         let version = manifest.as_ref().and_then(|m| m.version.clone());
-        let skill_dirs = discover_skills_for_plugin(&plugin_dir, manifest.as_ref());
+        let skill_dirs = discover_skills_for_plugin(plugin_dir, manifest.as_ref());
+        let agent_scan_paths = agent_scan_paths_for_plugin(manifest.as_ref());
         Ok(PluginInstallContext {
             version,
             skill_dirs,
+            agent_scan_paths,
         })
     }
 }
@@ -822,6 +855,22 @@ fn discover_skills_for_plugin(
     };
 
     discover_skill_dirs(plugin_dir, &skill_paths)
+}
+
+/// Resolve the list of agent-scan paths a plugin declares, falling
+/// back to [`crate::DEFAULT_AGENT_PATHS`] when the manifest is absent
+/// or its `agents` list is empty. Mirrors the "empty list means no
+/// custom paths, not no agents" fallback policy used by
+/// [`discover_skills_for_plugin`].
+fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
+    if let Some(m) = manifest.filter(|m| !m.agents.is_empty()) {
+        m.agents.clone()
+    } else {
+        crate::DEFAULT_AGENT_PATHS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect()
+    }
 }
 
 /// Project a `resolve_local_plugin_dir` error into a [`SkippedReason`].
@@ -2721,5 +2770,79 @@ mod tests {
             matches!(err, Error::Plugin(PluginError::RemoteSourceNotLocal { .. })),
             "expected Plugin::RemoteSourceNotLocal, got: {err:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_plugin_install_context_from_dir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_plugin_install_context_from_dir_refuses_symlinked_manifest() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, svc) = temp_service();
+        let plugin_dir = dir.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+
+        // Real manifest lives elsewhere; symlink it into plugin_dir. A
+        // hardened loader must treat the symlink as absent — following it
+        // would leak `real-plugin.json` into the plugin's identity.
+        let real_manifest = dir.path().join("real-plugin.json");
+        fs::write(&real_manifest, br#"{"name":"smuggled","version":"9.9.9"}"#)
+            .expect("write real manifest");
+        symlink(&real_manifest, plugin_dir.join("plugin.json")).expect("create symlink");
+
+        let ctx = svc
+            .resolve_plugin_install_context_from_dir(&plugin_dir)
+            .expect("symlinked manifest must be treated as absent, not error");
+        assert!(
+            ctx.version.is_none(),
+            "symlinked manifest must not leak its version, got: {:?}",
+            ctx.version
+        );
+        assert!(
+            ctx.skill_dirs.is_empty(),
+            "no skills/ tree exists, expected empty, got: {:?}",
+            ctx.skill_dirs
+        );
+    }
+
+    #[test]
+    fn resolve_plugin_install_context_from_dir_falls_back_to_default_agent_paths_when_manifest_absent()
+     {
+        let (dir, svc) = temp_service();
+        let plugin_dir = dir.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        // No plugin.json — fallback path must activate.
+
+        let ctx = svc
+            .resolve_plugin_install_context_from_dir(&plugin_dir)
+            .expect("missing manifest must yield default agent paths, not error");
+        assert_eq!(
+            ctx.agent_scan_paths,
+            crate::DEFAULT_AGENT_PATHS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<Vec<_>>(),
+            "absent manifest must fall back to DEFAULT_AGENT_PATHS"
+        );
+    }
+
+    #[test]
+    fn resolve_plugin_install_context_from_dir_uses_manifest_agents_when_declared() {
+        let (dir, svc) = temp_service();
+        let plugin_dir = dir.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name": "p", "agents": ["./custom-agents/"]}"#,
+        )
+        .expect("write plugin.json");
+
+        let ctx = svc
+            .resolve_plugin_install_context_from_dir(&plugin_dir)
+            .expect("happy path");
+        assert_eq!(ctx.agent_scan_paths, vec!["./custom-agents/".to_string()]);
     }
 }

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -702,7 +702,7 @@ impl MarketplaceService {
                 })
             })?;
         let plugin_dir = self.resolve_local_plugin_dir(plugin_entry, &marketplace_path)?;
-        self.resolve_plugin_install_context_from_dir(&plugin_dir)
+        Self::resolve_plugin_install_context_from_dir(&plugin_dir)
     }
 
     /// Build a [`PluginInstallContext`] from an already-resolved plugin
@@ -723,7 +723,6 @@ impl MarketplaceService {
     ///   [`PluginError::ManifestReadFailed`]) if `plugin.json` is
     ///   present but malformed or unreadable.
     pub fn resolve_plugin_install_context_from_dir(
-        &self,
         plugin_dir: &Path,
     ) -> Result<PluginInstallContext, Error> {
         let manifest = load_plugin_manifest(plugin_dir)?;
@@ -2787,7 +2786,7 @@ mod tests {
     fn resolve_plugin_install_context_from_dir_refuses_symlinked_manifest() {
         use std::os::unix::fs::symlink;
 
-        let (dir, svc) = temp_service();
+        let (dir, _svc) = temp_service();
         let plugin_dir = dir.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
 
@@ -2799,8 +2798,7 @@ mod tests {
             .expect("write real manifest");
         symlink(&real_manifest, plugin_dir.join("plugin.json")).expect("create symlink");
 
-        let ctx = svc
-            .resolve_plugin_install_context_from_dir(&plugin_dir)
+        let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("symlinked manifest must be treated as absent, not error");
         assert!(
             ctx.version.is_none(),
@@ -2825,12 +2823,11 @@ mod tests {
     #[test]
     fn resolve_plugin_install_context_from_dir_falls_back_to_default_agent_paths_when_manifest_absent()
      {
-        let (dir, svc) = temp_service();
+        let (dir, _svc) = temp_service();
         let plugin_dir = dir.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
 
-        let ctx = svc
-            .resolve_plugin_install_context_from_dir(&plugin_dir)
+        let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("missing manifest must yield default agent paths, not error");
         assert_eq!(
             ctx.agent_scan_paths,
@@ -2844,7 +2841,7 @@ mod tests {
 
     #[test]
     fn resolve_plugin_install_context_from_dir_uses_manifest_agents_when_declared() {
-        let (dir, svc) = temp_service();
+        let (dir, _svc) = temp_service();
         let plugin_dir = dir.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
         fs::write(
@@ -2853,8 +2850,7 @@ mod tests {
         )
         .expect("write plugin.json");
 
-        let ctx = svc
-            .resolve_plugin_install_context_from_dir(&plugin_dir)
+        let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("happy path");
         assert_eq!(ctx.agent_scan_paths, vec!["./custom-agents/".to_string()]);
         assert!(

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -356,11 +356,14 @@ pub enum SkillCount {
     ManifestFailed { reason: SkippedReason },
 }
 
-/// Inputs that [`MarketplaceService::install_skills`] needs for a
-/// single-plugin install, resolved from a `(marketplace, plugin)` pair.
+/// Inputs that [`MarketplaceService::install_skills`] and
+/// [`MarketplaceService::install_plugin_agents`] need for a single-plugin
+/// install.
 ///
 /// Constructed by [`MarketplaceService::resolve_plugin_install_context`]
-/// or [`MarketplaceService::resolve_plugin_install_context_from_dir`].
+/// (registry-driven) or
+/// [`MarketplaceService::resolve_plugin_install_context_from_dir`]
+/// (directory-driven, for fetch-aware CLI callers).
 /// Rust-internal only — never crosses the FFI boundary, so no `Serialize`
 /// or `specta::Type` derive. The type is `pub` so frontend handlers can
 /// hold onto the resolved inputs between the context-resolution call and
@@ -674,8 +677,9 @@ impl MarketplaceService {
     ///   [`PluginError::RemoteSourceNotLocal`]) from
     ///   [`Self::resolve_local_plugin_dir`].
     /// - [`Error::Plugin`] ([`PluginError::InvalidManifest`] /
-    ///   [`PluginError::ManifestReadFailed`]) from [`load_plugin_manifest`]
-    ///   if `plugin.json` is present but malformed or unreadable.
+    ///   [`PluginError::ManifestReadFailed`]) from
+    ///   [`Self::resolve_plugin_install_context_from_dir`] if `plugin.json`
+    ///   is present but malformed or unreadable.
     ///
     /// All errors propagate rather than fold into a partial-success shape
     /// — the caller explicitly asked to install this plugin, so missing
@@ -965,8 +969,7 @@ fn skipped_reason_from_manifest_error(
 /// - `Ok(None)` when the file is genuinely absent (`NotFound`) or when
 ///   it is a symlink — a symlinked `plugin.json` inside an untrusted
 ///   cloned repository could point at arbitrary host files, so it is
-///   treated as absent with a `warn!`. Matches the hardening in
-///   `crate::commands::install::load_plugin_manifest` in the CLI crate.
+///   treated as absent with a `warn!`.
 /// - `Err(PluginError::InvalidManifest)` if the file exists but could
 ///   not be parsed.
 /// - `Err(PluginError::ManifestReadFailed)` for any other read or stat
@@ -1431,9 +1434,7 @@ mod tests {
     }
 
     /// Regression guard: `load_plugin_manifest` treats a symlinked
-    /// `plugin.json` as absent (matching the CLI-side
-    /// `kiro_market::commands::install::load_plugin_manifest` and the
-    /// agent discovery hardening). A symlinked manifest inside a cloned
+    /// `plugin.json` as absent. A symlinked manifest inside a cloned
     /// repo could leak host file contents through the `InvalidManifest`
     /// error path, which embeds the serde parse error over the target
     /// bytes.
@@ -2640,7 +2641,7 @@ mod tests {
         }
         fs::write(
             plugin_dir.join("plugin.json"),
-            br#"{"name": "withcustom", "version": "0.1.0", "skills": ["./agents/"]}"#,
+            br#"{"name": "withcustom", "version": "0.1.0", "skills": ["./agents/"], "agents": ["./custom-agents/"]}"#,
         )
         .expect("write plugin.json");
 
@@ -2648,6 +2649,11 @@ mod tests {
             .resolve_plugin_install_context("mp1", "withcustom")
             .expect("happy path");
         assert_eq!(ctx.version.as_deref(), Some("0.1.0"));
+        assert_eq!(
+            ctx.agent_scan_paths,
+            vec!["./custom-agents/".to_string()],
+            "wrapper must thread agent_scan_paths through from the delegate"
+        );
         let mut names: Vec<String> = ctx
             .skill_dirs
             .iter()
@@ -2806,6 +2812,14 @@ mod tests {
             "no skills/ tree exists, expected empty, got: {:?}",
             ctx.skill_dirs
         );
+        assert_eq!(
+            ctx.agent_scan_paths,
+            crate::DEFAULT_AGENT_PATHS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<Vec<_>>(),
+            "symlinked manifest must fall back to DEFAULT_AGENT_PATHS, not leak target's agents"
+        );
     }
 
     #[test]
@@ -2814,7 +2828,6 @@ mod tests {
         let (dir, svc) = temp_service();
         let plugin_dir = dir.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
-        // No plugin.json — fallback path must activate.
 
         let ctx = svc
             .resolve_plugin_install_context_from_dir(&plugin_dir)
@@ -2844,5 +2857,15 @@ mod tests {
             .resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("happy path");
         assert_eq!(ctx.agent_scan_paths, vec!["./custom-agents/".to_string()]);
+        assert!(
+            ctx.version.is_none(),
+            "manifest has no version field, got: {:?}",
+            ctx.version
+        );
+        assert!(
+            ctx.skill_dirs.is_empty(),
+            "manifest declares no skills and no skills/ tree exists, got: {:?}",
+            ctx.skill_dirs
+        );
     }
 }

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -1,13 +1,11 @@
 //! `install` command: install a plugin or specific skill into a Kiro project.
 
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use kiro_market_core::cache::CacheDir;
 use kiro_market_core::git::{GitProtocol, GixCliBackend};
-use kiro_market_core::plugin::{PluginManifest, discover_skill_dirs};
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
     FailedAgent, InstallAgentsResult, InstallFilter, InstallMode, InstallSkillsResult,
@@ -63,23 +61,22 @@ pub fn run(
         protocol,
     )?;
 
-    let plugin_manifest = load_plugin_manifest(&plugin_dir)?;
-    let skill_dirs = discover_plugin_skills(&plugin_dir, plugin_manifest.as_ref());
-    let agent_scan_paths = agent_scan_paths(plugin_manifest.as_ref());
+    let ctx = svc
+        .resolve_plugin_install_context_from_dir(&plugin_dir)
+        .with_context(|| format!("failed to resolve install context for '{plugin_name}'"))?;
 
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let project = KiroProject::new(cwd);
-    let version = plugin_manifest.as_ref().and_then(|m| m.version.clone());
 
     let skill_result = run_skill_install(
         &svc,
         &project,
-        &skill_dirs,
+        &ctx.skill_dirs,
         skill_filter,
         mode,
         marketplace_name,
         plugin_name,
-        version.as_deref(),
+        ctx.version.as_deref(),
     );
     print_install_outcome(plugin_ref, &skill_result);
 
@@ -87,13 +84,13 @@ pub fn run(
         &svc,
         &project,
         &plugin_dir,
-        &agent_scan_paths,
+        &ctx.agent_scan_paths,
         skill_filter,
         mode,
         accept_mcp,
         marketplace_name,
         plugin_name,
-        version.as_deref(),
+        ctx.version.as_deref(),
     );
     print_agent_outcome(&agent_result);
 
@@ -230,18 +227,6 @@ fn summarize_outcome(
     Ok(())
 }
 
-/// Resolve the list of agent scan paths for a plugin.
-fn agent_scan_paths(plugin_manifest: Option<&PluginManifest>) -> Vec<String> {
-    if let Some(m) = plugin_manifest.filter(|m| !m.agents.is_empty()) {
-        m.agents.clone()
-    } else {
-        kiro_market_core::DEFAULT_AGENT_PATHS
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect()
-    }
-}
-
 /// Render the agent install summary plus any warnings and per-agent
 /// failures. Warnings and failures go to stderr so they don't pollute
 /// stdout piping, matching the skill flow.
@@ -266,21 +251,6 @@ fn print_agent_outcome(result: &InstallAgentsResult) {
     for w in &result.warnings {
         eprintln!("  {} {w}", "!".yellow().bold());
     }
-}
-
-/// Discover skill directories from a plugin, using its manifest or defaults.
-fn discover_plugin_skills(
-    plugin_dir: &Path,
-    plugin_manifest: Option<&PluginManifest>,
-) -> Vec<PathBuf> {
-    let skill_paths: Vec<&str> =
-        if let Some(manifest) = plugin_manifest.filter(|m| !m.skills.is_empty()) {
-            manifest.skills.iter().map(String::as_str).collect()
-        } else {
-            kiro_market_core::DEFAULT_SKILL_PATHS.to_vec()
-        };
-
-    discover_skill_dirs(plugin_dir, &skill_paths)
 }
 
 /// Render a per-skill summary plus the rolled-up totals from a service-layer
@@ -379,115 +349,6 @@ fn print_install_outcome(plugin_ref: &str, result: &InstallSkillsResult) {
             } else {
                 "s"
             }
-        );
-    }
-}
-
-/// Load a `plugin.json` from the given directory.
-///
-/// Returns:
-/// - `Ok(Some(manifest))` on success.
-/// - `Ok(None)` when the file is genuinely absent (`NotFound`) or when it is
-///   a symlink — a symlinked `plugin.json` inside a cloned repo could point
-///   at arbitrary host files, so it is treated as absent with a `warn!`.
-/// - `Err` for every other condition: permission denied, EIO, interrupted,
-///   malformed JSON, etc. Matches the allowlist-style error handling in
-///   `find_plugin_entry` — never mask a broken cache as "missing manifest."
-fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>> {
-    let manifest_path = plugin_dir.join("plugin.json");
-
-    // Refuse to follow symlinks. plugin_dir lives inside a cloned (untrusted)
-    // repository; matches project::copy_dir_recursive and
-    // agent::discover_agents_in_dirs.
-    match fs::symlink_metadata(&manifest_path) {
-        Ok(m) if m.file_type().is_symlink() => {
-            warn!(
-                path = %manifest_path.display(),
-                "plugin.json is a symlink, refusing to follow; treating as missing"
-            );
-            return Ok(None);
-        }
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            debug!(
-                path = %manifest_path.display(),
-                "plugin.json not found, using defaults"
-            );
-            return Ok(None);
-        }
-        Err(e) => {
-            return Err(anyhow::Error::new(e).context(format!(
-                "failed to stat plugin.json at {}",
-                manifest_path.display()
-            )));
-        }
-    }
-
-    let bytes = fs::read(&manifest_path)
-        .with_context(|| format!("failed to read plugin.json at {}", manifest_path.display()))?;
-    let manifest = PluginManifest::from_json(&bytes)
-        .with_context(|| format!("plugin.json at {} is malformed", manifest_path.display()))?;
-    debug!(name = %manifest.name, "loaded plugin manifest");
-    Ok(Some(manifest))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn load_plugin_manifest_reads_regular_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        fs::write(
-            tmp.path().join("plugin.json"),
-            r#"{"name":"ok","version":"1.0.0"}"#,
-        )
-        .unwrap();
-        let m = load_plugin_manifest(tmp.path())
-            .expect("ok result")
-            .expect("some manifest");
-        assert_eq!(m.name, "ok");
-    }
-
-    #[test]
-    fn load_plugin_manifest_returns_ok_none_when_absent() {
-        // Genuine absence is expected — NotFound is part of the contract,
-        // not an error. Regression guard for the allowlist split.
-        let tmp = tempfile::tempdir().unwrap();
-        let result = load_plugin_manifest(tmp.path()).expect("NotFound must be Ok(None)");
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn load_plugin_manifest_errors_on_malformed_json() {
-        // Regression: previously malformed plugin.json silently fell back
-        // to defaults. Allowlist-style handling requires it to surface.
-        let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("plugin.json"), b"{ not json").unwrap();
-        let err = load_plugin_manifest(tmp.path()).expect_err("malformed must error");
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("malformed") || msg.contains("plugin.json"),
-            "error chain should mention the manifest: {msg}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_plugin_manifest_refuses_symlinked_manifest() {
-        // A malicious cloned repo could include a symlink
-        // `plugin.json -> /etc/passwd`. We must not follow it. Symlink is
-        // treated as absent (Ok(None)) with a warn!, not as an error —
-        // the install degrades to "no skills" rather than aborting.
-        let tmp = tempfile::tempdir().unwrap();
-        let target = tmp.path().join("elsewhere.json");
-        fs::write(&target, r#"{"name":"smuggled"}"#).unwrap();
-        std::os::unix::fs::symlink(&target, tmp.path().join("plugin.json")).unwrap();
-
-        let result = load_plugin_manifest(tmp.path()).expect("symlink should not error");
-        assert!(
-            result.is_none(),
-            "symlinked plugin.json must be treated as absent, got: {result:?}"
         );
     }
 }

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -128,7 +128,9 @@ fn fetch_plugin_dir(
     protocol: GitProtocol,
 ) -> Result<PathBuf> {
     print!("  Fetching plugin '{plugin_name}'...");
-    let _ = std::io::Write::flush(&mut std::io::stdout());
+    if let Err(e) = std::io::Write::flush(&mut std::io::stdout()) {
+        warn!(error = %e, "failed to flush stdout before fetch progress message");
+    }
     let dir = svc
         .resolve_plugin_dir(entry, marketplace_path, marketplace_name, protocol)
         .with_context(|| format!("failed to resolve plugin directory for '{plugin_name}'"))?;

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -61,8 +61,7 @@ pub fn run(
         protocol,
     )?;
 
-    let ctx = svc
-        .resolve_plugin_install_context_from_dir(&plugin_dir)
+    let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
         .with_context(|| format!("failed to resolve install context for '{plugin_name}'"))?;
 
     let cwd = std::env::current_dir().context("failed to determine current directory")?;


### PR DESCRIPTION
## Summary

**Fetch stays in CLI, resolution moves to core.** The CLI's install flow had three helpers (`load_plugin_manifest`, `discover_plugin_skills`, `agent_scan_paths`) that duplicated logic already living in `kiro-market-core::service::browse`. This PR closes the duplication by extracting a directory-based resolver in core, extending `PluginInstallContext` with `agent_scan_paths`, and collapsing the CLI's three helper calls into one.

- Core gains `MarketplaceService::resolve_plugin_install_context_from_dir(&Path) -> Result<PluginInstallContext, Error>`. The existing `resolve_plugin_install_context` now delegates to it after `resolve_local_plugin_dir`, so Tauri's call-site is unchanged.
- `PluginInstallContext` grows by one field — `agent_scan_paths: Vec<String>` — deliberately, the first time a second consumer needed more than `version` + `skill_dirs`. Validates the "minimal but `pub`" design call from #33.
- CLI keeps `fetch_plugin_dir` (progress UI is load-bearing — users need to know a multi-MB clone is in progress). Everything downstream of the fetch moves to the new core method: 139 LOC removed from `install.rs`.

Rejected alternative: adding a fetch-aware variant to core (`resolve_plugin_install_context_fetched`). That would push network I/O into the "install context" concept and eliminate the CLI's progress UX. The split approach keeps core lean and leaves presentation at the CLI boundary.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — core: 536, CLI: 11 (down 4, each replaced by existing or new core tests), Tauri: 61 unchanged
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] Commit atomicity: each commit builds and tests green on its own base (Tauri's `install_skills_impl` consumes via field access, so the new `agent_scan_paths` field flows through unused)
- [x] No `bindings.ts` regeneration — `PluginInstallContext` is Rust-internal; no `#[specta::Type]` type grew
- [x] No new `.unwrap()`/`.expect()`/`let _ =` on Result/`#[allow(...)]` in production code

## Test migration

Four CLI tests deleted — each has a typed-match core equivalent (stronger than the CLI's string-grep assertions per CLAUDE.md Rule 42):

| Deleted CLI test | Core equivalent |
|---|---|
| `load_plugin_manifest_reads_regular_file` | `resolve_plugin_install_context_returns_context_for_local_plugin` |
| `load_plugin_manifest_returns_ok_none_when_absent` | `resolve_plugin_install_context_from_dir_falls_back_to_default_agent_paths_when_manifest_absent` (new in this PR) |
| `load_plugin_manifest_errors_on_malformed_json` | `resolve_plugin_install_context_errors_on_malformed_plugin_json` |
| `load_plugin_manifest_refuses_symlinked_manifest` | `resolve_plugin_install_context_from_dir_refuses_symlinked_manifest` (new in this PR) |

## Commits

1. `ebb9749 feat(core): add resolve_plugin_install_context_from_dir + agent_scan_paths` (+126/-3) — new method + field + 3 tests.
2. `1b33b40 refactor(cli): replace local manifest helpers with resolve_plugin_install_context_from_dir` (+7/-146) — CLI swap + deletions.
3. `8f18ba2 fix(core): address PR review — trim stale references, tighten tests, fix doc drift` (+35/-12) — review-fix pass (see below).

## Review-fix pass (commit 3)

A comprehensive 5-reviewer sweep (code / tests / comments / errors / type-design) found 2 Critical + 5 Important issues, all addressed:

- **2 stale cross-references** to the deleted CLI `load_plugin_manifest` in core's doc comments (both reviewers converged). Trimmed.
- **`agent_scan_paths` untested through the wrapper** — added assertion in `resolve_plugin_install_context_uses_manifest_skills_when_declared`.
- **Symlink test missing `agent_scan_paths` fallback assertion** — added, pins "every field falls back when manifest is treated as absent."
- **Manifest-declared-agents test didn't prove field independence** — added `version.is_none()` + `skill_dirs.is_empty()` assertions.
- **Struct-level doc drifted after gaining third field** — widened to cover both `install_skills` and `install_plugin_agents` pipelines.
- **`# Errors` doc pointed at private `load_plugin_manifest`** — swapped to `Self::resolve_plugin_install_context_from_dir`. Bonus: kills one pre-existing `private_intra_doc_links` rustdoc warning.

## Deferred (acknowledged, not addressed)

Per type-design reviewer's recommendation, these wait for the next consumer (Tauri agent-install pipeline):

- `agent_scan_paths: Vec<String>` is non-empty-by-construction but the type doesn't express it. Fold into a `NonEmptyVec` or drop-to-method when adding `plugin_dir`.
- `PluginInstallContext` is missing `plugin_dir` — the CLI currently holds it as a local alongside `ctx` to drive `install_plugin_agents`. Structural tell that the type isn't self-sufficient. The next consumer (Tauri agent-install) will want the same field; add it then and simultaneously convert `&self` on `_from_dir` to associated-fn (currently dead weight).

## Scope notes

- **No Tauri-side changes.** Tauri's `install_skills_impl` consumes `ctx.skill_dirs` + `ctx.version` via field access; the new `agent_scan_paths` field flows through unused. No call-site update required.
- **Error surface preserved and strictly more observable.** Silent-failure-hunter traced every fallible branch end-to-end: the core version even adds a `warn!` on stat-failure that the deleted CLI helper lacked.
- **CLI still uses `anyhow::Result`** — the boundary maps from core's `Error` via one `.with_context(|| format!("failed to resolve install context for '{plugin_name}'"))?`.

Closes #42.