### PR TITLE
docs(core): drop Error::Json overclaim and private intra-doc-link (#40)

### DIFF
--- a/crates/kiro-market-core/src/platform.rs
+++ b/crates/kiro-market-core/src/platform.rs
@@ -85,7 +85,7 @@ mod sys {
     use std::ffi::OsString;
     use std::io;
     use std::os::windows::fs::MetadataExt;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use super::LinkResult;
 

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -468,7 +468,7 @@ impl MarketplaceService {
     ///
     /// # Errors
     ///
-    /// - [`Error::Marketplace`] / [`Error::Plugin`] / [`Error::Io`] from
+    /// - [`Error::Marketplace`] / [`Error::Io`] from
     ///   [`Self::list_plugin_entries`] (unknown marketplace, corrupt or
     ///   unreadable registry).
     /// - [`Error::Plugin`] ([`PluginError::NotFound`]) if `plugin`
@@ -535,8 +535,7 @@ impl MarketplaceService {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Marketplace`] / [`Error::Plugin`] /
-    /// [`Error::Io`] / [`Error::Json`] from
+    /// Returns [`Error::Marketplace`] / [`Error::Io`] from
     /// [`Self::list_plugin_entries`] when the marketplace is unknown
     /// or its registry is corrupt / unreadable. Non-plugin-level
     /// errors during iteration propagate; plugin-level errors

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -341,7 +341,7 @@ pub enum SkillCount {
     /// - [`SkippedReason::DirectoryUnreadable`] — stat failed for any
     ///   other reason (permission denied, transient I/O, etc.).
     ///
-    /// From [`load_plugin_manifest`]:
+    /// From the `plugin.json` load:
     /// - [`SkippedReason::InvalidManifest`] — `plugin.json` malformed.
     /// - [`SkippedReason::ManifestReadFailed`] — `plugin.json` read
     ///   failed after a successful stat.
@@ -468,9 +468,9 @@ impl MarketplaceService {
     ///
     /// # Errors
     ///
-    /// - [`Error::Marketplace`] / [`Error::Plugin`] / [`Error::Io`] /
-    ///   [`Error::Json`] from [`Self::list_plugin_entries`] (unknown
-    ///   marketplace, corrupt or unreadable registry).
+    /// - [`Error::Marketplace`] / [`Error::Plugin`] / [`Error::Io`] from
+    ///   [`Self::list_plugin_entries`] (unknown marketplace, corrupt or
+    ///   unreadable registry).
     /// - [`Error::Plugin`] ([`PluginError::NotFound`]) if `plugin`
     ///   does not appear in the marketplace.
     /// - [`Error::Plugin`] ([`PluginError::DirectoryMissing`] /
@@ -666,7 +666,7 @@ impl MarketplaceService {
     ///
     /// # Errors
     ///
-    /// - [`Error::Marketplace`] / [`Error::Io`] / [`Error::Json`] from
+    /// - [`Error::Marketplace`] / [`Error::Io`] from
     ///   [`Self::list_plugin_entries`] (unknown marketplace, corrupt or
     ///   unreadable registry).
     /// - [`Error::Plugin`] ([`PluginError::NotFound`]) if `plugin` is not
@@ -1055,6 +1055,7 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Err
 mod tests {
     use std::path::Path;
 
+    #[cfg(unix)]
     use tempfile::tempdir;
 
     use super::*;


### PR DESCRIPTION
## Summary

Closes #40. Three sibling sites on `MarketplaceService` documented errors the code path cannot surface, plus one private intra-doc link that emitted a `private_intra_doc_links` warning.

- `count_skills_for_plugin` (`browse.rs:344`): replaced `` [`load_plugin_manifest`] `` with bare-prose `From the `plugin.json` load:`. `load_plugin_manifest` is module-private; `cargo doc -p kiro-market-core --no-deps` was emitting *"public documentation for `ManifestFailed` links to private item `load_plugin_manifest`"*.
- `list_skills_for_plugin` (`browse.rs:472`) and `resolve_plugin_install_context` (`browse.rs:669`): dropped `Error::Json` from `# Errors`. `list_plugin_entries` swallows registry JSON errors (`warn!` + manifest fallback at `service/mod.rs:847-854`) and manifest JSON errors (`warn!` + `Ok(None)` at `service/mod.rs:1416-1423`); reachable variants are `Error::Marketplace(NotFound)` and non-`NotFound` `Error::Io` only.
- The original issue listed `[load_plugin_manifest]` as a second bug at `resolve_plugin_install_context`, but that link was already cleaned up before this PR; only the `Error::Json` overclaim remained at that site.

Folded in two pre-existing unused-import clippy errors surfaced by the local pre-commit gate (`cargo clippy --workspace --tests -- -D warnings`):
- `platform.rs:88`: dropped unused `PathBuf` from the `#[cfg(windows)]` `sys` module.
- `browse.rs:1058`: gated `use tempfile::tempdir;` behind `#[cfg(unix)]` to match its sole call site.

> Note: upstream `lint` job runs `cargo clippy --workspace -- -D warnings` (no `--tests`) on `ubuntu-latest`, so neither warning was actually blocking CI — but they were blocking the documented pre-commit gate, so they're folded in here.

`cargo doc -p kiro-market-core --no-deps` warning count: **14 → 13**.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings` (clean)
- [x] `cargo test -p kiro-market-core -p kiro-market` (541 lib + 2 doctests, matches the Windows CI command)
- [x] `cargo doc -p kiro-market-core --no-deps` — confirmed `load_plugin_manifest` private-link warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)