### PR TITLE
feat(xtask): three architecture-fitness gates for plan-lint

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -66,6 +66,13 @@ fn load_settings(dir: &std::path::Path) -> Result<JsonValue, CommandError> {
             format!("could not read settings file: {e}"),
             ErrorType::IoError,
         )),
+        // `LoadSettingsError` is `#[non_exhaustive]`. A future variant
+        // added in core compiles here without forcing a frontend edit;
+        // its `Display` impl provides the user-facing string.
+        Err(other) => Err(CommandError::new(
+            format!("settings load failed: {other}"),
+            ErrorType::Unknown,
+        )),
     }
 }
 

--- a/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/kiro_settings.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use kiro_market_core::error::error_full_chain;
 use kiro_market_core::file_lock::with_file_lock;
 use kiro_market_core::kiro_settings::{
     apply_registered_setting, default_kiro_dir, kiro_settings_path, load_kiro_settings_from,
@@ -55,22 +56,23 @@ fn load_settings(dir: &std::path::Path) -> Result<JsonValue, CommandError> {
     match load_kiro_settings_from(dir) {
         Ok(json) => Ok(json),
         Err(LoadSettingsError::NotFound) => Ok(serde_json::json!({})),
-        Err(LoadSettingsError::InvalidJson(e)) => Err(CommandError::new(
+        Err(e @ LoadSettingsError::InvalidJson(_)) => Err(CommandError::new(
             format!(
-                "settings file contains invalid JSON and cannot be safely updated: {e}. \
-                 Back up or delete ~/.kiro/settings/cli.json and try again."
+                "settings file contains invalid JSON and cannot be safely updated: {chain}. \
+                 Back up or delete ~/.kiro/settings/cli.json and try again.",
+                chain = error_full_chain(&e),
             ),
             ErrorType::ParseError,
         )),
-        Err(LoadSettingsError::Io(e)) => Err(CommandError::new(
-            format!("could not read settings file: {e}"),
+        Err(e @ LoadSettingsError::Io(_)) => Err(CommandError::new(
+            format!("could not read settings file: {}", error_full_chain(&e)),
             ErrorType::IoError,
         )),
         // `LoadSettingsError` is `#[non_exhaustive]`. A future variant
         // added in core compiles here without forcing a frontend edit;
         // its `Display` impl provides the user-facing string.
         Err(other) => Err(CommandError::new(
-            format!("settings load failed: {other}"),
+            format!("settings load failed: {}", error_full_chain(&other)),
             ErrorType::Unknown,
         )),
     }

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -910,7 +910,13 @@ pub fn resolve_settings(json: &JsonValue) -> Vec<SettingEntry> {
 const SETTINGS_FILE: &str = "settings/cli.json";
 
 /// Errors from loading the Kiro CLI settings file.
+///
+/// `#[non_exhaustive]` so future variants (file corruption mid-write,
+/// permission-denied with diagnostics, etc.) are additive without
+/// breaking matches in downstream crates. Pattern matches outside
+/// `kiro-market-core` MUST include a catch-all `_ =>` arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum LoadSettingsError {
     /// The file does not exist — use empty defaults.
     #[error("settings file not found")]

--- a/crates/kiro-market-core/src/skill.rs
+++ b/crates/kiro-market-core/src/skill.rs
@@ -8,7 +8,13 @@ use serde::Deserialize;
 use thiserror::Error;
 
 /// Errors that can occur while parsing `SKILL.md` frontmatter.
+///
+/// `#[non_exhaustive]` so future variants (e.g. NUL-byte rejection,
+/// length cap, schema-version mismatch) are additive without breaking
+/// matches in downstream crates. Pattern matches outside
+/// `kiro-market-core` MUST include a catch-all `_ =>` arm.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The file does not start with a `---` frontmatter fence.
     #[error("missing opening `---` frontmatter fence")]

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -173,6 +173,15 @@ ORDER BY f.path, i.symbol_name";
 /// This gate flags any public enum in `kiro-market-core` whose name ends
 /// in `Error` and that lacks the attribute.
 ///
+/// **Heuristic limitation:** the SQL matches on `LIKE '%Error'` only.
+/// Error-like enums named `*Failure`, `*Kind`, or `*Reason` (e.g.
+/// `NativeParseFailure`, `ParseFailure`) deriving `thiserror::Error` are
+/// invisible to this gate and must carry `#[non_exhaustive]` by manual
+/// review. Widening the SQL would require joining the `attributes` table
+/// to detect `thiserror::Error` derives regardless of name; the current
+/// `*Error` convention catches the common case and the existing
+/// `*Failure` enums in core already opt in.
+///
 /// Scoped to `kiro-market-core` because the rule is about the public
 /// surface of the *library* — Tauri command errors and CLI binary
 /// errors don't carry the same downstream-stability requirement.
@@ -213,7 +222,7 @@ const ALL_GATES: &[Gate] = &[
     },
     Gate {
         name: "non-exhaustive-error-enum",
-        description: "pub Error enum in kiro-market-core missing #[non_exhaustive]",
+        description: "pub *Error-named enum in kiro-market-core missing #[non_exhaustive] (heuristic: name LIKE '%Error' only)",
         sql: NON_EXHAUSTIVE_ERROR_ENUM_SQL,
     },
     Gate {
@@ -535,8 +544,22 @@ pub fn run(args: impl Iterator<Item = String>) -> Result<usize> {
 
 fn print_finding(f: &Finding) {
     let signature = f.signature.as_deref().unwrap_or("<no signature>");
-    println!("    {}:{}", f.path, f.line);
+    println!("    {}", format_path_line(&f.path, f.line));
     println!("        {} : {}", f.qualified_name, signature);
+}
+
+/// Format the `path:line` prefix shown for a finding. The
+/// `no-frontend-deps-in-core` gate uses `line = 0` as a sentinel because
+/// the `imports` tethys table has no line column; rendering that as
+/// `path:0` invites editors and CI log parsers to treat it as a real
+/// line reference. This helper substitutes a human-readable hint so the
+/// reviewer knows to grep the file for the import.
+fn format_path_line(path: &str, line: u32) -> String {
+    if line == 0 {
+        format!("{path} (line unknown — grep for import)")
+    } else {
+        format!("{path}:{line}")
+    }
 }
 
 fn ensure_tethys_index(workspace: &Path) -> Result<()> {
@@ -1086,6 +1109,28 @@ mod tests {
         assert!(findings.is_empty());
     }
 
+    // ─── format_path_line (line=0 sentinel) ─────────────────────────────
+
+    #[test]
+    fn format_path_line_renders_real_line_normally() {
+        assert_eq!(
+            format_path_line("crates/kiro-market-core/src/git.rs", 42),
+            "crates/kiro-market-core/src/git.rs:42"
+        );
+    }
+
+    #[test]
+    fn format_path_line_substitutes_hint_for_zero_line_sentinel() {
+        // The no-frontend-deps-in-core gate uses line=0 as a sentinel
+        // (imports tethys table has no line column). Rendering as
+        // `path:0` would mislead editors and CI parsers into following
+        // a nonexistent line reference.
+        assert_eq!(
+            format_path_line("crates/kiro-market-core/src/foo.rs", 0),
+            "crates/kiro-market-core/src/foo.rs (line unknown — grep for import)"
+        );
+    }
+
     // ─── --gate <name> validation ───────────────────────────────────────
 
     #[test]
@@ -1342,6 +1387,69 @@ mod tests {
         assert!(findings.is_empty());
     }
 
+    #[test]
+    fn no_panic_skips_files_under_tests_dir() {
+        // Anything under `tests/` is test code by virtue of where it
+        // lives, even if the function itself isn't `#[test]`-marked
+        // (e.g. helpers in tests/common/). Mirrors the no-unwrap test
+        // so a future SQL edit dropping the `'/' || f.path NOT LIKE
+        // '%/tests/%'` clause regresses both gates symmetrically.
+        let conn = fresh_db();
+        seed_function(
+            &conn,
+            2,
+            "crates/core/tests/common/fixtures.rs",
+            10,
+            "make_fixture",
+            false,
+        );
+        insert_panic_ref(&conn, 2, 10, 42, "panic");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(
+            findings.is_empty(),
+            "files under tests/ are exempt; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn no_panic_skips_workspace_root_tests_and_benches() {
+        // The `'/' || f.path` prepend in NO_PANIC_SQL must handle both
+        // workspace-root (`tests/integration.rs`) and crate-nested
+        // (`crates/foo/tests/...`) paths uniformly.
+        let conn = fresh_db();
+        seed_function(&conn, 2, "tests/integration.rs", 10, "test_helper", false);
+        seed_function(&conn, 3, "benches/throughput.rs", 11, "bench_helper", false);
+        insert_panic_ref(&conn, 2, 10, 42, "panic");
+        insert_panic_ref(&conn, 3, 11, 42, "todo");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(
+            findings.is_empty(),
+            "workspace-root tests/ and benches/ exempt; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn no_panic_skips_test_support_modules() {
+        let conn = fresh_db();
+        seed_function(
+            &conn,
+            2,
+            "crates/core/src/service/test_support.rs",
+            10,
+            "MarketplaceService::stub",
+            false,
+        );
+        insert_panic_ref(&conn, 2, 10, 42, "unimplemented");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(
+            findings.is_empty(),
+            "test_support modules exempt; got {findings:?}"
+        );
+    }
+
     // ─── non-exhaustive-error-enum ──────────────────────────────────────
 
     fn non_exhaustive() -> &'static Gate {
@@ -1551,5 +1659,42 @@ mod tests {
 
         let findings = no_frontend_deps().run(&conn).expect("query");
         assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn no_frontend_deps_flags_bare_tauri_import() {
+        // Covers the `OR i.source_module = 'tauri'` SQL branch — `use
+        // tauri;` (bare crate import, no `::path`). Existing tests only
+        // exercise the `LIKE 'tauri::%'` branch, so a regression that
+        // accidentally changed `=` to `LIKE` would slip past untested.
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "tauri",
+            "tauri",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].signature.as_deref(), Some("tauri"));
+    }
+
+    #[test]
+    fn no_frontend_deps_flags_bare_tokio_import() {
+        // Covers the `OR i.source_module = 'tokio'` SQL branch.
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "tokio",
+            "tokio",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].signature.as_deref(), Some("tokio"));
     }
 }

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -140,6 +140,34 @@ WHERE r.reference_name IN ('panic', 'todo', 'unimplemented')
   AND f.path NOT LIKE '%test_utils%'
 ORDER BY f.path, r.line";
 
+/// CLAUDE.md "Dependencies point inward" — `kiro-market-core` is the
+/// domain core and must stay free of UI / Tauri / async-runtime / frontend
+/// deps. Adding `use tauri::...`, `use tauri_plugin_*::...`, or `use tokio::...`
+/// to a file in `kiro-market-core/src/` would violate this even before
+/// `Cargo.toml` notices.
+///
+/// Queries the `imports` table (one row per `use` statement) and flags
+/// any import in `kiro-market-core/src/` whose `source_module` starts
+/// with one of the forbidden prefixes. `cargo-deny` solves the
+/// crate-Cargo.toml version of this rule; this gate solves the
+/// per-file version, catching the bad import the moment it lands.
+// `imports` does not carry a line column (one row per
+// (file_id, symbol_name, source_module) tuple), so we report `line = 0`
+// as a sentinel and the reviewer greps the file for the import. The
+// path + (symbol_name, source_module) signature is enough to locate it.
+const NO_FRONTEND_DEPS_IN_CORE_SQL: &str = "\
+SELECT f.path, 0 AS line, i.symbol_name AS qualified_name, i.source_module AS signature
+FROM imports i
+JOIN files f ON f.id = i.file_id
+WHERE f.path LIKE '%kiro-market-core/src/%'
+  AND f.path NOT LIKE '%/tests/%'
+  AND (i.source_module LIKE 'tauri::%'
+       OR i.source_module = 'tauri'
+       OR i.source_module LIKE 'tauri_plugin_%'
+       OR i.source_module LIKE 'tokio::%'
+       OR i.source_module = 'tokio')
+ORDER BY f.path, i.symbol_name";
+
 /// CLAUDE.md mandates `#[non_exhaustive]` on error enums so adding a new
 /// variant in core doesn't silently break downstream pattern matches.
 /// This gate flags any public enum in `kiro-market-core` whose name ends
@@ -187,6 +215,11 @@ const ALL_GATES: &[Gate] = &[
         name: "non-exhaustive-error-enum",
         description: "pub Error enum in kiro-market-core missing #[non_exhaustive]",
         sql: NON_EXHAUSTIVE_ERROR_ENUM_SQL,
+    },
+    Gate {
+        name: "no-frontend-deps-in-core",
+        description: "tauri / tokio import in kiro-market-core (dependencies-point-inward)",
+        sql: NO_FRONTEND_DEPS_IN_CORE_SQL,
     },
 ];
 
@@ -580,6 +613,13 @@ mod tests {
             name TEXT NOT NULL,
             args TEXT,
             line INTEGER NOT NULL
+        );
+        CREATE TABLE imports (
+            file_id INTEGER NOT NULL,
+            symbol_name TEXT NOT NULL,
+            source_module TEXT NOT NULL,
+            alias TEXT,
+            PRIMARY KEY (file_id, symbol_name, source_module)
         );
     ";
 
@@ -1405,5 +1445,111 @@ mod tests {
         );
         let findings = non_exhaustive().run(&conn).expect("query");
         assert!(findings.is_empty());
+    }
+
+    // ─── no-frontend-deps-in-core ───────────────────────────────────────
+
+    fn no_frontend_deps() -> &'static Gate {
+        ALL_GATES
+            .iter()
+            .find(|g| g.name == "no-frontend-deps-in-core")
+            .expect("no-frontend-deps gate registered")
+    }
+
+    fn seed_import(conn: &Connection, file_id: i64, path: &str, symbol: &str, source: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO files (id, path, language) VALUES (?1, ?2, 'rust')",
+            rusqlite::params![file_id, path],
+        )
+        .expect("file");
+        conn.execute(
+            "INSERT INTO imports (file_id, symbol_name, source_module) VALUES (?1, ?2, ?3)",
+            rusqlite::params![file_id, symbol, source],
+        )
+        .expect("import");
+    }
+
+    #[test]
+    fn no_frontend_deps_flags_tauri_in_core() {
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "Manager",
+            "tauri::Manager",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].signature.as_deref(), Some("tauri::Manager"));
+    }
+
+    #[test]
+    fn no_frontend_deps_flags_tokio_in_core() {
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "spawn",
+            "tokio::spawn",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].signature.as_deref(), Some("tokio::spawn"));
+    }
+
+    #[test]
+    fn no_frontend_deps_does_not_flag_tauri_in_other_crates() {
+        // Tauri imports are FINE in the Tauri crate itself.
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-control-center/src-tauri/src/lib.rs",
+            "Manager",
+            "tauri::Manager",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "tauri imports outside core are fine; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn no_frontend_deps_does_not_flag_unrelated_crate_with_similar_name() {
+        // `tauri_anything` would not start with `tauri::` so the LIKE
+        // pattern excludes it. Defensive test in case someone adds a
+        // crate named `tauri_extra` etc. in the future.
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "thing",
+            "taurus::thing", // similar but not tauri::
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn no_frontend_deps_flags_tauri_plugin_imports() {
+        let conn = fresh_db();
+        seed_import(
+            &conn,
+            2,
+            "crates/kiro-market-core/src/foo.rs",
+            "init",
+            "tauri_plugin_dialog::init",
+        );
+
+        let findings = no_frontend_deps().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
     }
 }

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -115,6 +115,31 @@ WHERE r.reference_name IN ('unwrap', 'expect')
   AND f.path NOT LIKE '%test_utils%'
 ORDER BY f.path, r.line";
 
+/// Catches `panic!`, `todo!`, and `unimplemented!` macro invocations in
+/// non-test production code. Same JOIN shape as `no-unwrap-in-production`,
+/// just a different `reference_name` list — these macros are not method
+/// calls but tree-sitter-rust extracts `macro_invocation` references the
+/// same way it extracts method calls, so the query is identical in shape.
+///
+/// `unreachable!()` is *not* in the list — it's the canonical replacement
+/// when restructuring code to satisfy zero-tolerance, and treating it as
+/// a violation would defeat its purpose. If `unreachable!()` ever shows
+/// up at a runtime-reachable site, that's a code-review concern, not a
+/// gate concern.
+const NO_PANIC_SQL: &str = "\
+SELECT f.path, r.line, s.qualified_name, r.reference_name
+FROM refs r
+JOIN symbols s ON s.id = r.in_symbol_id
+JOIN files f ON f.id = r.file_id
+WHERE r.reference_name IN ('panic', 'todo', 'unimplemented')
+  AND s.kind IN ('function', 'method')
+  AND s.is_test = 0
+  AND '/' || f.path NOT LIKE '%/tests/%'
+  AND '/' || f.path NOT LIKE '%/benches/%'
+  AND f.path NOT LIKE '%test_support%'
+  AND f.path NOT LIKE '%test_utils%'
+ORDER BY f.path, r.line";
+
 const ALL_GATES: &[Gate] = &[
     Gate {
         name: "gate-4-external-error-boundary",
@@ -125,6 +150,11 @@ const ALL_GATES: &[Gate] = &[
         name: "no-unwrap-in-production",
         description: ".unwrap() or .expect() in non-test production code",
         sql: NO_UNWRAP_SQL,
+    },
+    Gate {
+        name: "no-panic-in-production",
+        description: "panic!, todo!, or unimplemented! in non-test production code",
+        sql: NO_PANIC_SQL,
     },
 ];
 
@@ -1181,5 +1211,62 @@ mod tests {
             stale.is_empty(),
             "no entries should be stale when every index matched"
         );
+    }
+
+    // ─── no-panic-in-production ─────────────────────────────────────────
+
+    fn no_panic() -> &'static Gate {
+        ALL_GATES
+            .iter()
+            .find(|g| g.name == "no-panic-in-production")
+            .expect("no-panic gate registered")
+    }
+
+    #[test]
+    fn no_panic_flags_panic_macro() {
+        let conn = fresh_db();
+        seed_function(&conn, 2, "crates/core/src/lib.rs", 10, "do_thing", false);
+        insert_panic_ref(&conn, 2, 10, 42, "panic");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].signature.as_deref(), Some("panic"));
+    }
+
+    #[test]
+    fn no_panic_flags_todo_and_unimplemented() {
+        let conn = fresh_db();
+        seed_function(&conn, 2, "crates/core/src/lib.rs", 10, "do_thing", false);
+        insert_panic_ref(&conn, 2, 10, 1, "todo");
+        insert_panic_ref(&conn, 2, 10, 2, "unimplemented");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert_eq!(findings.len(), 2);
+    }
+
+    #[test]
+    fn no_panic_does_not_flag_unreachable() {
+        // unreachable!() is the canonical replacement when restructuring to
+        // satisfy zero-tolerance — it must NOT be flagged by this gate or
+        // the gate would defeat its own remediation path.
+        let conn = fresh_db();
+        seed_function(&conn, 2, "crates/core/src/lib.rs", 10, "do_thing", false);
+        insert_panic_ref(&conn, 2, 10, 5, "unreachable");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(
+            findings.is_empty(),
+            "unreachable! is exempt; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn no_panic_skips_test_marked_functions() {
+        let conn = fresh_db();
+        seed_function(&conn, 2, "crates/core/src/lib.rs", 10, "test_thing", true);
+        insert_panic_ref(&conn, 2, 10, 42, "panic");
+
+        let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(findings.is_empty());
     }
 }

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -140,6 +140,33 @@ WHERE r.reference_name IN ('panic', 'todo', 'unimplemented')
   AND f.path NOT LIKE '%test_utils%'
 ORDER BY f.path, r.line";
 
+/// CLAUDE.md mandates `#[non_exhaustive]` on error enums so adding a new
+/// variant in core doesn't silently break downstream pattern matches.
+/// This gate flags any public enum in `kiro-market-core` whose name ends
+/// in `Error` and that lacks the attribute.
+///
+/// Scoped to `kiro-market-core` because the rule is about the public
+/// surface of the *library* — Tauri command errors and CLI binary
+/// errors don't carry the same downstream-stability requirement.
+///
+/// `signature` is `NULL` (no useful per-finding text); the gate's
+/// description carries the explanation.
+const NON_EXHAUSTIVE_ERROR_ENUM_SQL: &str = "\
+SELECT f.path, s.line, s.qualified_name, NULL AS signature
+FROM symbols s
+JOIN files f ON f.id = s.file_id
+WHERE s.kind = 'enum'
+  AND s.visibility = 'public'
+  AND s.name LIKE '%Error'
+  AND f.path LIKE '%kiro-market-core/src/%'
+  AND f.path NOT LIKE '%/tests/%'
+  AND NOT EXISTS (
+      SELECT 1 FROM attributes a
+      WHERE a.symbol_id = s.id
+        AND a.name = 'non_exhaustive'
+  )
+ORDER BY f.path, s.line";
+
 const ALL_GATES: &[Gate] = &[
     Gate {
         name: "gate-4-external-error-boundary",
@@ -155,6 +182,11 @@ const ALL_GATES: &[Gate] = &[
         name: "no-panic-in-production",
         description: "panic!, todo!, or unimplemented! in non-test production code",
         sql: NO_PANIC_SQL,
+    },
+    Gate {
+        name: "non-exhaustive-error-enum",
+        description: "pub Error enum in kiro-market-core missing #[non_exhaustive]",
+        sql: NON_EXHAUSTIVE_ERROR_ENUM_SQL,
     },
 ];
 
@@ -1267,6 +1299,111 @@ mod tests {
         insert_panic_ref(&conn, 2, 10, 42, "panic");
 
         let findings = no_panic().run(&conn).expect("query should succeed");
+        assert!(findings.is_empty());
+    }
+
+    // ─── non-exhaustive-error-enum ──────────────────────────────────────
+
+    fn non_exhaustive() -> &'static Gate {
+        ALL_GATES
+            .iter()
+            .find(|g| g.name == "non-exhaustive-error-enum")
+            .expect("non-exhaustive gate registered")
+    }
+
+    fn seed_error_enum(
+        conn: &Connection,
+        sym_id: i64,
+        path: &str,
+        name: &str,
+        with_non_exhaustive: bool,
+    ) {
+        conn.execute(
+            "INSERT OR IGNORE INTO files (id, path, language) VALUES (2, ?1, 'rust')",
+            [path],
+        )
+        .expect("file");
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, visibility)
+             VALUES (?1, 2, ?2, ?2, 'enum', 1, 'public')",
+            rusqlite::params![sym_id, name],
+        )
+        .expect("enum");
+        if with_non_exhaustive {
+            conn.execute(
+                "INSERT INTO attributes (symbol_id, name, args, line)
+                 VALUES (?1, 'non_exhaustive', NULL, 1)",
+                [sym_id],
+            )
+            .expect("attr");
+        }
+    }
+
+    #[test]
+    fn non_exhaustive_flags_pub_error_enum_without_attribute() {
+        let conn = fresh_db();
+        seed_error_enum(
+            &conn,
+            10,
+            "crates/kiro-market-core/src/error.rs",
+            "PluginError",
+            false,
+        );
+        let findings = non_exhaustive().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].qualified_name, "PluginError");
+    }
+
+    #[test]
+    fn non_exhaustive_passes_when_attribute_present() {
+        let conn = fresh_db();
+        seed_error_enum(
+            &conn,
+            10,
+            "crates/kiro-market-core/src/error.rs",
+            "PluginError",
+            true,
+        );
+        let findings = non_exhaustive().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "enum with #[non_exhaustive] is exempt; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn non_exhaustive_only_scopes_to_kiro_market_core() {
+        // A pub Error enum in the Tauri crate or CLI binary doesn't carry
+        // the same downstream-stability requirement; this gate only fires
+        // on `kiro-market-core` symbols.
+        let conn = fresh_db();
+        seed_error_enum(
+            &conn,
+            10,
+            "crates/kiro-control-center/src-tauri/src/error.rs",
+            "CommandError",
+            false,
+        );
+        let findings = non_exhaustive().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "non-core crates exempt from non-exhaustive rule; got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn non_exhaustive_ignores_non_error_enums() {
+        // Heuristic: only enums whose name ends in `Error` are subject to
+        // this rule. `Status`, `Kind`, etc. don't trigger.
+        let conn = fresh_db();
+        seed_error_enum(
+            &conn,
+            10,
+            "crates/kiro-market-core/src/lib.rs",
+            "Status",
+            false,
+        );
+        let findings = non_exhaustive().run(&conn).expect("query");
         assert!(findings.is_empty());
     }
 }


### PR DESCRIPTION
> 📌 **Stacked on [#72](https://github.com/dwalleck/kiro-control-center/pull/72)** (plan-lint runner). Sibling to [#73](https://github.com/dwalleck/kiro-control-center/pull/73) (zero-tolerance cleanup). Merge order: #72 → either #73 or this PR → the other.

## Summary

Three new gates in `xtask/src/plan_lint.rs`, each enforcing a CLAUDE.md rule that previously had no executable check:

- **`no-panic-in-production`** — `panic!`, `todo!`, `unimplemented!` in non-test production code (CLAUDE.md zero-tolerance, same shape as `no-unwrap-in-production`). `unreachable!` is deliberately exempt — it's the canonical replacement when restructuring.
- **`non-exhaustive-error-enum`** — `pub enum *Error` in `kiro-market-core` missing `#[non_exhaustive]`. Found and fixed 2 real violations in this PR (`LoadSettingsError`, `ParseError`), plus a downstream catch-all in the Tauri-side `load_settings` match.
- **`no-frontend-deps-in-core`** — `use tauri::*` / `use tauri_plugin_*::*` / `use tokio::*` in any file under `kiro-market-core/src/`. CLAUDE.md "Dependencies point inward". Per-file enforcement; finer-grained than `cargo-deny`.

After this PR, `cargo xtask plan-lint` runs five gates total. All architecture-fitness gates are green on marketplace-cli HEAD; the no-unwrap gate still reports 10 production violations until #73 lands (or independently — the gates are non-blocking until CI is wired up).

## What this proves

The plan-lint mechanism scales gate-by-gate. Each new gate is a `~10-30 line SQL query` plus a `~3-5 unit tests` plus one entry in `ALL_GATES`. The `Finding` shape (path/line/qualified_name/signature) carries across all gates — the printer and runner don't change.

The pattern is now consistent: a gate's first run against real code finds the deliberate-or-accidental violations the rule was always meant to forbid. Gate 4 found `NativeParseFailure::InvalidJson(serde_json::Error)`. No-unwrap found 10. Non-exhaustive-error-enum found 2 (fixed in this PR). No-panic and no-frontend-deps run clean — those rules are currently honored even without enforcement, but locking them down means they stay that way.

## Smoke against marketplace-cli HEAD

```
$ cargo xtask plan-lint
Indexed 60 files, found 1306 symbols, 12706 references
Duration: 9.3s

gate-4-external-error-boundary OK
no-unwrap-in-production — .unwrap() or .expect() in non-test production code (10 findings)
    [ ... 10 findings — see #73 for the cleanup ... ]
no-panic-in-production OK
non-exhaustive-error-enum OK
no-frontend-deps-in-core OK
```

## Commits

1. `a77c636` — `feat(xtask): no-panic-in-production gate`
   Same JOIN shape as no-unwrap. `reference_name IN ('panic', 'todo', 'unimplemented')`. `unreachable!` deliberately exempt. 4 unit tests.

2. `f4a6c2d` — `feat(xtask,core): non-exhaustive-error-enum gate + fix two violations`
   New gate scoped to `kiro-market-core/src/`. Found 2 real violations (`LoadSettingsError` at `kiro_settings.rs:844`, `ParseError` at `skill.rs:12`); both fixed by adding `#[non_exhaustive]`. The Tauri-side `load_settings` match in `kiro-control-center/src-tauri/src/commands/kiro_settings.rs` gains a catch-all `Err(other) =>` arm to satisfy the new attribute on the consumer side. 4 unit tests.

3. `be45dc1` — `feat(xtask): no-frontend-deps-in-core gate (dependencies-point-inward)`
   Uses tethys's `imports` table (one row per `use` statement). Flags `tauri::*`, `tauri_plugin_*::*`, `tokio::*` imports in `kiro-market-core/src/`. `imports` carries no line column so `line` is reported as 0; the path + (symbol, source_module) signature is enough to locate the violation. 5 unit tests.

## Test plan

- [x] `cargo test --workspace` — 656 (core, +4 fixed cases) + 31 (xtask, +13 new) + others, all pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] All 13 new unit tests pass against the in-memory SQLite fixture (with the new `imports` table added to `TEST_SCHEMA`)
- [x] End-to-end smoke against marketplace-cli HEAD: 3 new gates report clean, the 2 `non-exhaustive` violations are fixed in this same PR
- [ ] Reviewer to confirm the rule scope choices: non-exhaustive-error-enum is core-only; no-frontend-deps targets `tauri` + `tauri_plugin_*` + `tokio`. Easy to extend either if a follow-up gate wants different scoping.
- [ ] Reviewer to confirm `unreachable!` exemption is correct for `no-panic`. Argument for: it's the documented refactoring escape hatch in CLAUDE.md. Argument against: it's still a panic at runtime. I lean exempt; reviewer's call.

## Out of scope (genuine follow-ups)

- **CI wiring** — `cargo xtask plan-lint` as a workflow step. Blocked until #73 lands (no-unwrap goes from 10 to 2-allowlisted). The mechanism is now in place; the workflow integration is one config file.
- **More gates.** The natural next batch (Gate 5.2 specta cfg-attr on validation newtypes, boolean-pair → enum, no direct `Command::new("git")` outside `git.rs`) all fit the same shape. Each is roughly an evening's work.
- **Gate 1 grounding** — operates on plan markdown text, not the index. Different shape, separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)