### PR TITLE
feat(tauri): install_plugin_steering command

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -5,9 +5,8 @@ use std::path::PathBuf;
 use serde::Serialize;
 use tracing::warn;
 
-use kiro_market_core::cache::{CacheDir, MarketplaceSource};
+use kiro_market_core::cache::MarketplaceSource;
 use kiro_market_core::error::error_full_chain;
-use kiro_market_core::git::GixCliBackend;
 use kiro_market_core::marketplace::{PluginSource, StructuredSource};
 use kiro_market_core::project::{InstalledSkills, KiroProject};
 use kiro_market_core::service::{
@@ -15,6 +14,7 @@ use kiro_market_core::service::{
     PluginSkillsResult, SkillCount,
 };
 
+use crate::commands::make_service;
 use crate::error::{CommandError, ErrorType};
 
 // ---------------------------------------------------------------------------
@@ -70,20 +70,6 @@ pub struct ProjectInfo {
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
-
-/// Construct a `MarketplaceService` for read-side handlers.
-///
-/// All Tauri commands here are read-only or install-only; the [`GitBackend`]
-/// is unused on every code path, so the default `GixCliBackend` is fine.
-fn make_service() -> Result<MarketplaceService, CommandError> {
-    let cache = CacheDir::default_location().ok_or_else(|| {
-        CommandError::new(
-            "could not determine data directory; is $HOME set?",
-            ErrorType::IoError,
-        )
-    })?;
-    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
-}
 
 /// List all registered marketplaces with plugin counts.
 #[tauri::command]

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -508,7 +508,6 @@ mod tests {
         .expect("first install");
         assert_eq!(first.installed, vec!["alpha".to_string()]);
 
-        // Re-installing with InstallMode::New must skip, not re-install.
         let second_safe = install_skills_impl(
             &svc,
             "mp1",
@@ -524,7 +523,6 @@ mod tests {
             second_safe.installed
         );
 
-        // InstallMode::Force must re-install.
         let third_force = install_skills_impl(
             &svc,
             "mp1",
@@ -567,7 +565,6 @@ mod tests {
 
         assert_eq!(result.installed, vec!["alpha".to_string()]);
 
-        // beta was not requested — it must not appear in the result or on disk.
         let project = KiroProject::new(std::path::PathBuf::from(&project_path));
         let installed = project.load_installed().expect("load installed-skills");
         assert!(

--- a/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/marketplaces.rs
@@ -2,31 +2,11 @@
 //!
 //! Thin wrappers around [`kiro_market_core::service::MarketplaceService`].
 
-use kiro_market_core::cache::CacheDir;
-use kiro_market_core::git::{GitProtocol, GixCliBackend};
-use kiro_market_core::service::{MarketplaceAddResult, MarketplaceService, UpdateResult};
+use kiro_market_core::git::GitProtocol;
+use kiro_market_core::service::{MarketplaceAddResult, UpdateResult};
 
-use crate::error::{CommandError, ErrorType};
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Obtain the `CacheDir`, returning a `CommandError` if the data directory
-/// cannot be determined.
-fn get_cache() -> Result<CacheDir, CommandError> {
-    CacheDir::default_location().ok_or_else(|| {
-        CommandError::new(
-            "could not determine data directory; is $HOME set?",
-            ErrorType::IoError,
-        )
-    })
-}
-
-fn service() -> Result<MarketplaceService, CommandError> {
-    let cache = get_cache()?;
-    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
-}
+use crate::commands::make_service;
+use crate::error::CommandError;
 
 // ---------------------------------------------------------------------------
 // Commands
@@ -39,7 +19,7 @@ pub async fn add_marketplace(
     source: String,
     protocol: Option<GitProtocol>,
 ) -> Result<MarketplaceAddResult, CommandError> {
-    let svc = service()?;
+    let svc = make_service()?;
     let protocol = protocol.unwrap_or_default();
     svc.add(&source, protocol).map_err(CommandError::from)
 }
@@ -48,7 +28,7 @@ pub async fn add_marketplace(
 #[tauri::command]
 #[specta::specta]
 pub async fn remove_marketplace(name: String) -> Result<(), CommandError> {
-    let svc = service()?;
+    let svc = make_service()?;
     svc.remove(&name).map_err(CommandError::from)
 }
 
@@ -56,6 +36,6 @@ pub async fn remove_marketplace(name: String) -> Result<(), CommandError> {
 #[tauri::command]
 #[specta::specta]
 pub async fn update_marketplace(name: Option<String>) -> Result<UpdateResult, CommandError> {
-    let svc = service()?;
+    let svc = make_service()?;
     svc.update(name.as_deref()).map_err(CommandError::from)
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod installed;
 pub mod kiro_settings;
 pub mod marketplaces;
 pub mod settings;
+pub mod steering;

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -20,7 +20,7 @@ use crate::error::{CommandError, ErrorType};
 /// is unused on every code path, so the default backend is fine. If a
 /// command grows that needs a different backend, take the service as a
 /// parameter on the `_impl` instead of branching here.
-pub(super) fn make_service() -> Result<MarketplaceService, CommandError> {
+pub(in crate::commands) fn make_service() -> Result<MarketplaceService, CommandError> {
     let cache = CacheDir::default_location().ok_or_else(|| {
         CommandError::new(
             "could not determine data directory; is $HOME set?",
@@ -28,4 +28,45 @@ pub(super) fn make_service() -> Result<MarketplaceService, CommandError> {
         )
     })?;
     Ok(MarketplaceService::new(cache, GixCliBackend::default()))
+}
+
+/// Fail-fast validation of a Tauri-supplied `project_path` before it
+/// flows into [`kiro_market_core::project::KiroProject::new`] (which is
+/// infallible). Rejects:
+///
+/// - an empty string — frontend default-construction would otherwise
+///   silently write to `./.kiro/...` relative to the Tauri process cwd
+///   instead of the user's project,
+/// - a non-existent path,
+/// - a path with no `.kiro/` subdirectory.
+///
+/// Without this guard, the install layer's per-file failures wouldn't
+/// fire (it would create `.kiro/` on the wrong root), so the user sees
+/// "install succeeded" with bytes landing nowhere near their project.
+pub(in crate::commands) fn validate_kiro_project_path(
+    project_path: &str,
+) -> Result<(), CommandError> {
+    if project_path.is_empty() {
+        return Err(CommandError::new(
+            "project_path must not be empty",
+            ErrorType::Validation,
+        ));
+    }
+    let path = std::path::Path::new(project_path);
+    if !path.exists() {
+        return Err(CommandError::new(
+            format!("project_path `{project_path}` does not exist"),
+            ErrorType::Validation,
+        ));
+    }
+    if !path.join(".kiro").is_dir() {
+        return Err(CommandError::new(
+            format!(
+                "project_path `{project_path}` is not a Kiro project \
+                 (missing `.kiro/` directory)"
+            ),
+            ErrorType::Validation,
+        ));
+    }
+    Ok(())
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -4,3 +4,28 @@ pub mod kiro_settings;
 pub mod marketplaces;
 pub mod settings;
 pub mod steering;
+
+use kiro_market_core::cache::CacheDir;
+use kiro_market_core::git::GixCliBackend;
+use kiro_market_core::service::MarketplaceService;
+
+use crate::error::{CommandError, ErrorType};
+
+/// Construct a [`MarketplaceService`] for read-side and install-only
+/// command handlers. Centralized here so every `#[tauri::command]` wrapper
+/// resolves the cache directory and `GitBackend` the same way; previously
+/// the body was duplicated in every command file.
+///
+/// All current callers are read-only or install-only; the [`GixCliBackend`]
+/// is unused on every code path, so the default backend is fine. If a
+/// command grows that needs a different backend, take the service as a
+/// parameter on the `_impl` instead of branching here.
+pub(super) fn make_service() -> Result<MarketplaceService, CommandError> {
+    let cache = CacheDir::default_location().ok_or_else(|| {
+        CommandError::new(
+            "could not determine data directory; is $HOME set?",
+            ErrorType::IoError,
+        )
+    })?;
+    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
+}

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -12,7 +12,7 @@ use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{InstallMode, MarketplaceService};
 use kiro_market_core::steering::{InstallSteeringResult, SteeringInstallContext};
 
-use crate::commands::make_service;
+use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
 
 /// Install every steering file declared by a plugin into the active
@@ -48,6 +48,7 @@ fn install_plugin_steering_impl(
     mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSteeringResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
     let ctx = svc
         .resolve_plugin_install_context(marketplace, plugin)
         .map_err(CommandError::from)?;
@@ -100,12 +101,13 @@ mod tests {
 
     #[test]
     fn install_plugin_steering_impl_installs_default_path_files() {
+        use kiro_market_core::project::InstallOutcomeKind;
+
         let (dir, svc) = temp_service();
         let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
         let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
         let plugin_dir = marketplace_path.join("plugins/myplugin");
         fs::create_dir_all(&plugin_dir).expect("plugin dir");
-        // No plugin.json -> falls back to DEFAULT_STEERING_PATHS = ["./steering/"].
         write_steering_file(&plugin_dir, "steering/code-style.md", "# style\n");
         let project_path = make_kiro_project(dir.path());
 
@@ -123,6 +125,35 @@ mod tests {
             result.failed.is_empty(),
             "no failures expected: {:?}",
             result.failed
+        );
+        // A regression that stops populating `result.warnings` (or that
+        // surfaces a spurious warning on the happy path) would be
+        // invisible to every other test in this file — none assert on it.
+        assert!(
+            result.warnings.is_empty(),
+            "happy path must produce no warnings, got: {:?}",
+            result.warnings
+        );
+        let outcome = &result.installed[0];
+        // Locks the outcome `kind`. Without this assertion, a regression
+        // that returned `Idempotent` or `ForceOverwrote` for a clean
+        // first install would still pass `installed.len() == 1`.
+        assert!(
+            matches!(outcome.kind, InstallOutcomeKind::Installed),
+            "clean first install must report InstallOutcomeKind::Installed, got: {:?}",
+            outcome.kind
+        );
+        assert!(
+            outcome.source.ends_with("steering/code-style.md"),
+            "source must point at the resolved file under the plugin's steering dir, got: {:?}",
+            outcome.source
+        );
+        assert!(
+            outcome
+                .destination
+                .ends_with(".kiro/steering/code-style.md"),
+            "destination must land under the project's .kiro/steering/, got: {:?}",
+            outcome.destination
         );
         assert!(
             std::path::PathBuf::from(&project_path)
@@ -299,6 +330,137 @@ mod tests {
         assert!(
             rendered.contains("guide.md"),
             "rendered error must mention the path, got: {rendered}"
+        );
+    }
+
+    /// A bad scan path declared in `plugin.json` must surface as a
+    /// `SteeringWarning::ScanPathInvalid` at the Tauri command layer
+    /// without aborting the install batch — a legitimate scan path
+    /// alongside it still installs. Without this test, a regression
+    /// where the impl emptied `result.warnings` (or dropped the warning
+    /// vec entirely on the wire format) would survive every other
+    /// assertion in this file.
+    #[test]
+    fn install_plugin_steering_impl_surfaces_scan_path_invalid_warning() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        // Mix one legitimate scan path with one path-traversal attempt.
+        // The legitimate one still installs `ok.md`; the traversal
+        // surfaces as a structured warning rather than aborting.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name": "myplugin", "steering": ["./steering/", "../escape/"]}"#,
+        )
+        .expect("write plugin.json");
+        write_steering_file(&plugin_dir, "steering/ok.md", "# ok\n");
+        let project_path = make_kiro_project(dir.path());
+
+        let result =
+            install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+                .expect("install with mixed scan paths");
+
+        assert_eq!(
+            result.installed.len(),
+            1,
+            "legitimate scan path must still install, got: {:?}",
+            result.installed
+        );
+        assert!(
+            result.failed.is_empty(),
+            "no per-file failures expected: {:?}",
+            result.failed
+        );
+        assert_eq!(
+            result.warnings.len(),
+            1,
+            "bad scan path must surface exactly one warning, got: {:?}",
+            result.warnings
+        );
+        assert!(
+            matches!(
+                &result.warnings[0],
+                kiro_market_core::steering::SteeringWarning::ScanPathInvalid { path, .. }
+                    if path == std::path::Path::new("../escape/")
+            ),
+            "wrong warning variant or path: {:?}",
+            result.warnings[0]
+        );
+
+        // Wire-format lock — the FFI must carry warnings as a string array
+        // tagged with `kind`. A regression to externally-tagged serde or
+        // dropping the vec on the result would silently pass the typed
+        // assertion above.
+        let json = serde_json::to_value(&result).expect("InstallSteeringResult serializes");
+        let warnings = json
+            .pointer("/warnings")
+            .and_then(|w| w.as_array())
+            .expect("/warnings must be a JSON array on the wire format");
+        assert_eq!(warnings.len(), 1, "wire format must carry the warning");
+        assert_eq!(
+            warnings[0]
+                .pointer("/kind")
+                .and_then(|k| k.as_str())
+                .expect("warning must carry a `kind` discriminant"),
+            "scan_path_invalid",
+        );
+    }
+
+    /// `KiroProject::new` is infallible. Without fail-fast validation in
+    /// the wrapper, an empty `project_path` from the FFI lands writes at
+    /// `./.kiro/...` relative to the Tauri process cwd — the user thinks
+    /// the install succeeded, but the bytes are nowhere near their
+    /// project. This test pins the empty-string branch.
+    #[test]
+    fn install_plugin_steering_impl_empty_project_path_returns_validation() {
+        let (_dir, svc) = temp_service();
+        let err = install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, "")
+            .expect_err("empty project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+        assert!(
+            err.message.contains("project_path"),
+            "error message must name the offending field, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn install_plugin_steering_impl_nonexistent_project_path_returns_validation() {
+        let (dir, svc) = temp_service();
+        let bogus = dir
+            .path()
+            .join("does-not-exist")
+            .to_str()
+            .expect("utf-8 path")
+            .to_owned();
+        let err = install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &bogus)
+            .expect_err("nonexistent project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    #[test]
+    fn install_plugin_steering_impl_missing_kiro_dir_returns_validation() {
+        let (dir, svc) = temp_service();
+        let project_path = dir.path().join("not-a-kiro-project");
+        fs::create_dir_all(&project_path).expect("create dir");
+        // Note: no .kiro/ subdirectory — this is what differentiates
+        // "directory exists" from "directory is a Kiro project".
+        let project_path_str = project_path.to_str().expect("utf-8 path").to_owned();
+        let err = install_plugin_steering_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            &project_path_str,
+        )
+        .expect_err("missing .kiro/ must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+        assert!(
+            err.message.contains(".kiro"),
+            "error message must mention .kiro/, got: {}",
+            err.message
         );
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -1,0 +1,198 @@
+//! Steering install command for the Tauri frontend.
+//!
+//! Mirrors the shape of [`crate::commands::browse::install_skills`]:
+//! a thin `#[tauri::command]` wrapper builds the [`MarketplaceService`]
+//! from process globals, then delegates to a private `_impl` whose body
+//! is unit-testable against [`kiro_market_core::service::test_support`]
+//! fixtures without a Tauri runtime.
+
+use std::path::PathBuf;
+
+use kiro_market_core::cache::CacheDir;
+use kiro_market_core::git::GixCliBackend;
+use kiro_market_core::project::KiroProject;
+use kiro_market_core::service::{InstallMode, MarketplaceService};
+use kiro_market_core::steering::{InstallSteeringResult, SteeringInstallContext};
+
+use crate::error::{CommandError, ErrorType};
+
+/// Install every steering file declared by a plugin into the active
+/// project's `.kiro/steering/` directory.
+///
+/// The wrapper exists only to construct a [`MarketplaceService`] from
+/// process globals and translate the FFI `force: bool` into an
+/// [`InstallMode`]; the install itself runs in
+/// [`install_plugin_steering_impl`] so it can be tested without a Tauri
+/// runtime.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_plugin_steering(
+    marketplace: String,
+    plugin: String,
+    force: bool,
+    project_path: String,
+) -> Result<InstallSteeringResult, CommandError> {
+    let svc = make_service()?;
+    install_plugin_steering_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        InstallMode::from(force),
+        &project_path,
+    )
+}
+
+fn install_plugin_steering_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    project_path: &str,
+) -> Result<InstallSteeringResult, CommandError> {
+    let ctx = svc
+        .resolve_plugin_install_context(marketplace, plugin)
+        .map_err(CommandError::from)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+
+    let install_ctx = SteeringInstallContext {
+        mode,
+        marketplace,
+        plugin,
+        version: ctx.version.as_deref(),
+    };
+
+    Ok(MarketplaceService::install_plugin_steering(
+        &project,
+        &ctx.plugin_dir,
+        &ctx.steering_scan_paths,
+        install_ctx,
+    ))
+}
+
+fn make_service() -> Result<MarketplaceService, CommandError> {
+    let cache = CacheDir::default_location().ok_or_else(|| {
+        CommandError::new(
+            "could not determine data directory; is $HOME set?",
+            ErrorType::IoError,
+        )
+    })?;
+    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    //! `_impl`-level tests. The `#[tauri::command]` wrapper is a thin
+    //! serde shim and is not re-exercised here; see
+    //! `commands/browse.rs::tests` for the canonical pattern.
+
+    use std::fs;
+
+    use kiro_market_core::service::test_support::{
+        relative_path_entry, seed_marketplace_with_registry, temp_service,
+    };
+
+    use super::*;
+
+    fn make_kiro_project(dir: &std::path::Path) -> String {
+        let project_path = dir.join("kproj");
+        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
+        project_path.to_str().expect("utf-8 path").to_owned()
+    }
+
+    fn write_steering_file(plugin_dir: &std::path::Path, rel: &str, body: &str) {
+        let p = plugin_dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create steering parent");
+        }
+        fs::write(&p, body).expect("write steering file");
+    }
+
+    #[test]
+    fn install_plugin_steering_impl_installs_default_path_files() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        // No plugin.json -> falls back to DEFAULT_STEERING_PATHS = ["./steering/"].
+        write_steering_file(&plugin_dir, "steering/code-style.md", "# style\n");
+        let project_path = make_kiro_project(dir.path());
+
+        let result =
+            install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+                .expect("happy path");
+
+        assert_eq!(
+            result.installed.len(),
+            1,
+            "expected one install, got: {:?}",
+            result.installed
+        );
+        assert!(
+            result.failed.is_empty(),
+            "no failures expected: {:?}",
+            result.failed
+        );
+        assert!(
+            std::path::PathBuf::from(&project_path)
+                .join(".kiro/steering/code-style.md")
+                .exists(),
+            "steering file must land under the requested project_path"
+        );
+    }
+
+    #[test]
+    fn install_plugin_steering_impl_returns_not_found_for_unknown_plugin() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("real-plugin", "plugins/real-plugin")];
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let project_path = make_kiro_project(dir.path());
+
+        let err = install_plugin_steering_impl(
+            &svc,
+            "mp1",
+            "does-not-exist",
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("unknown plugin must error");
+
+        assert_eq!(err.error_type, ErrorType::NotFound);
+    }
+
+    #[test]
+    fn install_plugin_steering_impl_threads_resolved_version_into_install_ctx() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name": "myplugin", "version": "3.1.4"}"#,
+        )
+        .expect("write plugin.json");
+        write_steering_file(&plugin_dir, "steering/guide.md", "# guide\n");
+        let project_path = make_kiro_project(dir.path());
+
+        let result =
+            install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+                .expect("install with manifest version");
+
+        assert_eq!(result.installed.len(), 1);
+        let project = KiroProject::new(std::path::PathBuf::from(&project_path));
+        let tracking = project
+            .load_installed_steering()
+            .expect("load installed steering");
+        let entry = tracking
+            .files
+            .get(std::path::Path::new("guide.md"))
+            .expect("guide.md should be tracked under .kiro/steering/");
+        // The `version: "3.1.4"` from plugin.json must thread into the
+        // tracking record — `install_skills_impl_threads_resolved_version`
+        // (browse.rs) locks the same contract for the skills path.
+        assert_eq!(entry.version.as_deref(), Some("3.1.4"));
+        assert_eq!(entry.marketplace, "mp1");
+        assert_eq!(entry.plugin, "myplugin");
+    }
+}

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -8,13 +8,12 @@
 
 use std::path::PathBuf;
 
-use kiro_market_core::cache::CacheDir;
-use kiro_market_core::git::GixCliBackend;
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{InstallMode, MarketplaceService};
 use kiro_market_core::steering::{InstallSteeringResult, SteeringInstallContext};
 
-use crate::error::{CommandError, ErrorType};
+use crate::commands::make_service;
+use crate::error::CommandError;
 
 /// Install every steering file declared by a plugin into the active
 /// project's `.kiro/steering/` directory.
@@ -69,16 +68,6 @@ fn install_plugin_steering_impl(
     ))
 }
 
-fn make_service() -> Result<MarketplaceService, CommandError> {
-    let cache = CacheDir::default_location().ok_or_else(|| {
-        CommandError::new(
-            "could not determine data directory; is $HOME set?",
-            ErrorType::IoError,
-        )
-    })?;
-    Ok(MarketplaceService::new(cache, GixCliBackend::default()))
-}
-
 #[cfg(test)]
 mod tests {
     //! `_impl`-level tests. The `#[tauri::command]` wrapper is a thin
@@ -90,6 +79,8 @@ mod tests {
     use kiro_market_core::service::test_support::{
         relative_path_entry, seed_marketplace_with_registry, temp_service,
     };
+
+    use crate::error::ErrorType;
 
     use super::*;
 
@@ -189,10 +180,125 @@ mod tests {
             .get(std::path::Path::new("guide.md"))
             .expect("guide.md should be tracked under .kiro/steering/");
         // The `version: "3.1.4"` from plugin.json must thread into the
-        // tracking record — `install_skills_impl_threads_resolved_version`
+        // tracking record —
+        // `install_skills_impl_threads_resolved_version_into_install_result`
         // (browse.rs) locks the same contract for the skills path.
         assert_eq!(entry.version.as_deref(), Some("3.1.4"));
         assert_eq!(entry.marketplace, "mp1");
         assert_eq!(entry.plugin, "myplugin");
+    }
+
+    /// Mirrors `install_skills_impl_force_mode_overwrites_existing_install`
+    /// (browse.rs) for the steering path. The `force: bool` parameter is the
+    /// primary user-facing control; without this test, a regression where
+    /// `InstallMode::from(force)` returned `New` unconditionally would
+    /// silently pass the rest of the suite.
+    #[test]
+    fn install_plugin_steering_impl_force_mode_overwrites_changed_source() {
+        use kiro_market_core::project::InstallOutcomeKind;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        write_steering_file(&plugin_dir, "steering/guide.md", "# v1\n");
+        let project_path = make_kiro_project(dir.path());
+
+        let first =
+            install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+                .expect("first install");
+        assert_eq!(first.installed.len(), 1, "first install must succeed");
+
+        write_steering_file(&plugin_dir, "steering/guide.md", "# v2\n");
+
+        let forced = install_plugin_steering_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::Force,
+            &project_path,
+        )
+        .expect("force re-install");
+
+        assert_eq!(
+            forced.installed.len(),
+            1,
+            "force must re-install the changed file, got: installed={:?}, failed={:?}",
+            forced.installed,
+            forced.failed
+        );
+        assert!(
+            matches!(forced.installed[0].kind, InstallOutcomeKind::ForceOverwrote),
+            "force outcome must be ForceOverwrote, got: {:?}",
+            forced.installed[0].kind
+        );
+        let installed_bytes = fs::read_to_string(
+            std::path::PathBuf::from(&project_path).join(".kiro/steering/guide.md"),
+        )
+        .expect("read installed steering file");
+        assert_eq!(installed_bytes, "# v2\n");
+    }
+
+    /// Companion to the force test above — without `force`, a changed
+    /// source must surface `ContentChangedRequiresForce` in `failed`
+    /// (not silently no-op into `installed`). Also exercises
+    /// `serialize_steering_error` end-to-end: serializing the result
+    /// must produce a JSON `error: string` for the failure.
+    #[test]
+    fn install_plugin_steering_impl_new_mode_surfaces_content_changed_in_failed() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        write_steering_file(&plugin_dir, "steering/guide.md", "# v1\n");
+        let project_path = make_kiro_project(dir.path());
+
+        install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+            .expect("first install");
+
+        write_steering_file(&plugin_dir, "steering/guide.md", "# v2\n");
+
+        let result =
+            install_plugin_steering_impl(&svc, "mp1", "myplugin", InstallMode::New, &project_path)
+                .expect("second install (should not error at the impl level)");
+
+        assert!(
+            result.installed.is_empty(),
+            "InstallMode::New must NOT overwrite a changed source, got: {:?}",
+            result.installed
+        );
+        assert_eq!(
+            result.failed.len(),
+            1,
+            "expected one failure with ContentChangedRequiresForce, got: {:?}",
+            result.failed
+        );
+        assert!(
+            matches!(
+                &result.failed[0].error,
+                kiro_market_core::steering::SteeringError::ContentChangedRequiresForce { .. }
+            ),
+            "wrong error variant: {:?}",
+            result.failed[0].error
+        );
+
+        let json = serde_json::to_value(&result).expect("InstallSteeringResult serializes");
+        let failed_error = json
+            .pointer("/failed/0/error")
+            .expect("/failed/0/error must exist in wire format");
+        assert!(
+            failed_error.is_string(),
+            "FailedSteeringFile.error must serialize as string (FFI contract), \
+             got non-string: {failed_error:?}"
+        );
+        let rendered = failed_error
+            .as_str()
+            .expect("error rendered as string per the FFI contract");
+        assert!(
+            rendered.contains("guide.md"),
+            "rendered error must mention the path, got: {rendered}"
+        );
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::kiro_settings::get_kiro_settings,
         commands::kiro_settings::set_kiro_setting,
         commands::kiro_settings::reset_kiro_setting,
+        commands::steering::install_plugin_steering,
     ])
 }
 

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -196,10 +196,13 @@ export type FailedSkillReason =
 /**
  *  Per-file failure entry in a steering install batch.
  * 
- *  `error` stays typed in-process so consumers can match on
- *  [`SteeringError`] variants. The wire format projects it to a string
- *  via [`error_full_chain`], mirroring the precedent set by
- *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  In-process consumers see `error` as a typed [`SteeringError`] and can
+ *  match on its variants. **Across the Tauri FFI** (and in the generated
+ *  `bindings.ts`) `error` is a pre-rendered string carrying the full
+ *  chain produced by [`crate::error::error_full_chain`] — TypeScript
+ *  consumers should treat it as opaque diagnostic text, not as a
+ *  structured value. Mirrors the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error`:
  *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
  *  don't implement `Serialize`, and the serialized chain stays stable
  *  across variant additions.
@@ -209,10 +212,13 @@ export type FailedSteeringFile = FailedSteeringFile_Serialize | FailedSteeringFi
 /**
  *  Per-file failure entry in a steering install batch.
  * 
- *  `error` stays typed in-process so consumers can match on
- *  [`SteeringError`] variants. The wire format projects it to a string
- *  via [`error_full_chain`], mirroring the precedent set by
- *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  In-process consumers see `error` as a typed [`SteeringError`] and can
+ *  match on its variants. **Across the Tauri FFI** (and in the generated
+ *  `bindings.ts`) `error` is a pre-rendered string carrying the full
+ *  chain produced by [`crate::error::error_full_chain`] — TypeScript
+ *  consumers should treat it as opaque diagnostic text, not as a
+ *  structured value. Mirrors the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error`:
  *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
  *  don't implement `Serialize`, and the serialized chain stays stable
  *  across variant additions.
@@ -225,10 +231,13 @@ export type FailedSteeringFile_Deserialize = {
 /**
  *  Per-file failure entry in a steering install batch.
  * 
- *  `error` stays typed in-process so consumers can match on
- *  [`SteeringError`] variants. The wire format projects it to a string
- *  via [`error_full_chain`], mirroring the precedent set by
- *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  In-process consumers see `error` as a typed [`SteeringError`] and can
+ *  match on its variants. **Across the Tauri FFI** (and in the generated
+ *  `bindings.ts`) `error` is a pre-rendered string carrying the full
+ *  chain produced by [`crate::error::error_full_chain`] — TypeScript
+ *  consumers should treat it as opaque diagnostic text, not as a
+ *  structured value. Mirrors the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error`:
  *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
  *  don't implement `Serialize`, and the serialized chain stays stable
  *  across variant additions.
@@ -688,10 +697,7 @@ export type SteeringWarning =
  *  worth surfacing to the plugin author. The validation rejection
  *  is also logged at `tracing::warn!` for operators.
  */
-({ ScanPathInvalid: {
-	path: string,
-	reason: string,
-} }) & { ScanDirUnreadable?: never } | 
+{ kind: "scan_path_invalid"; path: string; reason: string } | 
 /**
  *  A steering scan directory exists but couldn't be read
  *  (permission denied, I/O error). Distinct from `NotFound` —
@@ -699,10 +705,7 @@ export type SteeringWarning =
  *  declare `./steering/` without authoring any files. This variant
  *  fires only for system-level failures the user can act on.
  */
-({ ScanDirUnreadable: {
-	path: string,
-	reason: string,
-} }) & { ScanPathInvalid?: never };
+{ kind: "scan_dir_unreadable"; path: string; reason: string };
 
 /**
  *  Provider-specific structured source descriptor, internally tagged on `"source"`.

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -84,6 +84,17 @@ export const commands = {
 	setKiroSetting: (key: string, value: SettingValue) => typedError<SettingEntry, CommandError>(__TAURI_INVOKE("set_kiro_setting", { key, value })),
 	// Remove a single Kiro CLI setting by key, reverting it to its default.
 	resetKiroSetting: (key: string) => typedError<null, CommandError>(__TAURI_INVOKE("reset_kiro_setting", { key })),
+	/**
+	 *  Install every steering file declared by a plugin into the active
+	 *  project's `.kiro/steering/` directory.
+	 * 
+	 *  The wrapper exists only to construct a [`MarketplaceService`] from
+	 *  process globals and translate the FFI `force: bool` into an
+	 *  [`InstallMode`]; the install itself runs in
+	 *  [`install_plugin_steering_impl`] so it can be tested without a Tauri
+	 *  runtime.
+	 */
+	installPluginSteering: (marketplace: string, plugin: string, force: boolean, projectPath: string) => typedError<InstallSteeringResult_Serialize, CommandError>(__TAURI_INVOKE("install_plugin_steering", { marketplace, plugin, force, projectPath })),
 };
 
 /* Types */
@@ -182,6 +193,51 @@ export type FailedSkillReason =
  */
 { kind: "requested_but_not_found"; plugin: string };
 
+/**
+ *  Per-file failure entry in a steering install batch.
+ * 
+ *  `error` stays typed in-process so consumers can match on
+ *  [`SteeringError`] variants. The wire format projects it to a string
+ *  via [`error_full_chain`], mirroring the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
+ *  don't implement `Serialize`, and the serialized chain stays stable
+ *  across variant additions.
+ */
+export type FailedSteeringFile = FailedSteeringFile_Serialize | FailedSteeringFile_Deserialize;
+
+/**
+ *  Per-file failure entry in a steering install batch.
+ * 
+ *  `error` stays typed in-process so consumers can match on
+ *  [`SteeringError`] variants. The wire format projects it to a string
+ *  via [`error_full_chain`], mirroring the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
+ *  don't implement `Serialize`, and the serialized chain stays stable
+ *  across variant additions.
+ */
+export type FailedSteeringFile_Deserialize = {
+	source: string,
+	error: string,
+};
+
+/**
+ *  Per-file failure entry in a steering install batch.
+ * 
+ *  `error` stays typed in-process so consumers can match on
+ *  [`SteeringError`] variants. The wire format projects it to a string
+ *  via [`error_full_chain`], mirroring the precedent set by
+ *  [`crate::service::FailedAgent`] / `serialize_agent_error` —
+ *  [`SteeringError`] carries `io::Error` / `HashError` payloads that
+ *  don't implement `Serialize`, and the serialized chain stays stable
+ *  across variant additions.
+ */
+export type FailedSteeringFile_Serialize = {
+	source: string,
+	error: string,
+};
+
 // A marketplace that failed to update, with the reason.
 export type FailedUpdate = {
 	name: string,
@@ -197,6 +253,27 @@ export type GitProtocol =
 "https" | 
 // Clone via SSH (uses SSH agent / keys).
 "ssh";
+
+/**
+ *  What happened during one native install call. Three states are
+ *  distinct variants rather than a `(was_idempotent: bool,
+ *  forced_overwrite: bool)` pair so that the contradictory
+ *  `(true, true)` state is unrepresentable by construction.
+ */
+export type InstallOutcomeKind = 
+/**
+ *  Verified no-op — `source_hash` matched the existing tracking
+ *  entry's `source_hash`. No bytes were written.
+ */
+"idempotent" | 
+// Clean first install — no prior tracking entry, no orphan on disk.
+"installed" | 
+/**
+ *  Force-mode overwrote a tracked path (same plugin's prior content,
+ *  another plugin's content via ownership transfer, or an orphan
+ *  without tracking).
+ */
+"force_overwrote";
 
 // Outcome of installing a list of skill directories from one plugin.
 export type InstallSkillsResult = {
@@ -220,6 +297,23 @@ export type InstallSkillsResult = {
 	skipped_skills: SkippedSkill[],
 };
 
+// Aggregate result of `MarketplaceService::install_plugin_steering`.
+export type InstallSteeringResult = InstallSteeringResult_Serialize | InstallSteeringResult_Deserialize;
+
+// Aggregate result of `MarketplaceService::install_plugin_steering`.
+export type InstallSteeringResult_Deserialize = {
+	installed: InstalledSteeringOutcome[],
+	failed: FailedSteeringFile_Deserialize[],
+	warnings: SteeringWarning[],
+};
+
+// Aggregate result of `MarketplaceService::install_plugin_steering`.
+export type InstallSteeringResult_Serialize = {
+	installed: InstalledSteeringOutcome[],
+	failed: FailedSteeringFile_Serialize[],
+	warnings: SteeringWarning[],
+};
+
 // Information about a single installed skill.
 export type InstalledSkillInfo = {
 	name: string,
@@ -228,6 +322,21 @@ export type InstalledSkillInfo = {
 	version: string | null,
 	// ISO 8601 timestamp of when the skill was installed.
 	installed_at: string,
+};
+
+/**
+ *  Per-call outcome of `KiroProject::install_steering_file`.
+ * 
+ *  The `kind` field uses the workspace-shared [`InstallOutcomeKind`] so
+ *  presenters can match exhaustively over the same 3-variant enum used
+ *  by `InstalledNativeAgentOutcome` and `InstalledNativeCompanionsOutcome`.
+ */
+export type InstalledSteeringOutcome = {
+	source: string,
+	destination: string,
+	kind: InstallOutcomeKind,
+	source_hash: string,
+	installed_hash: string,
 };
 
 // Result of adding a new marketplace.
@@ -411,7 +520,7 @@ export type SkillCount =
  *  - [`SkippedReason::DirectoryUnreadable`] — stat failed for any
  *    other reason (permission denied, transient I/O, etc.).
  * 
- *  From [`load_plugin_manifest`]:
+ *  From the `plugin.json` load:
  *  - [`SkippedReason::InvalidManifest`] — `plugin.json` malformed.
  *  - [`SkippedReason::ManifestReadFailed`] — `plugin.json` read
  *    failed after a successful stat.
@@ -553,6 +662,47 @@ export type SkippedSkillReason =
  *  type like `"github" | "git" | "local" | "relative" | "git_subdir"`.
  */
 export type SourceType = "github" | "git" | "local" | "relative" | "git-subdir";
+
+/**
+ *  Non-fatal issues raised during steering discovery. Surface
+ *  actionable signals only — by-design exclusions (README-style files,
+ *  symlinks refused for security) stay as `tracing::debug!` so the
+ *  CLI doesn't spam users with normal product behaviour.
+ * 
+ *  Per the original S3-2 amendment this enum was scoped wider; the
+ *  `Skipped` variant was retired during PR-64 review when it became
+ *  clear surfacing every README would teach users to ignore warnings,
+ *  and that symlink/junction refusals are by-design security behaviour
+ *  rather than actionable feedback for plugin authors.
+ * 
+ *  The `reason: String` payloads on both variants are pre-rendered;
+ *  upgrading them to typed payloads (`ValidationError` / `io::Error`)
+ *  is tracked at
+ *  <https://github.com/dwalleck/kiro-control-center/issues/66>.
+ */
+export type SteeringWarning = 
+/**
+ *  A steering scan path declared in the manifest failed validation
+ *  (path-traversal, absolute, embedded NUL, non-utf-8 component).
+ *  `path` carries the raw manifest value — almost always a typo
+ *  worth surfacing to the plugin author. The validation rejection
+ *  is also logged at `tracing::warn!` for operators.
+ */
+({ ScanPathInvalid: {
+	path: string,
+	reason: string,
+} }) & { ScanDirUnreadable?: never } | 
+/**
+ *  A steering scan directory exists but couldn't be read
+ *  (permission denied, I/O error). Distinct from `NotFound` —
+ *  missing directories are a silent no-op since plugins commonly
+ *  declare `./steering/` without authoring any files. This variant
+ *  fires only for system-level failures the user can act on.
+ */
+({ ScanDirUnreadable: {
+	path: string,
+	reason: string,
+} }) & { ScanPathInvalid?: never };
 
 /**
  *  Provider-specific structured source descriptor, internally tagged on `"source"`.

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -85,10 +85,8 @@ impl SkippedPlugin {
     ///
     /// This is the ONLY way to build a [`SkippedPlugin`] outside the
     /// service module (fields are `pub(crate)`), so `reason` and `kind`
-    /// cannot drift from the underlying error. Subsumes the previous
-    /// free helper `plugin_skip_reason(&Error) -> Option<SkippedReason>`
-    /// — callers that only need the kind still have
-    /// [`SkippedReason::from_plugin_error`].
+    /// cannot drift from the underlying error. Callers that only need
+    /// the kind have [`SkippedReason::from_plugin_error`].
     #[must_use]
     pub(crate) fn from_plugin_error(name: String, err: &Error) -> Option<Self> {
         let Error::Plugin(pe) = err else { return None };
@@ -364,11 +362,14 @@ pub enum SkillCount {
 /// (registry-driven) or
 /// [`MarketplaceService::resolve_plugin_install_context_from_dir`]
 /// (directory-driven, for fetch-aware CLI callers).
+///
 /// Rust-internal only — never crosses the FFI boundary, so no `Serialize`
-/// or `specta::Type` derive. The type is `pub` so frontend handlers can
-/// hold onto the resolved inputs between the context-resolution call and
-/// the install call without pulling the preamble logic back into each
-/// handler.
+/// or `specta::Type` derive. **Do not add `Serialize`** — `plugin_dir`
+/// and `skill_dirs` are absolute host paths whose disclosure to the
+/// frontend would leak filesystem layout. The type is `pub` so frontend
+/// handlers can hold onto the resolved inputs between the
+/// context-resolution call and the install call without pulling the
+/// preamble logic back into each handler.
 #[derive(Clone, Debug)]
 pub struct PluginInstallContext {
     /// Resolved plugin root directory. Required by install paths that
@@ -2594,6 +2595,14 @@ mod tests {
         let ctx = svc
             .resolve_plugin_install_context("mp1", "myplugin")
             .expect("happy path");
+        assert_eq!(
+            ctx.plugin_dir,
+            marketplace_path.join("plugins").join("myplugin"),
+            "plugin_dir must point at the resolved plugin root so callers \
+             of install_plugin_steering / install_plugin_agents don't have \
+             to re-resolve. A regression to e.g. `plugin_dir.parent()` would \
+             pass every other assertion in this test."
+        );
         assert_eq!(ctx.version.as_deref(), Some("1.2.3"));
         let mut names: Vec<String> = ctx
             .skill_dirs
@@ -2870,6 +2879,11 @@ mod tests {
 
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("missing manifest must yield default agent paths, not error");
+        assert_eq!(
+            ctx.plugin_dir, plugin_dir,
+            "plugin_dir must echo the input path so install_plugin_steering / \
+             install_plugin_agents callers can use it without re-resolving"
+        );
         assert_eq!(
             ctx.agent_scan_paths,
             crate::DEFAULT_AGENT_PATHS

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -412,7 +412,7 @@ pub struct PluginInstallContext {
 // impls" trick from `static_assertions::assert_not_impl_any!`. The
 // generic parameter on `AmbiguousIfSerialize` is inferable when only
 // the unconditional impl applies (`T: !Serialize`); when `T: Serialize`
-// both impls match and inference becomes ambiguous, producing E0282.
+// both impls match and inference becomes ambiguous, producing E0283.
 // Diagnostic is cryptic — read this comment when it fires.
 const _: fn() = || {
     trait AmbiguousIfSerialize<A> {

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -371,6 +371,14 @@ pub enum SkillCount {
 /// handler.
 #[derive(Clone, Debug)]
 pub struct PluginInstallContext {
+    /// Resolved plugin root directory. Required by install paths that
+    /// scan the plugin tree directly (agents, steering) rather than
+    /// consuming pre-resolved subdirectory lists like
+    /// [`Self::skill_dirs`]. Always set by the resolver — callers can
+    /// pass `&ctx.plugin_dir` directly to
+    /// [`MarketplaceService::install_plugin_steering`] /
+    /// [`MarketplaceService::install_plugin_agents`].
+    pub plugin_dir: PathBuf,
     pub version: Option<String>,
     pub skill_dirs: Vec<PathBuf>,
     /// Directories to scan for agent `.md` files inside the plugin.
@@ -742,6 +750,7 @@ impl MarketplaceService {
         let steering_scan_paths = steering_scan_paths_for_plugin(manifest.as_ref());
         let format = manifest.as_ref().and_then(|m| m.format);
         Ok(PluginInstallContext {
+            plugin_dir: plugin_dir.to_path_buf(),
             version,
             skill_dirs,
             agent_scan_paths,

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -401,6 +401,38 @@ pub struct PluginInstallContext {
     pub format: Option<crate::plugin::PluginFormat>,
 }
 
+// Compile-time lock for the "Do not add `Serialize`" invariant on
+// `PluginInstallContext`. `plugin_dir` and `skill_dirs` are absolute
+// host paths; serializing them would leak filesystem layout to the
+// frontend. The doc comment on the struct documents the rule, but a
+// future contributor typing `#[derive(Serialize)]` would break the
+// invariant silently — this block turns it into a compile error.
+//
+// Implementation note: uses the standard "two overlapping blanket
+// impls" trick from `static_assertions::assert_not_impl_any!`. The
+// generic parameter on `AmbiguousIfSerialize` is inferable when only
+// the unconditional impl applies (`T: !Serialize`); when `T: Serialize`
+// both impls match and inference becomes ambiguous, producing E0282.
+// Diagnostic is cryptic — read this comment when it fires.
+const _: fn() = || {
+    trait AmbiguousIfSerialize<A> {
+        fn check() {}
+    }
+    impl<T: ?Sized> AmbiguousIfSerialize<()> for T {}
+    impl<T: ?Sized + serde::Serialize> AmbiguousIfSerialize<u8> for T {}
+    <PluginInstallContext as AmbiguousIfSerialize<_>>::check();
+};
+
+#[cfg(feature = "specta")]
+const _: fn() = || {
+    trait AmbiguousIfSpectaType<A> {
+        fn check() {}
+    }
+    impl<T: ?Sized> AmbiguousIfSpectaType<()> for T {}
+    impl<T: ?Sized + specta::Type> AmbiguousIfSpectaType<u8> for T {}
+    <PluginInstallContext as AmbiguousIfSpectaType<_>>::check();
+};
+
 // ---------------------------------------------------------------------------
 // Service methods
 // ---------------------------------------------------------------------------

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -148,10 +148,33 @@ pub struct InstalledSteeringOutcome {
 }
 
 /// Per-file failure entry in a steering install batch.
-#[derive(Debug)]
+///
+/// `error` stays typed in-process so consumers can match on
+/// [`SteeringError`] variants. The wire format projects it to a string
+/// via [`error_full_chain`], mirroring the precedent set by
+/// [`crate::service::FailedAgent`] / `serialize_agent_error` —
+/// [`SteeringError`] carries `io::Error` / `HashError` payloads that
+/// don't implement `Serialize`, and the serialized chain stays stable
+/// across variant additions.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct FailedSteeringFile {
     pub source: PathBuf,
+    #[serde(serialize_with = "serialize_steering_error")]
+    #[cfg_attr(feature = "specta", specta(type = String))]
     pub error: SteeringError,
+}
+
+/// Serialize a [`SteeringError`] as the rendered chain produced by
+/// [`crate::error::error_full_chain`]. Mirrors
+/// [`crate::service::serialize_agent_error`] — the typed variants carry
+/// `io::Error` / `HashError` payloads that don't implement `Serialize`,
+/// so the wire format projects through the chain string instead.
+fn serialize_steering_error<S: serde::Serializer>(
+    err: &SteeringError,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    serializer.serialize_str(&crate::error::error_full_chain(err))
 }
 
 /// Non-fatal issues raised during steering discovery. Surface
@@ -229,7 +252,8 @@ impl std::fmt::Display for SteeringWarning {
 }
 
 /// Aggregate result of `MarketplaceService::install_plugin_steering`.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct InstallSteeringResult {
     pub installed: Vec<InstalledSteeringOutcome>,
     pub failed: Vec<FailedSteeringFile>,
@@ -257,8 +281,7 @@ mod tests {
         // re-introduce the `serde_json::Error` type by walking `.source()`.
         // Re-introducing `#[source]` would silently break this assertion.
         // Mirrors the same lock at
-        // `crate::error::tests::native_manifest_parse_failed_exposes_no_source_chain`
-        // and `crate::agent::parse_native::tests::invalid_json_materializes_chain_into_reason_and_hides_source`.
+        // `crate::error::tests::native_manifest_parse_failed_renders_path_and_reason`.
         assert!(
             err.source().is_none(),
             "TrackingMalformed must not expose a source chain — \

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -285,7 +285,7 @@ mod tests {
         // re-introduce the `serde_json::Error` type by walking `.source()`.
         // Re-introducing `#[source]` would silently break this assertion.
         // Mirrors the same lock at
-        // `crate::error::tests::native_manifest_parse_failed_renders_path_and_reason`.
+        // `crate::error::tests::native_manifest_parse_failed_exposes_no_source_chain`.
         assert!(
             err.source().is_none(),
             "TrackingMalformed must not expose a source chain — \
@@ -329,6 +329,47 @@ mod tests {
              SkippedReason / FailedSkillReason / InstallOutcomeKind. Frontend code \
              writes `if (warning.kind === \"scan_path_invalid\")` — reverting this \
              attribute would silently break that pattern."
+        );
+    }
+
+    /// `serialize_steering_error` projects through `error_full_chain`, which
+    /// walks `Error::source()`. The end-to-end test in
+    /// `commands::steering::tests` only exercises
+    /// `ContentChangedRequiresForce` (no `#[source]` field), so a regression
+    /// that stopped walking the source chain would survive that test —
+    /// every source-bearing variant (`SourceReadFailed`, `TrackingIoFailed`,
+    /// `HashFailed`, `StagingWriteFailed`, `DestinationDirFailed`) would
+    /// silently lose its inner detail. Lock the chain walk here using
+    /// `SourceReadFailed` as the canary.
+    #[test]
+    fn serialize_steering_error_renders_source_chain_for_source_bearing_variant() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "denied for test");
+        let failed = FailedSteeringFile {
+            source: PathBuf::from("plugin/steering/locked.md"),
+            error: SteeringError::SourceReadFailed {
+                path: PathBuf::from("/abs/plugin/steering/locked.md"),
+                source: io_err,
+            },
+        };
+
+        let json = serde_json::to_value(&failed).expect("FailedSteeringFile serializes");
+        let rendered = json
+            .pointer("/error")
+            .and_then(|e| e.as_str())
+            .expect("error must serialize as string per FFI contract");
+
+        assert!(
+            rendered.contains("locked.md"),
+            "rendered chain must include the path component, got: {rendered}"
+        );
+        // The decisive assertion: a regression that stops walking
+        // `Error::source()` in `error_full_chain` drops the inner
+        // io::Error message, leaving operators with a generic top-level
+        // string and no actionable detail.
+        assert!(
+            rendered.contains("denied for test"),
+            "rendered chain must include the io::Error source message; \
+             got: {rendered}"
         );
     }
 }

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -149,10 +149,13 @@ pub struct InstalledSteeringOutcome {
 
 /// Per-file failure entry in a steering install batch.
 ///
-/// `error` stays typed in-process so consumers can match on
-/// [`SteeringError`] variants. The wire format projects it to a string
-/// via [`error_full_chain`], mirroring the precedent set by
-/// [`crate::service::FailedAgent`] / `serialize_agent_error` —
+/// In-process consumers see `error` as a typed [`SteeringError`] and can
+/// match on its variants. **Across the Tauri FFI** (and in the generated
+/// `bindings.ts`) `error` is a pre-rendered string carrying the full
+/// chain produced by [`crate::error::error_full_chain`] — TypeScript
+/// consumers should treat it as opaque diagnostic text, not as a
+/// structured value. Mirrors the precedent set by
+/// [`crate::service::FailedAgent`] / `serialize_agent_error`:
 /// [`SteeringError`] carries `io::Error` / `HashError` payloads that
 /// don't implement `Serialize`, and the serialized chain stays stable
 /// across variant additions.
@@ -194,6 +197,7 @@ fn serialize_steering_error<S: serde::Serializer>(
 /// <https://github.com/dwalleck/kiro-control-center/issues/66>.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SteeringWarning {
     /// A steering scan path declared in the manifest failed validation
@@ -286,6 +290,45 @@ mod tests {
             err.source().is_none(),
             "TrackingMalformed must not expose a source chain — \
              reason: String is the only carrier of the materialized serde_json detail"
+        );
+    }
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::scan_path_invalid(
+        SteeringWarning::ScanPathInvalid {
+            path: PathBuf::from("../escape"),
+            reason: "path traversal".into(),
+        },
+        serde_json::json!({
+            "kind": "scan_path_invalid",
+            "path": "../escape",
+            "reason": "path traversal",
+        }),
+    )]
+    #[case::scan_dir_unreadable(
+        SteeringWarning::ScanDirUnreadable {
+            path: PathBuf::from("/tmp/plugins/x/steering"),
+            reason: "permission denied".into(),
+        },
+        serde_json::json!({
+            "kind": "scan_dir_unreadable",
+            "path": "/tmp/plugins/x/steering",
+            "reason": "permission denied",
+        }),
+    )]
+    fn steering_warning_variants_json_shape(
+        #[case] warning: SteeringWarning,
+        #[case] expected: serde_json::Value,
+    ) {
+        let json = serde_json::to_value(&warning).expect("serialize");
+        assert_eq!(
+            json, expected,
+            "wire format must use internally-tagged `kind` + snake_case to match \
+             SkippedReason / FailedSkillReason / InstallOutcomeKind. Frontend code \
+             writes `if (warning.kind === \"scan_path_invalid\")` — reverting this \
+             attribute would silently break that pattern."
         );
     }
 }


### PR DESCRIPTION
## Summary

- New \`#[tauri::command]\` handler **\`install_plugin_steering\`** wires the existing \`MarketplaceService::install_plugin_steering\` API through to the desktop UI. Mirrors the \`install_skills_impl\` pattern: thin async wrapper + testable \`_impl\` exercised by three unit tests against \`service::test_support\` fixtures.
- Prereq core change: **\`PluginInstallContext.plugin_dir: PathBuf\`** — the steering install API takes \`plugin_dir\` directly (unlike \`install_skills\`, which consumes pre-resolved \`skill_dirs\`), so callers need the resolved root without re-running plugin resolution. The agent command will reuse this same field.
- Prereq core change: **\`InstallSteeringResult\` + \`FailedSteeringFile\` derive \`Serialize\` + cfg-gated \`specta::Type\`** so the result type can cross the FFI. The typed \`error: SteeringError\` field projects through a new \`serialize_steering_error\` helper that mirrors \`serialize_agent_error\` — \`error_full_chain\` renders the chain string for the wire format while in-process consumers keep the typed variant for matching (per CLAUDE.md "FFI source-chain rule" / classifier discipline).
- TypeScript bindings regenerated: \`installPluginSteering\`, \`InstallSteeringResult\`, \`FailedSteeringFile\`, \`InstalledSteeringOutcome\`, \`SteeringWarning\` are now exported from \`bindings.ts\`.

## Test plan

- [x] \`cargo build -p kiro-market-core -p kiro-control-center\` clean
- [x] 3 new \`commands::steering::tests\` pass (\`install_plugin_steering_impl_installs_default_path_files\`, \`..._returns_not_found_for_unknown_plugin\`, \`..._threads_resolved_version_into_install_ctx\`)
- [x] 30 existing core steering tests still green (no regression from the new derives)
- [x] Full \`cargo test --workspace\` passes (~780 tests)
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`bindings.ts\` regenerated via the ignored \`tests::generate_types\` test
- [ ] Manual smoke test from the desktop UI once a frontend consumer lands (out of scope for this PR — agent command + UI panels follow)

## Follow-ups

- \`commands/agents.rs\` — the agent install command can now mirror this exactly, plus the \`format\` and \`accept_mcp\` knobs from \`AgentInstallContext\`. \`PluginInstallContext.plugin_dir\` was added with that reuse in mind.
- Frontend consumers (Svelte components/routes) for both steering and agent install — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)