### PR TITLE
chore(repo): add .editorconfig + .gitattributes for LF/EOL policy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,8 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+
+# Windows shells require CRLF — keep editors aligned with .gitattributes
+# so editor saves don't fight git's normalization on stage.
+[*.{bat,ps1}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.bat       text eol=crlf
+*.ps1       text eol=crlf
+*.sh        text eol=lf
+*.png       binary
+*.pdf       binary


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` (root config: LF, final newline) and `.gitattributes` (`* text=auto eol=lf` plus per-extension overrides).
- Eliminates the `CRLF will be replaced by LF the next time Git touches it` warning that fires on every Windows branch switch — observed twice while opening PRs #69 and #70 today.
- Per-extension overrides:
  - `*.bat`, `*.ps1` → CRLF (Windows shells require it)
  - `*.sh` → LF (POSIX shells require it)
  - `*.png`, `*.pdf` → binary

## Scope
- Pure metadata. No code, no tests, no functional change.
- **Does not retroactively renormalize existing files.** Files currently in the repo with CRLF in their working-tree representation on Windows will continue to show CRLF until the file is touched. Running `git add --renormalize .` workspace-wide can be a separate follow-up if desired — keeping it out of this PR so the diff stays minimal.

## Test plan
- [x] Both files render correctly on GitHub
- [x] `git status` on branch checkout is silent (no normalization warning on these two files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)