### PR TITLE
chore(core): HashSet<&Path> in companion diff helpers (#62)

### DIFF
--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -2373,7 +2373,8 @@ impl KiroProject {
         rel_paths: &[PathBuf],
         agents_dir: &Path,
     ) -> crate::error::Result<()> {
-        let new_set: std::collections::HashSet<&PathBuf> = rel_paths.iter().collect();
+        let new_set: std::collections::HashSet<&Path> =
+            rel_paths.iter().map(PathBuf::as_path).collect();
         let other_plugins: Vec<String> = installed
             .native_companions
             .keys()
@@ -2384,7 +2385,7 @@ impl KiroProject {
         for p in other_plugins {
             if let Some(meta) = installed.native_companions.get_mut(&p) {
                 let len_before = meta.files.len();
-                meta.files.retain(|f| !new_set.contains(f));
+                meta.files.retain(|f| !new_set.contains(f.as_path()));
                 if meta.files.len() != len_before {
                     modified.push(p);
                 }
@@ -2424,11 +2425,12 @@ impl KiroProject {
         let Some(prior) = installed.native_companions.get(plugin) else {
             return Vec::new();
         };
-        let new_set: std::collections::HashSet<&PathBuf> = rel_paths.iter().collect();
+        let new_set: std::collections::HashSet<&Path> =
+            rel_paths.iter().map(PathBuf::as_path).collect();
         prior
             .files
             .iter()
-            .filter(|f| !new_set.contains(*f))
+            .filter(|f| !new_set.contains(f.as_path()))
             .cloned()
             .collect()
     }


### PR DESCRIPTION
## Summary
- Swap `HashSet<&PathBuf>` for `HashSet<&Path>` in `strip_transferred_paths_from_other_plugins` (`project.rs:2376`) and `diff_prior_companion_files` (`project.rs:2427`). Pure polish — eliminates the clippy::ptr_arg-style anti-pattern called out in #62.
- The `&self`/`unused_self` items #62 also flagged are already cleaned in the merged native-install branch (`promote_native_companions` is an associated function and no `let _ = self;` survives), so this PR closes the remaining leg.
- Out of scope but same pattern: `crates/kiro-market-core/src/hash.rs:53` still has a `Vec<&PathBuf>` for sort. Punted to a separate cleanup if desired.

Closes #62.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace` (634 core unit + 4 native-install integration + doctests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)