### PR TITLE
docs(plans): plugin-first install — design, Phase 1 plan, amendments

### DIFF
--- a/docs/plans/2026-04-29-plugin-first-install-design.md
+++ b/docs/plans/2026-04-29-plugin-first-install-design.md
@@ -1,0 +1,314 @@
+# Plugin-First Install — Design
+
+> **Status:** design draft. Phase 1 plan in `2026-04-29-plugin-first-install-plan.md`. Phase 2 plan deferred until Phase 1 ships.
+
+## Problem
+
+PR 92 wired `install_plugin_steering` into the desktop UI, completing one slice of an end-to-end install path for steering files. Manual testing on `dwalleck/kiro-starter-kit` revealed two adjacent gaps that compose into one architectural issue:
+
+1. **Steering installs are invisible after the fact.** The `Installed` side-menu view lists only skills (`commands.listInstalledSkills`); a successful steering install produces no observable state change in the UI. The user has no way to discover what they have installed, no way to remove it, and no signal that the install actually succeeded after the green banner fades.
+2. **Plugin authors think in packages.** A plugin like `kiro-code-reviewer` ships steering + agents + skills as a coherent bundle — the agent uses the steering as context, the skills are tools the agent invokes. Installing one piece without the others imports a half-functional reviewer. The current UI lets the user install any one piece without the others, with no signal that the bundle is meant to be coherent.
+
+The current UI treats **skills as the first-class object**, with steering as a recently-bolted-on side action and agents not yet wired at all. The data model in `kiro-market-core` already treats the three content types as peers (separate `installed-*.json` tracking files, separate install paths). The asymmetry is in the UI/orchestration layer above core, not in core itself.
+
+## Approach
+
+**Make plugins the first-class user-facing object** while keeping content-type-first separation in core. Two phases:
+
+### Phase 1 — Plugin-first install + lifecycle
+
+- A new Tauri-level coordinator `install_plugin(marketplace, plugin, force, project_path)` runs all three install paths (skills + steering + agents) in one call. Returns a unified `InstallPluginResult` aggregating the three sub-results.
+- A new `list_installed_plugins(project_path)` Tauri command reads the three tracking files and groups by `(marketplace, plugin)` for the UI.
+- A new `remove_plugin(marketplace, plugin, project_path)` cascades removal through the three tracking files plus on-disk files.
+- `install_plugin_agents` Tauri command lands as part of this work (subsumes the previously-deferred "item 4" from the post-PR-83 follow-up list) — `MarketplaceService::install_plugin_agents` already exists in core; the wrapper has just never been wired.
+- BrowseTab's primary surface becomes plugin cards, each with a single "Install" action (all-or-nothing per the user's decision below). The skill-grid view is preserved as a secondary path so power users can still pick subsets.
+- InstalledTab's primary surface becomes installed-plugin rows showing the per-content-type breakdown, with "Remove" cascading through `remove_plugin`.
+
+### Phase 2 — Updates
+
+- Detection: compare `installed-*.json` `version` fields against current marketplace plugin manifest version. Plugin has an update available if **any** content from that plugin has a newer version in the marketplace.
+- Surface: per-plugin "Update available" indicator on the plugin card.
+- Action: `install_plugin` with `force=true` (effectively a re-install). No new Tauri command needed for the action; one new command for detection.
+
+## User-locked decisions
+
+These came out of the `2026-04-29` design conversation. Documented here so they don't drift during implementation:
+
+1. **Customization granularity: all-or-nothing.** Phase 1 ships one "Install plugin" button per plugin that installs everything the plugin declares. No per-content-type checkboxes in v1. If users ask for subset-install, that becomes a Phase 1.1 follow-up. *Rationale:* matches plugin-author intent (plugins ship as coherent bundles); reduces decision-paralysis for new users; keeps the UI simpler.
+2. **Update granularity: per-plugin (with per-content-type fallback documented for posterity).** When the marketplace plugin manifest moves from v1 to v2, the UI surfaces "Update available" at the plugin level and re-installs all of the plugin's content. The alternative — per-content-type updates — is rejected for v1 because it adds nuance most users don't need; if a plugin's steering changes, treating that as a plugin-level update keeps the bundle coherent. Per-content-type updates are sketched in **Phase 2 alternatives** below for future reference.
+
+## Phase 1 architecture
+
+### Backend coordinator
+
+```rust
+// crates/kiro-market-core/src/service/mod.rs
+impl MarketplaceService {
+    /// Install everything a plugin declares — skills, steering, agents
+    /// — in a single call. Aggregates the three per-type results so a
+    /// caller sees one coherent outcome for the whole plugin.
+    ///
+    /// Errors fail fast: if `resolve_plugin_install_context` errors,
+    /// nothing is attempted. Per-content-type partial failures (e.g.
+    /// one steering file fails to write) land in the corresponding
+    /// sub-result (`InstallSteeringResult.failed`) without aborting
+    /// the other content types. This matches each existing
+    /// `install_plugin_*` function's individual error policy.
+    pub fn install_plugin(
+        &self,
+        project: &KiroProject,
+        marketplace: &str,
+        plugin: &str,
+        mode: InstallMode,
+        accept_mcp: bool,
+    ) -> Result<InstallPluginResult, Error>;
+}
+
+pub struct InstallPluginResult {
+    pub plugin: String,
+    pub version: Option<String>,
+    /// `None` when the plugin declares no skills (or has them but none
+    /// passed name filtering). `Some` even when all installs failed —
+    /// the inner `failed` vec carries the detail.
+    pub skills: Option<InstallSkillsResult>,
+    pub steering: Option<InstallSteeringResult>,
+    pub agents: Option<InstallAgentsResult>,
+}
+```
+
+`Option<...>` distinguishes "this content type wasn't applicable" (no agents declared) from "this content type was attempted and yielded zero installs" (declared 1 file, that file failed).
+
+### Tauri command surface
+
+| Command | Status | Purpose |
+|---|---|---|
+| `install_skills` | Existing | Per-content install (kept for skill-grid path) |
+| `install_plugin_steering` | Existing | Per-content install (kept) |
+| `install_plugin_agents` | **New (Phase 1)** | Per-content install for agents (mirror steering) |
+| `install_plugin` | **New (Phase 1)** | Coordinator |
+| `list_installed_skills` | Existing | Per-content list (kept) |
+| `list_installed_plugins` | **New (Phase 1)** | Aggregator (skills + steering + agents grouped by plugin) |
+| `remove_skill` | Existing | Per-content remove (kept) |
+| `remove_plugin` | **New (Phase 1)** | Cascade remove |
+
+Per-content-type list/remove for steering and agents are *not* added in Phase 1. The plugin-level aggregator covers the InstalledTab use case; per-content-type remove can be added later when there's a UX driver for it.
+
+### Plugin-aware tracking aggregation
+
+`list_installed_plugins` reads all three `installed-*.json` files and groups by `(marketplace, plugin)`:
+
+```rust
+pub struct InstalledPluginInfo {
+    pub marketplace: String,
+    pub plugin: String,
+    /// Highest version across the three content types. They may
+    /// differ if the user installed at different times — the latest
+    /// wins for the "what version do I have?" UX question.
+    pub installed_version: Option<String>,
+    pub skill_count: u32,
+    pub steering_count: u32,
+    pub agent_count: u32,
+    /// Per-type detail for InstalledTab drill-down. Empty vecs when
+    /// nothing of that type is installed.
+    pub installed_skills: Vec<String>,        // skill names
+    pub installed_steering: Vec<PathBuf>,     // relative paths under .kiro/steering/
+    pub installed_agents: Vec<String>,        // agent names
+    pub earliest_install: chrono::DateTime<chrono::Utc>,
+    pub latest_install: chrono::DateTime<chrono::Utc>,
+}
+```
+
+A plugin appears in the result if it has at least one installed entry across the three tracking files.
+
+### remove_plugin cascade
+
+```rust
+// crates/kiro-market-core/src/project.rs
+impl KiroProject {
+    /// Remove every tracked entry from this plugin across all three
+    /// content types. Unlinks the on-disk files, updates the three
+    /// tracking files atomically (each `with_file_lock`'d), and
+    /// returns aggregated counts.
+    pub fn remove_plugin(
+        &self,
+        marketplace: &str,
+        plugin: &str,
+    ) -> Result<RemovePluginResult, Error>;
+}
+
+pub struct RemovePluginResult {
+    pub skills_removed: u32,
+    pub steering_removed: u32,
+    pub agents_removed: u32,
+}
+```
+
+If any sub-removal fails, return early with the error — `remove_plugin` is best-effort but doesn't try to roll back. The CLAUDE.md "tracking files are user-owned" note still applies: we never delete files we don't have a tracking entry for.
+
+### Frontend changes
+
+**BrowseTab restructure.** Today's structure:
+- Filter bar
+- Filter chips
+- Skill grid (the primary surface)
+- Bottom action bar (force toggle + "Install N selected" + "Install steering for X")
+
+After Phase 1:
+- Filter bar (unchanged)
+- Filter chips (unchanged)
+- **View toggle:** `[Plugins] [Skills]` (Plugins = default)
+- **Plugins view:** plugin cards with Install button per card, content-count breakdown, description
+- **Skills view:** today's skill grid (preserved for power users)
+- Bottom action bar simplified: force toggle stays for the Skills view; per-plugin install lives on the cards
+
+**InstalledTab restructure.** Today's structure:
+- Single skills table
+
+After Phase 1:
+- **Plugins** section (primary): rows with plugin name, content-count breakdown, "Remove" button
+- **All skills** section (collapsed by default): today's flat skills table for users who liked it
+
+The cosmetic Force-reinstall checkbox issue you flagged earlier dissolves when the install action moves to the plugin card. The card's Install button can carry its own state (e.g. error → "Retry with overwrite" inline button) without a global toggle. The skill-grid Force toggle stays for the secondary path.
+
+### Wire format / FFI shape
+
+`InstallPluginResult` and `InstalledPluginInfo` cross the FFI. They embed existing types (`InstallSkillsResult`, `InstallSteeringResult`, `InstallAgentsResult`) which already have `Serialize + cfg_attr(specta::Type)` from earlier PRs. The new aggregate types follow the same pattern.
+
+Per the `ffi-enum-serde-tag` plan-lint gate from PR 91: any new public enum that ships in these aggregates needs `#[serde(tag = "kind", rename_all = "snake_case")]`. None are introduced in Phase 1 (the result types are structs), but worth noting for any error variants that surface in the `RemovePluginResult` sibling types.
+
+### Concurrent-install behavior
+
+Today's UI gates concurrent skill installs with the global `installing: boolean` flag. After Phase 1, plugin installs are per-card and can run in parallel — analogous to PR 92's `pendingSteeringInstalls: SvelteSet<string>` keyed by `pluginKey(marketplace, plugin)`. Two plugins installing in parallel don't block each other. The skill-grid Install button keeps its existing single-flight behavior since the existing `installing` flag covers the same scope.
+
+The banner-collision concern (code-reviewer finding from PR 92's review) is addressed by replacing the single global `installError`/`installMessage` with **per-card status**. Each plugin card carries its own status text. The bottom-bar banner collapses to "X / Y plugin installs in flight" or similar coarse summary when multiple are running.
+
+## Phase 2 architecture (sketch)
+
+### Update detection
+
+```rust
+// crates/kiro-market-core/src/service/mod.rs
+impl MarketplaceService {
+    /// Compare each installed-plugin entry's `version` field against
+    /// the current marketplace manifest's plugin version. Returns the
+    /// list of plugins that have an update available, with both the
+    /// installed and available versions.
+    ///
+    /// "Update available" semantics: for the `(marketplace, plugin)`
+    /// pair, if the marketplace's plugin manifest carries a `version`
+    /// that does not equal the highest installed version across the
+    /// three tracking files, return that plugin in the result. No
+    /// semver comparison — strict string inequality is enough; we
+    /// don't want to silently skip downgrades a marketplace owner
+    /// intentionally pushed.
+    pub fn detect_plugin_updates(
+        &self,
+        project: &KiroProject,
+    ) -> Result<Vec<PluginUpdateInfo>, Error>;
+}
+
+pub struct PluginUpdateInfo {
+    pub marketplace: String,
+    pub plugin: String,
+    pub installed_version: Option<String>,
+    pub available_version: Option<String>,
+}
+```
+
+Tauri command `detect_plugin_updates(project_path)` returns the same shape.
+
+### Update action
+
+No new Tauri command. The update action is `install_plugin(..., force=true)`. The frontend renders an "Update" button in place of "Install" when `detect_plugin_updates` shows the plugin needs one.
+
+### Phase 2 alternatives (rejected for v1, documented for future)
+
+**Per-content-type updates.** A plugin's steering files change but the skills don't. The user wants to update only the steering. To do this:
+- `detect_plugin_updates` returns per-content-type version diffs, not just a single per-plugin diff.
+- The "Update" button gets a dropdown: "Update everything / Update steering only / Update agents only" etc.
+- Implementation: probably a new `update_plugin_content(marketplace, plugin, types: Vec<ContentType>)` Tauri command.
+
+This is rejected for v1 because (a) the user's stated intent is "plugins are coherent bundles" and per-type updates fight that intent, and (b) the underlying core code is `force=true` per-type, so the surface is purely a UI concern that can be added later without changing the data model.
+
+**Auto-update.** Background polling for updates and applying them without user action. Out of scope; security-sensitive (a malicious marketplace could push a version that adds a hostile MCP server). Always require an explicit user click.
+
+## Out of scope (Phase 1 + Phase 2)
+
+- Plugin uninstall confirmation dialog (just a button for now; cascade-remove is the contract).
+- Plugin search beyond the existing skill filter input (the filter applies to skill names; a plugin-name filter is a Phase 1.1 polish).
+- Per-content-type install customization (the rejected alternative above).
+- Per-content-type list/remove Tauri commands (use the plugin-level aggregator + cascade for now).
+- Plugin dependencies (some plugins might require others; deferred).
+- Marketplace-level "install all plugins" or "update all plugins" batch actions.
+- Plugin ratings / popularity / signing / publisher trust signals.
+- Auto-update / background update polling.
+- Plan-lint gate for "every plugin-shaped type that crosses FFI must specta::Type" — PR 91's `ffi-enum-serde-tag` gate covers enums; a struct-side gate isn't yet in scope but worth tracking.
+
+## Testing strategy
+
+- Each new Tauri command splits into wrapper + `_impl`; `_impl` is unit-tested directly against `service::test_support` fixtures, mirroring the PR 83 / PR 92 pattern.
+- New core APIs (`MarketplaceService::install_plugin`, `KiroProject::remove_plugin`) get rstest cases against `temp_service` fixtures.
+- Aggregation logic (`installed_plugins`) gets a fixture with mixed content-type tracking and asserts the grouping shape.
+- Wire-format JSON shape locks for any new struct that crosses FFI (mirror `steering_warning_variants_json_shape` from PR 83).
+- Frontend: Playwright e2e test in `tests/e2e/app.spec.ts` for the happy-path "click Install on plugin card → see counts in InstalledTab" flow.
+
+## Module map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | Add `install_plugin`, `detect_plugin_updates`, `InstallPluginResult`, `PluginUpdateInfo` |
+| `crates/kiro-market-core/src/project.rs` | Modify | Add `installed_plugins`, `remove_plugin`, `InstalledPluginInfo`, `RemovePluginResult` |
+| `crates/kiro-control-center/src-tauri/src/commands/agents.rs` | **New** | `install_plugin_agents` Tauri command (mirror `commands/steering.rs`) |
+| `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` | **New** | `install_plugin`, `list_installed_plugins`, `remove_plugin`, `detect_plugin_updates` Tauri commands |
+| `crates/kiro-control-center/src-tauri/src/commands/mod.rs` | Modify | Register new modules |
+| `crates/kiro-control-center/src-tauri/src/lib.rs` | Modify | Add new commands to `invoke_handler!` |
+| `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` | Modify | Plugin cards, view toggle, simpler bottom bar |
+| `crates/kiro-control-center/src/lib/components/InstalledTab.svelte` | Modify | Plugins-grouped view + collapsible flat skills |
+| `crates/kiro-control-center/src/lib/components/PluginCard.svelte` | **New** | Reusable plugin card with Install/Update/Remove states |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | New types via `cargo test ... -- --ignored` |
+| `crates/kiro-control-center/tests/e2e/app.spec.ts` | Modify | Plugin-install happy-path test |
+
+## 5-Gates self-review
+
+### Gate 1 — Grounding
+
+**Real incident driving this work?** Yes. PR 92 shipped steering install but the user manually testing on `kiro-starter-kit` immediately hit the "I installed something but the Installed tab shows nothing" gap. The plugin-first reframe came from the user's observation that plugins are designed as coherent bundles (a code-review agent without its steering isn't useful). Both grounded in real user feedback.
+
+### Gate 2 — Threat Model
+
+**Untrusted inputs:**
+- Plugin manifest fields (`version`, content lists) — already validated by existing core parsers (`PluginManifest`, `RelativePath`, etc.); Phase 1 doesn't introduce new untrusted parse points.
+- `project_path` from Tauri FFI — `validate_kiro_project_path` from PR 83 still applies; new Tauri commands must call it for any path-bearing operation. **Action item:** include `validate_kiro_project_path` calls in all new commands' `_impl` functions.
+- Marketplace-supplied agent files in MCP-bearing plugins — `accept_mcp` flag flows through `install_plugin` to `install_plugin_agents`; the existing opt-in semantics must not be silently bypassed by the coordinator. **Action item:** plumb `accept_mcp` through `install_plugin` from the Tauri layer; default to `false` if the frontend doesn't send it.
+
+### Gate 3 — Wire Format / FFI Shape
+
+**New types crossing the FFI:**
+- `InstallPluginResult` — struct, embeds existing `Option<InstallSkillsResult>` etc. Serialize + cfg_attr(specta::Type) on the new struct; the inner types already carry the asymmetric serde from PR 83 work. The `_Serialize`/`_Deserialize` TS noise from item 3a will propagate up to the new struct — accepted as known cosmetic debt.
+- `InstalledPluginInfo` — struct of primitives + `Vec<String>`/`Vec<PathBuf>`. Clean Serialize.
+- `PluginUpdateInfo` — struct of primitives + `Option<String>`. Clean.
+- `RemovePluginResult` — struct of `u32`s. Clean.
+
+**Action item:** explicit JSON-shape rstest case for `InstallPluginResult` to lock the aggregate shape (mirroring `steering_warning_variants_json_shape`).
+
+### Gate 4 — External Type Boundary
+
+No new external errors are introduced. The coordinator and aggregator wrap existing typed errors. `KiroProject::remove_plugin` reads three tracking files via existing `load_installed_*` paths — `serde_json::Error` is already mapped at those boundaries via `tracking_malformed`-style constructors. Phase 1 doesn't add new adapter-boundary work.
+
+`cargo xtask plan-lint --gate gate-4-external-error-boundary` will cover this automatically.
+
+### Gate 5 — Type Design
+
+- `InstallPluginResult` uses `Option<T>` for "wasn't applicable" — distinguishes "plugin has no agents declared" (`None`) from "agents were attempted, all failed" (`Some` with empty `installed`). Encodes the distinction in the type rather than as a magic `len() == 0` check.
+- `InstalledPluginInfo` — flat struct, all `pub` fields. Internal state, not parsed from external input. Acceptable for a DTO.
+- `RemovePluginResult` — `u32` counts; saturating-cast is the existing pattern. `try_from` + warn-and-saturate via the existing `saturate_to_u32` helper.
+- `PluginUpdateInfo` keeps `installed_version: Option<String>` and `available_version: Option<String>` rather than a single sentinel. `None` means "tracking file said no version" (which is legal for older installs).
+
+**No new validation newtypes** are introduced; existing newtypes (`RelativePath`, `AgentName`) already cover the parse-don't-validate boundaries. **Action item:** if any new field accepts a path string from the FFI, it goes through `RelativePath::new` or equivalent at the boundary.
+
+## References
+
+- `2026-04-23-stage3-steering-import-plan.md` — original steering plan, established `_impl` pattern Phase 1 follows
+- `2026-04-17-agent-tauri-wiring-plan.md` — pre-PR-83 agent wiring sketch (some content reusable for the Phase 1 agent Tauri command)
+- `docs/plan-review-checklist.md` — 5-gates self-review used above
+- PR 83 (steering install backend), PR 91 (plan-lint tag gate), PR 92 (steering install UI) — direct precedents

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -420,6 +420,192 @@ the source tree and quote the drift verbatim. That's the bar.
 
 ---
 
+## A-10 — Gate 1: Task 8's inline `pluginKey` drops the US-delimiter
+
+**Original (plan Task 8, Step 1):**
+
+```typescript
+function pluginKey(mp: string, plugin: string): string {
+  return `${mp}${plugin}`;
+}
+```
+
+**Drift.** BrowseTab.svelte (PR 92) already defines `pluginKey` with an
+ASCII Unit-Separator (``) delimiter precisely so a marketplace
+literally named `"foo"` + plugin `"bar"` cannot collide with a
+marketplace `"fooba"` + plugin `"r"`. From `BrowseTab.svelte:108-111`:
+
+```typescript
+const DELIM = "";
+const pluginKey = (mp: string, plugin: string) => `${mp}${DELIM}${plugin}`;
+```
+
+My Task 8 InstalledTab redefinition uses naive concatenation, breaking
+the collision-safe contract. The two files would then key the same
+plugin differently — anything that round-trips a key between the
+components (none does today, but the temptation is real once
+`installedPluginKeys` proves useful) would silently mismatch.
+
+**Amended.** Two equivalent fixes; pick one:
+
+**(a) Inline the delimiter** in Task 8's script block:
+
+```typescript
+const DELIM = "";
+function pluginKey(mp: string, plugin: string): string {
+  return `${mp}${DELIM}${plugin}`;
+}
+```
+
+**(b) Extract to `$lib/keys.ts`** (preferred — matches Task 6's
+extraction-first pattern and avoids any future drift):
+
+```typescript
+// crates/kiro-control-center/src/lib/keys.ts
+const DELIM = "";
+export const pluginKey = (mp: string, plugin: string): string =>
+  `${mp}${DELIM}${plugin}`;
+export const skillKey = (mp: string, plugin: string, name: string): string =>
+  `${mp}${DELIM}${plugin}${DELIM}${name}`;
+export const parsePluginKey = (key: string): { marketplace: string; plugin: string } => {
+  const [marketplace, plugin] = key.split(DELIM);
+  return { marketplace, plugin };
+};
+```
+
+Then BOTH BrowseTab.svelte and InstalledTab.svelte import from
+`$lib/keys`, and the BrowseTab in-script copy of these helpers
+(currently at `BrowseTab.svelte:108-118`) gets deleted.
+
+**Recommendation:** (b). The `pluginKey` helper is the kind of
+single-source-of-truth utility that earns its keep across the
+codebase — and the lift is mechanical, ~6 lines of diff plus the
+imports. Setting the precedent here also paves the way for the
+future Phase 1.5 / Phase 2 work that'll need the same key shape.
+
+**Rationale.** Gate 1 — "every API the plan references actually
+exists at the SHA the plan was written against" expanded to "and
+matches the existing contract." A `pluginKey` whose collision-safety
+silently differs from BrowseTab's is a contract violation even
+though the symbol exists.
+
+---
+
+## A-11 — Gate 1: Task 7's conditional structure under-specifies how `browseView` composes with the existing empty-state branch
+
+**Original (plan Task 7, Step 5):**
+
+```svelte
+{:else if browseView === "skills"}
+  <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+    {#each filteredSkills as skill ... }
+      <SkillCard ... />
+    {/each}
+  </div>
+{:else}
+  {#if availablePlugins.length === 0}
+    ... (plugin empty state)
+  {:else}
+    ... (plugin grid)
+  {/if}
+{/if}
+```
+
+Plus a free-floating note:
+
+> "the existing `{:else if filteredSkills.length === 0}` empty-state
+> block (PR 92's per-plugin steering install in the empty state)
+> needs to be removed in favor of the new Plugins view"
+
+**Drift.** The note is correct but the code block doesn't show how to
+compose with the parent `{#if showLoadingSpinner}` chain. The
+implementer has to figure out where the existing
+`{:else if filteredSkills.length === 0}` branch goes — keep it gated
+on `browseView === "skills"`, or remove it entirely? Both are
+defensible; the plan should pick one and show the full structure.
+
+**Amended.** Show the complete conditional, with PR 92's empty-state
+removed (the Plugins view is the new home for plugin-based install):
+
+```svelte
+{#if showLoadingSpinner}
+  <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+    <!-- existing loading spinner unchanged -->
+  </div>
+{:else if initialLoadFailed}
+  <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+    <!-- existing initial-load-failed message unchanged -->
+  </div>
+{:else if browseView === "skills"}
+  {#if filteredSkills.length === 0}
+    <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+      <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <p class="text-sm">
+        {#if filterText}
+          No skills match the filter
+        {:else if fetchErrors.size > 0}
+          Skills unavailable due to errors above
+        {:else}
+          No skills available — try the Plugins view to install plugins that ship steering.
+        {/if}
+      </p>
+    </div>
+  {:else}
+    <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+      {#each filteredSkills as skill (skillKey(skill.marketplace, skill.plugin, skill.name))}
+        {@const key = skillKey(skill.marketplace, skill.plugin, skill.name)}
+        <SkillCard
+          {skill}
+          selected={selectedSkills.has(key)}
+          onToggle={() => toggleSkill(key)}
+        />
+      {/each}
+    </div>
+  {/if}
+{:else}
+  <!-- browseView === "plugins" -->
+  {#if availablePlugins.length === 0}
+    <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+      <p class="text-sm">No plugins available — pick a marketplace from Filters.</p>
+    </div>
+  {:else}
+    <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+      {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
+        {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
+        <PluginCard
+          plugin={ap.plugin}
+          marketplace={ap.marketplace}
+          installed={installedPluginKeys.has(key)}
+          installing={pendingPluginInstalls.has(key)}
+          projectPicked={!!projectPath}
+          onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+        />
+      {/each}
+    </div>
+  {/if}
+{/if}
+```
+
+**Concretely deleted by this amendment** — the current BrowseTab
+empty-state plugin-card list added in PR 92 commit `0102ec5` (the
+`{:else if !filterText && availablePlugins.length > 0}` branch
+introduced when the user reported "I don't see anything in the UI
+to install steering"). That UI moves into the new Plugins view as
+the *primary* surface; the empty-state is just "No skills available
+— try the Plugins view" text now.
+
+**Rationale.** Gate 1 — the plan's "remove PR 92's empty-state"
+note moved a non-trivial chunk of working code into "implementer's
+discretion." Showing the explicit before/after structure removes
+the ambiguity. Also lands a small UX win: the skill empty-state
+now points users at the Plugins view, completing the discovery
+loop.
+
+---
+
 ## A-9 — Performance: hoist `Utc::now()` out of `installed_plugins`'s map closure
 
 **Original (plan Task 2, Step 4):**
@@ -541,6 +727,13 @@ lesson so future plan-reviews start with the right tool.
   closure. Caught by gemini-code-assist on PR #93. Surfaces a
   separate semantic concern — `unwrap_or(now)` may be papering over
   a malformed-tracking case that should fail loudly instead.
+- A-10: Task 8's inline `pluginKey` drops BrowseTab's `` delim,
+  breaking the collision-safe contract. Lift `pluginKey`/`skillKey`/
+  `parsePluginKey` to `$lib/keys.ts`; both files import.
+- A-11: Task 7's conditional structure under-specifies how
+  `browseView` composes with the existing chain. Explicit before/
+  after rendering tree shown. PR 92's empty-state plugin cards
+  retired in favor of the new Plugins view as primary surface.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -420,6 +420,64 @@ the source tree and quote the drift verbatim. That's the bar.
 
 ---
 
+## A-9 — Performance: hoist `Utc::now()` out of `installed_plugins`'s map closure
+
+**Original (plan Task 2, Step 4):**
+
+```rust
+Ok(by_pair
+    .into_iter()
+    .map(|((marketplace, plugin), acc)| {
+        let now = chrono::Utc::now();   // <- called per plugin
+        InstalledPluginInfo {
+            ...
+            earliest_install: acc.earliest.unwrap_or(now),
+            latest_install: acc.latest.unwrap_or(now),
+        }
+    })
+    .collect())
+```
+
+**Drift.** `chrono::Utc::now()` is a syscall (reads the system clock).
+Calling it inside the `map` closure means one syscall per plugin in the
+result vec. For a project with 50 installed plugins that's 50 redundant
+clock reads, all returning effectively the same value. The whole vec is
+built in well under a millisecond — semantically the timestamps would
+differ by nanoseconds at most — but the code shape is wasteful, and the
+fix is mechanical. Caught by gemini-code-assist on PR #93.
+
+**Amended.** Capture the time once before the loop, reuse the binding:
+
+```rust
+let now = chrono::Utc::now();
+Ok(by_pair
+    .into_iter()
+    .map(|((marketplace, plugin), acc)| {
+        InstalledPluginInfo {
+            ...
+            earliest_install: acc.earliest.unwrap_or(now),
+            latest_install: acc.latest.unwrap_or(now),
+        }
+    })
+    .collect())
+```
+
+Same hoist applies to the A-6 rewrite — the `now` in
+`acc.latest.map_or_else(|| (now, None), |(t, v)| (t, v))` should come
+from a single binding outside the closure too.
+
+**Rationale.** Strictly speaking this is a perf nit; the cost is
+negligible at expected plugin counts. But the `unwrap_or(now)` arm is
+also semantically suspect — a missing `installed_at` from the tracking
+file is a degenerate state (every install path writes one), so we're
+substituting "right now" for "we don't actually know" and presenting it
+to the UI as a real install timestamp. The hoisting fix sidesteps the
+multi-call concern AND makes the substitution explicit at one site
+where a future reviewer can ask "is this fallback right?" rather than
+having it scattered across N closure invocations.
+
+---
+
 ## A-8 — Tooling: use LSP `documentSymbol` for Gate 1, not grep
 
 **Process drift.** The original Gate 1 pass used `grep -n` to spot
@@ -479,6 +537,10 @@ lesson so future plan-reviews start with the right tool.
 - A-8: Tooling correction — use LSP `documentSymbol` for Gate 1,
   not grep. Spot fix that LSP would have surfaced earlier and at
   lower cost.
+- A-9: Hoist `chrono::Utc::now()` out of `installed_plugins`'s map
+  closure. Caught by gemini-code-assist on PR #93. Surfaces a
+  separate semantic concern — `unwrap_or(now)` may be papering over
+  a malformed-tracking case that should fail loudly instead.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -1,0 +1,492 @@
+# Plugin-First Install — Plan Amendments
+
+> **Status:** plan-review pass. Fixes drift between
+> `2026-04-29-plugin-first-install-plan.md` and the actual SHA at
+> `de59270` (post-PR-92 `main`). Format follows the precedent set by
+> `2026-04-24-stage2-3-plan-amendments.md`.
+
+The original self-review section in the plan listed gate names but
+didn't do the work each gate prescribes. A second-pass `grep` against
+the current source tree (Gate 1 specifically) caught five drift points
+between plan code and reality, plus one threat-model gap (Gate 2) that
+the surface-level review missed.
+
+Each amendment cites the gate that fired, names the original plan
+text, gives the amended text, and explains the rationale. Apply these
+during execution; they don't require re-opening the design conversation.
+
+---
+
+## A-1 — Gate 1: `install_plugin_agents` is an associated function, not a method
+
+**Original (plan Task 1, Step 4):**
+
+```rust
+let agents = if ctx.agent_scan_paths.is_empty() {
+    None
+} else {
+    Some(self.install_plugin_agents(
+        project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext { ... },
+    ))
+};
+```
+
+**Drift.** `service/mod.rs:1299` declares
+`pub fn install_plugin_agents(project: &KiroProject, ...)` — no `&self`
+receiver. The plan's `self.install_plugin_agents(...)` won't compile.
+
+**Amended.** Use the associated-function form. Same fix for
+`install_plugin_steering` (already at `service/mod.rs:1330`, no `&self`):
+
+```rust
+let agents = if ctx.agent_scan_paths.is_empty() {
+    None
+} else {
+    Some(Self::install_plugin_agents(
+        project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext { ... },
+    ))
+};
+
+let steering = if ctx.steering_scan_paths.is_empty() {
+    None
+} else {
+    Some(Self::install_plugin_steering(
+        project,
+        &ctx.plugin_dir,
+        &ctx.steering_scan_paths,
+        crate::steering::SteeringInstallContext { ... },
+    ))
+};
+```
+
+`install_skills` is unchanged because it *is* a method (`pub fn install_skills(&self, ...)` at `service/mod.rs:1021`).
+
+**Rationale.** Mechanical compile-error catch. PR-64-style: the original
+plan referenced an API signature that didn't match reality. The April 23
+plan-review precedent caught four of these (`test_marketplace_service`,
+`uuid_or_pid`, etc.); this is the same class.
+
+---
+
+## A-2 — Gate 1: `KiroProject::remove_steering_file` and `remove_agent` do not exist
+
+**Original (plan Task 3, Step 4):**
+
+> "Confirm whether `remove_steering_file(&Path)` and `remove_agent(&str)`
+> exist on `KiroProject`. If not, add them following `remove_skill`'s
+> shape. **Sub-task:** if either is missing, write a separate failing
+> test first..."
+
+**Drift.** Verified by `grep -n "pub fn remove_" crates/kiro-market-core/src/project.rs`:
+
+```
+562:    pub fn remove_skill(&self, name: &str) -> crate::error::Result<()> {
+```
+
+That is the *only* `pub fn remove_*` on `KiroProject`. Both
+`remove_steering_file` and `remove_agent` are absent. My "if missing"
+hedge soft-pedals what is in fact a hard prerequisite — `remove_plugin`
+cannot exist without these two methods.
+
+**Amended.** Promote the prerequisite to two named tasks before the
+cascade lands. Insert into the plan as Tasks 3a and 3b, before what is
+currently Task 3:
+
+### Task 3a (new): `KiroProject::remove_steering_file(rel: &Path)`
+
+Follow the shape of `remove_skill` at `project.rs:562`:
+
+1. Acquire `with_file_lock` on `installed-steering.json`'s tracking path.
+2. Load `InstalledSteering`, look up `files.get(rel)`.
+3. If absent → return `SteeringError::NotInstalled` (or whatever the
+   project's not-found-on-remove convention is — check `remove_skill`
+   for the pattern; CLAUDE.md "user-owned tracking files" applies).
+4. Compute the on-disk destination path
+   (`self.steering_dir().join(rel)` — if `steering_dir()` doesn't exist
+   yet, use `self.kiro_dir().join("steering").join(rel)`).
+5. Validate the joined path stays under `steering_dir` after `canonicalize`
+   (Gate 2 — see A-4 below).
+6. Unlink the destination. `io::ErrorKind::NotFound` is non-fatal — the
+   tracking entry may outlive the file if a user manually deleted it.
+7. Remove the entry from `InstalledSteering.files`.
+8. Atomically rewrite the tracking JSON.
+
+Test: `remove_steering_file_unlinks_and_updates_tracking` — seed
+`installed-steering.json` + an on-disk file, call remove, assert both gone.
+
+### Task 3b (new): `KiroProject::remove_agent(name: &str)`
+
+Mirror the steering shape but for agent prompts in `.kiro/agents/prompts/`
+(see `agent_prompts_dir()` at `project.rs:669`). Account for the
+`InstalledAgents.native_companions` per-plugin map — see A-3.
+
+Test: `remove_agent_unlinks_prompt_and_updates_tracking`.
+
+### Task 3 (was 3, now 3c): cascade in `remove_plugin`
+
+Unchanged from the original plan's Task 3 except the body now relies
+on Tasks 3a/3b being present rather than conditionally creating them.
+
+**Rationale.** "If missing, write the test first" is a hedge I made
+because I hadn't verified absence at write time. The 5-gates checklist
+explicitly calls out this failure mode ("plan referenced
+`test_marketplace_service()` — actual helper was `temp_service()`").
+Promoting the prerequisites to first-class tasks removes the conditional.
+
+---
+
+## A-3 — Gate 1: `InstalledAgents.native_companions` map needs cleanup in `remove_plugin`
+
+**Original.** `remove_plugin` cascade in plan Task 3 step 3 only iterates
+`InstalledAgents.agents` entries.
+
+**Drift.** `project.rs:113-119`:
+
+```rust
+pub struct InstalledAgents {
+    pub agents: HashMap<String, InstalledAgentMeta>,
+    pub native_companions: HashMap<String, InstalledNativeCompanionsMeta>,
+}
+```
+
+`native_companions` is keyed by **plugin name** (one entry per plugin
+that ships native-format companions). When `remove_plugin` removes
+every entry from a plugin, the corresponding `native_companions` entry
+must also go — otherwise the tracking file accumulates orphan
+companion records.
+
+**Amended.** Extend the cascade in Task 3c:
+
+```rust
+// After removing per-agent entries, also drop the per-plugin
+// native_companions map entry if present. The companions map is
+// keyed by plugin name (not marketplace-qualified), so a plugin
+// reinstall under a different marketplace would leave a stale
+// companions record otherwise.
+let agents_post = self.load_installed_agents()?;
+if agents_post.native_companions.contains_key(plugin) {
+    // Use whichever helper KiroProject exposes for native_companions
+    // tracking updates. If none exists, write a small one-shot
+    // helper in this same impl block — pattern: with_file_lock the
+    // tracking path, mutate the map, save.
+    self.remove_native_companions_for_plugin(plugin)?;
+}
+```
+
+If `remove_native_companions_for_plugin` doesn't already exist (it
+likely doesn't — the cascade is the first caller that needs it), add
+it as Task 3b.5 alongside `remove_agent`.
+
+**Rationale.** Gate 1 ("every API the plan references actually exists")
+— the original plan didn't grep `InstalledAgents` to discover the
+`native_companions` field, so the cascade silently skipped the cleanup
+that's required for a clean uninstall.
+
+---
+
+## A-4 — Gate 2: Tracking-file path validation on remove
+
+**Original.** No threat-model treatment of tracking-file content
+during `remove_plugin`. My grep pass also missed the existing
+mitigation — see **Update via LSP** below.
+
+**Threat scenario.** A malicious plugin (or a corrupted previous
+install state) writes a tracking entry like:
+
+```json
+{ "files": { "../../etc/passwd": { ... } } }
+```
+
+`remove_plugin` calling `steering_dir.join(rel)` followed by an unlink
+on the result would resolve to `/etc/passwd` because `Path::join`
+does NOT collapse `..`.
+
+**Update via LSP `documentSymbol` on `project.rs`** — this work
+should have happened *before* writing the original plan. The
+codebase already mitigates the threat at the load boundary, and
+already has a path-validation helper:
+
+- `validate_tracking_path_entry(rel: &Path) -> Result<(), &'static str>` at `project.rs:409` — the project-wide helper for "is this tracking-file path safe to use?"
+- `validate_tracking_steering_files(installed: &InstalledSteering, tracking_path: &Path)` at `project.rs:476` — runs at load time. Returns `Err` if any entry fails the path check. Tested by `load_installed_steering_rejects_path_traversal_in_files_key` (`project.rs:2737`).
+- `validate_tracking_companion_files(installed: &InstalledAgents, tracking_path: &Path)` at `project.rs:445` — same shape for native companions. Tested by `load_installed_agents_rejects_path_traversal_in_companion_files` (`project.rs:2780`).
+
+So the moment `KiroProject::load_installed_steering()` returns `Ok`,
+the `InstalledSteering.files` map has been validated against
+traversal. By the time `remove_plugin` reads it, the bad entries
+have already turned into `Err`s on `load`. **The original threat
+scenario doesn't materialize** — `remove_plugin` would propagate the
+load-time Err before ever reaching an unlink.
+
+**Amended.** The earlier plan asked for canonicalize-and-prefix-check
+inside the cascade. That was the right shape but the wrong layer —
+the load boundary already does it. Two narrower asks for the actual
+implementation:
+
+1. Add an explicit test that `remove_plugin` propagates the load-time
+   error: seed a tracking file with a traversal entry, call
+   `remove_plugin`, assert it returns the same `Err` shape as
+   `load_installed_steering` would have. Locks the contract that
+   removal can't accidentally widen the threat surface by reading
+   tracking entries some other way.
+
+2. The new `remove_steering_file(&Path)` / `remove_agent(&str)`
+   methods (Tasks 3a / 3b) MUST reuse `validate_tracking_path_entry`
+   rather than rolling their own canonicalization. Defense in depth
+   against future refactors that bypass the load helpers — e.g., a
+   path that constructs an `InstalledSteering` in memory without
+   going through `load_installed_steering`. Mirror the
+   `remove_skill_rejects_path_traversal` pattern (`project.rs:3902`).
+
+**Rationale.** Original Gate 2 instinct was correct (the threat
+exists in principle). LSP-first analysis showed the codebase
+already addresses it at the load boundary, with a tested helper.
+The amendment narrows the ask from "add new validation" to "reuse
+the existing helper and add a regression test that the cascade path
+inherits the protection."
+
+---
+
+## A-5 — Gate 3: JSON shape lock only covers all-`None`, not `Some` cases
+
+**Original.** Plan Task 1 step 6 has one rstest case asserting the
+all-`None` JSON shape:
+
+```rust
+let result = InstallPluginResult {
+    plugin: "p".into(),
+    version: Some("1.0.0".into()),
+    skills: None,
+    steering: None,
+    agents: None,
+};
+```
+
+**Drift.** This locks the field-presence contract for "no content
+applicable." It does NOT lock the shape when one or more sub-results
+are populated. A regression that, say, mistakenly serialized
+`Some(InstallSteeringResult)` as a flattened struct (vs. nested) would
+slip past this test.
+
+**Amended.** Add a second rstest case:
+
+```rust
+#[test]
+fn install_plugin_result_json_shape_with_populated_subresult() {
+    let result = InstallPluginResult {
+        plugin: "p".into(),
+        version: Some("1.0.0".into()),
+        skills: Some(crate::service::InstallSkillsResult {
+            installed: vec!["alpha".into()],
+            skipped: vec![],
+            failed: vec![],
+            skipped_skills: vec![],
+        }),
+        steering: None,
+        agents: None,
+    };
+    let json = serde_json::to_value(&result).expect("serialize");
+    let skills = json.pointer("/skills").expect("skills field exists");
+    assert!(
+        skills.is_object(),
+        "skills must serialize as a nested object, not flatten into the parent",
+    );
+    assert_eq!(
+        skills.pointer("/installed").and_then(|v| v.as_array()).map(Vec::len),
+        Some(1),
+    );
+}
+```
+
+**Rationale.** Gate 3 fail signature: "fields constructed in two paths
+must produce semantically equivalent values." `Option<T>` constructed
+as `None` vs. `Some(default)` would both serialize cleanly today, but a
+serde-attribute change (e.g., `#[serde(flatten)]` accidentally
+appearing) would break the second only. Single-test coverage of the
+all-`None` case is insufficient.
+
+---
+
+## A-6 — Gate 5: "Highest version" via lexicographic string comparison is unreliable
+
+**Original.** Plan Task 2 step 4, `update_version_and_dates`:
+
+```rust
+fn update_version_and_dates(
+    acc: &mut Acc,
+    version: Option<&str>,
+    installed_at: chrono::DateTime<chrono::Utc>,
+) {
+    if let Some(v) = version {
+        // Latest wins by string comparison (no semver).
+        if acc.version.as_deref().map_or(true, |existing| existing < v) {
+            acc.version = Some(v.to_string());
+        }
+    }
+    ...
+}
+```
+
+**Drift.** Plain `&str` `<` is *lexicographic*, not semantic.
+`"0.10.0" < "0.9.0"` is true lexicographically (`'1'` < `'9'`). The
+design doc says "no semver comparison — strict string inequality is
+enough" but that's the *update-detection* (Phase 2) rule —
+`detect_plugin_updates` only needs equality. The *aggregator*
+(`installed_plugins`) wants the version of the user's latest install,
+which is a different semantic.
+
+**Amended.** Sidestep version comparison entirely by tracking the
+version of the **most recent install by `installed_at` timestamp**:
+
+```rust
+#[derive(Default)]
+struct Acc {
+    /// (installed_at, version) of the most recent tracking entry seen
+    /// across the three content types. The version of the latest
+    /// install — semantically what the UI wants to show under "this
+    /// plugin's installed version."
+    latest: Option<(chrono::DateTime<chrono::Utc>, Option<String>)>,
+    skills: Vec<String>,
+    steering: Vec<std::path::PathBuf>,
+    agents: Vec<String>,
+    earliest: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn update_latest(
+    acc: &mut Acc,
+    version: Option<&str>,
+    installed_at: chrono::DateTime<chrono::Utc>,
+) {
+    let new_version = version.map(str::to_string);
+    let should_replace = acc
+        .latest
+        .as_ref()
+        .map_or(true, |(when, _)| installed_at >= *when);
+    if should_replace {
+        acc.latest = Some((installed_at, new_version));
+    }
+    acc.earliest = Some(acc.earliest.map_or(installed_at, |e| e.min(installed_at)));
+}
+```
+
+In the final `InstalledPluginInfo` construction:
+
+```rust
+let (latest_install, installed_version) = acc
+    .latest
+    .map_or_else(|| (now, None), |(t, v)| (t, v));
+```
+
+**Rationale.** Gate 5 ("encode invariants in types"): the original code
+relied on lexicographic string ordering being semantic for version
+strings. It isn't. Switching to "latest by timestamp" is both more
+correct *and* requires no version-format assumption — it just defers
+the question of "which version is current?" to the order in which the
+user actually ran installs, which is the UX-correct answer anyway.
+
+---
+
+## A-7 (meta) — process: actually run gates, don't just write section headers
+
+**Drift.** The original plan's "5-Gates self-review" section listed
+each gate and wrote a paragraph that read like a gate result — but
+several paragraphs were *what I expected the gate to find*, not *what
+the gate actually surfaced after running it*. Specifically:
+
+- Gate 1 paragraph asserted "no drift" without grepping the actual SHA.
+- Gate 2 paragraph listed `validate_kiro_project_path` and `accept_mcp`
+  but missed the tracking-file path-traversal vector (A-4).
+- Gate 4 paragraph asserted "no new external errors" without checking
+  whether `remove_plugin`'s new failure modes might re-introduce one.
+
+**Mitigation.** Treat the gate paragraphs as *outputs of running the
+gate*, not *predictions*. For Gate 1 specifically: run the grep, paste
+the matching lines into the paragraph, then write the conclusion. For
+Gate 2: enumerate every byte source the new code reads from and walk
+the (source × capability) table explicitly. The next plan's self-review
+section should cite the actual `grep` command output, the actual
+`cargo xtask plan-lint --gate gate-4` output, etc.
+
+The PR-64 plan-review precedent (`2026-04-23-plan-review-findings.md`)
+followed this discipline — its findings cite specific line numbers in
+the source tree and quote the drift verbatim. That's the bar.
+
+---
+
+## A-8 — Tooling: use LSP `documentSymbol` for Gate 1, not grep
+
+**Process drift.** The original Gate 1 pass used `grep -n` to spot
+APIs the plan referenced. That found the most obvious drift but
+missed two existing helpers I should have been reusing:
+
+- `validate_tracking_path_entry` (free fn at `project.rs:409`)
+- `validate_tracking_steering_files` / `validate_tracking_companion_files`
+  (`project.rs:445, 476`) and their already-passing
+  `*_rejects_path_traversal_in_files_key` regression tests at
+  `project.rs:2737, 2780`
+
+**Mitigation.** A single LSP `documentSymbol` call on `project.rs`
+returned the full symbol map — every `pub fn`, every struct field
+with its type, every test, in one query. The full call:
+
+```
+LSP operation=documentSymbol
+    filePath=crates/kiro-market-core/src/project.rs
+```
+
+returned ~200 symbols including the validation helpers, the existing
+`remove_skill` traversal test (`project.rs:3902`), and the
+`InstalledAgents.native_companions` field that drove A-3. None of
+these were reachable by `grep "pub fn remove"` alone — `documentSymbol`
+sees the whole structural surface and returns it grouped by type.
+
+**Rule going forward.** First step of any plan-review Gate 1 pass:
+`documentSymbol` on every file the plan modifies. Then `grep` for
+any specific names the plan introduces (it's still useful for
+"does this exact identifier exist?" — LSP `workspaceSymbol` is the
+better answer there too). The PR-64-era plans pre-dated
+LSP-as-a-tool; the new gold standard is LSP-first, grep-as-fallback.
+
+This amendment is process-only — no code change. Captures the
+lesson so future plan-reviews start with the right tool.
+
+---
+
+## Summary of changes
+
+- A-1: Single line fix in Task 1 step 4 (`self.` → `Self::`).
+- A-2: Two new tasks (3a, 3b) before the cascade. Real prerequisites,
+  not "if missing."
+- A-3: Add `native_companions` cleanup in the cascade. Possibly a new
+  helper at Task 3b.5.
+- A-4: Reuse existing `validate_tracking_path_entry` helper in new
+  `remove_steering_file` / `remove_agent` methods. Add regression
+  test that `remove_plugin` propagates the load-time validation Err.
+  (Original ask was canonicalize-and-prefix; LSP-first analysis showed
+  the helper already exists.)
+- A-5: Second JSON-shape rstest case for the populated-subresult shape.
+- A-6: Replace lexicographic version comparison with "version of the
+  latest install by timestamp."
+- A-7: Process correction — future plan-reviews must run each gate,
+  not paraphrase.
+- A-8: Tooling correction — use LSP `documentSymbol` for Gate 1,
+  not grep. Spot fix that LSP would have surfaced earlier and at
+  lower cost.
+
+No design-doc revisions required. The amendments are all execution-time
+corrections; the architecture in
+`2026-04-29-plugin-first-install-design.md` stands as written.
+
+## References
+
+- `docs/plan-review-checklist.md` — the 5 gates this pass applied
+- `2026-04-24-stage2-3-plan-amendments.md` — format precedent
+- `2026-04-23-plan-review-findings.md` — bar for "what good looks like"
+- Source SHA at review time: `de59270` (post-PR-92 main)

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -664,6 +664,626 @@ having it scattered across N closure invocations.
 
 ---
 
+## A-12 — Gate 1: `remove_plugin` cascade aborts on orphan tracking entries
+
+**Original (plan Task 3, Step 3):**
+
+```rust
+for name in &to_remove {
+    self.remove_skill(name)?;     // <- propagates SkillError::NotInstalled
+    result.skills_removed = result.skills_removed.saturating_add(1);
+}
+// ...steering and agents follow the same pattern
+```
+
+**Drift.** `KiroProject::remove_skill` returns `SkillError::NotInstalled`
+when the on-disk skill *directory* is absent (verified at
+`project.rs:568-572`) — a normal state-divergence case the user can
+reach by running `rm -rf .kiro/skills/<name>/` manually. The
+cascade's `?` aborts on the first such error, dropping the
+`result.skills_removed` count and skipping steering + agents
+entirely. Result: a single orphan tracking entry stalls every
+subsequent removal in the same plugin. The user has no path to
+recover except hand-editing tracking JSON.
+
+**Amended.** Treat per-entry "not installed" as a *recoverable*
+case — log + count it as removed, continue the cascade:
+
+```rust
+for name in &to_remove {
+    match self.remove_skill(name) {
+        Ok(()) => {
+            result.skills_removed = result.skills_removed.saturating_add(1);
+        }
+        // Orphan tracking entry — directory was already gone. The
+        // cascade's job is to drive the project to "no entries from
+        // this plugin"; absent directory is a step in the right
+        // direction, not an error.
+        Err(crate::error::Error::Skill(SkillError::NotInstalled { .. })) => {
+            tracing::warn!(
+                skill = %name, plugin, marketplace,
+                "remove_plugin: skill tracking entry had no on-disk directory; \
+                 treating as already-removed",
+            );
+            result.skills_removed = result.skills_removed.saturating_add(1);
+        }
+        Err(e) => return Err(e),
+    }
+}
+```
+
+Mirror the same `match` pattern in the steering and agent loops.
+Other error variants (`Skill(_)`, `Plugin(_)`, `Io(_)`) still abort
+the cascade — they indicate genuine problems, not state divergence.
+
+**Rationale.** Gate 2 / Gate 5 (semantic correctness): the `?`
+collapses two distinct cases into one error path, losing the
+recoverable-vs-fatal distinction that the typed error variants
+were designed to encode. `remove_plugin` is a "drive toward
+absence" operation; finding things already absent is not a
+failure.
+
+---
+
+## A-13 — Gate 1: `SteeringError::NotInstalled` does not exist
+
+**Original (plan Task 3a, Step 3):**
+
+> "If absent → return `SteeringError::NotInstalled` (or whatever
+> the project's not-found-on-remove convention is)..."
+
+**Drift.** Verified by `grep "NotInstalled"` against
+`crates/kiro-market-core/src/steering/types.rs`: `SteeringError`
+has no `NotInstalled` variant. Variants present:
+`SourceReadFailed`, `SourceHardlinked`, `PathOwnedByOtherPlugin`,
+`OrphanFileAtDestination`, `ContentChangedRequiresForce`,
+`TrackingIoFailed`, `HashFailed`, `StagingWriteFailed`,
+`DestinationDirFailed`, `TrackingMalformed`. The "not installed"
+case isn't represented today because `install_plugin_steering`
+never had a corresponding `remove_*` operation.
+
+**Amended.** Task 3a step 3 must add a new typed variant before
+the `remove_steering_file` method can return it:
+
+```rust
+// crates/kiro-market-core/src/steering/types.rs — add to SteeringError
+#[non_exhaustive]
+#[error("steering file `{rel}` is not tracked in installed-steering.json")]
+NotInstalled { rel: PathBuf },
+```
+
+Update the existing `cargo xtask plan-lint --gate
+ffi-enum-serde-tag` cycle: the new variant is a unit-payload-bearing
+addition, so the `tag = "kind"` discriminant attribute stays valid;
+the JSON-shape rstest at `steering/types.rs:298-333` should grow a
+case for `NotInstalled`.
+
+Same pattern for `AgentError::NotInstalled` already exists at
+`error.rs:276` — confirm by reading the variant before reusing.
+The agent path's Task 3b can use the existing `AgentError::NotInstalled`
+without adding anything.
+
+**Rationale.** Gate 1 — naming a fictitious variant in a code block
+is the exact failure mode the checklist is designed to catch.
+A-2's "if missing, write the test first" hedge passed the buck;
+this amendment names the variant that needs to land.
+
+---
+
+## A-14 — Gate 1: Task 4's wrapper has the same `Self::` drift as A-1
+
+**Original (plan Task 4, Step 1, the example wrapper body):**
+
+```rust
+fn install_plugin_agents_impl(
+    svc: &MarketplaceService,
+    ...
+) -> Result<InstallAgentsResult, CommandError> {
+    ...
+    Ok(svc.install_plugin_agents(   // <- method call on associated function
+        &project,
+        &ctx.plugin_dir,
+        ...
+    ))
+}
+```
+
+**Drift.** `MarketplaceService::install_plugin_agents` is an
+associated function (no `&self`) at `service/mod.rs:1299`, same
+shape as `install_plugin_steering`. The plan's example uses
+`svc.install_plugin_agents(...)` — method-call syntax —
+which won't compile.
+
+A-1 covered the same drift in Task 1's orchestrator but not in
+Task 4's standalone Tauri command. Cross-task consistency check
+missed.
+
+**Amended.** Task 4's `_impl` should call the function via its
+absolute path:
+
+```rust
+Ok(MarketplaceService::install_plugin_agents(
+    &project,
+    &ctx.plugin_dir,
+    &ctx.agent_scan_paths,
+    ctx.format,
+    AgentInstallContext { ... },
+))
+```
+
+Strip `svc` from the `_impl` signature too — the function doesn't
+use the receiver. The wrapper still calls `make_service()?` for
+its own error path but the `_impl` doesn't need it. Or: keep
+`svc` in the signature for symmetry with the steering `_impl` and
+just unused-bind it; the existing `commands/steering.rs::install_plugin_steering_impl`
+takes `svc: &MarketplaceService` even though it calls
+`MarketplaceService::install_plugin_steering(...)` as an
+associated function — same shape applies here.
+
+**Rationale.** Gate 1 — cross-task consistency. When fixing one
+instance of a drift pattern, search for the same pattern in
+sibling tasks. This is a "did you grep for the bug shape, not just
+the bug instance" failure.
+
+---
+
+## A-15 — Gate 1: orchestrator's `is_empty()` branches are unreachable dead code
+
+**Original (plan Task 1, Step 4):**
+
+```rust
+let agents = if ctx.agent_scan_paths.is_empty() {
+    None
+} else {
+    Some(Self::install_plugin_agents(...))  // (A-1's fix applied)
+};
+// same shape for skills and steering
+```
+
+**Drift.** `agent_scan_paths_for_plugin` at `service/browse.rs:884-901`
+falls back to `crate::DEFAULT_AGENT_PATHS` (`["./agents/"]`)
+whenever the manifest is absent or its `agents` list is empty.
+`steering_scan_paths_for_plugin` at `:907-916` does the same with
+`DEFAULT_STEERING_PATHS`. Both functions ALWAYS return at least
+one element. Therefore `ctx.agent_scan_paths.is_empty()` and
+`ctx.steering_scan_paths.is_empty()` are tautologically false —
+the `None` branches never fire.
+
+The skills branch is similarly affected: `ctx.skill_dirs` comes
+from a different code path (registry-driven discovery), but for
+plugins that declare no `skills/` directory, the discovery yields
+an empty `Vec` — so the skills `is_empty()` MIGHT fire. Need to
+verify with LSP / read.
+
+**Amended.** Drop the conditional entirely for steering and
+agents — always run those install paths, let them return empty
+`installed`/`failed`/`warnings` vecs when nothing's there. Update
+`InstallPluginResult` to make `skills`/`steering`/`agents` non-
+optional:
+
+```rust
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallPluginResult {
+    pub plugin: String,
+    pub version: Option<String>,
+    pub skills: InstallSkillsResult,
+    pub steering: InstallSteeringResult,
+    pub agents: InstallAgentsResult,
+}
+```
+
+Frontend consumers check `result.skills.installed.length > 0`
+etc. directly — no `Option` unwrap needed. The "did this plugin
+have any of X content" question is implicitly answered by
+`installed.is_empty() && failed.is_empty() && warnings.is_empty()`.
+
+Updates the JSON-shape lock from A-5: instead of asserting `null`
+for unattempted content types, assert empty vecs.
+
+**Rationale.** Gate 1 + Gate 5 — the original design's `Option<T>`
+distinction ("applicable vs. attempted but empty") was based on a
+pre-condition check (`is_empty()`) that doesn't actually catch
+the "not applicable" case because of the default fallback. The
+distinction was illusory; encoding it in the type was wrong.
+Removing the `Option` simplifies the wire format AND eliminates
+the dead branches.
+
+---
+
+## A-16 — Gate 1: `native_companions` cleanup over-deletes across marketplaces
+
+**Original (A-3 amendment text):**
+
+```rust
+let agents_post = self.load_installed_agents()?;
+if agents_post.native_companions.contains_key(plugin) {
+    self.remove_native_companions_for_plugin(plugin)?;
+}
+```
+
+**Drift.** `InstalledAgents.native_companions: HashMap<String,
+InstalledNativeCompanionsMeta>` is keyed by **plugin name only**
+(`project.rs:114`). `InstalledNativeCompanionsMeta` carries a
+`marketplace: String` field at `project.rs:97` precisely so two
+different marketplaces shipping a plugin with the same name can
+coexist.
+
+A-3's `contains_key(plugin)` test ignores the marketplace
+distinction. If marketplace A and marketplace B both ship a plugin
+named `"code-reviewer"`, removing marketplace A's entry would
+match-and-delete marketplace B's `native_companions` record too
+— a cross-marketplace data corruption.
+
+**Amended.** Match on BOTH plugin name AND marketplace:
+
+```rust
+let agents_post = self.load_installed_agents()?;
+if let Some(meta) = agents_post.native_companions.get(plugin) {
+    if meta.marketplace == marketplace {
+        self.remove_native_companions_for_plugin(plugin, marketplace)?;
+    }
+    // else: this `plugin` name belongs to a different marketplace's
+    // record. Leave it alone — the `(marketplace, plugin)` pair we
+    // were asked to remove is not represented in native_companions.
+}
+```
+
+The new `remove_native_companions_for_plugin` helper signature
+takes `(plugin: &str, marketplace: &str)` and only removes when
+both match. The HashMap keying-by-plugin-only is a pre-existing
+data-model quirk that this fix works around at the read site;
+restructuring `native_companions` to be keyed on `(marketplace,
+plugin)` is a larger change and out of scope.
+
+**Rationale.** Gate 1 + Gate 2 (data-corruption threat from a
+plausible same-name-across-marketplaces scenario). A-3 surfaced
+the field but didn't grep its `Meta` struct to discover the
+disambiguator. LSP `documentSymbol` would have shown
+`InstalledNativeCompanionsMeta.marketplace` immediately, but A-3
+predated the A-8 LSP-first discipline.
+
+---
+
+## A-17 — Gate 5: `>=` tie-break in `update_latest` is non-deterministic
+
+**Original (A-6 amendment code):**
+
+```rust
+let should_replace = acc
+    .latest
+    .as_ref()
+    .map_or(true, |(when, _)| installed_at >= *when);
+```
+
+**Drift.** `install_plugin` runs the three install paths in a
+single call, all sharing the `Utc::now()` snapshot — so when the
+aggregator iterates the three tracking maps, the `installed_at`
+timestamps for entries from one `install_plugin` call are equal.
+With `>=`, equal timestamps always replace, so the
+`installed_version` that wins depends on which content type's
+`HashMap` was iterated last. `HashMap` iteration order is
+non-deterministic in Rust (per `std::collections::HashMap` docs).
+
+User-visible effect: the `installed_version` field on
+`InstalledPluginInfo` flickers between content-type values across
+process restarts when the three sub-results' versions differ
+(e.g. plugin manifest's `version` is one of them, but the entries
+might have been written by older code paths with stale versions).
+
+**Amended.** Use `>` instead — first-seen wins on ties:
+
+```rust
+let should_replace = acc
+    .latest
+    .as_ref()
+    .map_or(true, |(when, _)| installed_at > *when);
+```
+
+Document the iteration order explicitly: the aggregator iterates
+skills, then steering, then agents — so on tied timestamps, the
+*first* of those three with a tracking entry contributes the
+displayed `installed_version`. Stable across process restarts.
+
+**Rationale.** Gate 5 (encode invariants in semantics, not in
+HashMap-iteration-order accidents). `>=` looks innocent but
+silently couples the result to a non-deterministic substrate;
+`>` makes the iteration order load-bearing in a documented way.
+
+---
+
+## A-18 — Gate 2: Task 5's `install_plugin` Tauri wrapper drops `accept_mcp`
+
+**Original (plan Task 5, Step 2):**
+
+> "Same wrapper + `_impl` pattern as steering. Calls
+> `svc.install_plugin(...)` from Task 1."
+
+**Drift.** Steering's `install_plugin_steering` Tauri command
+takes `(marketplace, plugin, force, project_path)` — no
+`accept_mcp`. Following that template literally for `install_plugin`
+gives the same signature, but `svc.install_plugin(...)` from
+Task 1 takes `accept_mcp: bool` as its 5th parameter. The
+implementer would either (a) omit `accept_mcp` from the wrapper
+and hardcode `false` in the `_impl`, silently bypassing the
+user's MCP opt-in, or (b) hand-add it without reading the design
+doc's Gate 2 action item that explicitly calls this out.
+
+**Amended.** Task 5 Step 2's wrapper signature MUST include
+`accept_mcp: bool`:
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn install_plugin(
+    marketplace: String,
+    plugin: String,
+    force: bool,
+    accept_mcp: bool,
+    project_path: String,
+) -> Result<InstallPluginResult, CommandError> {
+    let svc = make_service()?;
+    install_plugin_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        InstallMode::from(force),
+        accept_mcp,
+        &project_path,
+    )
+}
+
+fn install_plugin_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallPluginResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+    svc.install_plugin(&project, marketplace, plugin, mode, accept_mcp)
+        .map_err(CommandError::from)
+}
+```
+
+Frontend `commands.installPlugin(marketplace, plugin, force,
+acceptMcp, projectPath)` — `acceptMcp` defaults to `false` at the
+Svelte caller (per the design doc's `accept_mcp` is opt-in
+default-deny rule). When/where the user toggles MCP consent in
+the UI is a Phase 2 concern; for Phase 1, ship the binding with
+`acceptMcp: false` hardcoded at the BrowseTab call site and wire
+a real toggle later.
+
+**Rationale.** Gate 2 — the design doc explicitly listed
+"plumb `accept_mcp` through `install_plugin` from the Tauri
+layer" as an action item. The plan's Task 5 silently dropped
+it. CLAUDE.md "frontend error-path rigor" applies: a security-
+sensitive flag the design doc said to plumb cannot be left
+implicit.
+
+---
+
+## A-19 — Gate 1: `list_installed_plugins` and `remove_plugin` don't follow the `_impl(svc, ...)` pattern; existing `list_installed_skills` doesn't either
+
+**Original (plan Task 5, Steps 3-4):**
+
+```rust
+fn list_installed_plugins_impl(
+    project_path: &str,
+) -> Result<Vec<InstalledPluginInfo>, CommandError> { ... }
+
+fn remove_plugin_impl(
+    marketplace: &str,
+    plugin: &str,
+    project_path: &str,
+) -> Result<RemovePluginResult, CommandError> { ... }
+```
+
+**Drift.** CLAUDE.md says `_impl(svc: &MarketplaceService, ...)`.
+My code drops `svc` because these commands operate on
+`KiroProject` only — no service needed. Claude's review flagged
+this as a CLAUDE.md violation.
+
+**Update via LSP read of existing `commands/installed.rs`:**
+`list_installed_skills` and `remove_skill` are BOTH defined
+without an `_impl` — the body is inline in the wrapper:
+
+```rust
+pub async fn list_installed_skills(
+    project_path: String,
+) -> Result<Vec<InstalledSkillInfo>, CommandError> {
+    let project = KiroProject::new(PathBuf::from(&project_path));
+    let installed = project.load_installed().map_err(CommandError::from)?;
+    // ... transform + return
+}
+```
+
+So the existing convention is "no `_impl` for non-service-
+consuming commands." CLAUDE.md's wrapper-`_impl`-svc rule
+applies to commands that consume `MarketplaceService`; it doesn't
+apply to project-only reads.
+
+**Amended.** Two equivalent shapes — pick one and document the
+choice:
+
+**(a) Match the existing `list_installed_skills` precedent** — no
+`_impl`, body inline:
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn list_installed_plugins(
+    project_path: String,
+) -> Result<Vec<InstalledPluginInfo>, CommandError> {
+    validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(PathBuf::from(&project_path));
+    project.installed_plugins().map_err(CommandError::from)
+}
+```
+
+**(b) Keep the `_impl` for testability without `svc`** — document
+the deviation from CLAUDE.md's rule with a one-line comment:
+
+```rust
+// `_impl` exists for direct unit-test access without spinning up
+// a full MarketplaceService. CLAUDE.md's wrapper-`_impl`-svc rule
+// applies to service-consuming commands; this one operates on
+// KiroProject only.
+fn list_installed_plugins_impl(project_path: &str) -> Result<...>
+```
+
+**Recommendation:** (a). Match the existing precedent.
+`commands/installed.rs::tests` already shows that wrapper-only
+commands can be unit-tested by calling them directly (it's
+async, but `#[tokio::test]` handles that). No `_impl` needed.
+
+`remove_plugin` (Task 5 Step 4) gets the same treatment — body
+inline in the wrapper.
+
+**Rationale.** Gate 1 — Claude's reading of CLAUDE.md was strict;
+the actual project convention is more permissive. Verifying via
+LSP-read of an existing peer command (`commands/installed.rs`)
+gives the right answer instead of guessing from the doc text.
+A-8's LSP-first discipline applies: when the rule and the
+practice diverge, read the practice.
+
+---
+
+## A-20 — Gate 1: `make_kiro_project` test helper is private to `commands/steering.rs::tests`
+
+**Original (plan Task 5, Step 1 test code):**
+
+```rust
+let project_path = make_kiro_project(dir.path());
+```
+
+**Drift.** `make_kiro_project` is defined at
+`commands/steering.rs:88-92` (per LSP `documentSymbol`) inside
+`#[cfg(test)] mod tests` — it's private to that module. Tests in
+a NEW `commands/plugins.rs` file cannot import it. The PR 92
+review's `code-simplifier` agent flagged the same helper as
+duplicated between `steering.rs::tests` and `browse.rs::tests`
+and recommended hoisting to `kiro_market_core::service::test_support`,
+but that recommendation was deferred.
+
+**Amended.** Add a sub-task before Task 5's tests can be written:
+
+### Task 5.0 (new, prerequisite to 5.1+ tests): Hoist `make_kiro_project` to `service::test_support`
+
+1. Add `pub fn make_kiro_project(dir: &Path) -> String` to
+   `crates/kiro-market-core/src/service/test_support.rs` (gated
+   `#[cfg(any(test, feature = "test-support"))]` per the existing
+   pattern). Same body as the inline helper in `steering.rs:88-92`.
+2. Update `commands/steering.rs::tests` to import from
+   `kiro_market_core::service::test_support::make_kiro_project`
+   instead of defining locally.
+3. Update `commands/browse.rs::tests` (which defines an identical
+   inline copy at `browse.rs:451-455` per the PR 92 review) to
+   import the same.
+4. The new `commands/plugins.rs::tests` (Task 5.1+) imports from
+   the same location.
+5. Test: existing `steering.rs::tests` and `browse.rs::tests` all
+   continue to pass.
+6. Commit: `refactor(test): hoist make_kiro_project to service::test_support`.
+
+This pre-task closes a real PR-92 follow-up (the
+`code-simplifier`'s "high-value simplification #1") AND unblocks
+Task 5's tests in one stroke. Roughly ~10 lines moved across
+three files.
+
+**Rationale.** Gate 1 — naming a function that doesn't exist at
+the call site. The original Task 5 plan wrote test code referencing
+`make_kiro_project` as if it were globally available; LSP
+`documentSymbol` would have shown it scoped to `steering.rs::tests`
+only. Test code is code; the same naming-resolution rules apply.
+
+---
+
+## A-21 — Gate 1 (process): A-1 over-claimed scope
+
+**Original (A-1 amendment):**
+
+> "Same fix for `install_plugin_steering` (already at
+> `service/mod.rs:1330`, no `&self`)..."
+
+**Drift.** The original Task 1 plan code already used
+`MarketplaceService::install_plugin_steering(...)` (associated-
+function form, correct). My A-1 amendment text claimed "same fix
+for steering" implying drift; there was no drift in steering's
+call site. The agents arm (`self.install_plugin_agents`) was the
+sole drift A-1 addressed.
+
+**Amended.** Strike the steering reference from A-1's body. The
+amendment applies to the agents arm only. The steering call site
+is correct as originally written.
+
+**Rationale.** Process — amendments are statements of fact about
+plan drift. Over-broad amendment text dilutes the audit trail
+and may cause the implementer to "fix" already-correct code.
+Cross-reference Claude's review at PR #93 (round 3) for the
+original flag.
+
+---
+
+## A-22 — Process: code-reviewer-style audit catches what LSP-first cannot
+
+**Observation.** After A-1 through A-11 (rigorous LSP-first gate
+review), Claude's three-round review on PR #93 surfaced 9
+substantive findings I missed:
+
+- A-12 (`remove_plugin` cascade abort on orphan) — behavioral
+  semantic concern about a `?` operator
+- A-13 (`SteeringError::NotInstalled` fictitious) — variant
+  enumeration
+- A-14 (Task 4 `Self::` drift) — same shape as A-1 in a sibling
+  task
+- A-15 (dead `is_empty()` branches) — logical reachability
+- A-16 (`native_companions` over-delete) — cross-marketplace
+  ambiguity given a HashMap-key-by-name-only data shape
+- A-17 (`>=` tie-break) — non-determinism from HashMap iteration
+- A-18 (`accept_mcp` plumbing) — design-doc action-item drift
+- A-19 (`_impl(svc, ...)` rule mismatch with practice) — CLAUDE.md
+  vs. actual existing-code convention
+- A-20 (`make_kiro_project` private helper) — module-scope
+  visibility
+
+**Pattern.** LSP-first answers "does this symbol exist?" and
+"what's its signature?" — strong on shape, weak on semantics.
+The 9 findings above need a different review lens:
+
+- **Reachability analysis** (which branches are actually taken):
+  A-15
+- **Semantic equivalence** (do these two error paths have the
+  same recoverable-vs-fatal contract?): A-12, A-19
+- **Cross-task / cross-instance consistency** (when fixing
+  pattern X in task N, is the same pattern in tasks M and P also
+  fixed?): A-14, A-21
+- **Data-shape correctness across hidden disambiguators** (is
+  this HashMap keyed by enough fields?): A-16, A-17
+- **Action-item-vs-task linkage** (did the design doc say to do
+  X, and does the plan actually do X?): A-18
+- **Test-code naming resolution** (is this helper visible from
+  where the test calls it?): A-20
+
+**Mitigation going forward.** After the LSP-first Gate 1 pass,
+schedule a code-reviewer-style second pass that walks each task
+and asks the six questions above explicitly. This is what
+Claude did on PR #93 — the rigor isn't unique to a bot; it's
+the *checklist of review angles* that's the artifact. The next
+plan-review pass should run both:
+
+1. LSP-first (A-8): catches signature drift, missing exports,
+   field-access typos.
+2. Code-reviewer-style (A-22): catches behavioral semantics,
+   cross-task drift, action-item linkage.
+
+These are complementary, not substitutable. A plan that passes
+only one is half-reviewed.
+
+---
+
 ## A-8 — Tooling: use LSP `documentSymbol` for Gate 1, not grep
 
 **Process drift.** The original Gate 1 pass used `grep -n` to spot
@@ -734,6 +1354,40 @@ lesson so future plan-reviews start with the right tool.
   `browseView` composes with the existing chain. Explicit before/
   after rendering tree shown. PR 92's empty-state plugin cards
   retired in favor of the new Plugins view as primary surface.
+- A-12: `remove_plugin` cascade aborts on orphan tracking entries.
+  Use `match` + log + count-as-removed for `NotInstalled`; only
+  abort on genuine fs/parse errors.
+- A-13: `SteeringError::NotInstalled` is fictitious. Add the
+  variant before Task 3a can use it. `AgentError::NotInstalled`
+  already exists.
+- A-14: Task 4's wrapper has the same `Self::` drift as Task 1.
+  A-1 didn't grep sibling tasks for the bug shape.
+- A-15: `is_empty()` checks on `agent_scan_paths`/`steering_scan_paths`
+  are dead code (defaults always populate). Drop `Option<...>` from
+  `InstallPluginResult` sub-results — always populate.
+- A-16: `native_companions` cleanup over-deletes when two
+  marketplaces ship same-named plugins. Match on
+  `(plugin, marketplace)`, not `plugin` alone.
+- A-17: `>=` tie-break in `update_latest` is non-deterministic
+  given equal timestamps + HashMap iteration order. Use `>` for
+  stable first-seen-wins.
+- A-18: Task 5's wrapper drops `accept_mcp`. Plumb it through
+  per the design doc's Gate 2 action item.
+- A-19: `list_installed_plugins_impl` and `remove_plugin_impl`
+  don't follow CLAUDE.md's `_impl(svc, ...)` rule. The existing
+  `list_installed_skills` precedent is "no `_impl` for non-
+  service-consuming commands." Match precedent (a).
+- A-20: `make_kiro_project` is private to `commands/steering.rs::tests`.
+  Hoist to `service::test_support::make_kiro_project` as
+  prerequisite Task 5.0.
+- A-21: A-1's amendment text over-claimed scope — the steering
+  call was already correct, only the agents arm needed the fix.
+  Strike the steering reference.
+- A-22: Process — Claude's three-round review on PR #93 surfaced
+  9 findings (A-12 to A-20) that the LSP-first pass missed. The
+  rigor lives in the checklist of review angles, not in any one
+  tool. Future plan-reviews run BOTH LSP-first AND
+  code-reviewer-style.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -1227,6 +1227,124 @@ original flag.
 
 ---
 
+## A-23 — Gate 1 + Gate 3: `DateTime<Utc>` fields are incompatible with the project's `specta` feature config
+
+**Original (plan Task 2, Step 3):**
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstalledPluginInfo {
+    ...
+    pub earliest_install: chrono::DateTime<chrono::Utc>,
+    pub latest_install: chrono::DateTime<chrono::Utc>,
+}
+```
+
+**Drift.** `kiro-market-core/Cargo.toml:30` declares:
+
+```toml
+specta = { version = "2.0.0-rc.24", optional = true, features = ["derive", "serde_json"] }
+```
+
+The `"chrono"` feature is NOT in that list. Without it,
+`chrono::DateTime<chrono::Utc>` does not implement `specta::Type`.
+The Tauri crate always enables the `specta` feature on
+`kiro-market-core` (since its commands call `specta::specta` to
+generate bindings), so compiling with the new
+`InstalledPluginInfo` would fail with `the trait specta::Type is
+not implemented for chrono::DateTime<chrono::Utc>`.
+
+The existing precedent at `commands/installed.rs:17-25`
+(`InstalledSkillInfo.installed_at: String`) shows the project's
+established pattern: convert to `String` at the FFI boundary,
+filled via `.to_rfc3339()` in the wrapper. Every `DateTime<Utc>`
+field in `project.rs` lives on a struct that intentionally does
+NOT derive `specta::Type` (`InstalledSkillMeta`,
+`InstalledSteeringMeta`, `InstalledAgentMeta`,
+`InstalledNativeCompanionsMeta` — verified via LSP
+`documentSymbol`).
+
+`InstalledPluginInfo` is meant to cross the FFI (it's the return
+type of `commands.listInstalledPlugins`), so it MUST follow the
+String-at-boundary pattern.
+
+**Amended.** Two changes to Task 2:
+
+1. **Field types**: `earliest_install` and `latest_install` become
+   `String`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstalledPluginInfo {
+    pub marketplace: String,
+    pub plugin: String,
+    pub installed_version: Option<String>,
+    pub skill_count: u32,
+    pub steering_count: u32,
+    pub agent_count: u32,
+    pub installed_skills: Vec<String>,
+    pub installed_steering: Vec<std::path::PathBuf>, // PathBuf has specta::Type
+    pub installed_agents: Vec<String>,
+    /// RFC3339-formatted timestamp. Matches the shape used by
+    /// [`commands/installed.rs::InstalledSkillInfo`].
+    pub earliest_install: String,
+    pub latest_install: String,
+}
+```
+
+2. **Construction in `installed_plugins()`**: keep the
+   `DateTime<Utc>` internally in the `Acc` struct (so A-17's
+   timestamp-based "latest wins" tie-break still works), then
+   convert at the final field assignment:
+
+```rust
+let now = chrono::Utc::now();
+Ok(by_pair
+    .into_iter()
+    .map(|((marketplace, plugin), acc)| {
+        let (latest_install_dt, installed_version) = acc
+            .latest
+            .map_or_else(|| (now, None), |(t, v)| (t, v));
+        let earliest_install_dt = acc.earliest.unwrap_or(now);
+        InstalledPluginInfo {
+            marketplace,
+            plugin,
+            installed_version,
+            skill_count: u32::try_from(acc.skills.len()).unwrap_or(u32::MAX),
+            steering_count: u32::try_from(acc.steering.len()).unwrap_or(u32::MAX),
+            agent_count: u32::try_from(acc.agents.len()).unwrap_or(u32::MAX),
+            installed_skills: acc.skills,
+            installed_steering: acc.steering,
+            installed_agents: acc.agents,
+            earliest_install: earliest_install_dt.to_rfc3339(),
+            latest_install: latest_install_dt.to_rfc3339(),
+        }
+    })
+    .collect())
+```
+
+The frontend's `formatDate(p.latest_install)` already does
+`new Date(iso)` — works directly with the RFC3339 string. No
+frontend changes needed.
+
+**Verified `PathBuf` survives unchanged.** `installed_steering:
+Vec<PathBuf>` is fine — `PathBuf` does implement `specta::Type`
+out of the box (specta serializes it as a TS `string`). Confirmed
+by the existing `InstalledSteeringOutcome.source: PathBuf` /
+`destination: PathBuf` at `steering/types.rs:142-148`, which DOES
+derive `specta::Type` and renders as `string` in `bindings.ts:351-358`.
+
+**Rationale.** Gate 1 + Gate 3 — the field type doesn't
+implement the trait the derive requires, with the project's
+specific Cargo.toml config. Catching this at plan-review is
+cheaper than at first-build of Task 2. Also a Gate 5 win:
+String-at-boundary makes the wire format more predictable for
+the frontend (no chrono-specific JS deserialization needed).
+
+---
+
 ## A-22 — Process: code-reviewer-style audit catches what LSP-first cannot
 
 **Observation.** After A-1 through A-11 (rigorous LSP-first gate
@@ -1388,6 +1506,12 @@ lesson so future plan-reviews start with the right tool.
   rigor lives in the checklist of review angles, not in any one
   tool. Future plan-reviews run BOTH LSP-first AND
   code-reviewer-style.
+- A-23: `DateTime<Utc>` fields on `InstalledPluginInfo` are
+  incompatible with `kiro-market-core`'s specta feature config
+  (no `"chrono"` flag). Convert to `String` (RFC3339) at the FFI
+  boundary, matching the existing `InstalledSkillInfo.installed_at`
+  precedent. `PathBuf` survives — verified `InstalledSteeringOutcome`
+  uses it under specta::Type today.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/docs/plans/2026-04-29-plugin-first-install-plan.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan.md
@@ -1,0 +1,1088 @@
+# Plugin-First Install — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make plugins the first-class user-facing object in BrowseTab and InstalledTab. Add a backend coordinator (`install_plugin`) and aggregator (`list_installed_plugins`) so the UI can install / list / remove a plugin in one action that bundles its skills + steering + agents.
+
+**Architecture:** Backend stays content-type-first (`installed-skills.json`, `installed-steering.json`, `installed-agents.json` remain separate). The new plugin-level Tauri commands are *coordinators* that call the existing per-content APIs and aggregate. The UI shifts to plugin cards as the primary surface; the existing skill grid is preserved as a secondary drill-down.
+
+**Tech Stack:** Rust (`kiro-market-core`, `kiro-control-center` Tauri crate), TypeScript bindings via specta, Svelte 5 frontend, rstest, Playwright e2e.
+
+**Companion design doc:** `2026-04-29-plugin-first-install-design.md`
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | `install_plugin` orchestrator, `InstallPluginResult` struct |
+| `crates/kiro-market-core/src/project.rs` | Modify | `installed_plugins()`, `remove_plugin()`, `InstalledPluginInfo`, `RemovePluginResult` |
+| `crates/kiro-control-center/src-tauri/src/commands/agents.rs` | **New** | `install_plugin_agents` Tauri command + `_impl` (mirrors `commands/steering.rs`) |
+| `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` | **New** | `install_plugin`, `list_installed_plugins`, `remove_plugin` Tauri commands |
+| `crates/kiro-control-center/src-tauri/src/commands/mod.rs` | Modify | Register `agents` and `plugins` modules |
+| `crates/kiro-control-center/src-tauri/src/lib.rs` | Modify | Add new commands to `invoke_handler!` |
+| `crates/kiro-control-center/src/lib/components/PluginCard.svelte` | **New** | Reusable plugin card |
+| `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` | Modify | Plugin-cards primary view + skill-grid secondary view + view toggle |
+| `crates/kiro-control-center/src/lib/components/InstalledTab.svelte` | Modify | Plugins-grouped section + collapsible flat skills |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | Auto-generated; run via `cargo test -p kiro-control-center --lib -- --ignored` |
+| `crates/kiro-control-center/tests/e2e/app.spec.ts` | Modify | Plugin-install happy-path |
+
+---
+
+## Task 1: Core `install_plugin` orchestrator
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` (add `InstallPluginResult` near other result types ~line 387 region; add `install_plugin` method on `MarketplaceService` near other `install_plugin_*` methods)
+- Test: same file, `mod tests` block
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/kiro-market-core/src/service/mod.rs::tests` (find the existing `mod tests` near line 1928), add:
+
+```rust
+#[test]
+fn install_plugin_runs_skills_steering_agents_in_one_call() {
+    use crate::project::KiroProject;
+    use crate::service::test_support::{
+        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+        temp_service,
+    };
+    use std::fs;
+
+    let (dir, svc) = temp_service();
+    let entries = vec![relative_path_entry("p", "plugins/p")];
+    let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+    let plugin_dir = mp_path.join("plugins/p");
+    fs::create_dir_all(&plugin_dir).expect("plugin dir");
+    // Skill, steering file, and an agent — exercise all three install paths.
+    make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        br#"{"name": "p", "version": "1.0.0"}"#,
+    )
+    .expect("write plugin.json");
+    fs::create_dir_all(plugin_dir.join("steering")).expect("steering dir");
+    fs::write(plugin_dir.join("steering/guide.md"), "# guide\n").expect("steering");
+    fs::create_dir_all(plugin_dir.join("agents")).expect("agents dir");
+    fs::write(
+        plugin_dir.join("agents/reviewer.md"),
+        "---\nname: reviewer\ndescription: Reviews\n---\nBody.\n",
+    )
+    .expect("agent");
+
+    let project_dir = tempfile::tempdir().expect("project tempdir");
+    let project = KiroProject::new(project_dir.path().to_path_buf());
+
+    let result = svc
+        .install_plugin(&project, "mp", "p", InstallMode::New, false)
+        .expect("install_plugin happy path");
+
+    assert_eq!(result.plugin, "p");
+    assert_eq!(result.version.as_deref(), Some("1.0.0"));
+    let skills = result.skills.expect("skills attempted");
+    assert_eq!(skills.installed, vec!["alpha".to_string()]);
+    let steering = result.steering.expect("steering attempted");
+    assert_eq!(steering.installed.len(), 1);
+    let agents = result.agents.expect("agents attempted");
+    assert_eq!(agents.installed.len(), 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p kiro-market-core install_plugin_runs_skills_steering_agents_in_one_call -- --nocapture 2>&1 | tail -10
+```
+
+Expected: FAIL with `error[E0599]: no method named install_plugin found for struct MarketplaceService`.
+
+- [ ] **Step 3: Add the result type**
+
+Insert near the existing `pub struct InstallAgentsResult` (approx. line 387):
+
+```rust
+/// Aggregate result of [`MarketplaceService::install_plugin`] — the
+/// outcome of running every install path a plugin declares (skills,
+/// steering, agents) in one coordinated call.
+///
+/// `Option<...>` distinguishes "this content type wasn't applicable"
+/// (`None` — plugin declares no agents at all) from "this content type
+/// was attempted and yielded zero installs" (`Some` with empty
+/// `installed`). Encoding the distinction in the type avoids a magic
+/// `len() == 0` ambiguity at the UI layer.
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallPluginResult {
+    pub plugin: String,
+    pub version: Option<String>,
+    pub skills: Option<InstallSkillsResult>,
+    pub steering: Option<InstallSteeringResult>,
+    pub agents: Option<InstallAgentsResult>,
+}
+```
+
+- [ ] **Step 4: Add the method on `MarketplaceService`**
+
+Insert near `install_plugin_steering` (search for `pub fn install_plugin_steering`):
+
+```rust
+/// Install everything a plugin declares — skills, steering, agents
+/// — in a single call. Aggregates the three per-type results.
+///
+/// Errors from `resolve_plugin_install_context` propagate (the
+/// caller can't recover from "plugin not found"). Per-content-type
+/// partial failures land in the corresponding sub-result without
+/// aborting the other content types — same policy each
+/// `install_plugin_*` already follows individually.
+///
+/// `accept_mcp` is forwarded to the agent install path; defaults
+/// `false` at the caller for safety (matches the existing CLI
+/// `--accept-mcp` opt-in semantic).
+pub fn install_plugin(
+    &self,
+    project: &crate::project::KiroProject,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+) -> Result<InstallPluginResult, Error> {
+    let ctx = self.resolve_plugin_install_context(marketplace, plugin)?;
+    let mp_path = self.marketplace_path(marketplace);
+
+    let skills = if ctx.skill_dirs.is_empty() {
+        None
+    } else {
+        Some(self.install_skills(
+            project,
+            &ctx.skill_dirs,
+            &InstallFilter::All,
+            mode,
+            marketplace,
+            plugin,
+            ctx.version.as_deref(),
+        ))
+    };
+
+    let steering = if ctx.steering_scan_paths.is_empty() {
+        None
+    } else {
+        Some(MarketplaceService::install_plugin_steering(
+            project,
+            &ctx.plugin_dir,
+            &ctx.steering_scan_paths,
+            crate::steering::SteeringInstallContext {
+                mode,
+                marketplace,
+                plugin,
+                version: ctx.version.as_deref(),
+            },
+        ))
+    };
+
+    let agents = if ctx.agent_scan_paths.is_empty() {
+        None
+    } else {
+        Some(self.install_plugin_agents(
+            project,
+            &ctx.plugin_dir,
+            &ctx.agent_scan_paths,
+            ctx.format,
+            AgentInstallContext {
+                mode,
+                accept_mcp,
+                marketplace,
+                plugin,
+                version: ctx.version.as_deref(),
+            },
+        ))
+    };
+
+    let _ = mp_path; // suppress unused if future additions don't need it
+    Ok(InstallPluginResult {
+        plugin: plugin.to_string(),
+        version: ctx.version,
+        skills,
+        steering,
+        agents,
+    })
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cargo test -p kiro-market-core install_plugin_runs_skills_steering_agents_in_one_call -- --nocapture 2>&1 | tail -10
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add JSON wire-format lock**
+
+Mirror the `steering_warning_variants_json_shape` precedent. Add in the same `mod tests` block:
+
+```rust
+#[test]
+fn install_plugin_result_json_shape_locks_optional_subresults() {
+    let result = InstallPluginResult {
+        plugin: "p".into(),
+        version: Some("1.0.0".into()),
+        skills: None,
+        steering: None,
+        agents: None,
+    };
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "plugin": "p",
+            "version": "1.0.0",
+            "skills": null,
+            "steering": null,
+            "agents": null,
+        }),
+        "Option fields must serialize as JSON null when None — frontend \
+         consumers branch on this; switching to a tagged or omitted shape \
+         silently breaks them.",
+    );
+}
+```
+
+- [ ] **Step 7: Run + commit**
+
+```bash
+cargo test -p kiro-market-core install_plugin -- --nocapture 2>&1 | tail -10
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+```
+
+Expected: all green. Then:
+
+```bash
+git add crates/kiro-market-core/src/service/mod.rs
+git commit -m "feat(core): add install_plugin orchestrator + InstallPluginResult"
+```
+
+---
+
+## Task 2: Core `installed_plugins()` aggregator
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/kiro-market-core/src/project.rs::tests`:
+
+```rust
+#[test]
+fn installed_plugins_groups_skills_steering_agents_by_marketplace_plugin_pair() {
+    use chrono::Utc;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(dir.path().to_path_buf());
+    std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+    // Hand-write the three tracking files. Two plugins, mixed content.
+    let now = Utc::now();
+    let skills_json = serde_json::json!({
+        "skills": {
+            "alpha": {
+                "marketplace": "mp",
+                "plugin": "plug-a",
+                "version": "1.0.0",
+                "installed_at": now,
+                "source_hash": "deadbeef"
+            }
+        }
+    });
+    std::fs::write(
+        project.kiro_dir().join("installed-skills.json"),
+        serde_json::to_vec_pretty(&skills_json).unwrap(),
+    )
+    .expect("skills tracking");
+
+    let steering_json = serde_json::json!({
+        "files": {
+            "guide.md": {
+                "marketplace": "mp",
+                "plugin": "plug-a",
+                "version": "1.0.0",
+                "installed_at": now,
+                "source_hash": "cafebabe",
+                "installed_hash": "cafebabe"
+            },
+            "review.md": {
+                "marketplace": "mp",
+                "plugin": "plug-b",
+                "version": "0.5.0",
+                "installed_at": now,
+                "source_hash": "feedface",
+                "installed_hash": "feedface"
+            }
+        }
+    });
+    std::fs::write(
+        project.kiro_dir().join("installed-steering.json"),
+        serde_json::to_vec_pretty(&steering_json).unwrap(),
+    )
+    .expect("steering tracking");
+
+    let result = project.installed_plugins().expect("installed_plugins");
+    assert_eq!(result.len(), 2, "two plugins expected");
+
+    let plug_a = result
+        .iter()
+        .find(|p| p.plugin == "plug-a")
+        .expect("plug-a present");
+    assert_eq!(plug_a.skill_count, 1);
+    assert_eq!(plug_a.steering_count, 1);
+    assert_eq!(plug_a.agent_count, 0);
+    assert_eq!(plug_a.installed_skills, vec!["alpha".to_string()]);
+
+    let plug_b = result
+        .iter()
+        .find(|p| p.plugin == "plug-b")
+        .expect("plug-b present");
+    assert_eq!(plug_b.skill_count, 0);
+    assert_eq!(plug_b.steering_count, 1);
+    assert_eq!(plug_b.agent_count, 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p kiro-market-core installed_plugins_groups -- --nocapture 2>&1 | tail -10
+```
+
+Expected: FAIL — method doesn't exist.
+
+- [ ] **Step 3: Add the result type**
+
+Near the other `Installed*` types in `project.rs` (around the `InstalledSteering` definition):
+
+```rust
+/// Aggregated view of a single installed plugin — the union of
+/// what's tracked across `installed-skills.json`,
+/// `installed-steering.json`, and `installed-agents.json` for a
+/// given `(marketplace, plugin)` pair.
+///
+/// Returned by [`KiroProject::installed_plugins`]. The frontend
+/// renders one row per `InstalledPluginInfo`.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstalledPluginInfo {
+    pub marketplace: String,
+    pub plugin: String,
+    /// Highest version across the three content types — they may
+    /// differ if installed at different times. The latest wins for
+    /// "what version do I have?".
+    pub installed_version: Option<String>,
+    pub skill_count: u32,
+    pub steering_count: u32,
+    pub agent_count: u32,
+    pub installed_skills: Vec<String>,
+    pub installed_steering: Vec<std::path::PathBuf>,
+    pub installed_agents: Vec<String>,
+    pub earliest_install: chrono::DateTime<chrono::Utc>,
+    pub latest_install: chrono::DateTime<chrono::Utc>,
+}
+```
+
+- [ ] **Step 4: Add the method**
+
+Inside `impl KiroProject` (near `load_installed`):
+
+```rust
+/// Aggregate the three installed-* tracking files into a per-plugin
+/// view. Returns one [`InstalledPluginInfo`] per `(marketplace,
+/// plugin)` pair that has at least one tracked entry. Returns an
+/// empty vec if no tracking files exist (a fresh project).
+///
+/// Used by the InstalledTab UI to show "what plugins are installed"
+/// without forcing the frontend to make three round-trips and
+/// stitch the results client-side.
+pub fn installed_plugins(&self) -> crate::error::Result<Vec<InstalledPluginInfo>> {
+    use std::collections::BTreeMap;
+
+    #[derive(Default)]
+    struct Acc {
+        version: Option<String>,
+        skills: Vec<String>,
+        steering: Vec<std::path::PathBuf>,
+        agents: Vec<String>,
+        earliest: Option<chrono::DateTime<chrono::Utc>>,
+        latest: Option<chrono::DateTime<chrono::Utc>>,
+    }
+
+    let mut by_pair: BTreeMap<(String, String), Acc> = BTreeMap::new();
+
+    let skills = self.load_installed()?;
+    for (name, meta) in &skills.skills {
+        let acc = by_pair
+            .entry((meta.marketplace.clone(), meta.plugin.clone()))
+            .or_default();
+        acc.skills.push(name.clone());
+        update_version_and_dates(acc, meta.version.as_deref(), meta.installed_at);
+    }
+
+    let steering = self.load_installed_steering()?;
+    for (rel, meta) in &steering.files {
+        let acc = by_pair
+            .entry((meta.marketplace.clone(), meta.plugin.clone()))
+            .or_default();
+        acc.steering.push(rel.clone());
+        update_version_and_dates(acc, meta.version.as_deref(), meta.installed_at);
+    }
+
+    let agents = self.load_installed_agents()?;
+    for (name, meta) in &agents.agents {
+        let acc = by_pair
+            .entry((meta.marketplace.clone(), meta.plugin.clone()))
+            .or_default();
+        acc.agents.push(name.clone());
+        update_version_and_dates(acc, meta.version.as_deref(), meta.installed_at);
+    }
+
+    Ok(by_pair
+        .into_iter()
+        .map(|((marketplace, plugin), acc)| {
+            let now = chrono::Utc::now();
+            InstalledPluginInfo {
+                marketplace,
+                plugin,
+                installed_version: acc.version,
+                skill_count: u32::try_from(acc.skills.len()).unwrap_or(u32::MAX),
+                steering_count: u32::try_from(acc.steering.len()).unwrap_or(u32::MAX),
+                agent_count: u32::try_from(acc.agents.len()).unwrap_or(u32::MAX),
+                installed_skills: acc.skills,
+                installed_steering: acc.steering,
+                installed_agents: acc.agents,
+                earliest_install: acc.earliest.unwrap_or(now),
+                latest_install: acc.latest.unwrap_or(now),
+            }
+        })
+        .collect())
+}
+
+fn update_version_and_dates(
+    acc: &mut Acc,
+    version: Option<&str>,
+    installed_at: chrono::DateTime<chrono::Utc>,
+) {
+    if let Some(v) = version {
+        // Latest wins by string comparison (no semver).
+        if acc.version.as_deref().map_or(true, |existing| existing < v) {
+            acc.version = Some(v.to_string());
+        }
+    }
+    acc.earliest = Some(acc.earliest.map_or(installed_at, |e| e.min(installed_at)));
+    acc.latest = Some(acc.latest.map_or(installed_at, |l| l.max(installed_at)));
+}
+```
+
+Note: `update_version_and_dates` takes `&mut Acc` where `Acc` is the local struct above. Move it next to the inner struct or into `installed_plugins`'s body — pick whichever the compiler accepts.
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+cargo test -p kiro-market-core installed_plugins -- --nocapture 2>&1 | tail -10
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/project.rs
+git commit -m "feat(core): add installed_plugins aggregator"
+```
+
+---
+
+## Task 3: Core `remove_plugin()` cascade
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn remove_plugin_cascades_through_skills_steering_agents_tracking() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(dir.path().to_path_buf());
+    std::fs::create_dir_all(project.kiro_dir().join("steering")).expect("dirs");
+
+    // Pre-seed: tracking files + on-disk steering file.
+    let now = chrono::Utc::now();
+    std::fs::write(
+        project.kiro_dir().join("installed-skills.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "deadbeef"
+                }
+            }
+        })).unwrap(),
+    ).expect("skills");
+    std::fs::write(
+        project.kiro_dir().join("installed-steering.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "files": {
+                "guide.md": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "feedface", "installed_hash": "feedface"
+                }
+            }
+        })).unwrap(),
+    ).expect("steering");
+    std::fs::write(
+        project.kiro_dir().join("steering/guide.md"),
+        "# guide\n",
+    ).expect("steering file");
+
+    let result = project.remove_plugin("mp", "p").expect("remove_plugin");
+    assert_eq!(result.skills_removed, 1);
+    assert_eq!(result.steering_removed, 1);
+    assert_eq!(result.agents_removed, 0);
+
+    // Tracking files are now empty for this plugin.
+    let post = project.installed_plugins().expect("installed_plugins");
+    assert!(
+        post.iter().all(|p| p.plugin != "p"),
+        "plugin p must be gone from the aggregated view"
+    );
+    // On-disk steering file is gone.
+    assert!(
+        !project.kiro_dir().join("steering/guide.md").exists(),
+        "on-disk steering file must be unlinked"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p kiro-market-core remove_plugin_cascades -- --nocapture 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Add the result type and method**
+
+```rust
+#[derive(Debug, Clone, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemovePluginResult {
+    pub skills_removed: u32,
+    pub steering_removed: u32,
+    pub agents_removed: u32,
+}
+
+impl KiroProject {
+    /// Cascade-remove every tracked entry from `(marketplace,
+    /// plugin)` across all three content-type tracking files. Unlinks
+    /// the on-disk files, updates the tracking JSON files atomically
+    /// (each `with_file_lock`'d), and returns aggregated counts.
+    ///
+    /// Best-effort: if a sub-removal errors, returns early with the
+    /// error. No rollback. CLAUDE.md "tracking files are user-owned"
+    /// still applies — we never delete files we don't have a
+    /// tracking entry for.
+    pub fn remove_plugin(
+        &self,
+        marketplace: &str,
+        plugin: &str,
+    ) -> crate::error::Result<RemovePluginResult> {
+        let mut result = RemovePluginResult::default();
+
+        let skills = self.load_installed()?;
+        let to_remove: Vec<String> = skills
+            .skills
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &to_remove {
+            self.remove_skill(name)?;
+            result.skills_removed = result.skills_removed.saturating_add(1);
+        }
+
+        // For steering and agents, mirror the per-file pattern with
+        // tracking-only updates plus on-disk unlink. (Adjust to match
+        // each existing remove API or add minimal helpers as needed —
+        // see project.rs near `remove_skill` for the precedent.)
+        let steering = self.load_installed_steering()?;
+        let steering_to_remove: Vec<std::path::PathBuf> = steering
+            .files
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(rel, _)| rel.clone())
+            .collect();
+        for rel in &steering_to_remove {
+            self.remove_steering_file(rel)?;
+            result.steering_removed = result.steering_removed.saturating_add(1);
+        }
+
+        let agents = self.load_installed_agents()?;
+        let agents_to_remove: Vec<String> = agents
+            .agents
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &agents_to_remove {
+            self.remove_agent(name)?;
+            result.agents_removed = result.agents_removed.saturating_add(1);
+        }
+
+        Ok(result)
+    }
+}
+```
+
+- [ ] **Step 4: Add the supporting per-file remove methods if missing**
+
+Confirm whether `remove_steering_file(&Path)` and `remove_agent(&str)` exist on `KiroProject`. If not, add them following `remove_skill`'s shape. **Sub-task:** if either is missing, write a separate failing test first (`remove_steering_file_unlinks_and_updates_tracking`) and add it before the cascade test passes.
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+cargo test -p kiro-market-core remove_plugin -- --nocapture 2>&1 | tail -10
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/project.rs
+git commit -m "feat(core): add remove_plugin cascade across the three tracking files"
+```
+
+---
+
+## Task 4: Tauri `install_plugin_agents` command
+
+**Files:**
+- Create: `crates/kiro-control-center/src-tauri/src/commands/agents.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/mod.rs` (add `pub mod agents;`)
+- Modify: `crates/kiro-control-center/src-tauri/src/lib.rs` (add to `invoke_handler!`)
+
+- [ ] **Step 1: Mirror `commands/steering.rs` exactly**
+
+Copy `commands/steering.rs` to `commands/agents.rs` and rename: `install_plugin_steering` → `install_plugin_agents`, `SteeringInstallContext` → `AgentInstallContext`, etc. The agent install accepts an extra `accept_mcp: bool` and a `format: Option<PluginFormat>` (the latter from `PluginInstallContext`).
+
+Reference shape (the existing `commands::steering::install_plugin_steering_impl` is the template):
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn install_plugin_agents(
+    marketplace: String,
+    plugin: String,
+    force: bool,
+    accept_mcp: bool,
+    project_path: String,
+) -> Result<InstallAgentsResult, CommandError> {
+    let svc = make_service()?;
+    install_plugin_agents_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        InstallMode::from(force),
+        accept_mcp,
+        &project_path,
+    )
+}
+
+fn install_plugin_agents_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallAgentsResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let ctx = svc
+        .resolve_plugin_install_context(marketplace, plugin)
+        .map_err(CommandError::from)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+    Ok(svc.install_plugin_agents(
+        &project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext {
+            mode,
+            accept_mcp,
+            marketplace,
+            plugin,
+            version: ctx.version.as_deref(),
+        },
+    ))
+}
+```
+
+- [ ] **Step 2: Add 5 `_impl`-level tests mirroring `commands/steering.rs::tests`**
+
+The five tests for steering are:
+1. `..._installs_default_path_files`
+2. `..._returns_not_found_for_unknown_plugin`
+3. `..._threads_resolved_version_into_install_ctx`
+4. `..._force_mode_overwrites_changed_source`
+5. `..._new_mode_surfaces_<failure>_in_failed`
+
+Mirror each for agents. The agent equivalents are mechanical — replace fixture content (steering `.md` → agent `.md` with frontmatter) and assertion fields (`installed.len()` → `installed.len()` of agents).
+
+- [ ] **Step 3: Register the module + command**
+
+In `commands/mod.rs`:
+
+```rust
+pub mod agents;
+```
+
+In `lib.rs::create_builder()`'s `invoke_handler!`:
+
+```rust
+commands::agents::install_plugin_agents,
+```
+
+- [ ] **Step 4: Regenerate bindings**
+
+```bash
+cargo test -p kiro-control-center --lib -- --ignored 2>&1 | tail -5
+```
+
+Expected: `bindings.ts` now includes `installPluginAgents`.
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAILED" | tail -5
+cargo clippy --workspace --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-control-center/src-tauri/src/commands/agents.rs \
+        crates/kiro-control-center/src-tauri/src/commands/mod.rs \
+        crates/kiro-control-center/src-tauri/src/lib.rs \
+        crates/kiro-control-center/src/lib/bindings.ts
+git commit -m "feat(tauri): install_plugin_agents command + impl-level tests"
+```
+
+---
+
+## Task 5: Tauri `commands/plugins.rs` — install_plugin, list_installed_plugins, remove_plugin
+
+**Files:**
+- Create: `crates/kiro-control-center/src-tauri/src/commands/plugins.rs`
+- Modify: `commands/mod.rs`, `lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Following the `_impl`-only test pattern, create `commands/plugins.rs::tests::install_plugin_impl_orchestrates_all_three_paths`:
+
+```rust
+#[test]
+fn install_plugin_impl_orchestrates_all_three_paths() {
+    use kiro_market_core::service::test_support::{
+        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+        temp_service,
+    };
+    use std::fs;
+
+    let (dir, svc) = temp_service();
+    let entries = vec![relative_path_entry("p", "plugins/p")];
+    let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+    let plugin_dir = mp_path.join("plugins/p");
+    fs::create_dir_all(&plugin_dir).expect("plugin dir");
+    make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+    fs::write(plugin_dir.join("plugin.json"), br#"{"name":"p","version":"1.0.0"}"#).unwrap();
+    fs::create_dir_all(plugin_dir.join("steering")).unwrap();
+    fs::write(plugin_dir.join("steering/guide.md"), "# g\n").unwrap();
+
+    let project_path = make_kiro_project(dir.path());
+    let result = install_plugin_impl(&svc, "mp", "p", InstallMode::New, false, &project_path)
+        .expect("happy path");
+
+    assert_eq!(result.plugin, "p");
+    assert!(result.skills.is_some());
+    assert!(result.steering.is_some());
+}
+```
+
+- [ ] **Step 2: Add `install_plugin` Tauri command**
+
+Same wrapper + `_impl` pattern as steering. Calls `svc.install_plugin(...)` from Task 1.
+
+- [ ] **Step 3: Add `list_installed_plugins` Tauri command**
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn list_installed_plugins(
+    project_path: String,
+) -> Result<Vec<InstalledPluginInfo>, CommandError> {
+    list_installed_plugins_impl(&project_path)
+}
+
+fn list_installed_plugins_impl(
+    project_path: &str,
+) -> Result<Vec<InstalledPluginInfo>, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+    project.installed_plugins().map_err(CommandError::from)
+}
+```
+
+Plus 2 tests: empty project returns empty vec; project with mixed tracking returns aggregated.
+
+- [ ] **Step 4: Add `remove_plugin` Tauri command**
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn remove_plugin(
+    marketplace: String,
+    plugin: String,
+    project_path: String,
+) -> Result<RemovePluginResult, CommandError> {
+    remove_plugin_impl(&marketplace, &plugin, &project_path)
+}
+
+fn remove_plugin_impl(
+    marketplace: &str,
+    plugin: &str,
+    project_path: &str,
+) -> Result<RemovePluginResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+    project
+        .remove_plugin(marketplace, plugin)
+        .map_err(CommandError::from)
+}
+```
+
+Plus 2 tests: removing-nonexistent returns zeros (not an error); removing-installed returns expected counts.
+
+- [ ] **Step 5: Register, regenerate bindings, commit**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAILED" | tail -5
+cargo test -p kiro-control-center --lib -- --ignored 2>&1 | tail -3
+cargo clippy --workspace --tests -- -D warnings
+cargo fmt --all
+git add -A
+git commit -m "feat(tauri): plugins.rs — install_plugin / list_installed_plugins / remove_plugin"
+```
+
+---
+
+## Task 6: `PluginCard.svelte` reusable component
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/PluginCard.svelte`
+
+- [ ] **Step 1: Define the component contract**
+
+Props:
+- `plugin: PluginInfo` (existing type from bindings)
+- `marketplace: string`
+- `installed: boolean` (whether this plugin appears in `installed_plugins`)
+- `installing: boolean` (in-flight indicator)
+- `onInstall: () => void`
+- `onUpdate?: () => void` (Phase 2 hook; render disabled stub for v1)
+- `onRemove?: () => void`
+
+- [ ] **Step 2: Compose the visual**
+
+Card with:
+- Top row: plugin name (bold) + content-count chips (`3 skills · 1 steering · 0 agents`)
+- Optional: description (truncated)
+- Bottom row: action button (Install | Installed | Updating | Removing)
+
+Use the existing tailwind theme tokens (`bg-kiro-overlay`, `border-kiro-muted`, `text-kiro-accent-300`, etc.) — match `BrowseTab.svelte`'s empty-state plugin cards as a starting point.
+
+- [ ] **Step 3: Add a small story-like test in `app.spec.ts`** (optional — Playwright-only)
+
+Skip this step for v1; covered by Task 9's e2e test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/PluginCard.svelte
+git commit -m "feat(ui): PluginCard reusable component"
+```
+
+---
+
+## Task 7: BrowseTab — plugins primary view
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`
+
+- [ ] **Step 1: Add view-toggle state**
+
+Near the existing state declarations:
+
+```typescript
+type BrowseView = "plugins" | "skills";
+let browseView: BrowseView = $state("plugins");
+```
+
+- [ ] **Step 2: Add view-toggle UI**
+
+Above the current grid (around line 985), insert a 2-button toggle: `[Plugins] [Skills]`. Tailwind: `inline-flex gap-1 px-1 py-1 rounded-md bg-kiro-overlay border border-kiro-muted`. Each button styles based on `browseView`.
+
+- [ ] **Step 3: Conditionally render**
+
+Wrap the existing skill-grid block (lines 1019-1028) in `{#if browseView === "skills"}` ... `{/if}`. Add an else branch that renders `PluginCard` for each `availablePlugins[i]`:
+
+```svelte
+{:else}
+  <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+    {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
+      {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
+      <PluginCard
+        plugin={ap.plugin}
+        marketplace={ap.marketplace}
+        installed={installedPluginKeys.has(key)}
+        installing={pendingPluginInstalls.has(key)}
+        onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+      />
+    {/each}
+  </div>
+{/if}
+```
+
+- [ ] **Step 4: Add `installWholePlugin` async function**
+
+Mirrors PR 92's `installSteering` but calls `commands.installPlugin(...)`. Renders aggregate result (counts across the three sub-results) into `installMessage`/`installError`.
+
+- [ ] **Step 5: Add `installedPluginKeys` derived from `commands.listInstalledPlugins`**
+
+Fetch on mount + when `projectPath` changes; mirror the existing `installed` lookup pattern for skills.
+
+- [ ] **Step 6: Run svelte-check + commit**
+
+```bash
+cd crates/kiro-control-center && npm run check 2>&1 | tail -5
+git add crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+git commit -m "feat(ui): plugin cards as primary BrowseTab view"
+```
+
+---
+
+## Task 8: InstalledTab — plugins-grouped view
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/InstalledTab.svelte`
+
+- [ ] **Step 1: Replace the skill-list fetch with `listInstalledPlugins`**
+
+```typescript
+const result = await commands.listInstalledPlugins(projectPath);
+```
+
+- [ ] **Step 2: Render plugin rows**
+
+Each row shows: plugin name, version, content counts (`3 skills · 1 steering · 0 agents`), `installed_at`, `[Remove]` button.
+
+- [ ] **Step 3: Wire `removePlugin`**
+
+Call `commands.removePlugin(marketplace, plugin, projectPath)`. On success, refresh the list.
+
+- [ ] **Step 4: Optional collapsible "All installed skills" sub-section**
+
+Below the plugins list, add a `<details>` for the existing flat skill table. Preserves backward-compat for users who liked it.
+
+- [ ] **Step 5: Run svelte-check + commit**
+
+```bash
+cd crates/kiro-control-center && npm run check 2>&1 | tail -5
+git add crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+git commit -m "feat(ui): plugins-grouped InstalledTab"
+```
+
+---
+
+## Task 9: Playwright e2e — plugin install happy path
+
+**Files:**
+- Modify: `crates/kiro-control-center/tests/e2e/app.spec.ts`
+
+- [ ] **Step 1: Add the test**
+
+```typescript
+test("install plugin from BrowseTab and verify in InstalledTab", async ({ page }) => {
+  // Skip if FIXTURE_MARKETPLACE_PATH not set (matches existing skill test).
+  // Pick the test project, click Browse, switch to Plugins view if not default,
+  // click Install on the test plugin's card, wait for success banner,
+  // navigate to Installed, assert the plugin row appears.
+});
+```
+
+The existing `"install skill from browse tab"` is the template; mirror its env-var skips and locator patterns.
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+cd crates/kiro-control-center && npm run test:e2e 2>&1 | tail -10
+git add crates/kiro-control-center/tests/e2e/app.spec.ts
+git commit -m "test(e2e): plugin install happy-path"
+```
+
+---
+
+## Task 10: Final sweep + open PR
+
+- [ ] **Step 1: Run all gates**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --tests -- -D warnings
+cargo test --workspace 2>&1 | grep "test result\|FAILED" | tail -10
+cargo xtask plan-lint --no-reindex 2>&1 | tail -10
+cd crates/kiro-control-center && npm run check 2>&1 | tail -3
+```
+
+All green.
+
+- [ ] **Step 2: Open PR**
+
+Title: `feat: plugin-first install (BrowseTab + InstalledTab + agents.rs)`
+
+Body: reference design doc, list new commands, note out-of-scope items.
+
+- [ ] **Step 3: Manual smoke**
+
+Run `npm run tauri dev` against `dwalleck/kiro-starter-kit`. Click Install on the plugin card. Verify:
+- Green banner with content-count breakdown
+- Switch to InstalledTab, see the plugin listed
+- Click Remove, watch it disappear, verify on-disk files cleaned up
+
+---
+
+## Self-review
+
+### Spec coverage
+Each design-doc bullet maps to a task: `install_plugin` → Task 1, `installed_plugins` → Task 2, `remove_plugin` → Task 3, `install_plugin_agents` Tauri → Task 4, the rest of the Tauri commands → Task 5, frontend → Tasks 6-8, e2e → Task 9. **Phase 2 is design-only** in the design doc — no Phase 2 tasks in this plan. Intentional.
+
+### Placeholder scan
+Spotted and resolved:
+- Task 3 step 4 conditionally adds `remove_steering_file` and `remove_agent` if missing — flagged as a sub-task with TDD shape rather than left as "TODO." Reviewer-implementer should write the failing test first if either method is absent.
+- Task 4 step 2 lists the 5 mirror tests as a checklist rather than reproducing 200+ lines. Acceptable because the steering tests are right there as the reference; the implementer reads them and renames.
+
+### Type consistency
+- `InstallPluginResult` shape consistent across Task 1 (definition) and Task 5 (Tauri command return type).
+- `InstalledPluginInfo` shape consistent across Task 2 (definition) and Task 5 (`list_installed_plugins`) and Task 8 (frontend consumer).
+- `RemovePluginResult` shape consistent.
+- `pluginKey(marketplace, plugin)` reused from existing `BrowseTab.svelte` helper.
+- `pendingPluginInstalls: SvelteSet<string>` follows the `pendingSteeringInstalls` precedent from PR 92.
+
+No type-name drift detected.
+
+### 5-Gates summary
+
+See design doc's "5-Gates self-review" section. **Action items extracted into the plan above:**
+- Every new Tauri `_impl` calls `validate_kiro_project_path` (Task 4 step 1, Task 5 steps 3 + 4).
+- `install_plugin` plumbs `accept_mcp` (Task 1 step 4, Task 5 step 2).
+- JSON wire-format lock for `InstallPluginResult` (Task 1 step 6).
+- New struct types follow existing `Serialize + cfg_attr(specta::Type)` pattern (Tasks 1, 2, 3 — explicit in the code blocks).
+
+---
+
+**Plan complete.** Suggested execution: subagent-driven, one task per subagent, two-stage review between tasks. Tasks are independent enough that a fresh agent can pick up each one with the design doc as context.

--- a/docs/plans/2026-04-29-plugin-first-install-plan.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan.md
@@ -871,38 +871,247 @@ git commit -m "feat(tauri): plugins.rs — install_plugin / list_installed_plugi
 
 ---
 
-## Task 6: `PluginCard.svelte` reusable component
+## Task 6: Extract format helpers + create `PluginCard.svelte`
 
 **Files:**
+- Create: `crates/kiro-control-center/src/lib/format.ts`
+- Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` (replace 3 inlined functions with imports from `$lib/format`)
 - Create: `crates/kiro-control-center/src/lib/components/PluginCard.svelte`
 
-- [ ] **Step 1: Define the component contract**
+**Why this task starts with an extraction:** PR 92 left `formatSkippedReason`, `skillCountLabel`, and `skillCountTitle` as module-private functions inside `BrowseTab.svelte`. Both BrowseTab AND the new PluginCard need them. Lifting to `$lib/format.ts` first means PluginCard imports rather than re-implements — addresses the "duplicate the code" red flag from PR 92's review.
 
-Props:
-- `plugin: PluginInfo` (existing type from bindings)
-- `marketplace: string`
-- `installed: boolean` (whether this plugin appears in `installed_plugins`)
-- `installing: boolean` (in-flight indicator)
-- `onInstall: () => void`
-- `onUpdate?: () => void` (Phase 2 hook; render disabled stub for v1)
-- `onRemove?: () => void`
+- [ ] **Step 1: Create `$lib/format.ts`**
 
-- [ ] **Step 2: Compose the visual**
+```typescript
+// crates/kiro-control-center/src/lib/format.ts
 
-Card with:
-- Top row: plugin name (bold) + content-count chips (`3 skills · 1 steering · 0 agents`)
-- Optional: description (truncated)
-- Bottom row: action button (Install | Installed | Updating | Removing)
+import type { SkillCount, SkippedReason, SkippedSkill } from "$lib/bindings";
 
-Use the existing tailwind theme tokens (`bg-kiro-overlay`, `border-kiro-muted`, `text-kiro-accent-300`, etc.) — match `BrowseTab.svelte`'s empty-state plugin cards as a starting point.
+/**
+ * Render a SkippedReason as a one-line label suitable for tooltips and
+ * banner bodies. Total over all variants — TypeScript's discriminated-
+ * union exhaustiveness check forces full coverage.
+ *
+ * Lifted from BrowseTab.svelte (PR 92). Two consumers now: BrowseTab's
+ * skill-count tooltip and PluginCard's matching tooltip.
+ */
+export function formatSkippedReason(r: SkippedReason): string {
+  switch (r.kind) {
+    case "directory_missing":
+      return `plugin directory not found: ${r.path}`;
+    case "not_a_directory":
+      return `plugin path is not a directory: ${r.path}`;
+    case "symlink_refused":
+      return `plugin path is a symlink (refused): ${r.path}`;
+    case "directory_unreadable":
+      return `could not read ${r.path}: ${r.reason}`;
+    case "invalid_manifest":
+      return `malformed plugin.json at ${r.path}: ${r.reason}`;
+    case "manifest_read_failed":
+      return `could not read plugin.json at ${r.path}: ${r.reason}`;
+    case "remote_source_not_local":
+      return `plugin source is remote: ${r.plugin}`;
+    case "no_skills":
+      return `plugin declares no skills: ${r.path}`;
+  }
+}
 
-- [ ] **Step 3: Add a small story-like test in `app.spec.ts`** (optional — Playwright-only)
+export function skillCountLabel(sc: SkillCount): string {
+  switch (sc.state) {
+    case "known":
+      return String(sc.count);
+    case "remote_not_counted":
+      return "–";
+    case "manifest_failed":
+      return "!";
+  }
+}
 
-Skip this step for v1; covered by Task 9's e2e test.
+export function skillCountTitle(sc: SkillCount): string | undefined {
+  switch (sc.state) {
+    case "known":
+      return undefined;
+    case "remote_not_counted":
+      return "Remote plugin — skills cannot be counted without cloning";
+    case "manifest_failed":
+      return formatSkippedReason(sc.reason);
+  }
+}
 
-- [ ] **Step 4: Commit**
+export function formatSkippedSkill(s: SkippedSkill): string {
+  const label = s.name_hint ?? "<unnamed>";
+  let reason: string;
+  switch (s.reason.kind) {
+    case "read_failed":
+      reason = `could not read SKILL.md: ${s.reason.reason}`;
+      break;
+    case "frontmatter_invalid":
+      reason = `malformed frontmatter: ${s.reason.reason}`;
+      break;
+    default:
+      reason = "unreadable";
+  }
+  return `${label}: ${reason}`;
+}
+
+export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): string {
+  const MAX = 5;
+  const parts = list.slice(0, MAX).map(formatSkippedSkill);
+  const overflow = list.length - parts.length;
+  const joined = parts.join("; ");
+  return overflow > 0
+    ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
+    : `${list.length} skill(s) failed to load — ${joined}`;
+}
+```
+
+- [ ] **Step 2: Replace inlined functions in BrowseTab.svelte with imports**
+
+In `BrowseTab.svelte` (currently lines 5-101), replace the inlined function bodies with:
+
+```svelte
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
+  import { commands } from "$lib/bindings";
+  import {
+    formatSkippedReason,
+    skillCountLabel,
+    skillCountTitle,
+    formatSkippedSkill,
+    formatSkippedSkillsForPlugin,
+  } from "$lib/format";
+  import type {
+    MarketplaceInfo,
+    PluginInfo,
+    SkillInfo,
+    SkillCount,
+    SkippedReason,
+    SkippedSkill,
+    SteeringWarning,
+  } from "$lib/bindings";
+  import SkillCard from "./SkillCard.svelte";
+
+  // formatSteeringWarning stays inline — it's specific to BrowseTab's
+  // installSteering rendering. If a second consumer appears, lift it
+  // to $lib/format.ts in a follow-up.
+  function formatSteeringWarning(w: SteeringWarning): string {
+    // ... existing body unchanged
+  }
+```
+
+Delete the now-duplicated `formatSkippedReason`, `skillCountLabel`, `skillCountTitle`, `formatSkippedSkill`, and `formatSkippedSkillsForPlugin` definitions from BrowseTab.svelte.
+
+- [ ] **Step 3: Run svelte-check after the extraction (catches accidental name drift)**
 
 ```bash
+cd crates/kiro-control-center && npm run check 2>&1 | tail -5
+```
+
+Expected: `0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`. Then commit:
+
+```bash
+git add crates/kiro-control-center/src/lib/format.ts \
+        crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+git commit -m "refactor(ui): lift format helpers to \$lib/format.ts"
+```
+
+- [ ] **Step 4: Create `PluginCard.svelte`**
+
+```svelte
+<!-- crates/kiro-control-center/src/lib/components/PluginCard.svelte -->
+<script lang="ts">
+  import type { PluginInfo } from "$lib/bindings";
+  import { skillCountLabel, skillCountTitle } from "$lib/format";
+
+  type Props = {
+    /** The plugin to render. From `commands.listPlugins(...)` results. */
+    plugin: PluginInfo;
+    /** Owning marketplace name (not in `PluginInfo` itself). */
+    marketplace: string;
+    /** Whether the plugin appears in `commands.listInstalledPlugins(...)`. */
+    installed: boolean;
+    /** True while a per-plugin install is in flight for this card. */
+    installing: boolean;
+    /** True when project_path is empty — disables the install button. */
+    projectPicked: boolean;
+    onInstall: () => void;
+  };
+
+  let {
+    plugin,
+    marketplace,
+    installed,
+    installing,
+    projectPicked,
+    onInstall,
+  }: Props = $props();
+
+  const title = $derived(
+    !projectPicked
+      ? "Pick a project first"
+      : installed
+        ? `${plugin.name} is already installed in this project`
+        : `Install ${plugin.name} (skills + steering + agents) into the active project`,
+  );
+</script>
+
+<div class="flex items-start gap-3 px-3 py-3 rounded-md border border-kiro-muted bg-kiro-overlay">
+  <div class="flex-1 min-w-0">
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="text-sm font-medium text-kiro-text truncate">{plugin.name}</span>
+      <span
+        class="text-[11px] {plugin.skill_count.state === 'manifest_failed'
+          ? 'text-kiro-warning'
+          : 'text-kiro-subtle'} flex-shrink-0"
+        title={skillCountTitle(plugin.skill_count)}
+        aria-label={skillCountTitle(plugin.skill_count)}
+      >
+        {skillCountLabel(plugin.skill_count)} skill{plugin.skill_count.state === "known" &&
+        plugin.skill_count.count === 1
+          ? ""
+          : "s"}
+      </span>
+    </div>
+    {#if plugin.description}
+      <div class="mt-1 text-xs text-kiro-subtle">{plugin.description}</div>
+    {/if}
+    <div class="mt-1.5 text-[10px] uppercase tracking-wider text-kiro-subtle">
+      {marketplace}
+    </div>
+  </div>
+
+  <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
+    {#if installed}
+      <span
+        class="px-2 py-0.5 text-[11px] font-medium text-kiro-success border border-kiro-success/40 rounded"
+      >
+        Installed
+      </span>
+    {:else}
+      <button
+        type="button"
+        onclick={onInstall}
+        disabled={!projectPicked || installing}
+        aria-busy={installing}
+        {title}
+        aria-label="Install {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+          {projectPicked && !installing
+            ? 'bg-kiro-overlay border border-kiro-muted text-kiro-accent-300 hover:bg-kiro-muted hover:text-kiro-accent-200'
+            : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
+      >
+        {installing ? "Installing…" : "Install"}
+      </button>
+    {/if}
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Run svelte-check + commit**
+
+```bash
+cd crates/kiro-control-center && npm run check 2>&1 | tail -5
 git add crates/kiro-control-center/src/lib/components/PluginCard.svelte
 git commit -m "feat(ui): PluginCard reusable component"
 ```
@@ -914,47 +1123,224 @@ git commit -m "feat(ui): PluginCard reusable component"
 **Files:**
 - Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`
 
-- [ ] **Step 1: Add view-toggle state**
+- [ ] **Step 1: Import the new component + add state**
 
-Near the existing state declarations:
-
-```typescript
-type BrowseView = "plugins" | "skills";
-let browseView: BrowseView = $state("plugins");
-```
-
-- [ ] **Step 2: Add view-toggle UI**
-
-Above the current grid (around line 985), insert a 2-button toggle: `[Plugins] [Skills]`. Tailwind: `inline-flex gap-1 px-1 py-1 rounded-md bg-kiro-overlay border border-kiro-muted`. Each button styles based on `browseView`.
-
-- [ ] **Step 3: Conditionally render**
-
-Wrap the existing skill-grid block (lines 1019-1028) in `{#if browseView === "skills"}` ... `{/if}`. Add an else branch that renders `PluginCard` for each `availablePlugins[i]`:
+In the script block (top of the file), add:
 
 ```svelte
-{:else}
+<script lang="ts">
+  // ... existing imports
+  import PluginCard from "./PluginCard.svelte";
+  import type { InstalledPluginInfo } from "$lib/bindings";
+
+  // ... existing state declarations (selectedMarketplaces, selectedPlugins,
+  // selectedSkills, installedOnly, filterText, forceInstall, popoverOpen,
+  // popRef, loadingMarketplaces, pendingFetches, installing, fetchErrors,
+  // installError, installMessage, pendingSteeringInstalls)
+
+  type BrowseView = "plugins" | "skills";
+  let browseView: BrowseView = $state("plugins");
+
+  // Per-plugin in-flight tracker for plugin installs (parallels
+  // pendingSteeringInstalls). Same key shape: pluginKey(marketplace,
+  // plugin) so two plugins can install in parallel without colliding.
+  let pendingPluginInstalls = new SvelteSet<string>();
+
+  // Set of pluginKey()s currently installed in this project. Driven by
+  // the listInstalledPlugins fetch below. Used by PluginCard to render
+  // "Installed" vs. "Install" state.
+  let installedPlugins: InstalledPluginInfo[] = $state([]);
+  let installedPluginKeys = $derived(
+    new Set(installedPlugins.map((p) => pluginKey(p.marketplace, p.plugin))),
+  );
+</script>
+```
+
+- [ ] **Step 2: Add `fetchInstalledPlugins` + wire it to project changes**
+
+Below the existing `fetchSkillsFor` function, add:
+
+```typescript
+async function fetchInstalledPlugins() {
+  if (!projectPath) {
+    installedPlugins = [];
+    return;
+  }
+  try {
+    const result = await commands.listInstalledPlugins(projectPath);
+    installedPlugins = result.status === "ok" ? result.data : [];
+  } catch (e) {
+    console.error("[BrowseTab] listInstalledPlugins rejected", e);
+    installedPlugins = [];
+  }
+}
+
+onMount(fetchInstalledPlugins);
+
+// Refresh whenever projectPath changes — same pattern the existing
+// `priorProjectPath` watcher uses for skill state.
+$effect(() => {
+  // Read projectPath to register the dependency.
+  const _path = projectPath;
+  fetchInstalledPlugins();
+});
+```
+
+- [ ] **Step 3: Add `installWholePlugin` async function**
+
+Below the existing `installSteering` function:
+
+```typescript
+async function installWholePlugin(marketplace: string, plugin: string) {
+  const key = pluginKey(marketplace, plugin);
+  if (pendingPluginInstalls.has(key)) return;
+  pendingPluginInstalls.add(key);
+  installError = null;
+  installMessage = null;
+
+  try {
+    const result = await commands.installPlugin(
+      marketplace,
+      plugin,
+      forceInstall,
+      projectPath,
+    );
+    if (result.status === "ok") {
+      const r = result.data;
+      const parts: string[] = [];
+      if (r.skills) {
+        const installed = r.skills.installed.length;
+        const failed = r.skills.failed.length;
+        if (installed > 0) {
+          parts.push(`${installed} skill${installed === 1 ? "" : "s"}`);
+        }
+        if (failed > 0) {
+          parts.push(`${failed} skill${failed === 1 ? "" : "s"} failed`);
+        }
+      }
+      if (r.steering) {
+        const installed = r.steering.installed.length;
+        const failed = r.steering.failed.length;
+        if (installed > 0) {
+          parts.push(`${installed} steering file${installed === 1 ? "" : "s"}`);
+        }
+        if (failed > 0) {
+          parts.push(`${failed} steering failed`);
+        }
+      }
+      if (r.agents) {
+        const installed = r.agents.installed.length;
+        const failed = r.agents.failed.length;
+        if (installed > 0) {
+          parts.push(`${installed} agent${installed === 1 ? "" : "s"}`);
+        }
+        if (failed > 0) {
+          parts.push(`${failed} agent${failed === 1 ? "" : "s"} failed`);
+        }
+      }
+      const anyFailed =
+        (r.skills?.failed.length ?? 0) +
+          (r.steering?.failed.length ?? 0) +
+          (r.agents?.failed.length ?? 0) >
+        0;
+      const anyInstalled =
+        (r.skills?.installed.length ?? 0) +
+          (r.steering?.installed.length ?? 0) +
+          (r.agents?.installed.length ?? 0) >
+        0;
+      const summary = parts.length > 0 ? parts.join(" · ") : "nothing to install";
+      if (anyFailed && !anyInstalled) {
+        installError = `Plugin install failed for ${plugin}: ${summary}`;
+      } else {
+        installMessage = `Plugin ${plugin}: ${summary}`;
+      }
+      // Refresh the installed-plugin set so the card flips to "Installed".
+      await fetchInstalledPlugins();
+    } else {
+      installError = `Plugin install failed for ${plugin}: ${result.error.message}`;
+    }
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    installError = `Plugin install failed for ${plugin}: ${reason}`;
+  } finally {
+    pendingPluginInstalls.delete(key);
+  }
+}
+```
+
+- [ ] **Step 4: Add the view-toggle UI**
+
+Above the main scrollable grid container (around line 985, just before `<div class="flex-1 overflow-y-auto p-4">`), insert:
+
+```svelte
+<div class="px-4 py-2 border-b border-kiro-muted bg-kiro-surface/40 flex items-center gap-2">
+  <span class="text-xs text-kiro-subtle">Browse:</span>
+  <div class="inline-flex gap-1 px-1 py-1 rounded-md bg-kiro-overlay border border-kiro-muted">
+    <button
+      type="button"
+      onclick={() => (browseView = "plugins")}
+      aria-pressed={browseView === "plugins"}
+      class="px-2.5 py-0.5 text-xs font-medium rounded {browseView === 'plugins'
+        ? 'bg-kiro-accent-900/40 text-kiro-accent-300'
+        : 'text-kiro-text-secondary hover:text-kiro-text'}"
+    >
+      Plugins
+    </button>
+    <button
+      type="button"
+      onclick={() => (browseView = "skills")}
+      aria-pressed={browseView === "skills"}
+      class="px-2.5 py-0.5 text-xs font-medium rounded {browseView === 'skills'
+        ? 'bg-kiro-accent-900/40 text-kiro-accent-300'
+        : 'text-kiro-text-secondary hover:text-kiro-text'}"
+    >
+      Skills
+    </button>
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Conditionally render skill grid vs. plugin grid**
+
+Find the existing skill-grid block (around line 1019-1028, the `{#each filteredSkills as skill ...}` block). Wrap it and add the plugin-grid else branch:
+
+```svelte
+{:else if browseView === "skills"}
   <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
-    {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
-      {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
-      <PluginCard
-        plugin={ap.plugin}
-        marketplace={ap.marketplace}
-        installed={installedPluginKeys.has(key)}
-        installing={pendingPluginInstalls.has(key)}
-        onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+    {#each filteredSkills as skill (skillKey(skill.marketplace, skill.plugin, skill.name))}
+      {@const key = skillKey(skill.marketplace, skill.plugin, skill.name)}
+      <SkillCard
+        {skill}
+        selected={selectedSkills.has(key)}
+        onToggle={() => toggleSkill(key)}
       />
     {/each}
   </div>
+{:else}
+  <!-- Plugins view: every plugin in scope, install action per card. -->
+  {#if availablePlugins.length === 0}
+    <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+      <p class="text-sm">No plugins available — pick a marketplace from Filters.</p>
+    </div>
+  {:else}
+    <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+      {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
+        {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
+        <PluginCard
+          plugin={ap.plugin}
+          marketplace={ap.marketplace}
+          installed={installedPluginKeys.has(key)}
+          installing={pendingPluginInstalls.has(key)}
+          projectPicked={!!projectPath}
+          onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+        />
+      {/each}
+    </div>
+  {/if}
 {/if}
 ```
 
-- [ ] **Step 4: Add `installWholePlugin` async function**
-
-Mirrors PR 92's `installSteering` but calls `commands.installPlugin(...)`. Renders aggregate result (counts across the three sub-results) into `installMessage`/`installError`.
-
-- [ ] **Step 5: Add `installedPluginKeys` derived from `commands.listInstalledPlugins`**
-
-Fetch on mount + when `projectPath` changes; mirror the existing `installed` lookup pattern for skills.
+Note: the existing `{:else if filteredSkills.length === 0}` empty-state block (PR 92's per-plugin steering install in the empty state) needs to be removed in favor of the new Plugins view — Plugins is the new home for that flow. Confirm by reading the surrounding code; the `{:else if filteredSkills.length === 0}` branch should now ONLY fire when `browseView === "skills"`.
 
 - [ ] **Step 6: Run svelte-check + commit**
 
@@ -971,30 +1357,209 @@ git commit -m "feat(ui): plugin cards as primary BrowseTab view"
 **Files:**
 - Modify: `crates/kiro-control-center/src/lib/components/InstalledTab.svelte`
 
-- [ ] **Step 1: Replace the skill-list fetch with `listInstalledPlugins`**
+The existing InstalledTab is 215 lines, all skill-table rendering. After this task it has two sections: a primary "Installed plugins" grouped view, and a collapsible `<details>` "All installed skills" preserving the flat-table backward compat.
 
-```typescript
-const result = await commands.listInstalledPlugins(projectPath);
+- [ ] **Step 1: Add state + fetchers**
+
+In the `<script lang="ts">` block:
+
+```svelte
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { commands } from "$lib/bindings";
+  import type {
+    InstalledSkillInfo,
+    InstalledPluginInfo,
+  } from "$lib/bindings";
+
+  let { projectPath }: { projectPath: string } = $props();
+
+  let plugins: InstalledPluginInfo[] = $state([]);
+  let skills: InstalledSkillInfo[] = $state([]);
+  let loading: boolean = $state(true);
+  let loadError: string | null = $state(null);
+  let removingKey: string | null = $state(null);
+
+  function pluginKey(mp: string, plugin: string): string {
+    return `${mp}${plugin}`;
+  }
+
+  async function refresh() {
+    loading = true;
+    loadError = null;
+    try {
+      const [pluginsResult, skillsResult] = await Promise.all([
+        commands.listInstalledPlugins(projectPath),
+        commands.listInstalledSkills(projectPath),
+      ]);
+      if (pluginsResult.status === "ok") {
+        plugins = pluginsResult.data;
+      } else {
+        loadError = pluginsResult.error.message;
+      }
+      if (skillsResult.status === "ok") {
+        skills = skillsResult.data;
+      } else if (loadError === null) {
+        loadError = skillsResult.error.message;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      loadError = `Failed to load installed state: ${reason}`;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function removePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (removingKey !== null) return;
+    removingKey = key;
+    try {
+      const result = await commands.removePlugin(marketplace, plugin, projectPath);
+      if (result.status === "ok") {
+        await refresh();
+      } else {
+        loadError = `Remove failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      loadError = `Remove failed for ${plugin}: ${reason}`;
+    } finally {
+      removingKey = null;
+    }
+  }
+
+  function formatDate(iso: string): string {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+  }
+
+  function contentSummary(p: InstalledPluginInfo): string {
+    const parts: string[] = [];
+    if (p.skill_count > 0) parts.push(`${p.skill_count} skill${p.skill_count === 1 ? "" : "s"}`);
+    if (p.steering_count > 0)
+      parts.push(`${p.steering_count} steering`);
+    if (p.agent_count > 0)
+      parts.push(`${p.agent_count} agent${p.agent_count === 1 ? "" : "s"}`);
+    return parts.length > 0 ? parts.join(" · ") : "(empty)";
+  }
+
+  onMount(refresh);
+
+  $effect(() => {
+    const _path = projectPath;
+    refresh();
+  });
+</script>
 ```
 
-- [ ] **Step 2: Render plugin rows**
+- [ ] **Step 2: Render the markup**
 
-Each row shows: plugin name, version, content counts (`3 skills · 1 steering · 0 agents`), `installed_at`, `[Remove]` button.
+Replace the existing `<div>` body (lines ~135 onward) with:
 
-- [ ] **Step 3: Wire `removePlugin`**
+```svelte
+<div class="flex-1 overflow-y-auto p-4">
+  {#if loading}
+    <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+      <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+      <p class="text-sm">Loading installed state...</p>
+    </div>
+  {:else if loadError}
+    <div class="px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+      <p class="text-sm text-kiro-error">{loadError}</p>
+    </div>
+  {:else}
+    <section class="mb-6">
+      <h2 class="text-sm font-semibold text-kiro-text mb-3">Installed plugins</h2>
+      {#if plugins.length === 0}
+        <p class="text-sm text-kiro-subtle">No plugins installed in this project.</p>
+      {:else}
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+              <th class="px-4 py-2">Plugin</th>
+              <th class="px-4 py-2">Marketplace</th>
+              <th class="px-4 py-2">Version</th>
+              <th class="px-4 py-2">Contents</th>
+              <th class="px-4 py-2">Installed</th>
+              <th class="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each plugins as p (pluginKey(p.marketplace, p.plugin))}
+              {@const key = pluginKey(p.marketplace, p.plugin)}
+              <tr class="border-b border-kiro-muted/50">
+                <td class="px-4 py-3 font-medium text-kiro-text">{p.plugin}</td>
+                <td class="px-4 py-3 text-kiro-text-secondary">{p.marketplace}</td>
+                <td class="px-4 py-3 text-kiro-text-secondary">{p.installed_version ?? "—"}</td>
+                <td class="px-4 py-3 text-kiro-text-secondary">{contentSummary(p)}</td>
+                <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(p.latest_install)}</td>
+                <td class="px-4 py-3 text-right">
+                  <button
+                    type="button"
+                    onclick={() => removePlugin(p.marketplace, p.plugin)}
+                    disabled={removingKey !== null}
+                    aria-busy={removingKey === key}
+                    class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed"
+                  >
+                    {removingKey === key ? "Removing…" : "Remove"}
+                  </button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    </section>
 
-Call `commands.removePlugin(marketplace, plugin, projectPath)`. On success, refresh the list.
+    <details class="mb-6">
+      <summary class="cursor-pointer text-sm font-medium text-kiro-text-secondary hover:text-kiro-text">
+        All installed skills (flat view)
+      </summary>
+      <div class="mt-3">
+        {#if skills.length === 0}
+          <p class="text-sm text-kiro-subtle">No skills installed.</p>
+        {:else}
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Marketplace</th>
+                <th class="px-4 py-2">Plugin</th>
+                <th class="px-4 py-2">Version</th>
+                <th class="px-4 py-2">Installed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each skills as skill (skill.name)}
+                <tr class="border-b border-kiro-muted/50">
+                  <td class="px-4 py-3 text-kiro-text">{skill.name}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{skill.marketplace}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{skill.plugin}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{skill.version ?? "—"}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(skill.installed_at)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </div>
+    </details>
+  {/if}
+</div>
+```
 
-- [ ] **Step 4: Optional collapsible "All installed skills" sub-section**
+The exact nav-rail wrapper / outer container should stay as the existing InstalledTab provides — only the inner body changes.
 
-Below the plugins list, add a `<details>` for the existing flat skill table. Preserves backward-compat for users who liked it.
-
-- [ ] **Step 5: Run svelte-check + commit**
+- [ ] **Step 3: Run svelte-check + commit**
 
 ```bash
 cd crates/kiro-control-center && npm run check 2>&1 | tail -5
 git add crates/kiro-control-center/src/lib/components/InstalledTab.svelte
-git commit -m "feat(ui): plugins-grouped InstalledTab"
+git commit -m "feat(ui): plugins-grouped InstalledTab + collapsible flat skills"
 ```
 
 ---
@@ -1004,18 +1569,55 @@ git commit -m "feat(ui): plugins-grouped InstalledTab"
 **Files:**
 - Modify: `crates/kiro-control-center/tests/e2e/app.spec.ts`
 
-- [ ] **Step 1: Add the test**
+The existing `"install skill from browse tab"` test (around line 91) is the structural template. The new test exercises the plugin path: switch to Plugins view, click Install on a card, assert appearance in Installed.
+
+- [ ] **Step 1: Add the test inside the `Marketplace workflow` describe block**
+
+After the existing `"install skill from browse tab"` test, add:
 
 ```typescript
-test("install plugin from BrowseTab and verify in InstalledTab", async ({ page }) => {
-  // Skip if FIXTURE_MARKETPLACE_PATH not set (matches existing skill test).
-  // Pick the test project, click Browse, switch to Plugins view if not default,
-  // click Install on the test plugin's card, wait for success banner,
-  // navigate to Installed, assert the plugin row appears.
+test("install plugin from browse tab and verify in installed tab", async ({ page }) => {
+  await page.getByRole("button", { name: "Browse", exact: true }).click();
+
+  // The earlier "add local marketplace" test seeds FIXTURE_MARKETPLACE_PATH.
+  // Skip if the fixture isn't available (matches the skill-install pattern
+  // at line ~95 of this file).
+  const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+  test.skip(!fixturePath, "FIXTURE_MARKETPLACE_PATH not set");
+
+  // Switch to the Plugins view if the toggle isn't already on it. The
+  // Plugins button is the default per Task 7's BrowseView state, but
+  // switching defensively keeps the test robust to a future default
+  // change.
+  const pluginsToggle = page.getByRole("button", { name: "Plugins", exact: true });
+  if (await pluginsToggle.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await pluginsToggle.click();
+  }
+
+  // Find a plugin card with the test fixture's plugin name. The card
+  // exposes an "Install plugin" button via aria-label="Install <name>".
+  const testPlugin = page.getByText(/test-plugin/i).first();
+  if (!(await testPlugin.isVisible({ timeout: 5_000 }).catch(() => false))) {
+    test.skip(true, "No marketplace with test-plugin available");
+  }
+
+  const installButton = page
+    .getByRole("button", { name: /install test-plugin/i })
+    .first();
+  await installButton.click();
+
+  // Wait for the installMessage banner to land (matches the success
+  // banner pattern from the skill-install test).
+  await expect(page.getByText(/Plugin test-plugin/i)).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Navigate to Installed tab and assert the plugin row appears.
+  await page.getByRole("button", { name: "Installed", exact: true }).click();
+  await expect(page.getByRole("heading", { name: /installed plugins/i })).toBeVisible();
+  await expect(page.getByText(/test-plugin/i).first()).toBeVisible();
 });
 ```
-
-The existing `"install skill from browse tab"` is the template; mirror its env-var skips and locator patterns.
 
 - [ ] **Step 2: Run + commit**
 
@@ -1024,6 +1626,8 @@ cd crates/kiro-control-center && npm run test:e2e 2>&1 | tail -10
 git add crates/kiro-control-center/tests/e2e/app.spec.ts
 git commit -m "test(e2e): plugin install happy-path"
 ```
+
+If `FIXTURE_MARKETPLACE_PATH` is unset locally, the test will skip (the pattern matches the skill-install precedent). CI configuration determines whether the fixture is set in the test environment — that's a separate concern from this PR.
 
 ---
 


### PR DESCRIPTION
## Summary

**Plan-only PR — no code changes.** Architecture and execution plan for the plugin-first install pivot surfaced by manual testing on PR #92. Implementation follows in a separate PR after this one is reviewed and merged.

Three docs, two commits:

- `2026-04-29-plugin-first-install-design.md` — architecture for Phase 1 (plugin-first install + lifecycle) and Phase 2 (update story). Documents the user-locked decisions: all-or-nothing customization in v1, per-plugin update granularity. Phase 2 alternatives (per-content-type updates, auto-update) sketched and explicitly rejected for v1 with rationale.

- `2026-04-29-plugin-first-install-plan.md` — Phase 1 task-by-task implementation plan, TDD-shaped, 10 tasks. Subsumes the previously-deferred "agents.rs" item from the post-PR-83 follow-up list (`install_plugin_agents` Tauri command lands as a prerequisite for the new `install_plugin` coordinator).

- `2026-04-29-plugin-first-install-plan-amendments.md` — plan-review pass against `docs/plan-review-checklist.md`. Eight findings across Gates 1, 2, 3, 5 + two process amendments. See "Amendments" below for the list.

## Background

PR #92 wired `install_plugin_steering` into the desktop UI, completing one slice of an end-to-end install path. Manual testing on `dwalleck/kiro-starter-kit` (a marketplace whose plugins ship steering but no skills) revealed that a successful steering install produced no observable state change in the InstalledTab — which only lists skills. The user observed, more deeply: plugin authors design their bundles as coherent units (a code-review agent without its steering files isn't useful), but the UI lets you install pieces in isolation. The asymmetry is in the UI/orchestration layer; core already treats the three content types as peers.

Phase 1 makes plugins the first-class user-facing object: a single coordinator (`install_plugin`) installs everything a plugin declares; `list_installed_plugins` aggregates the three tracking files for the UI; `remove_plugin` cascades. Backend stays content-type-first (separate `installed-*.json` files); UI absorbs the unification.

## User-locked decisions

1. **Customization granularity: all-or-nothing.** One Install button per plugin, installs everything the plugin declares. No per-content-type checkboxes in v1.
2. **Update granularity: per-plugin.** When the marketplace plugin manifest moves to a new version, surface "Update available" at the plugin level and re-install the bundle. Per-content-type updates documented as a Phase 2 alternative and rejected.

## Amendments (from rigorous Gate 1–5 review)

The original 5-gates section in the plan listed gate names but didn't run each gate rigorously. A second pass with `grep` AND LSP `documentSymbol` against the current SHA surfaced 8 findings:

| # | Gate | Finding |
|---|---|---|
| A-1 | 1 | `install_plugin_agents` is an associated function, not a method. Plan called it as `self.install_plugin_agents(...)` — won't compile. |
| A-2 | 1 | `KiroProject::remove_steering_file` and `remove_agent` don't exist. Promoted from "if missing" to hard prerequisites (Tasks 3a / 3b). |
| A-3 | 1 | `InstalledAgents.native_companions` field needs cleanup in `remove_plugin`. |
| A-4 | 2 | Original ask was new path validation. LSP surfaced existing `validate_tracking_path_entry` + load-boundary helpers — narrowed to "reuse + regression test." |
| A-5 | 3 | JSON shape lock only covered all-`None` case; added a populated-subresult case. |
| A-6 | 5 | Lexicographic version comparison mis-orders semver-shaped strings; switched to "latest install by timestamp." |
| A-7 | process | Future plan-reviews must run each gate and cite actual output, not paraphrase. |
| A-8 | tooling | First step of Gate 1 = LSP `documentSymbol` on every file the plan modifies. Grep is fallback. |

No design-doc revision required — architecture stands as written. All amendments are execution-time corrections.

## Why this is a plan-only PR

- Lets you (and any other reviewer) read and validate the architecture before any code is committed against it.
- Surfaces the amendments inline on GitHub for discussion.
- Keeps the eventual implementation PR small and focused on what's in the plan, with the design context already merged.

If approved, the implementation PR will reference this one and walk through the 10 tasks per the plan with the 8 amendments folded in.

## Test plan

- [x] No code; `cargo test` / `npm run check` not relevant
- [x] `markdownlint` (if configured) — N/A here
- [ ] Reviewer skim of the design doc (~314 lines)
- [ ] Reviewer skim of the plan doc — focus on the file-structure table and the 10 task headers, not every code block
- [ ] Reviewer skim of the amendments doc — eight A-* sections, each cites the gate that fired

## Next step

After this lands: open implementation PR on a successor branch, executing the 10 tasks (with amendments) via `superpowers:subagent-driven-development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)