### PR TITLE
ci(kiro-review): use raw_decode for JSON manifest + harden gh calls

### DIFF
--- a/.github/scripts/post-review-comments.py
+++ b/.github/scripts/post-review-comments.py
@@ -282,7 +282,10 @@ def parse_json_manifest(text):
               file=sys.stderr)
         return None
     try:
-        payload, _ = json.JSONDecoder().raw_decode(text[array_start:])
+        # Pass the full text + idx to raw_decode rather than slicing —
+        # avoids a memory copy AND preserves original line/col in any
+        # JSONDecodeError message for easier debugging.
+        payload, _ = json.JSONDecoder().raw_decode(text, array_start)
     except json.JSONDecodeError as exc:
         print(f"::warning::JSON manifest failed to parse ({exc}). "
               f"Falling back to regex parser.", file=sys.stderr)
@@ -450,10 +453,14 @@ def get_diff_lines(base_ref):
 
     Raises:
       ValueError — base_ref is empty (misconfigured workflow).
-      RuntimeError — git exited non-zero OR git itself isn't on PATH.
-                     FileNotFoundError from subprocess is normalized to
-                     RuntimeError so callers only need one except clause
-                     to route all git-lookup failures to the fallback.
+      RuntimeError — git exited non-zero, the git binary isn't on PATH,
+                     or it's present but unusable (non-executable bit,
+                     process-limit hit, permission denied, etc.). OSError
+                     is the parent class for FileNotFoundError +
+                     PermissionError + other subprocess-launch failures;
+                     catching it means callers only need one except
+                     clause to route all git-lookup failures to the
+                     fallback.
     """
     if not base_ref:
         raise ValueError("base_ref is empty; cannot compute diff range")
@@ -470,8 +477,8 @@ def get_diff_lines(base_ref):
             ],
             capture_output=True, text=True,
         )
-    except FileNotFoundError as exc:
-        raise RuntimeError(f"git binary not found on PATH: {exc}") from exc
+    except OSError as exc:
+        raise RuntimeError(f"git binary unavailable: {exc}") from exc
     if result.returncode != 0:
         raise RuntimeError(
             f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"
@@ -498,12 +505,14 @@ def looks_like_findings(text):
 def _gh_api_post_json(api_path, payload):
     """Shell out to `gh api --input -` with a JSON stdin payload.
 
-    Returns (returncode, stdout, stderr). Normalizes FileNotFoundError
-    (missing `gh` binary) to a synthetic (-1, "", "...") result so call
-    sites use one return-code check instead of mixing exception handling
-    with subprocess-result handling. `gh api` writes 4xx/5xx response
-    bodies to stdout (not stderr), so callers need both streams to
-    diagnose failures.
+    Returns (returncode, stdout, stderr). Normalizes OSError — the
+    parent class for FileNotFoundError (missing binary), PermissionError
+    (present but not executable), and other subprocess-launch failures
+    — to a synthetic (-1, "", "...") result so call sites use one
+    return-code check instead of mixing exception handling with
+    subprocess-result handling. `gh api` writes 4xx/5xx response bodies
+    to stdout (not stderr), so callers need both streams to diagnose
+    failures.
     """
     try:
         result = subprocess.run(
@@ -511,8 +520,8 @@ def _gh_api_post_json(api_path, payload):
             input=json.dumps(payload),
             capture_output=True, text=True,
         )
-    except FileNotFoundError as exc:
-        return -1, "", f"gh binary not found on PATH: {exc}"
+    except OSError as exc:
+        return -1, "", f"gh binary unavailable: {exc}"
     return result.returncode, result.stdout, result.stderr
 
 

--- a/.github/scripts/post-review-comments.py
+++ b/.github/scripts/post-review-comments.py
@@ -95,13 +95,19 @@ HEADING_TERMINATOR_RE = re.compile(r"^#{1,4}\s")
 
 # The orchestrator emits a structured JSON manifest after the markdown
 # review (see review-orchestrator.md "Machine-Readable Findings" section).
-# These regexes locate the section and the fenced JSON payload inside it,
-# so we can parse findings deterministically instead of regexing prose.
+# This regex locates the section heading; the JSON payload itself is
+# extracted with json.JSONDecoder.raw_decode starting at the first `[`
+# after the heading rather than pattern-matching a fence.
+#
+# Why not a fence regex: Kiro CLI's markdown renderer consumes ``` fence
+# markers before writing to stdout, the same way it consumes `**bold**`
+# and inline backticks. After ANSI stripping, a block that was emitted
+# as ```json\n[...]\n``` arrives as `json\n[...]` with no fence markers
+# to anchor on. Balanced-bracket parsing sidesteps the whole
+# fence-rendering concern and works whether markdown fences survive
+# rendering or not.
 MANIFEST_SECTION_RE = re.compile(
     r"^##\s+Machine-Readable Findings\b\s*$", re.MULTILINE
-)
-MANIFEST_FENCE_RE = re.compile(
-    r"```(?:json)?\s*\n(?P<payload>.*?)\n```", re.DOTALL
 )
 
 # Severity → emoji for reconstructing a finding's heading line when
@@ -249,28 +255,34 @@ def parse_json_manifest(text):
     Returns:
       list[dict] — when a valid manifest section exists. May be empty
                    if the orchestrator legitimately found no issues.
-      None       — when the manifest section is absent, the fenced JSON
-                   block is missing, JSON parsing fails, or any item
+      None       — when the manifest section is absent, no JSON array
+                   follows the heading, JSON parsing fails, or any item
                    fails schema validation. Signals "fall back to the
                    regex parser" — callers must distinguish this from
                    "valid empty manifest" so a clean review doesn't
                    accidentally trigger format-drift warnings.
 
-    The JSON path is preferred over the regex parser because it bypasses
-    markdown-rendering drift (bold markers eaten, backticks stripped,
-    emoji substitution) that the regex parser has to tolerate.
+    Extraction strategy: find `## Machine-Readable Findings`, then
+    locate the first `[` after it and hand the slice to
+    `json.JSONDecoder.raw_decode`. The decoder finds the matching `]`
+    itself and ignores trailing content, so we never need to detect a
+    closing marker. This is deliberate — kiro-cli's markdown renderer
+    consumes ``` fence markers before writing stdout, so a fence-based
+    regex like the one this used to use never actually matches in
+    production (PR #51 confirmed the orchestrator emits valid JSON but
+    loses the fence markers en route).
     """
     section_match = MANIFEST_SECTION_RE.search(text)
     if section_match is None:
         return None
-    fence_match = MANIFEST_FENCE_RE.search(text, pos=section_match.end())
-    if fence_match is None:
+    array_start = text.find("[", section_match.end())
+    if array_start == -1:
         print("::warning::Machine-Readable Findings section found but no "
-              "fenced JSON block inside it. Falling back to regex parser.",
+              "JSON array follows the heading. Falling back to regex parser.",
               file=sys.stderr)
         return None
     try:
-        payload = json.loads(fence_match.group("payload"))
+        payload, _ = json.JSONDecoder().raw_decode(text[array_start:])
     except json.JSONDecodeError as exc:
         print(f"::warning::JSON manifest failed to parse ({exc}). "
               f"Falling back to regex parser.", file=sys.stderr)
@@ -483,21 +495,39 @@ def looks_like_findings(text):
     )
 
 
+def _gh_api_post_json(api_path, payload):
+    """Shell out to `gh api --input -` with a JSON stdin payload.
+
+    Returns (returncode, stdout, stderr). Normalizes FileNotFoundError
+    (missing `gh` binary) to a synthetic (-1, "", "...") result so call
+    sites use one return-code check instead of mixing exception handling
+    with subprocess-result handling. `gh api` writes 4xx/5xx response
+    bodies to stdout (not stderr), so callers need both streams to
+    diagnose failures.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", api_path, "--input", "-"],
+            input=json.dumps(payload),
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError as exc:
+        return -1, "", f"gh binary not found on PATH: {exc}"
+    return result.returncode, result.stdout, result.stderr
+
+
 def gh_issue_comment(repo, pr, body):
     """Post a plain issue comment. Returns (returncode, stdout, stderr).
 
-    Passes the body through stdin as a JSON payload via `gh api --input -`.
-    Sending large bodies through `-f body=...` puts the text on argv, which
-    is bounded by ARG_MAX and fragile for content containing shell-special
-    sequences. `gh api` writes 4xx/5xx response bodies to stdout (not stderr),
-    so callers need both streams to diagnose failures.
+    Passes the body through stdin as a JSON payload. Sending large
+    bodies through `-f body=...` puts the text on argv, which is
+    bounded by ARG_MAX and fragile for content containing
+    shell-special sequences.
     """
-    result = subprocess.run(
-        ["gh", "api", f"/repos/{repo}/issues/{pr}/comments", "--input", "-"],
-        input=json.dumps({"body": body}),
-        capture_output=True, text=True,
+    return _gh_api_post_json(
+        f"/repos/{repo}/issues/{pr}/comments",
+        {"body": body},
     )
-    return result.returncode, result.stdout, result.stderr
 
 
 def _format_summary_entry(path, line, body):
@@ -642,19 +672,17 @@ def main():
         "comments": inline_comments,
     }
 
-    result = subprocess.run(
-        ["gh", "api", f"/repos/{args.repo}/pulls/{args.pr}/reviews",
-         "--input", "-"],
-        input=json.dumps(review_payload),
-        capture_output=True, text=True,
+    rc, out, err = _gh_api_post_json(
+        f"/repos/{args.repo}/pulls/{args.pr}/reviews",
+        review_payload,
     )
 
-    if result.returncode == 0:
+    if rc == 0:
         print(f"Posted review with {len(inline_comments)} inline comments.")
         return
 
     print(f"::warning::Primary review post failed. "
-          f"stderr={result.stderr} stdout={result.stdout}", file=sys.stderr)
+          f"stderr={err} stdout={out}", file=sys.stderr)
     fallback = "\n".join(body_parts)
     if inline_comments:
         fallback += "\n\n### Inline findings\n"

--- a/.github/scripts/test_post_review_comments.py
+++ b/.github/scripts/test_post_review_comments.py
@@ -685,9 +685,10 @@ class TestValidateManifestItem:
 
 class TestGetDiffLinesErrorNormalization:
     # get_diff_lines is the only boundary where subprocess.run can raise
-    # FileNotFoundError — if the git binary is missing from the runner's
-    # PATH, the exception type differs from the RuntimeError/ValueError
-    # the rest of the module uses. Verify the function normalizes it to
+    # OSError — missing git, non-executable git, or other
+    # subprocess-launch failures all raise OSError subclasses, but none
+    # of those match the RuntimeError/ValueError the rest of the module
+    # uses. Verify the function normalizes the whole OSError family to
     # RuntimeError so main()'s except clause catches every git failure
     # without a second exception type.
 
@@ -705,13 +706,27 @@ class TestGetDiffLinesErrorNormalization:
 
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
 
-        with pytest.raises(RuntimeError, match="git binary not found"):
+        with pytest.raises(RuntimeError, match="git binary unavailable"):
+            _mod.get_diff_lines("main")
+
+    def test_non_executable_git_raises_runtime_error(self, monkeypatch):
+        # PermissionError is a sibling of FileNotFoundError under OSError —
+        # raised when the binary exists but its execute bit is stripped
+        # (common in misconfigured container images). The OSError-based
+        # catch must handle this class too; a FileNotFoundError-only
+        # catch would silently drop all findings.
+        def fake_run(*args, **kwargs):
+            raise PermissionError("[Errno 13] Permission denied: 'git'")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="git binary unavailable"):
             _mod.get_diff_lines("main")
 
     def test_empty_base_ref_still_raises_value_error(self):
-        # Regression guard: normalizing FileNotFoundError must not
-        # accidentally swallow the ValueError for an empty base_ref,
-        # which is a distinct misconfiguration.
+        # Regression guard: normalizing OSError must not accidentally
+        # swallow the ValueError for an empty base_ref, which is a
+        # distinct misconfiguration.
         with pytest.raises(ValueError, match="base_ref is empty"):
             _mod.get_diff_lines("")
 
@@ -735,7 +750,22 @@ class TestGhApiPostJson:
         rc, out, err = _mod._gh_api_post_json("/repos/x/y/issues/1/comments", {})
         assert rc == -1
         assert out == ""
-        assert "gh binary not found" in err
+        assert "gh binary unavailable" in err
+
+    def test_non_executable_gh_returns_minus_one(self, monkeypatch):
+        # PermissionError is the realistic alternative mode: binary is
+        # present on PATH but its execute bit is stripped. Before the
+        # OSError widening this escaped uncaught and crashed main with
+        # a Python traceback instead of posting any review comment.
+        def fake_run(*args, **kwargs):
+            raise PermissionError("[Errno 13] Permission denied: 'gh'")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        rc, out, err = _mod._gh_api_post_json("/repos/x/y/issues/1/comments", {})
+        assert rc == -1
+        assert out == ""
+        assert "gh binary unavailable" in err
 
     def test_subprocess_success_passes_through(self, monkeypatch):
         # Happy path: subprocess returns normally, _gh_api_post_json

--- a/.github/scripts/test_post_review_comments.py
+++ b/.github/scripts/test_post_review_comments.py
@@ -245,7 +245,7 @@ class TestParseFindings:
         # Tight bound: MAX_BODY_CHARS (2000) plus the 15-char truncation
         # marker "\n\n… (truncated)". A looser bound would hide a
         # regression in the truncation logic.
-        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 20
+        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 15
 
     def test_line_range_uses_first_line(self):
         text = (
@@ -535,11 +535,15 @@ class TestParseJsonManifest:
         text = "# Code Review — PR #1\n\nJust prose.\n"
         assert parse_json_manifest(text) is None
 
-    def test_section_without_fence_returns_none(self):
+    def test_section_without_array_returns_none(self):
+        # No `[` after the heading → signal fallback. raw_decode can't
+        # locate a JSON array if there isn't one; this can happen if the
+        # orchestrator emitted the heading but crashed before producing
+        # findings, or wrote a prose apology instead.
         text = (
             "# Code Review — PR #1\n\n"
             "## Machine-Readable Findings\n\n"
-            "Oops, forgot the fence.\n"
+            "The orchestrator failed; no findings extracted.\n"
         )
         assert parse_json_manifest(text) is None
 
@@ -581,14 +585,34 @@ class TestParseJsonManifest:
         text = self._wrap(json.dumps([broken]))
         assert parse_json_manifest(text) is None
 
-    def test_fence_without_json_tag_still_matches(self):
-        # The fence language tag is optional — accept ```\n as well as ```json\n.
+    def test_unfenced_output_from_kiro_cli_still_parses(self):
+        # Kiro CLI's markdown renderer consumes ``` fence markers before
+        # writing stdout (PR #51 confirmed this by capturing the actual
+        # orchestrator output). After ANSI stripping, a block emitted as
+        # ```json\n[...]\n``` arrives as `json\n[...]` with no fences.
+        # raw_decode must handle this since the fence-free shape is what
+        # we see in production, not the shape a markdown-preserving tool
+        # would emit.
         text = (
             "# Code Review — PR #1\n\n"
             "## Machine-Readable Findings\n\n"
-            "```\n"
+            "json\n"
             f"{json.dumps([self._VALID])}\n"
-            "```\n"
+        )
+        findings = parse_json_manifest(text)
+        assert findings is not None
+        assert len(findings) == 1
+        assert findings[0]["path"] == "src/auth.ts"
+
+    def test_trailing_content_after_array_is_ignored(self):
+        # raw_decode parses one JSON value and stops. Any content after
+        # the closing `]` (e.g. the next section heading or orchestrator
+        # verdict text) must not interfere.
+        text = (
+            "## Machine-Readable Findings\n\n"
+            f"{json.dumps([self._VALID])}\n\n"
+            "## Verdict\n\n"
+            "✅ LGTM — all findings addressed.\n"
         )
         findings = parse_json_manifest(text)
         assert findings is not None
@@ -600,7 +624,7 @@ class TestParseJsonManifest:
         findings = parse_json_manifest(text)
         assert findings is not None
         assert findings[0]["body"].endswith("… (truncated)")
-        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 20
+        assert len(findings[0]["body"]) <= _mod.MAX_BODY_CHARS + 15
 
     def test_unknown_severity_renders_without_emoji(self):
         # Forward-compatible: a new severity bucket shouldn't crash; we
@@ -644,11 +668,15 @@ class TestValidateManifestItem:
             assert not _validate_manifest_item(bad), f"empty {key} should fail"
 
     def test_bool_line_is_rejected(self):
-        # `isinstance(True, int)` is True in Python because bool is an
-        # int subclass. Without the explicit bool-reject, a manifest with
-        # `"line": true` would pass as line=1 and silently fabricate an
-        # inline comment on line 1 of whatever file the orchestrator
-        # pointed at.
+        # True is the dangerous case: `isinstance(True, int)` is True
+        # (bool subclasses int) AND `True >= 1` is True, so without an
+        # explicit bool reject, `{"line": true}` passes as line=1 and
+        # fabricates an inline comment on line 1 of whatever file the
+        # orchestrator pointed at. False would actually be caught by the
+        # existing `< 1` check (False >= 1 is False), so it's already
+        # rejected — but we pin both cases for symmetry so a future
+        # refactor that removes the `< 1` check doesn't silently accept
+        # `{"line": false}`.
         bad_true = dict(self._BASE, line=True)
         bad_false = dict(self._BASE, line=False)
         assert not _validate_manifest_item(bad_true)
@@ -664,17 +692,17 @@ class TestGetDiffLinesErrorNormalization:
     # without a second exception type.
 
     def test_missing_git_binary_raises_runtime_error(self, monkeypatch):
-        import subprocess
-
+        # `_mod.subprocess` is the same object as the top-level
+        # `subprocess` module (verified: `_mod.subprocess is subprocess`
+        # → True), so patching `_mod.subprocess.run` is sufficient. The
+        # module uses attribute lookup (`subprocess.run(...)`) at call
+        # time, not at import time, so this patch takes effect even
+        # though the import happened during module load.
         def fake_run(*args, **kwargs):
             raise FileNotFoundError(
                 "[Errno 2] No such file or directory: 'git'"
             )
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        # Reload subprocess reference inside _mod — it was imported at module
-        # load, so monkeypatch on `subprocess.run` propagates via attribute
-        # lookup on the module the code actually uses.
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
 
         with pytest.raises(RuntimeError, match="git binary not found"):
@@ -686,6 +714,43 @@ class TestGetDiffLinesErrorNormalization:
         # which is a distinct misconfiguration.
         with pytest.raises(ValueError, match="base_ref is empty"):
             _mod.get_diff_lines("")
+
+
+class TestGhApiPostJson:
+    # _gh_api_post_json wraps subprocess.run to normalize missing-gh
+    # failures into a (rc, stdout, stderr) triple instead of a raised
+    # FileNotFoundError. Without this, call sites in main() (the review
+    # POST at line ~657 and the gh_issue_comment fallback) would need
+    # exception-handling duplicated at each site, and a missing `gh`
+    # would escape as an uncaught Python traceback.
+
+    def test_missing_gh_binary_returns_minus_one(self, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError(
+                "[Errno 2] No such file or directory: 'gh'"
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        rc, out, err = _mod._gh_api_post_json("/repos/x/y/issues/1/comments", {})
+        assert rc == -1
+        assert out == ""
+        assert "gh binary not found" in err
+
+    def test_subprocess_success_passes_through(self, monkeypatch):
+        # Happy path: subprocess returns normally, _gh_api_post_json
+        # forwards returncode/stdout/stderr unchanged.
+        class FakeResult:
+            returncode = 0
+            stdout = '{"id":42}'
+            stderr = ""
+
+        monkeypatch.setattr(_mod.subprocess, "run", lambda *a, **kw: FakeResult())
+
+        rc, out, err = _mod._gh_api_post_json("/repos/x/y/issues/1/comments", {"body": "hi"})
+        assert rc == 0
+        assert out == '{"id":42}'
+        assert err == ""
 
 
 class TestRenderFallbackSummary:
@@ -704,11 +769,14 @@ class TestRenderFallbackSummary:
         assert "- `a.py:10` — first finding" in out
         assert "- `b.py:20` — second finding" in out
 
-    def test_empty_list_still_renders_with_zero_count(self):
-        # Defensive: _render_fallback_summary is called when get_diff_lines
-        # fails after findings were parsed. Zero findings here is an edge
-        # case (the no-findings branch runs earlier), but it should still
-        # produce coherent output rather than crashing.
+    def test_empty_list_renders_coherently(self):
+        # Unit-level contract: main() never actually calls
+        # _render_fallback_summary with an empty list (the no-findings
+        # branch fires earlier and returns before reaching the
+        # get_diff_lines exception path that renders the fallback). This
+        # test is a contract check on the function in isolation — it
+        # should produce coherent output if ever called with [], rather
+        # than crashing or dropping the heading.
         out = _render_fallback_summary([])
         assert "Found **0** findings" in out
         assert "## Kiro Review Summary" in out


### PR DESCRIPTION
## Summary

PR #51 confirmed the JSON-manifest round-trip: the orchestrator *does* emit a perfectly valid JSON array under the `## Machine-Readable Findings` heading. The problem was that kiro-cli's markdown renderer **consumes** the ``` fence markers before writing stdout — the same way it consumes `**bold**` and inline backticks in every other finding block. After ANSI stripping, a fenced JSON block arrives as plain `json\n[...]` with nothing for a fence regex to anchor on, so the manifest path silently fell back to the regex parser on every run.

Fix: **stop trying to detect fences**. Find the first `[` after the section heading, hand the slice to `json.JSONDecoder.raw_decode`, let Python's JSON decoder handle balanced-bracket parsing. This works whether fences survive the CLI's rendering or not.

## Also in this PR

- **`gh` subprocess hardening** — the Suggestion Kiro flagged on #51 about `gh_issue_comment` and the direct `subprocess.run(["gh", ...])` in `main` having the same `FileNotFoundError` gap that was fixed for `git`. Factor out `_gh_api_post_json` helper and apply the same `FileNotFoundError → (-1, "", "...")` normalization both sites need.
- **Four Nitpicks from #51's Kiro review:**
  - Remove redundant first `monkeypatch.setattr` in `test_missing_git_binary_raises_runtime_error` (verified `_mod.subprocess is subprocess`).
  - Truncation-bound assertions tightened from `+ 20` to `+ 15` (exact max is 2015).
  - Extend `test_bool_line_is_rejected` comment to distinguish `True` (genuinely dangerous) from `False` (caught by `< 1` anyway).
  - Rename and re-comment `test_empty_list_still_renders_with_zero_count` to note the input is unreachable in production.

## Test plan

- [x] 70/70 tests pass, 4 new (unfenced JSON extraction, trailing content ignored, gh missing-binary normalization, gh happy-path passthrough).
- [ ] **Real end-to-end signal:** this PR's own Kiro review should log `Using json-manifest parser → N findings` for the first time. If it does, the full "JSON over markdown" architecture is proven. If it still falls back to regex — e.g. because the orchestrator emits `{}` instead of `[]`, or includes a verdict before the array — the fallback path still works cleanly, and we have a concrete next constraint to tune for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)