### PR TITLE
ci(kiro-review): unblock JSON manifest + address PR #50 review

### DIFF
--- a/.github/scripts/post-review-comments.py
+++ b/.github/scripts/post-review-comments.py
@@ -94,7 +94,7 @@ FENCE_RE = re.compile(r"^\s*(?:`{3,}|~{3,})")
 HEADING_TERMINATOR_RE = re.compile(r"^#{1,4}\s")
 
 # The orchestrator emits a structured JSON manifest after the markdown
-# review (see review-orchestrator.md "Machine-Readable Manifest" section).
+# review (see review-orchestrator.md "Machine-Readable Findings" section).
 # These regexes locate the section and the fenced JSON payload inside it,
 # so we can parse findings deterministically instead of regexing prose.
 MANIFEST_SECTION_RE = re.compile(
@@ -187,13 +187,19 @@ def _validate_manifest_item(item):
     """Return True iff a JSON-manifest entry passes schema checks.
 
     Required shape per the review-orchestrator prompt:
-      severity: str (one of the six buckets; not enforced here so new
-                     orchestrator severities don't break parsing)
-      agent:    str
-      path:     str, forward-slash
-      line:     int >= 1
-      title:    str
-      body:     str
+      severity: non-empty str (any value; exact-bucket enforcement is
+                left to the caller so a new orchestrator severity
+                doesn't silently invalidate the whole manifest)
+      agent:    non-empty str
+      path:     non-empty str (forward-slash convention is a prompt
+                rule, not validated here — an OS-native path still
+                passes; the PR review API accepts either and GitHub
+                normalizes internally)
+      line:     int >= 1, and NOT bool (`isinstance(True, int)` is True
+                in Python; without the explicit bool reject a manifest
+                with `"line": true` would pass as line=1)
+      title:    non-empty str
+      body:     non-empty str
 
     Any missing field, wrong type, or empty required string fails the
     check. The caller's contract is "all items valid or fall back to
@@ -204,6 +210,11 @@ def _validate_manifest_item(item):
         return False
     required = {"severity", "agent", "path", "line", "title", "body"}
     if not required.issubset(item):
+        return False
+    # bool subclasses int in Python, so isinstance(True, int) is True.
+    # Reject bool explicitly before the int check or `{"line": true}`
+    # silently passes as line=1.
+    if isinstance(item["line"], bool):
         return False
     if not isinstance(item["line"], int) or item["line"] < 1:
         return False
@@ -423,7 +434,15 @@ def parse_diff_hunks(diff_text):
 
 
 def get_diff_lines(base_ref):
-    """Shell out to `git diff -U0` and parse the result. Raises on git failure."""
+    """Shell out to `git diff -U0` and parse the result.
+
+    Raises:
+      ValueError — base_ref is empty (misconfigured workflow).
+      RuntimeError — git exited non-zero OR git itself isn't on PATH.
+                     FileNotFoundError from subprocess is normalized to
+                     RuntimeError so callers only need one except clause
+                     to route all git-lookup failures to the fallback.
+    """
     if not base_ref:
         raise ValueError("base_ref is empty; cannot compute diff range")
     # -U0 strips context lines so @@ hunk ranges cover only changed lines —
@@ -431,13 +450,16 @@ def get_diff_lines(base_ref):
     # core.quotepath=false disables C-style quoting of non-ASCII paths so
     # parse_diff_hunks sees raw UTF-8 filenames and matches finding paths
     # that were never quoted in the first place.
-    result = subprocess.run(
-        [
-            "git", "-c", "core.quotepath=false",
-            "diff", "-U0", f"origin/{base_ref}...HEAD",
-        ],
-        capture_output=True, text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "git", "-c", "core.quotepath=false",
+                "diff", "-U0", f"origin/{base_ref}...HEAD",
+            ],
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"git binary not found on PATH: {exc}") from exc
     if result.returncode != 0:
         raise RuntimeError(
             f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"

--- a/.github/scripts/test_post_review_comments.py
+++ b/.github/scripts/test_post_review_comments.py
@@ -242,7 +242,10 @@ class TestParseFindings:
         findings = parse_findings(text)
         assert len(findings) == 1
         assert findings[0]["body"].endswith("… (truncated)")
-        assert len(findings[0]["body"]) < 2500
+        # Tight bound: MAX_BODY_CHARS (2000) plus the 15-char truncation
+        # marker "\n\n… (truncated)". A looser bound would hide a
+        # regression in the truncation logic.
+        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 20
 
     def test_line_range_uses_first_line(self):
         text = (
@@ -597,7 +600,7 @@ class TestParseJsonManifest:
         findings = parse_json_manifest(text)
         assert findings is not None
         assert findings[0]["body"].endswith("… (truncated)")
-        assert len(findings[0]["body"]) < 2500
+        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 20
 
     def test_unknown_severity_renders_without_emoji(self):
         # Forward-compatible: a new severity bucket shouldn't crash; we
@@ -640,17 +643,75 @@ class TestValidateManifestItem:
             bad = dict(self._BASE, **{key: ""})
             assert not _validate_manifest_item(bad), f"empty {key} should fail"
 
+    def test_bool_line_is_rejected(self):
+        # `isinstance(True, int)` is True in Python because bool is an
+        # int subclass. Without the explicit bool-reject, a manifest with
+        # `"line": true` would pass as line=1 and silently fabricate an
+        # inline comment on line 1 of whatever file the orchestrator
+        # pointed at.
+        bad_true = dict(self._BASE, line=True)
+        bad_false = dict(self._BASE, line=False)
+        assert not _validate_manifest_item(bad_true)
+        assert not _validate_manifest_item(bad_false)
+
+
+class TestGetDiffLinesErrorNormalization:
+    # get_diff_lines is the only boundary where subprocess.run can raise
+    # FileNotFoundError — if the git binary is missing from the runner's
+    # PATH, the exception type differs from the RuntimeError/ValueError
+    # the rest of the module uses. Verify the function normalizes it to
+    # RuntimeError so main()'s except clause catches every git failure
+    # without a second exception type.
+
+    def test_missing_git_binary_raises_runtime_error(self, monkeypatch):
+        import subprocess
+
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError(
+                "[Errno 2] No such file or directory: 'git'"
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Reload subprocess reference inside _mod — it was imported at module
+        # load, so monkeypatch on `subprocess.run` propagates via attribute
+        # lookup on the module the code actually uses.
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="git binary not found"):
+            _mod.get_diff_lines("main")
+
+    def test_empty_base_ref_still_raises_value_error(self):
+        # Regression guard: normalizing FileNotFoundError must not
+        # accidentally swallow the ValueError for an empty base_ref,
+        # which is a distinct misconfiguration.
+        with pytest.raises(ValueError, match="base_ref is empty"):
+            _mod.get_diff_lines("")
+
 
 class TestRenderFallbackSummary:
-    def test_includes_count_and_entries(self):
+    def test_includes_headers_count_and_entries(self):
         findings = [
             {"path": "a.py", "line": 10, "body": "first finding"},
             {"path": "b.py", "line": 20, "body": "second finding"},
         ]
         out = _render_fallback_summary(findings)
+        # Top-level heading signals this as the Kiro review output to
+        # readers who see it in a PR comment thread mixed with other bots.
+        assert "## Kiro Review Summary" in out
+        # Subsection header delimits the finding list.
+        assert "### Findings" in out
         assert "Found **2** findings" in out
         assert "- `a.py:10` — first finding" in out
         assert "- `b.py:20` — second finding" in out
+
+    def test_empty_list_still_renders_with_zero_count(self):
+        # Defensive: _render_fallback_summary is called when get_diff_lines
+        # fails after findings were parsed. Zero findings here is an edge
+        # case (the no-findings branch runs earlier), but it should still
+        # produce coherent output rather than crashing.
+        out = _render_fallback_summary([])
+        assert "Found **0** findings" in out
+        assert "## Kiro Review Summary" in out
 
 
 class TestPreprocessReviewText:

--- a/.kiro/agents/prompts/review-orchestrator.md
+++ b/.kiro/agents/prompts/review-orchestrator.md
@@ -166,40 +166,40 @@ For each dimension below, state a specific observation OR write exactly `No conc
 
 ## Machine-Readable Findings
 
+**Why:** the GitHub-integration tooling parses this JSON manifest to post inline PR review comments. The markdown review above is for human readers; the JSON block below is the authoritative source for automation. Get it wrong and findings fall through to a regex fallback that tolerates drift but loses precision.
+
+**Required structure.** After this heading, emit exactly one fenced JSON block. The fence is a plain triple-backtick line with the `json` language tag; the fence closes with a matching triple-backtick line and nothing else on that line. No prose between the heading and the opening fence.
+
+~~~
+## Machine-Readable Findings
+
 ```json
 [
   {
-    "severity": "<Critical|Important|Suggestion|Nitpick>",
-    "agent": "<specialist name>",
-    "path": "<path/to/file.ext with forward slashes>",
-    "line": <integer, first line of the range>,
-    "title": "<same title as the markdown #### heading>",
-    "body": "<Problem / Failure scenario / Call-chain evidence / Verified with / Fix direction, in markdown, as one string>"
+    "severity": "Important",
+    "agent": "code-reviewer",
+    "path": "crates/kiro-market-core/src/hash.rs",
+    "line": 122,
+    "title": "<same title text as the #### markdown heading>",
+    "body": "Problem: …\n\nFailure scenario: …\n\nVerified with: …\n\nFix direction: …"
   }
 ]
 ```
-```
+~~~
 
-### Machine-Readable Findings — rules
+**Content rules:**
 
-The GitHub-integration tooling parses this JSON manifest to post inline PR review comments. The markdown review above is for human readers; this block is the authoritative source for automation.
-
-**Required:**
-
-- Include the `## Machine-Readable Findings` heading and exactly one fenced ```` ```json ```` block. The parser locates the block by searching after the heading for a fence — no second fence, no extra prose inside the fence.
-- One manifest entry per Critical, Important, Suggestion, or Nitpick finding that has a concrete `**File:**` line reference. Omit Verified and Uncertain findings from the manifest (they don't anchor to a specific line).
-- If the review has zero findings of those four severities, emit `[]` — **not** a missing section, and **not** commentary like `"no findings"`.
-
-**Field rules:**
-
+- One entry per Critical, Important, Suggestion, or Nitpick finding that has a concrete `**File:**` line reference. Omit Verified and Uncertain findings from the manifest — they don't anchor to a specific line.
+- If the review has zero findings of those four severities, emit `[]`. Never omit the section. Never write prose like `"no findings"` in place of the array.
+- `severity` is one of `Critical`, `Important`, `Suggestion`, `Nitpick` — exact capitalization.
 - `line` is a JSON integer, not a string. For a range like `42-48`, emit the first line (`42`).
-- `path` uses forward slashes even on Windows, matches the path the orchestrator cited in the markdown `File:` line.
-- `body` is a single JSON string containing the prose sections of the finding (Problem, Failure scenario, Call-chain evidence, Verified with, Fix direction). Multi-line prose uses `\n` escapes. Omit the `####` heading and `**File:**` line — the automation reconstructs them from the structured fields.
+- `path` uses forward slashes even on Windows, matching the path you cited in the markdown `File:` line.
+- `body` is a single JSON string containing the prose sections of the finding (Problem, Failure scenario, Call-chain evidence, Verified with, Fix direction). Multi-line prose uses `\n` escapes. Omit the `####` heading and the `**File:**` line — the automation reconstructs them from the structured fields.
 
 **Validity:**
 
-- Strict JSON: no trailing commas, no comments, all strings properly escaped (`\"`, `\\`, `\n`).
-- The automation falls back to regex-parsing the markdown if the JSON is malformed or any entry fails schema validation — but that's the degraded path. Treat strict JSON as load-bearing.
+- Strict JSON: no trailing commas, no JavaScript-style comments, all strings properly escaped (`\"`, `\\`, `\n`).
+- One bad entry invalidates the whole manifest: the automation falls back to regex-parsing the markdown if the JSON is malformed or any entry fails schema validation. That's the degraded path. Treat strict JSON as load-bearing.
 
 ---
 


### PR DESCRIPTION
Stacked on #50. Addresses every finding Kiro posted on #50's own review, and — more importantly — fixes the root cause of why the manifest path didn't fire.

## Root cause of #50's manifest no-op

Kiro's own review on #50 flagged it precisely: *"Unclosed fence in review-orchestrator.md hides rules section."* The prompt edit had a stray trailing ` ``` ` that opened a fence containing the entire rules paragraph — which never closed. From the orchestrator's point of view, the rules about how to format the JSON appeared as literal code inside a code block, not as prose instructions. So it emitted the `## Machine-Readable Findings` heading but nothing else.

Fixed by: removing the stray fence and wrapping the manifest template example in `~~~` so the inner ` ```json ` fence nests cleanly.

## Also fixes (Kiro findings on #50)

- ⚠️ **Important** — `get_diff_lines` now normalizes `FileNotFoundError` (missing `git` binary) to `RuntimeError`, so `main`'s existing except clause catches it rather than letting it escape and discard all parsed findings.
- 💡 `_validate_manifest_item` explicitly rejects `bool` for `line`. `isinstance(True, int)` is `True` in Python — without this, `{"line": true}` passes as `line=1` and fabricates a fake inline comment.
- 💡 `MANIFEST_SECTION_RE` comment references the correct section name ("Findings", not "Manifest").
- 💡 `_validate_manifest_item` docstring no longer overclaims enforcement of the forward-slash path convention.
- 💡 `TestRenderFallbackSummary` now asserts the top-level and subsection headers, with an empty-list edge case.
- 📝 Truncation-bound assertions tightened from `< 2500` to `<= MAX_BODY_CHARS + 20`.

## Test plan

- [x] 67/67 tests pass, 4 new (bool-line-rejected, FileNotFoundError-to-RuntimeError, empty-base-ref ValueError guard, empty-list fallback summary).
- [ ] **Real end-to-end verification:** this PR's Kiro review should now use the JSON manifest path. The log will show `Using json-manifest parser → N findings` — if that line appears, the prompt fix worked and the whole manifest pipeline is proven. If it still falls back to regex, we've learned the issue is LLM reliability with embedded JSON rather than markdown formatting, and would need a different strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)