### PR TITLE
feat(plan-lint): ffi-enum-serde-tag gate + fix 2 violations

### DIFF
--- a/crates/kiro-market-core/src/agent/parse.rs
+++ b/crates/kiro-market-core/src/agent/parse.rs
@@ -37,7 +37,9 @@ pub fn detect_dialect(path: &Path) -> AgentDialect {
 pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, AgentError> {
     let content = fs::read_to_string(path).map_err(|e| AgentError::ParseFailed {
         path: path.to_path_buf(),
-        failure: ParseFailure::IoError(e.to_string()),
+        failure: ParseFailure::IoError {
+            reason: e.to_string(),
+        },
     })?;
     let dialect = detect_dialect(path);
     let result = match dialect {
@@ -130,7 +132,7 @@ mod tests {
         assert!(matches!(
             err,
             AgentError::ParseFailed {
-                failure: ParseFailure::InvalidYaml(_),
+                failure: ParseFailure::InvalidYaml { .. },
                 ..
             }
         ));
@@ -143,7 +145,7 @@ mod tests {
         assert!(matches!(
             err,
             AgentError::ParseFailed {
-                failure: ParseFailure::IoError(_),
+                failure: ParseFailure::IoError { .. },
                 ..
             }
         ));

--- a/crates/kiro-market-core/src/agent/parse.rs
+++ b/crates/kiro-market-core/src/agent/parse.rs
@@ -38,7 +38,7 @@ pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, AgentError> {
     let content = fs::read_to_string(path).map_err(|e| AgentError::ParseFailed {
         path: path.to_path_buf(),
         failure: ParseFailure::IoError {
-            reason: e.to_string(),
+            reason: crate::error::error_full_chain(&e),
         },
     })?;
     let dialect = detect_dialect(path);

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -38,12 +38,16 @@ pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure
     // Validate the name at parse time so downstream fs operations (and the
     // file:// URI in the emitted JSON) can trust it without re-checking.
     crate::validation::validate_name(&name).map_err(|e| match e {
-        crate::error::ValidationError::InvalidName { reason, .. } => {
+        // Both ValidationError variants project to ParseFailure::InvalidName
+        // because validate_name only emits InvalidName in practice; the
+        // InvalidRelativePath arm is defensive against a future change to
+        // validate_name's contract. Listed explicitly (rather than via `_ =>`)
+        // so a new ValidationError variant forces a compile-time decision per
+        // CLAUDE.md "Classifier functions enumerate every variant".
+        crate::error::ValidationError::InvalidName { reason, .. }
+        | crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
             ParseFailure::InvalidName { reason }
         }
-        other => ParseFailure::InvalidName {
-            reason: other.to_string(),
-        },
     })?;
     // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
     // so the Kiro emitter omits the field and defers to the CLI default.

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -29,17 +29,21 @@ struct ClaudeFrontmatter {
 /// path and lifts into `AgentError::ParseFailed`.
 pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml_block, body) = split_frontmatter(content)?;
-    let fm: ClaudeFrontmatter = serde_yaml_ng::from_str(yaml_block)
-        .map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
+    let fm: ClaudeFrontmatter =
+        serde_yaml_ng::from_str(yaml_block).map_err(|e| ParseFailure::InvalidYaml {
+            reason: e.to_string(),
+        })?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
     // Validate the name at parse time so downstream fs operations (and the
     // file:// URI in the emitted JSON) can trust it without re-checking.
     crate::validation::validate_name(&name).map_err(|e| match e {
         crate::error::ValidationError::InvalidName { reason, .. } => {
-            ParseFailure::InvalidName(reason)
+            ParseFailure::InvalidName { reason }
         }
-        other => ParseFailure::InvalidName(other.to_string()),
+        other => ParseFailure::InvalidName {
+            reason: other.to_string(),
+        },
     })?;
     // Normalize `model: inherit` (Claude's "use parent model" sentinel) to None
     // so the Kiro emitter omits the field and defers to the CLI default.
@@ -105,7 +109,7 @@ mod tests {
         let src = "---\nname: ../escape\n---\nbody\n";
         let err = parse_claude_agent(src).unwrap_err();
         assert!(
-            matches!(err, ParseFailure::InvalidName(_)),
+            matches!(err, ParseFailure::InvalidName { .. }),
             "expected InvalidName for traversal, got {err:?}"
         );
     }
@@ -114,7 +118,7 @@ mod tests {
     fn parse_rejects_empty_name() {
         let src = "---\nname: \"\"\n---\nbody\n";
         let err = parse_claude_agent(src).unwrap_err();
-        assert!(matches!(err, ParseFailure::InvalidName(_)));
+        assert!(matches!(err, ParseFailure::InvalidName { .. }));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -52,16 +52,20 @@ struct CopilotFrontmatter {
 pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailure> {
     let (yaml, body) = split_frontmatter(content)?;
     let fm: CopilotFrontmatter =
-        serde_yaml_ng::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml(e.to_string()))?;
+        serde_yaml_ng::from_str(yaml).map_err(|e| ParseFailure::InvalidYaml {
+            reason: e.to_string(),
+        })?;
 
     let name = fm.name.ok_or(ParseFailure::MissingName)?;
     // Validate the name at parse time so downstream fs operations (and the
     // file:// URI in the emitted JSON) can trust it without re-checking.
     crate::validation::validate_name(&name).map_err(|e| match e {
         crate::error::ValidationError::InvalidName { reason, .. } => {
-            ParseFailure::InvalidName(reason)
+            ParseFailure::InvalidName { reason }
         }
-        other => ParseFailure::InvalidName(other.to_string()),
+        other => ParseFailure::InvalidName {
+            reason: other.to_string(),
+        },
     })?;
 
     Ok(AgentDefinition {
@@ -176,7 +180,7 @@ Body text.
                    body\n";
         let err = parse_copilot_agent(src).expect_err("unknown discriminator must be rejected");
         assert!(
-            matches!(err, ParseFailure::InvalidYaml(_)),
+            matches!(err, ParseFailure::InvalidYaml { .. }),
             "expected InvalidYaml for unknown MCP type, got {err:?}"
         );
     }
@@ -195,7 +199,7 @@ Body text.
                    body\n";
         let err = parse_copilot_agent(src).expect_err("missing command must be rejected");
         assert!(
-            matches!(err, ParseFailure::InvalidYaml(_)),
+            matches!(err, ParseFailure::InvalidYaml { .. }),
             "expected InvalidYaml for missing command, got {err:?}"
         );
     }
@@ -210,6 +214,6 @@ Body text.
                    ---\n\
                    body\n";
         let err = parse_copilot_agent(src).expect_err("missing url must be rejected");
-        assert!(matches!(err, ParseFailure::InvalidYaml(_)));
+        assert!(matches!(err, ParseFailure::InvalidYaml { .. }));
     }
 }

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -60,12 +60,12 @@ pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailur
     // Validate the name at parse time so downstream fs operations (and the
     // file:// URI in the emitted JSON) can trust it without re-checking.
     crate::validation::validate_name(&name).map_err(|e| match e {
-        crate::error::ValidationError::InvalidName { reason, .. } => {
+        // See parse_claude.rs for rationale on the explicit two-arm form
+        // — same CLAUDE.md classifier-exhaustiveness discipline.
+        crate::error::ValidationError::InvalidName { reason, .. }
+        | crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
             ParseFailure::InvalidName { reason }
         }
-        other => ParseFailure::InvalidName {
-            reason: other.to_string(),
-        },
     })?;
 
     Ok(AgentDefinition {

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -142,8 +142,16 @@ pub struct AgentDefinition {
 /// (e.g. to demote `MissingFrontmatter` to debug logs for README-style
 /// files) rather than substring-matching on error text — which would
 /// silently break the moment a message is reworded.
+///
+/// Wire format: internally tagged on `kind` (`snake_case` discriminant)
+/// to match the workspace convention for FFI-crossing enums
+/// (`SteeringWarning`, `SkippedReason`, `FailedSkillReason`, …). All
+/// payload-bearing variants use struct-style fields rather than tuple
+/// fields because internal tagging requires named fields. Enforced by
+/// the `ffi-enum-serde-tag` plan-lint gate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ParseFailure {
     /// No opening `---` fence. Usually a README or other prose file
@@ -154,15 +162,15 @@ pub enum ParseFailure {
     /// the user probably wants to hear about.
     UnclosedFrontmatter,
     /// YAML parser rejected the frontmatter block.
-    InvalidYaml(String),
+    InvalidYaml { reason: String },
     /// Frontmatter parsed but lacks the required `name` key.
     MissingName,
     /// Frontmatter `name` failed validation (unsafe for use as a filename).
-    /// Carries the validator's human-readable reason.
-    InvalidName(String),
+    /// `reason` carries the validator's human-readable explanation.
+    InvalidName { reason: String },
     /// File read failed (permission denied, not found during racy delete,
-    /// etc.). Carries the rendered I/O error message.
-    IoError(String),
+    /// etc.). `reason` carries the rendered I/O error message.
+    IoError { reason: String },
     /// The translated parser (`parse_agent_file`) was called with a file
     /// whose detected dialect belongs on a different install code path.
     /// Currently fires only for [`AgentDialect::Native`]: native agents are
@@ -186,14 +194,65 @@ impl std::fmt::Display for ParseFailure {
             ParseFailure::UnclosedFrontmatter => {
                 f.write_str("unclosed frontmatter: missing closing `---` fence")
             }
-            ParseFailure::InvalidYaml(msg) => write!(f, "invalid YAML: {msg}"),
+            ParseFailure::InvalidYaml { reason } => write!(f, "invalid YAML: {reason}"),
             ParseFailure::MissingName => f.write_str("missing required `name` field"),
-            ParseFailure::InvalidName(reason) => write!(f, "invalid `name` value: {reason}"),
-            ParseFailure::IoError(msg) => write!(f, "read failed: {msg}"),
+            ParseFailure::InvalidName { reason } => write!(f, "invalid `name` value: {reason}"),
+            ParseFailure::IoError { reason } => write!(f, "read failed: {reason}"),
             ParseFailure::UnsupportedDialect => f.write_str(
                 "translated parser called for a dialect that uses the validate-and-copy path \
                  (native agents go through `parse_native_kiro_agent_file`)",
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod parse_failure_tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Wire-format lock for `ParseFailure`. The `ffi-enum-serde-tag`
+    /// plan-lint gate enforces that pub `Serialize + specta::Type` enums
+    /// with payload-bearing variants carry an explicit
+    /// `#[serde(tag = "...")]` directive. These cases pin the resulting
+    /// JSON shape so a future revert (drop the attribute, change the
+    /// discriminant key, switch back to tuple variants) breaks loud
+    /// rather than silently emitting awkward externally-tagged shapes
+    /// to `bindings.ts` — exactly the regression that affected
+    /// `SteeringWarning` pre-PR-83. Frontend code patterns like
+    /// `if (failure.kind === "invalid_yaml")` rely on this wire shape.
+    #[rstest]
+    #[case::missing_frontmatter(
+        ParseFailure::MissingFrontmatter,
+        serde_json::json!({"kind": "missing_frontmatter"}),
+    )]
+    #[case::invalid_yaml(
+        ParseFailure::InvalidYaml { reason: "expected ':' at line 3".into() },
+        serde_json::json!({"kind": "invalid_yaml", "reason": "expected ':' at line 3"}),
+    )]
+    #[case::invalid_name(
+        ParseFailure::InvalidName { reason: "contains `..`".into() },
+        serde_json::json!({"kind": "invalid_name", "reason": "contains `..`"}),
+    )]
+    #[case::io_error(
+        ParseFailure::IoError { reason: "permission denied".into() },
+        serde_json::json!({"kind": "io_error", "reason": "permission denied"}),
+    )]
+    #[case::unsupported_dialect(
+        ParseFailure::UnsupportedDialect,
+        serde_json::json!({"kind": "unsupported_dialect"}),
+    )]
+    fn parse_failure_variants_json_shape(
+        #[case] failure: ParseFailure,
+        #[case] expected: serde_json::Value,
+    ) {
+        let json = serde_json::to_value(&failure).expect("serialize");
+        assert_eq!(
+            json, expected,
+            "wire format must use internally-tagged `kind` + snake_case to match \
+             SteeringWarning / SkippedReason / FailedSkillReason. Frontend code \
+             writes `if (failure.kind === \"...\")` — a revert to default external \
+             tagging or to tuple variants would silently break that pattern."
+        );
     }
 }

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -852,7 +852,9 @@ mod tests {
     #[case::agent_parse_invalid_yaml(
         AgentError::ParseFailed {
             path: PathBuf::from("a.md"),
-            failure: ParseFailure::InvalidYaml("bad yaml".into()),
+            failure: ParseFailure::InvalidYaml {
+                reason: "bad yaml".into(),
+            },
         },
         "failed to parse agent at a.md: invalid YAML: bad yaml"
     )]

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -524,8 +524,14 @@ fn serialize_agent_error<S: serde::Serializer>(
 /// Carries structured reason enums (not pre-rendered strings) so consumers
 /// can switch on them — the CLI formats for a human, the Tauri frontend
 /// can localize or map to its own UI states.
+///
+/// Wire format: internally tagged on `kind` (`snake_case` discriminant) to
+/// match the workspace convention for FFI-crossing enums (`SteeringWarning`,
+/// `SkippedReason`, `FailedSkillReason`, `ParseFailure`). Enforced by the
+/// `ffi-enum-serde-tag` plan-lint gate.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum InstallWarning {
     /// A source-declared tool had no Kiro equivalent and was dropped.
@@ -1959,7 +1965,9 @@ mod tests {
         use crate::agent::ParseFailure;
         let w = InstallWarning::AgentParseFailed {
             path: PathBuf::from("/tmp/bad.md"),
-            failure: ParseFailure::InvalidYaml("unexpected token".into()),
+            failure: ParseFailure::InvalidYaml {
+                reason: "unexpected token".into(),
+            },
         };
         let s = w.to_string();
         assert!(s.contains("/tmp/bad.md"));
@@ -1976,6 +1984,65 @@ mod tests {
         };
         let s = w.to_string();
         assert!(s.contains("name"));
+    }
+
+    /// Wire-format lock for `InstallWarning`. The `ffi-enum-serde-tag`
+    /// plan-lint gate enforces that pub `Serialize + specta::Type` enums
+    /// with payload-bearing variants carry an explicit
+    /// `#[serde(tag = "...")]` directive. These cases pin the resulting
+    /// JSON shape so a future revert (drop the attribute, change the
+    /// discriminant key) breaks loud rather than silently emitting
+    /// awkward externally-tagged shapes to `bindings.ts`. Frontend code
+    /// patterns like `if (warning.kind === "unmapped_tool")` rely on
+    /// this wire shape.
+    #[rstest::rstest]
+    #[case::unmapped_tool(
+        InstallWarning::UnmappedTool {
+            agent: "reviewer".into(),
+            tool: "NotebookEdit".into(),
+            reason: crate::agent::tools::UnmappedReason::NoKiroEquivalent,
+        },
+        serde_json::json!({
+            "kind": "unmapped_tool",
+            "agent": "reviewer",
+            "tool": "NotebookEdit",
+            "reason": "NoKiroEquivalent",
+        }),
+    )]
+    #[case::agent_parse_failed(
+        InstallWarning::AgentParseFailed {
+            path: PathBuf::from("/tmp/bad.md"),
+            failure: crate::agent::ParseFailure::MissingName,
+        },
+        serde_json::json!({
+            "kind": "agent_parse_failed",
+            "path": "/tmp/bad.md",
+            "failure": {"kind": "missing_name"},
+        }),
+    )]
+    #[case::mcp_servers_require_opt_in(
+        InstallWarning::McpServersRequireOptIn {
+            agent: "tester".into(),
+            transports: vec!["stdio".into(), "http".into()],
+        },
+        serde_json::json!({
+            "kind": "mcp_servers_require_opt_in",
+            "agent": "tester",
+            "transports": ["stdio", "http"],
+        }),
+    )]
+    fn install_warning_variants_json_shape(
+        #[case] warning: InstallWarning,
+        #[case] expected: serde_json::Value,
+    ) {
+        let json = serde_json::to_value(&warning).expect("serialize");
+        assert_eq!(
+            json, expected,
+            "wire format must use internally-tagged `kind` + snake_case to match \
+             SteeringWarning / ParseFailure / SkippedReason. Frontend code writes \
+             `if (warning.kind === \"...\")` — a revert to default external tagging \
+             would silently break that pattern."
+        );
     }
 
     #[test]
@@ -2622,7 +2689,7 @@ mod tests {
             matches!(
                 w,
                 InstallWarning::AgentParseFailed {
-                    failure: ParseFailure::InvalidName(_),
+                    failure: ParseFailure::InvalidName { .. },
                     ..
                 }
             )

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -204,6 +204,76 @@ WHERE s.kind = 'enum'
   )
 ORDER BY f.path, s.line";
 
+/// CLAUDE.md "Validation newtypes flowing through Tauri bindings need
+/// `cfg_attr(specta::Type)`" — and any pub enum that crosses the FFI must
+/// carry an explicit serde tagging directive. PR #83 commit 1 shipped
+/// `SteeringWarning` with default external tagging; the bindings.ts shape
+/// it generated was an awkward intersection type
+/// (`({ Foo: ... }) & { Bar?: never }`) that frontend code patterns like
+/// `if (warning.kind === "...")` would silently never match. Caught at
+/// review, fixed in commit 2 with `#[serde(tag = "kind", rename_all =
+/// "snake_case")]`.
+///
+/// This gate flags any public enum that:
+/// - derives both `Serialize` AND `specta::Type` (the tells that it
+///   crosses the FFI),
+/// - has at least one non-unit variant (default external tagging is
+///   structurally fine for unit-only enums — they serialize as plain
+///   strings and TS sees a clean union of string literals), AND
+/// - lacks an explicit `#[serde(tag = "...")]` or `#[serde(untagged)]`
+///   directive.
+///
+/// Detecting `specta::Type` covers both unconditional `derive(specta::
+/// Type)` and the codebase's canonical `cfg_attr(feature = "specta",
+/// derive(specta::Type))` form — both store the type name in
+/// `attributes.args` regardless of whether the wrapping attribute is
+/// `derive` or `cfg_attr`.
+///
+/// The non-unit-variant check uses tethys's sub-symbol extraction (rivets
+/// PR #58): enum variants are stored as `enum_variant` rows whose
+/// `signature` is NULL/empty for unit variants and carries the field list
+/// otherwise. Without this filter, every all-unit `pub enum` deriving
+/// `Serialize + specta::Type` (`SourceType`, `ErrorType`, etc.) would be
+/// a false positive — they don't need tagging because external tagging
+/// produces plain string literals for them.
+///
+/// `parent_symbol_id` is currently NULL on `enum_variant` rows in tethys
+/// (a known indexer gap), so the variant→parent link uses
+/// `qualified_name LIKE parent.name || '::%'`, matching gate-4's pattern.
+const FFI_ENUM_TAG_SQL: &str = "\
+SELECT f.path, s.line, s.qualified_name, NULL AS signature
+FROM symbols s
+JOIN files f ON f.id = s.file_id
+WHERE s.kind = 'enum'
+  AND s.visibility = 'public'
+  AND EXISTS (
+      SELECT 1 FROM attributes a
+      WHERE a.symbol_id = s.id
+        AND ((a.name = 'derive' AND a.args LIKE '%Serialize%')
+             OR (a.name = 'cfg_attr' AND a.args LIKE '%Serialize%'))
+  )
+  AND EXISTS (
+      SELECT 1 FROM attributes a
+      WHERE a.symbol_id = s.id
+        AND ((a.name = 'derive' AND a.args LIKE '%specta::Type%')
+             OR (a.name = 'cfg_attr' AND a.args LIKE '%specta::Type%'))
+  )
+  AND EXISTS (
+      SELECT 1 FROM symbols v
+      WHERE v.kind = 'enum_variant'
+        AND v.file_id = s.file_id
+        AND v.qualified_name LIKE s.name || '::%'
+        AND v.signature IS NOT NULL
+        AND v.signature != ''
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM attributes a
+      WHERE a.symbol_id = s.id
+        AND a.name = 'serde'
+        AND (a.args LIKE '%tag = %' OR a.args LIKE '%untagged%')
+  )
+ORDER BY f.path, s.line";
+
 const ALL_GATES: &[Gate] = &[
     Gate {
         name: "gate-4-external-error-boundary",
@@ -229,6 +299,11 @@ const ALL_GATES: &[Gate] = &[
         name: "no-frontend-deps-in-core",
         description: "tauri / tokio import in kiro-market-core (dependencies-point-inward)",
         sql: NO_FRONTEND_DEPS_IN_CORE_SQL,
+    },
+    Gate {
+        name: "ffi-enum-serde-tag",
+        description: "pub Serialize+specta::Type enum with non-unit variants missing #[serde(tag = \"...\")] / #[serde(untagged)]",
+        sql: FFI_ENUM_TAG_SQL,
     },
 ];
 
@@ -266,13 +341,13 @@ const ALLOWED_SITES: &[AllowedSite] = &[
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 49,
+        line: 50,
         reason: "Tauri scaffolding pattern — debug-only `specta_typescript::Typescript::default().export(...)` failure at app startup. Refactoring to `?` propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 60,
+        line: 61,
         reason: "Tauri scaffolding pattern — `tauri::Builder::run` failure at app startup. Replacing with Result propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
 ];
@@ -1181,7 +1256,7 @@ mod tests {
     fn is_allowed_matches_gate_path_and_line_exactly() {
         let f = Finding {
             path: "crates/kiro-control-center/src-tauri/src/lib.rs".to_string(),
-            line: 49,
+            line: 50,
             qualified_name: "run".to_string(),
             signature: Some("expect".to_string()),
         };
@@ -1696,5 +1771,282 @@ mod tests {
         let findings = no_frontend_deps().run(&conn).expect("query");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].signature.as_deref(), Some("tokio"));
+    }
+
+    // ─── ffi-enum-serde-tag ─────────────────────────────────────────────
+
+    fn ffi_tag_gate() -> &'static Gate {
+        ALL_GATES
+            .iter()
+            .find(|g| g.name == "ffi-enum-serde-tag")
+            .expect("ffi-enum-serde-tag gate registered")
+    }
+
+    /// Seed a `pub enum` row, optionally tagged with Serialize / specta
+    /// derives and a serde directive, then attach the requested variants.
+    /// `serde_args` is `None` for "no serde attribute"; `Some("tag = ...")`
+    /// or `Some("untagged")` for the two TS-friendly tagging modes.
+    /// `variants` carries `(name, signature_or_none)` — `None` is a unit
+    /// variant; `Some("{ ... }")` is a struct/tuple variant.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "knobs map 1:1 to the gate's predicate inputs; collapsing into a struct \
+                  would obscure the per-test intent at the call site"
+    )]
+    fn seed_ffi_candidate(
+        conn: &Connection,
+        sym_id: i64,
+        name: &str,
+        visibility: &str,
+        with_serialize: bool,
+        with_specta: bool,
+        serde_args: Option<&str>,
+        variants: &[(&str, Option<&str>)],
+    ) {
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, visibility)
+             VALUES (?1, 1, ?2, ?2, 'enum', 1, ?3)",
+            rusqlite::params![sym_id, name, visibility],
+        )
+        .expect("enum insert");
+        if with_serialize {
+            conn.execute(
+                "INSERT INTO attributes (symbol_id, name, args, line)
+                 VALUES (?1, 'derive', 'Clone, Debug, Serialize', 1)",
+                rusqlite::params![sym_id],
+            )
+            .expect("derive(Serialize) insert");
+        }
+        if with_specta {
+            // Mirrors the canonical codebase shape:
+            // `#[cfg_attr(feature = "specta", derive(specta::Type))]`.
+            conn.execute(
+                "INSERT INTO attributes (symbol_id, name, args, line)
+                 VALUES (?1, 'cfg_attr', 'feature = \"specta\", derive(specta::Type)', 1)",
+                rusqlite::params![sym_id],
+            )
+            .expect("cfg_attr(specta) insert");
+        }
+        if let Some(args) = serde_args {
+            conn.execute(
+                "INSERT INTO attributes (symbol_id, name, args, line)
+                 VALUES (?1, 'serde', ?2, 1)",
+                rusqlite::params![sym_id, args],
+            )
+            .expect("serde insert");
+        }
+        for (i, (vname, vsig)) in variants.iter().enumerate() {
+            let qualified = format!("{name}::{vname}");
+            let line = 10 + u32::try_from(i).expect("test fixture index fits u32");
+            conn.execute(
+                "INSERT INTO symbols (file_id, name, qualified_name, kind, line, signature)
+                 VALUES (1, ?1, ?2, 'enum_variant', ?3, ?4)",
+                rusqlite::params![vname, qualified, line, vsig],
+            )
+            .expect("variant insert");
+        }
+    }
+
+    #[test]
+    fn ffi_enum_tag_flags_untagged_pub_enum_with_payload() {
+        // The canonical SteeringWarning-shape bug pre-PR-83: pub enum,
+        // Serialize + specta, has struct variants, no serde tag.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Warning",
+            "public",
+            true,
+            true,
+            None,
+            &[
+                ("ScanPathInvalid", Some("{ path: PathBuf, reason: String }")),
+                (
+                    "ScanDirUnreadable",
+                    Some("{ path: PathBuf, reason: String }"),
+                ),
+            ],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].qualified_name, "Warning");
+    }
+
+    #[test]
+    fn ffi_enum_tag_passes_when_serde_tag_present() {
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Warning",
+            "public",
+            true,
+            true,
+            Some("tag = \"kind\", rename_all = \"snake_case\""),
+            &[("ScanPathInvalid", Some("{ path: PathBuf, reason: String }"))],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "explicit serde(tag = ...) satisfies the gate; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_passes_when_untagged() {
+        // SettingValue uses #[serde(untagged)] — produces a TS union of
+        // primitive shapes without a discriminant. Also acceptable.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Value",
+            "public",
+            true,
+            true,
+            Some("untagged"),
+            &[("Bool", Some("(bool)")), ("Number", Some("(f64)"))],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "explicit serde(untagged) satisfies the gate; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_exempts_unit_only_enum() {
+        // SourceType / ErrorType / GitProtocol / etc. — every variant is
+        // a bare identifier. Default external tagging serializes each
+        // variant as a plain string, producing a clean TS union of
+        // string literals. No serde(tag) directive is needed.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "SourceType",
+            "public",
+            true,
+            true,
+            None,
+            &[("GitHub", None), ("Git", None), ("Local", None)],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "unit-only enums are TS-friendly under default tagging; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_exempts_non_serialize_enum() {
+        // No `Serialize` derive means the type cannot be emitted by serde
+        // at all — there is no wire format to worry about.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Warning",
+            "public",
+            false,
+            true,
+            None,
+            &[("Variant", Some("{ x: u32 }"))],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "non-Serialize enum doesn't cross FFI; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_exempts_non_specta_enum() {
+        // Serialize alone doesn't materialize the type in `bindings.ts`;
+        // specta::Type is the FFI tell. An internal Serialize-only enum
+        // is fine without serde tagging — JSON consumers in-process
+        // tolerate the default shape.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Internal",
+            "public",
+            true,
+            false,
+            None,
+            &[("Variant", Some("{ x: u32 }"))],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "Serialize without specta doesn't cross FFI; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_exempts_private_enum() {
+        // The rule scopes to the *public* surface; pub(crate) and bare
+        // (private) enums don't materialize in bindings even with the
+        // derives present.
+        let conn = fresh_db();
+        seed_ffi_candidate(
+            &conn,
+            1,
+            "Internal",
+            "private",
+            true,
+            true,
+            None,
+            &[("Variant", Some("{ x: u32 }"))],
+        );
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert!(
+            findings.is_empty(),
+            "private enum is not public API; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ffi_enum_tag_flags_unconditional_specta_derive() {
+        // Less common shape: Serialize + specta::Type both inside one
+        // unconditional `#[derive(...)]` (no cfg_attr feature gate).
+        // Tethys stores this as a single `derive` attribute whose args
+        // list includes `specta::Type`; the SQL must match this branch
+        // as well as the `cfg_attr` form.
+        let conn = fresh_db();
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, visibility)
+             VALUES (1, 1, 'Foo', 'Foo', 'enum', 1, 'public')",
+            [],
+        )
+        .expect("enum insert");
+        conn.execute(
+            "INSERT INTO attributes (symbol_id, name, args, line)
+             VALUES (1, 'derive', 'Clone, Debug, Serialize, specta::Type', 1)",
+            [],
+        )
+        .expect("derive insert");
+        conn.execute(
+            "INSERT INTO symbols (file_id, name, qualified_name, kind, line, signature)
+             VALUES (1, 'V', 'Foo::V', 'enum_variant', 10, '{ x: u32 }')",
+            [],
+        )
+        .expect("variant insert");
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert_eq!(
+            findings.len(),
+            1,
+            "unconditional specta derive must also fire; got: {findings:?}"
+        );
     }
 }

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -62,6 +62,13 @@ struct Finding {
 /// The `EXISTS` clause uses `qualified_name`'s `Parent::*` prefix to
 /// walk up to the parent symbol, since `parent_symbol_id` is NULL on
 /// the current tethys schema (a known gap — see the reference memory).
+///
+/// The prefix anchor is `parent.qualified_name || '::%'`, NOT
+/// `parent.name || '::%'`. For an enum nested inside a `mod foo`
+/// block, `parent.name = 'Bar'` but its variants/fields carry
+/// `qualified_name = 'foo::Bar::...'`. A `LIKE 'Bar::%'` pattern
+/// would miss every nested-module case, silently exempting real
+/// gate-4 violations (caught by gemini-code-assist on PR #91).
 const GATE_4_SQL: &str = "\
 SELECT f.path, s.line, s.qualified_name, s.signature
 FROM symbols s
@@ -78,7 +85,7 @@ WHERE s.kind = 'struct_field'
       WHERE parent.kind IN ('enum', 'struct')
         AND parent.visibility = 'public'
         AND parent.file_id = s.file_id
-        AND s.qualified_name LIKE parent.name || '::%'
+        AND s.qualified_name LIKE parent.qualified_name || '::%'
   )
 ORDER BY f.path, s.line";
 
@@ -239,7 +246,11 @@ ORDER BY f.path, s.line";
 ///
 /// `parent_symbol_id` is currently NULL on `enum_variant` rows in tethys
 /// (a known indexer gap), so the variant→parent link uses
-/// `qualified_name LIKE parent.name || '::%'`, matching gate-4's pattern.
+/// `qualified_name LIKE s.qualified_name || '::%'`. The anchor is the
+/// parent enum's full `qualified_name`, NOT its short `name` — a nested
+/// `mod foo { pub enum Bar { ... } }` has `s.name = 'Bar'` but variants
+/// at `qualified_name = 'foo::Bar::Variant'`, and `LIKE 'Bar::%'` would
+/// silently miss them (caught by gemini-code-assist on PR #91).
 const FFI_ENUM_TAG_SQL: &str = "\
 SELECT f.path, s.line, s.qualified_name, NULL AS signature
 FROM symbols s
@@ -262,7 +273,7 @@ WHERE s.kind = 'enum'
       SELECT 1 FROM symbols v
       WHERE v.kind = 'enum_variant'
         AND v.file_id = s.file_id
-        AND v.qualified_name LIKE s.name || '::%'
+        AND v.qualified_name LIKE s.qualified_name || '::%'
         AND v.signature IS NOT NULL
         AND v.signature != ''
   )
@@ -998,6 +1009,45 @@ mod tests {
             findings.is_empty(),
             "pub(crate) parent enum is not public API; got {findings:?}",
         );
+    }
+
+    #[test]
+    fn gate_4_flags_field_inside_nested_module_enum() {
+        // gemini-code-assist (PR #91): for an enum nested inside a
+        // `mod foo` block, `parent.name = 'Bar'` but the field's
+        // `qualified_name = 'foo::Bar::field'`. The earlier prefix
+        // anchor `parent.name || '::%'` would have silently exempted
+        // every nested-module gate-4 violation. Anchor on
+        // `parent.qualified_name` so nesting depth is irrelevant.
+        let conn = fresh_db();
+        // Parent enum with module-qualified name (kind 'enum', public).
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, visibility)
+             VALUES (1000, 1, 'Inner', 'foo::Inner', 'enum', 1, 'public')",
+            [],
+        )
+        .expect("nested parent enum insert");
+        // Field whose qualified_name carries the same module prefix.
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, signature)
+             VALUES (1, 1, '0', 'foo::Inner::Bad::0', 'struct_field', 42, 'serde_json::Error')",
+            [],
+        )
+        .expect("nested field insert");
+        conn.execute(
+            "INSERT INTO attributes (symbol_id, name, args, line)
+             VALUES (1, 'source', NULL, 42)",
+            [],
+        )
+        .expect("source attr insert");
+
+        let findings = gate_4().run(&conn).expect("gate query should succeed");
+        assert_eq!(
+            findings.len(),
+            1,
+            "nested-module enum field with #[source] external error must be flagged; got: {findings:?}"
+        );
+        assert_eq!(findings[0].qualified_name, "foo::Inner::Bad::0");
     }
 
     // ─── no-unwrap-in-production ────────────────────────────────────────
@@ -2048,5 +2098,45 @@ mod tests {
             1,
             "unconditional specta derive must also fire; got: {findings:?}"
         );
+    }
+
+    #[test]
+    fn ffi_enum_tag_flags_enum_nested_in_module() {
+        // gemini-code-assist (PR #91): for `mod foo { pub enum Bar { ... } }`,
+        // `s.name = 'Bar'` but variants land at `qualified_name =
+        // 'foo::Bar::Variant'`. Anchoring the variant→parent link on
+        // `s.qualified_name || '::%'` instead of `s.name || '::%'` makes
+        // nesting depth irrelevant. Without this fix the enum looks
+        // unit-only to the gate (variant EXISTS clause never matches),
+        // silently exempting nested-module FFI enums from the rule.
+        let conn = fresh_db();
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, qualified_name, kind, line, visibility)
+             VALUES (1, 1, 'Inner', 'outer::Inner', 'enum', 1, 'public')",
+            [],
+        )
+        .expect("nested enum insert");
+        conn.execute(
+            "INSERT INTO attributes (symbol_id, name, args, line)
+             VALUES (1, 'derive', 'Clone, Debug, Serialize', 1),
+                    (1, 'cfg_attr', 'feature = \"specta\", derive(specta::Type)', 1)",
+            [],
+        )
+        .expect("derives insert");
+        conn.execute(
+            "INSERT INTO symbols (file_id, name, qualified_name, kind, line, signature)
+             VALUES (1, 'PayloadVariant', 'outer::Inner::PayloadVariant', 'enum_variant', 10,
+                     '{ value: u32 }')",
+            [],
+        )
+        .expect("nested variant insert");
+
+        let findings = ffi_tag_gate().run(&conn).expect("query");
+        assert_eq!(
+            findings.len(),
+            1,
+            "nested-module enum with payload must be flagged; got: {findings:?}"
+        );
+        assert_eq!(findings[0].qualified_name, "outer::Inner");
     }
 }


### PR DESCRIPTION
## Summary

- New **`ffi-enum-serde-tag` plan-lint gate** flags any pub enum deriving `Serialize + specta::Type` with payload-bearing variants but no explicit `#[serde(tag = "...")]` or `#[serde(untagged)]`. Default external tagging on such enums produces awkward TS intersection types (`({ Foo: ... }) & { Bar?: never }`) that frontend code patterns like `if (warning.kind === "...")` silently never match — exactly the regression PR #83 caught for `SteeringWarning` at review.
- Running the gate against post-PR-83 main surfaced **two real violations of the same shape** — both fixed in this PR so the gate ships against a green tree:
  - `ParseFailure` (`agent/types.rs`) — tuple variants `InvalidYaml(String)` / `InvalidName(String)` / `IoError(String)` converted to struct variants with `reason: String` (internal tagging requires named fields).
  - `InstallWarning` (`service/mod.rs`) — variants already struct-shaped; mechanical attribute add.
- Both fixes shipped with per-variant **JSON-shape rstest cases** mirroring `steering_warning_variants_json_shape` so a future revert breaks loud rather than silently emitting the broken external-tagging shape.
- 7 `ParseFailure` call sites updated across `parse.rs`, `parse_claude.rs`, `parse_copilot.rs`, `error.rs`, `service/mod.rs` (3 production, 4 test pattern-matches).
- `ALLOWED_SITES` repaired: `lib.rs:49→50` and `lib.rs:60→61` (PR #83's `install_plugin_steering` registration shifted both by one line; pre-existing drift the runner correctly flagged as stale).

## Why this is timely

`bindings.ts` is currently unaffected — neither `ParseFailure` nor `InstallWarning` is reachable from a `#[tauri::command]` return type yet. The agents.rs follow-up PR would expose `InstallWarning` via the install command and start emitting the broken external-tagging shape into TypeScript bindings. **Catching this one PR earlier avoids shipping that into the frontend.**

## Test plan

- [x] `cargo test --workspace` — 851 tests pass (+16 new: 8 gate cases + 5 ParseFailure JSON-shape + 3 InstallWarning JSON-shape)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo xtask plan-lint` — all 6 gates green (4 OK + 2 with allowlisted exceptions)
- [x] `ffi-enum-serde-tag` runs against post-fix tree with zero findings
- [x] No `bindings.ts` regen needed (neither fixed type is in bindings today)

## Tooling note

This work depends on the `attributes` table that landed in rivets PR #58 (`feat(tethys): persist symbol attributes to the index`, commit `217aae0`). The `tethys` release binary used during local development must be built from rivets `origin/main` ≥ that merge. CI will need to either pin a matching tethys version or build it from source — otherwise gate-4, non-exhaustive-error-enum, AND ffi-enum-serde-tag all fail with "no such table: attributes" against an older binary.

## Follow-ups

- Item 3a from the deferred-items review: DTO split for `FailedSteeringFile` / `InstallSteeringResult` / `FailedAgent` / `InstallAgentsResult` to eliminate the `_Serialize`/`_Deserialize` TypeScript artifact. Independent of this PR.
- Item 4: `commands/agents.rs` mirroring the steering exemplar. Will benefit from this gate enforcing the tag attribute on `InstallAgentsResult`'s warning vec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)