### PR TITLE
feat: plugin-first install (BrowseTab + InstalledTab + agents.rs)

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -13,12 +13,11 @@
 //! `None` for translated). Otherwise the wrapper / `_impl` split is
 //! identical.
 
-use std::path::PathBuf;
-
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
     AgentInstallContext, InstallAgentsResult, InstallMode, MarketplaceService,
 };
+use kiro_market_core::validation::validate_name;
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -59,18 +58,14 @@ fn install_plugin_agents_impl(
     accept_mcp: bool,
     project_path: &str,
 ) -> Result<InstallAgentsResult, CommandError> {
-    validate_kiro_project_path(project_path)?;
+    validate_name(marketplace)?;
+    validate_name(plugin)?;
+    let project_root = validate_kiro_project_path(project_path)?;
     let ctx = svc
         .resolve_plugin_install_context(marketplace, plugin)
         .map_err(CommandError::from)?;
-    let project = KiroProject::new(PathBuf::from(project_path));
+    let project = KiroProject::new(project_root);
 
-    // A-14: `install_plugin_agents` is an associated function (no `&self`),
-    // mirroring `install_plugin_steering`. Calling it as `svc.install_...`
-    // would not compile. The `svc` parameter on this `_impl` is kept for
-    // symmetry with `install_plugin_steering_impl` and is intentionally
-    // unused below.
-    let _ = svc;
     Ok(MarketplaceService::install_plugin_agents(
         &project,
         &ctx.plugin_dir,

--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -1,0 +1,462 @@
+//! Plugin-agents install command for the Tauri frontend.
+//!
+//! Mirrors [`crate::commands::steering::install_plugin_steering`]: a thin
+//! `#[tauri::command]` wrapper builds the [`MarketplaceService`] from
+//! process globals, then delegates to a private `_impl` whose body is
+//! unit-testable against [`kiro_market_core::service::test_support`]
+//! fixtures without a Tauri runtime.
+//!
+//! Agent installs differ from steering in two parameters: the FFI carries
+//! `accept_mcp: bool` (the per-call MCP opt-in gate documented on
+//! [`AgentInstallContext::accept_mcp`]), and the resolver hands us
+//! [`PluginInstallContext::format`] (`Some(KiroCli)` for native plugins,
+//! `None` for translated). Otherwise the wrapper / `_impl` split is
+//! identical.
+
+use std::path::PathBuf;
+
+use kiro_market_core::project::KiroProject;
+use kiro_market_core::service::{
+    AgentInstallContext, InstallAgentsResult, InstallMode, MarketplaceService,
+};
+
+use crate::commands::{make_service, validate_kiro_project_path};
+use crate::error::CommandError;
+
+/// Install every agent declared by a plugin into the active project's
+/// `.kiro/agents/` directory.
+///
+/// The wrapper exists only to construct a [`MarketplaceService`] from
+/// process globals and translate the FFI `force: bool` into an
+/// [`InstallMode`]; the install itself runs in
+/// [`install_plugin_agents_impl`] so it can be tested without a Tauri
+/// runtime.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_plugin_agents(
+    marketplace: String,
+    plugin: String,
+    force: bool,
+    accept_mcp: bool,
+    project_path: String,
+) -> Result<InstallAgentsResult, CommandError> {
+    let svc = make_service()?;
+    install_plugin_agents_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        InstallMode::from(force),
+        accept_mcp,
+        &project_path,
+    )
+}
+
+fn install_plugin_agents_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallAgentsResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let ctx = svc
+        .resolve_plugin_install_context(marketplace, plugin)
+        .map_err(CommandError::from)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+
+    // A-14: `install_plugin_agents` is an associated function (no `&self`),
+    // mirroring `install_plugin_steering`. Calling it as `svc.install_...`
+    // would not compile. The `svc` parameter on this `_impl` is kept for
+    // symmetry with `install_plugin_steering_impl` and is intentionally
+    // unused below.
+    let _ = svc;
+    Ok(MarketplaceService::install_plugin_agents(
+        &project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext {
+            mode,
+            accept_mcp,
+            marketplace,
+            plugin,
+            version: ctx.version.as_deref(),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    //! `_impl`-level tests. The `#[tauri::command]` wrapper is a thin
+    //! serde shim and is not re-exercised here; see
+    //! `commands/browse.rs::tests` for the canonical pattern.
+
+    use std::fs;
+
+    use kiro_market_core::service::test_support::{
+        relative_path_entry, seed_marketplace_with_registry, temp_service,
+    };
+
+    use crate::error::ErrorType;
+
+    use super::*;
+
+    // TODO(Task 5.0, A-20): hoist to
+    // `kiro_market_core::service::test_support::make_kiro_project` and
+    // delete this local copy. `commands/steering.rs::tests` carries the
+    // same temporary duplicate; both go away once the helper lands in
+    // `service::test_support`.
+    fn make_kiro_project(dir: &std::path::Path) -> String {
+        let project_path = dir.join("kproj");
+        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
+        project_path.to_str().expect("utf-8 path").to_owned()
+    }
+
+    /// Write a translated-path agent file (markdown + YAML frontmatter
+    /// `name`/`description`). The translated install path treats files
+    /// without frontmatter as non-agents and silently skips them, so the
+    /// frontmatter fence is required for the file to actually install.
+    fn write_translated_agent_file(
+        plugin_dir: &std::path::Path,
+        rel: &str,
+        name: &str,
+        body: &str,
+    ) {
+        let p = plugin_dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create agent parent");
+        }
+        let content = format!("---\nname: {name}\ndescription: Test agent\n---\n{body}");
+        fs::write(&p, content).expect("write agent file");
+    }
+
+    /// Write a native-format `plugin.json` declaring `format: kiro-cli`
+    /// plus a single agent JSON under `agents/`. The native install path
+    /// is the only one whose collision matrix surfaces
+    /// `ContentChangedRequiresForce`; the translated path's `New` mode
+    /// returns `AlreadyInstalled` (which becomes `skipped`, not `failed`)
+    /// regardless of whether the source bytes changed. Mirroring the
+    /// steering test's `force_mode_overwrites_changed_source` /
+    /// `new_mode_surfaces_content_changed_in_failed` semantics therefore
+    /// requires the native path.
+    fn write_native_plugin(plugin_dir: &std::path::Path, name: &str, body: &[u8]) {
+        fs::create_dir_all(plugin_dir).expect("plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            format!(r#"{{"name": "{name}", "format": "kiro-cli"}}"#),
+        )
+        .expect("write native plugin.json");
+        let agents = plugin_dir.join("agents");
+        fs::create_dir_all(&agents).expect("agents dir");
+        fs::write(agents.join(format!("{name}.json")), body).expect("write native agent json");
+    }
+
+    #[test]
+    fn install_plugin_agents_impl_installs_default_path_files() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        // No `plugin.json` => translated path with the default
+        // `./agents/` scan root, mirroring the steering happy-path test
+        // which has no manifest either.
+        write_translated_agent_file(
+            &plugin_dir,
+            "agents/reviewer.md",
+            "reviewer",
+            "You are a reviewer.\n",
+        );
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("happy path");
+
+        assert_eq!(
+            result.installed,
+            vec!["reviewer".to_string()],
+            "expected one installed agent named `reviewer`, got: installed={:?}, failed={:?}, warnings={:?}",
+            result.installed,
+            result.failed,
+            result.warnings,
+        );
+        assert!(
+            result.failed.is_empty(),
+            "no failures expected: {:?}",
+            result.failed
+        );
+        // A regression that surfaces a spurious warning on the happy path
+        // (e.g. the README-skip warning leaking through, or an unmapped
+        // tool warning when the agent declares no tools) would otherwise
+        // be invisible — none of the other assertions touch `warnings`.
+        assert!(
+            result.warnings.is_empty(),
+            "happy path must produce no warnings, got: {:?}",
+            result.warnings
+        );
+        assert!(
+            std::path::PathBuf::from(&project_path)
+                .join(".kiro/agents/reviewer.json")
+                .exists(),
+            "agent JSON must land under the requested project_path"
+        );
+        assert!(
+            std::path::PathBuf::from(&project_path)
+                .join(".kiro/agents/prompts/reviewer.md")
+                .exists(),
+            "translated-path prompt body must land under prompts/"
+        );
+    }
+
+    #[test]
+    fn install_plugin_agents_impl_returns_not_found_for_unknown_plugin() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("real-plugin", "plugins/real-plugin")];
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let project_path = make_kiro_project(dir.path());
+
+        let err = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "does-not-exist",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("unknown plugin must error");
+
+        assert_eq!(err.error_type, ErrorType::NotFound);
+    }
+
+    #[test]
+    fn install_plugin_agents_impl_threads_resolved_version_into_install_ctx() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name": "myplugin", "version": "3.1.4"}"#,
+        )
+        .expect("write plugin.json");
+        write_translated_agent_file(
+            &plugin_dir,
+            "agents/guide.md",
+            "guide",
+            "You are a guide.\n",
+        );
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("install with manifest version");
+
+        assert_eq!(result.installed, vec!["guide".to_string()]);
+        let project = KiroProject::new(std::path::PathBuf::from(&project_path));
+        let tracking = project
+            .load_installed_agents()
+            .expect("load installed agents");
+        let entry = tracking
+            .agents
+            .get("guide")
+            .expect("guide should be tracked under .kiro/agents/");
+        // The `version: "3.1.4"` from plugin.json must thread into the
+        // tracking record — same contract as
+        // `install_plugin_steering_impl_threads_resolved_version_into_install_ctx`
+        // for the steering path.
+        assert_eq!(entry.version.as_deref(), Some("3.1.4"));
+        assert_eq!(entry.marketplace, "mp1");
+        assert_eq!(entry.plugin, "myplugin");
+    }
+
+    /// Mirrors `install_plugin_steering_impl_force_mode_overwrites_changed_source`
+    /// for the agents path. Uses the **native** install path (`format: kiro-cli`)
+    /// because that's the only agent path whose collision matrix surfaces
+    /// `ContentChangedRequiresForce` — the translated path returns
+    /// `AlreadyInstalled` (skipped, not failed) regardless of source bytes.
+    #[test]
+    fn install_plugin_agents_impl_force_mode_overwrites_changed_source() {
+        use kiro_market_core::project::InstallOutcomeKind;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        write_native_plugin(
+            &plugin_dir,
+            "myplugin",
+            br#"{"name":"reviewer","prompt":"v1"}"#,
+        );
+        let project_path = make_kiro_project(dir.path());
+
+        let first = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("first install");
+        assert_eq!(
+            first.installed,
+            vec!["reviewer".to_string()],
+            "first install must succeed, got: installed={:?}, failed={:?}",
+            first.installed,
+            first.failed,
+        );
+
+        // Bump the source bytes — same plugin, same agent name, different
+        // hash. New mode would now refuse with ContentChangedRequiresForce
+        // (covered by the next test); Force mode must overwrite.
+        fs::write(
+            plugin_dir.join("agents/myplugin.json"),
+            br#"{"name":"reviewer","prompt":"v2"}"#,
+        )
+        .expect("rewrite agent v2");
+
+        let forced = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::Force,
+            false,
+            &project_path,
+        )
+        .expect("force re-install");
+
+        assert_eq!(
+            forced.installed,
+            vec!["reviewer".to_string()],
+            "force must re-install the changed agent, got: installed={:?}, failed={:?}",
+            forced.installed,
+            forced.failed,
+        );
+        assert_eq!(
+            forced.installed_native.len(),
+            1,
+            "native path must populate installed_native, got: {:?}",
+            forced.installed_native
+        );
+        assert!(
+            matches!(
+                forced.installed_native[0].kind,
+                InstallOutcomeKind::ForceOverwrote
+            ),
+            "force outcome must be ForceOverwrote, got: {:?}",
+            forced.installed_native[0].kind,
+        );
+        let installed_json = fs::read_to_string(
+            std::path::PathBuf::from(&project_path).join(".kiro/agents/reviewer.json"),
+        )
+        .expect("read installed agent json");
+        assert!(
+            installed_json.contains("\"v2\""),
+            "force overwrite must replace the bytes on disk, got: {installed_json}"
+        );
+    }
+
+    /// Companion to the force test above — without `force`, a same-plugin
+    /// reinstall whose source bytes have changed must surface
+    /// `ContentChangedRequiresForce` in `failed` (not silently no-op into
+    /// `skipped` or `installed`). Wire-format lock at the end pins the
+    /// custom `Serialize` projection on `FailedAgent` (typed enum →
+    /// string `error` on the FFI boundary).
+    #[test]
+    fn install_plugin_agents_impl_new_mode_surfaces_content_changed_in_failed() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        write_native_plugin(
+            &plugin_dir,
+            "myplugin",
+            br#"{"name":"reviewer","prompt":"v1"}"#,
+        );
+        let project_path = make_kiro_project(dir.path());
+
+        install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("first install");
+
+        fs::write(
+            plugin_dir.join("agents/myplugin.json"),
+            br#"{"name":"reviewer","prompt":"v2"}"#,
+        )
+        .expect("rewrite agent v2");
+
+        let result = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("second install (should not error at the impl level)");
+
+        assert!(
+            result.installed.is_empty(),
+            "InstallMode::New must NOT overwrite a changed source, got: {:?}",
+            result.installed
+        );
+        assert!(
+            result.skipped.is_empty(),
+            "changed source is not idempotent — must NOT land in skipped, got: {:?}",
+            result.skipped
+        );
+        assert_eq!(
+            result.failed.len(),
+            1,
+            "expected one failure with ContentChangedRequiresForce, got: {:?}",
+            result.failed
+        );
+        assert!(
+            matches!(
+                &result.failed[0].error,
+                kiro_market_core::error::AgentError::ContentChangedRequiresForce { name }
+                    if name == "reviewer"
+            ),
+            "wrong error variant: {:?}",
+            result.failed[0].error
+        );
+
+        let json = serde_json::to_value(&result).expect("InstallAgentsResult serializes");
+        let failed_error = json
+            .pointer("/failed/0/error")
+            .expect("/failed/0/error must exist in wire format");
+        assert!(
+            failed_error.is_string(),
+            "FailedAgent.error must serialize as string (FFI contract), \
+             got non-string: {failed_error:?}"
+        );
+        let rendered = failed_error
+            .as_str()
+            .expect("error rendered as string per the FFI contract");
+        assert!(
+            rendered.contains("reviewer"),
+            "rendered error must mention the agent name, got: {rendered}"
+        );
+    }
+}

--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -95,23 +95,12 @@ mod tests {
     use std::fs;
 
     use kiro_market_core::service::test_support::{
-        relative_path_entry, seed_marketplace_with_registry, temp_service,
+        make_kiro_project, relative_path_entry, seed_marketplace_with_registry, temp_service,
     };
 
     use crate::error::ErrorType;
 
     use super::*;
-
-    // TODO(Task 5.0, A-20): hoist to
-    // `kiro_market_core::service::test_support::make_kiro_project` and
-    // delete this local copy. `commands/steering.rs::tests` carries the
-    // same temporary duplicate; both go away once the helper lands in
-    // `service::test_support`.
-    fn make_kiro_project(dir: &std::path::Path) -> String {
-        let project_path = dir.join("kproj");
-        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
-        project_path.to_str().expect("utf-8 path").to_owned()
-    }
 
     /// Write a translated-path agent file (markdown + YAML frontmatter
     /// `name`/`description`). The translated install path treats files

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -13,8 +13,9 @@ use kiro_market_core::service::{
     BulkSkillsResult, InstallFilter, InstallMode, InstallSkillsResult, MarketplaceService,
     PluginSkillsResult, SkillCount,
 };
+use kiro_market_core::validation::validate_name;
 
-use crate::commands::make_service;
+use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::{CommandError, ErrorType};
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,7 @@ pub async fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, CommandError> {
 #[tauri::command]
 #[specta::specta]
 pub async fn list_plugins(marketplace: String) -> Result<Vec<PluginInfo>, CommandError> {
+    validate_name(&marketplace)?;
     let svc = make_service()?;
     let marketplace_path = svc.marketplace_path(&marketplace);
     let plugin_entries = svc
@@ -210,10 +212,13 @@ fn install_skills_impl(
     mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSkillsResult, CommandError> {
+    validate_name(marketplace)?;
+    validate_name(plugin)?;
+    let project_root = validate_kiro_project_path(project_path)?;
     let ctx = svc
         .resolve_plugin_install_context(marketplace, plugin)
         .map_err(CommandError::from)?;
-    let project = KiroProject::new(PathBuf::from(project_path));
+    let project = KiroProject::new(project_root);
     Ok(svc.install_skills(
         &project,
         &ctx.skill_dirs,

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -327,7 +327,8 @@ mod tests {
     use kiro_market_core::cache::MarketplaceSource;
     use kiro_market_core::marketplace::{PluginSource, StructuredSource};
     use kiro_market_core::service::test_support::{
-        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry, temp_service,
+        make_kiro_project, make_plugin_with_skills, relative_path_entry,
+        seed_marketplace_with_registry, temp_service,
     };
 
     use super::*;
@@ -433,12 +434,6 @@ mod tests {
     // -----------------------------------------------------------------------
     // install_skills_impl
     // -----------------------------------------------------------------------
-
-    fn make_kiro_project(dir: &std::path::Path) -> String {
-        let project_path = dir.join("kproj");
-        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
-        project_path.to_str().expect("utf-8 path").to_owned()
-    }
 
     #[test]
     fn install_skills_impl_threads_resolved_version_into_install_result() {

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -1,12 +1,12 @@
 //! Commands for managing installed skills.
 
-use std::path::PathBuf;
-
 use serde::Serialize;
 use tracing::debug;
 
 use kiro_market_core::project::KiroProject;
+use kiro_market_core::validation::validate_name;
 
+use crate::commands::validate_kiro_project_path;
 use crate::error::CommandError;
 
 // ---------------------------------------------------------------------------
@@ -34,7 +34,8 @@ pub struct InstalledSkillInfo {
 pub async fn list_installed_skills(
     project_path: String,
 ) -> Result<Vec<InstalledSkillInfo>, CommandError> {
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(project_root);
     let installed = project.load_installed().map_err(CommandError::from)?;
 
     let mut results: Vec<InstalledSkillInfo> = installed
@@ -59,7 +60,9 @@ pub async fn list_installed_skills(
 #[tauri::command]
 #[specta::specta]
 pub async fn remove_skill(name: String, project_path: String) -> Result<(), CommandError> {
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    validate_name(&name)?;
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(project_root);
     project.remove_skill(&name).map_err(CommandError::from)?;
     debug!(skill = %name, "skill removed via control center");
 
@@ -134,6 +137,10 @@ mod tests {
     #[tokio::test]
     async fn list_installed_skills_empty_project_returns_empty_vec() {
         let dir = tempfile::tempdir().expect("tempdir");
+        // The IPC-boundary `validate_kiro_project_path` requires `.kiro/`
+        // to exist; without it, an empty-tempdir call now returns
+        // `ErrorType::Validation` rather than an empty list.
+        std::fs::create_dir_all(dir.path().join(".kiro")).expect("create .kiro");
         let path = dir.path().to_str().expect("valid utf-8").to_owned();
 
         let result = list_installed_skills(path).await.expect("should succeed");
@@ -156,6 +163,11 @@ mod tests {
     #[tokio::test]
     async fn remove_skill_nonexistent_returns_error() {
         let dir = tempfile::tempdir().expect("tempdir");
+        // `validate_kiro_project_path` requires `.kiro/`, so create it
+        // even though the inner `remove_skill` is what we're stressing —
+        // otherwise the validation guard fires first and we'd assert on
+        // the wrong error.
+        std::fs::create_dir_all(dir.path().join(".kiro")).expect("create .kiro");
         let path = dir.path().to_str().expect("valid utf-8").to_owned();
 
         let err = remove_skill("nonexistent".into(), path)

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -32,43 +32,179 @@ pub(in crate::commands) fn make_service() -> Result<MarketplaceService, CommandE
     Ok(MarketplaceService::new(cache, GixCliBackend::default()))
 }
 
-/// Fail-fast validation of a Tauri-supplied `project_path` before it
-/// flows into [`kiro_market_core::project::KiroProject::new`] (which is
-/// infallible). Rejects:
+/// Fail-fast validation of a Tauri-supplied `project_path`, returning
+/// the canonical absolute path on success.
 ///
-/// - an empty string — frontend default-construction would otherwise
-///   silently write to `./.kiro/...` relative to the Tauri process cwd
-///   instead of the user's project,
-/// - a non-existent path,
-/// - a path with no `.kiro/` subdirectory.
+/// Rejects:
 ///
-/// Without this guard, the install layer's per-file failures wouldn't
-/// fire (it would create `.kiro/` on the wrong root), so the user sees
-/// "install succeeded" with bytes landing nowhere near their project.
+/// - an empty / whitespace-only string — frontend default-construction
+///   would otherwise silently write to `./.kiro/...` relative to the
+///   Tauri process cwd instead of the user's project,
+/// - a path that cannot be `stat`ed (does not exist, permission
+///   denied, ...),
+/// - a top-level symlink — defense-in-depth: the install layer in
+///   `kiro-market-core` validates per-content path entries, but the
+///   project root itself going through a symlink chain widens the trust
+///   boundary unnecessarily,
+/// - a path with no `.kiro/` subdirectory under the canonical root.
+///
+/// Returning the canonical [`PathBuf`] solves a separate problem too:
+/// `with_file_lock` keys derive from the path the caller hands in, so
+/// `/proj`, `/proj/./`, and `/proj/../proj` would all acquire distinct
+/// locks even though they alias to the same project on disk. Forcing
+/// every caller to thread the canonicalised result into
+/// [`kiro_market_core::project::KiroProject::new`] keeps the
+/// cross-call mutex coherent.
 pub(in crate::commands) fn validate_kiro_project_path(
     project_path: &str,
-) -> Result<(), CommandError> {
-    if project_path.is_empty() {
+) -> Result<std::path::PathBuf, CommandError> {
+    if project_path.trim().is_empty() {
         return Err(CommandError::new(
             "project_path must not be empty",
             ErrorType::Validation,
         ));
     }
-    let path = std::path::Path::new(project_path);
-    if !path.exists() {
+    let raw = std::path::Path::new(project_path);
+    let metadata = std::fs::symlink_metadata(raw).map_err(|e| {
+        CommandError::new(
+            format!("project_path `{project_path}` could not be read: {e}"),
+            ErrorType::Validation,
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
         return Err(CommandError::new(
-            format!("project_path `{project_path}` does not exist"),
+            format!("project_path `{project_path}` is a symlink (refused)"),
             ErrorType::Validation,
         ));
     }
-    if !path.join(".kiro").is_dir() {
+    let canonical = std::fs::canonicalize(raw).map_err(|e| {
+        CommandError::new(
+            format!("project_path `{project_path}` could not be canonicalized: {e}"),
+            ErrorType::Validation,
+        )
+    })?;
+    if !canonical.join(".kiro").is_dir() {
         return Err(CommandError::new(
             format!(
-                "project_path `{project_path}` is not a Kiro project \
-                 (missing `.kiro/` directory)"
+                "project_path `{}` is not a Kiro project (missing `.kiro/` directory)",
+                canonical.display()
             ),
             ErrorType::Validation,
         ));
     }
-    Ok(())
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    /// A real Kiro project directory must round-trip through the
+    /// validator and come back as a canonical absolute path.
+    #[test]
+    fn validate_kiro_project_path_succeeds_for_real_project_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join(".kiro")).expect("create .kiro");
+        let canonical = validate_kiro_project_path(dir.path().to_str().expect("utf-8"))
+            .expect("real project must validate");
+        assert!(
+            canonical.is_absolute(),
+            "validator must return an absolute path, got: {canonical:?}",
+        );
+        assert!(
+            canonical.join(".kiro").is_dir(),
+            ".kiro/ must be reachable under the returned canonical path",
+        );
+    }
+
+    /// Empty / whitespace-only strings short-circuit before any FS
+    /// access — the validator must not call `stat` on `""`.
+    #[test]
+    fn validate_kiro_project_path_rejects_empty_and_whitespace() {
+        for raw in ["", "   ", "\t"] {
+            let err = validate_kiro_project_path(raw).expect_err("must reject");
+            assert_eq!(err.error_type, ErrorType::Validation);
+        }
+    }
+
+    /// A top-level symlink — even one pointing at a valid Kiro project
+    /// — is refused. Defense-in-depth: the install layer's per-content
+    /// path checks don't see the project root itself, so we close that
+    /// gap at the IPC boundary.
+    #[cfg(unix)]
+    #[test]
+    fn validate_kiro_project_path_refuses_symlink_to_valid_kiro_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real");
+        fs::create_dir_all(real.join(".kiro")).expect("create real/.kiro");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("create symlink");
+
+        let err = validate_kiro_project_path(link.to_str().expect("utf-8"))
+            .expect_err("symlinked project root must be refused");
+        assert_eq!(err.error_type, ErrorType::Validation);
+        assert!(
+            err.message.contains("symlink"),
+            "error must mention symlink, got: {}",
+            err.message,
+        );
+    }
+
+    /// Three syntactically distinct paths that alias to the same
+    /// directory must canonicalize to a single `PathBuf`. Without this
+    /// guarantee, `with_file_lock` would acquire distinct keys for the
+    /// same project and the cross-call mutex would silently fail.
+    #[test]
+    fn validate_kiro_project_path_returns_canonical_path_normalizing_dot_segments() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join(".kiro")).expect("create .kiro");
+        let base = dir.path().to_str().expect("utf-8").to_owned();
+        let with_dot = format!("{base}/.");
+        // `<dir>/sub/..` resolves back to `<dir>` after canonicalization.
+        let sub = dir.path().join("sub");
+        fs::create_dir_all(&sub).expect("create sub");
+        let with_dotdot = format!("{base}/sub/..");
+
+        let a = validate_kiro_project_path(&base).expect("plain path");
+        let b = validate_kiro_project_path(&with_dot).expect("./ suffix");
+        let c = validate_kiro_project_path(&with_dotdot).expect("sub/.. round-trip");
+
+        assert_eq!(
+            a, b,
+            "trailing `.` must canonicalize to the same path: {a:?} vs {b:?}",
+        );
+        assert_eq!(
+            a, c,
+            "`sub/..` must canonicalize to the same path: {a:?} vs {c:?}",
+        );
+    }
+
+    /// Nonexistent path returns Validation (canonicalize fails on a
+    /// path the FS can't `stat`).
+    #[test]
+    fn validate_kiro_project_path_rejects_nonexistent_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bogus = dir.path().join("does-not-exist");
+        let err = validate_kiro_project_path(bogus.to_str().expect("utf-8"))
+            .expect_err("nonexistent path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// A real directory without `.kiro/` is rejected. Pins the
+    /// "missing .kiro" branch separately from the symlink and
+    /// nonexistent-path branches.
+    #[test]
+    fn validate_kiro_project_path_rejects_directory_without_kiro_subdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = validate_kiro_project_path(dir.path().to_str().expect("utf-8"))
+            .expect_err("missing .kiro/ must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+        assert!(
+            err.message.contains(".kiro"),
+            "error must mention .kiro/, got: {}",
+            err.message,
+        );
+    }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod browse;
 pub mod installed;
 pub mod kiro_settings;
 pub mod marketplaces;
+pub mod plugins;
 pub mod settings;
 pub mod steering;
 

--- a/crates/kiro-control-center/src-tauri/src/commands/mod.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod browse;
 pub mod installed;
 pub mod kiro_settings;

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -1,0 +1,520 @@
+//! Plugin-level commands for the Tauri frontend.
+//!
+//! Three commands live here:
+//!
+//! - [`install_plugin`] — orchestrator wrapper around
+//!   [`MarketplaceService::install_plugin`] (Task 1's core method). Carries
+//!   `accept_mcp: bool` per A-18 so the user's MCP opt-in flows through to
+//!   the agent install. Splits into `_impl(svc, ...)` per CLAUDE.md's
+//!   service-consuming-commands rule.
+//! - [`list_installed_plugins`] — aggregator wrapper around
+//!   [`KiroProject::installed_plugins`] (Task 2). No `_impl` per A-19; the
+//!   command operates on `KiroProject` only and follows the
+//!   [`crate::commands::installed::list_installed_skills`] precedent of
+//!   inlining the body in the wrapper.
+//! - [`remove_plugin`] — cascade wrapper around
+//!   [`KiroProject::remove_plugin`] (Task 3). No `_impl` per A-19; same
+//!   project-only-read shape as `list_installed_plugins`.
+
+use std::path::PathBuf;
+
+use kiro_market_core::project::{InstalledPluginInfo, KiroProject, RemovePluginResult};
+use kiro_market_core::service::{InstallMode, InstallPluginResult, MarketplaceService};
+
+use crate::commands::{make_service, validate_kiro_project_path};
+use crate::error::CommandError;
+
+/// Install every skill, steering file, and agent declared by a plugin
+/// into the active project's `.kiro/` tree in one call.
+///
+/// The wrapper exists only to construct a [`MarketplaceService`] from
+/// process globals and translate the FFI `force: bool` into an
+/// [`InstallMode`]; the install itself runs in [`install_plugin_impl`]
+/// so it can be tested without a Tauri runtime.
+///
+/// `accept_mcp` is the per-call MCP opt-in gate (A-18). The Phase 1
+/// frontend hardcodes `false` at the call site until a user-toggle UI
+/// lands; the parameter is plumbed through so a later PR can flip it
+/// without touching this signature.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_plugin(
+    marketplace: String,
+    plugin: String,
+    force: bool,
+    accept_mcp: bool,
+    project_path: String,
+) -> Result<InstallPluginResult, CommandError> {
+    let svc = make_service()?;
+    install_plugin_impl(
+        &svc,
+        &marketplace,
+        &plugin,
+        InstallMode::from(force),
+        accept_mcp,
+        &project_path,
+    )
+}
+
+fn install_plugin_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallPluginResult, CommandError> {
+    validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(PathBuf::from(project_path));
+    svc.install_plugin(&project, marketplace, plugin, mode, accept_mcp)
+        .map_err(CommandError::from)
+}
+
+/// List every installed plugin in the project, aggregated by
+/// `(marketplace, plugin)` pair across the three tracking files.
+///
+/// No `_impl` split (A-19): the body is inline in the wrapper because
+/// the command consumes `KiroProject` only — there's no
+/// `MarketplaceService` to thread through. Mirrors the existing
+/// [`crate::commands::installed::list_installed_skills`] shape; tests
+/// exercise the wrapper directly via `#[tokio::test]`.
+#[tauri::command]
+#[specta::specta]
+pub async fn list_installed_plugins(
+    project_path: String,
+) -> Result<Vec<InstalledPluginInfo>, CommandError> {
+    validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(PathBuf::from(&project_path));
+    project.installed_plugins().map_err(CommandError::from)
+}
+
+/// Remove every skill, steering file, and agent for a given
+/// `(marketplace, plugin)` pair from the project, returning per-content
+/// removal counts.
+///
+/// No `_impl` split (A-19): same rationale as
+/// [`list_installed_plugins`] above — `KiroProject`-only read/write,
+/// no service.
+#[tauri::command]
+#[specta::specta]
+pub async fn remove_plugin(
+    marketplace: String,
+    plugin: String,
+    project_path: String,
+) -> Result<RemovePluginResult, CommandError> {
+    validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(PathBuf::from(&project_path));
+    project
+        .remove_plugin(&marketplace, &plugin)
+        .map_err(CommandError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    //! `_impl`-level tests for [`install_plugin_impl`] plus wrapper-level
+    //! tests for [`list_installed_plugins`] and [`remove_plugin`] (A-19:
+    //! the latter two have no `_impl`, so the wrapper IS the unit). The
+    //! `#[tauri::command]` attribute on `install_plugin` is a thin serde
+    //! shim and is not re-exercised here; see `commands/browse.rs::tests`
+    //! for the canonical pattern.
+
+    use std::fs;
+
+    use kiro_market_core::project::KiroProject;
+    use kiro_market_core::service::test_support::{
+        make_kiro_project, make_plugin_with_skills, relative_path_entry,
+        seed_marketplace_with_registry, temp_service,
+    };
+
+    use crate::error::ErrorType;
+
+    use super::*;
+
+    /// Write a `plugin.json` carrying the given JSON body into a plugin
+    /// directory. Mirrors the inline helpers in `agents.rs::tests` and
+    /// `steering.rs::tests` but without forcing `format: kiro-cli`, so
+    /// the install resolves through the translated path (which is what
+    /// [`install_plugin_impl`] tests want for the happy path).
+    fn write_plugin_manifest(plugin_dir: &std::path::Path, body: &[u8]) {
+        fs::create_dir_all(plugin_dir).expect("plugin dir");
+        fs::write(plugin_dir.join("plugin.json"), body).expect("write plugin.json");
+    }
+
+    /// Write a steering markdown file under `<plugin_dir>/steering/`.
+    fn write_steering_file(plugin_dir: &std::path::Path, rel: &str, body: &str) {
+        let p = plugin_dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create steering parent");
+        }
+        fs::write(&p, body).expect("write steering file");
+    }
+
+    /// Write a translated-path agent file (markdown + YAML frontmatter).
+    /// Without the frontmatter fence the translated install path silently
+    /// skips the file — matches `agents.rs::tests::write_translated_agent_file`.
+    fn write_translated_agent_file(
+        plugin_dir: &std::path::Path,
+        rel: &str,
+        name: &str,
+        body: &str,
+    ) {
+        let p = plugin_dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create agent parent");
+        }
+        let content = format!("---\nname: {name}\ndescription: Test agent\n---\n{body}");
+        fs::write(&p, content).expect("write agent file");
+    }
+
+    // -----------------------------------------------------------------------
+    // install_plugin_impl
+    // -----------------------------------------------------------------------
+
+    /// Happy path: a plugin declaring one skill, one steering file, and
+    /// one translated agent must populate all three sub-results in one
+    /// orchestrator call. Without this, a regression that dropped (say)
+    /// the agent install branch from `MarketplaceService::install_plugin`
+    /// would survive the per-content tests in `browse.rs`, `steering.rs`,
+    /// and `agents.rs` because each of those only exercises one branch.
+    #[test]
+    fn install_plugin_impl_orchestrates_skills_steering_and_agents() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        // No `plugin.json` => translated path with default scan roots
+        // for both steering and agents.
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        write_steering_file(&plugin_dir, "steering/guide.md", "# guide\n");
+        write_translated_agent_file(
+            &plugin_dir,
+            "agents/reviewer.md",
+            "reviewer",
+            "You are a reviewer.\n",
+        );
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_plugin_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("happy path");
+
+        assert_eq!(result.plugin, "myplugin");
+        assert_eq!(
+            result.skills.installed,
+            vec!["alpha".to_string()],
+            "skills sub-result must populate, got: {:?}",
+            result.skills,
+        );
+        assert!(
+            result.skills.failed.is_empty(),
+            "no skill failures expected: {:?}",
+            result.skills.failed
+        );
+        assert_eq!(
+            result.steering.installed.len(),
+            1,
+            "steering sub-result must populate, got: {:?}",
+            result.steering,
+        );
+        assert!(
+            result.steering.failed.is_empty(),
+            "no steering failures expected: {:?}",
+            result.steering.failed
+        );
+        assert_eq!(
+            result.agents.installed,
+            vec!["reviewer".to_string()],
+            "agents sub-result must populate, got: {:?}",
+            result.agents,
+        );
+        assert!(
+            result.agents.failed.is_empty(),
+            "no agent failures expected: {:?}",
+            result.agents.failed
+        );
+
+        let project_root = std::path::PathBuf::from(&project_path);
+        assert!(
+            project_root.join(".kiro/skills/alpha/SKILL.md").exists(),
+            "skill must land under .kiro/skills/"
+        );
+        assert!(
+            project_root.join(".kiro/steering/guide.md").exists(),
+            "steering must land under .kiro/steering/"
+        );
+        assert!(
+            project_root.join(".kiro/agents/reviewer.json").exists(),
+            "agent must land under .kiro/agents/"
+        );
+    }
+
+    /// Plugin manifest with `version: "4.5.6"` must thread through
+    /// `install_plugin`'s shared `ctx.version` into all three sub-results'
+    /// tracking entries. Without this, a regression that hardcoded
+    /// `version: None` on (say) the steering branch — while skills and
+    /// agents still wrote the version — would be invisible: each
+    /// per-content test only checks one branch.
+    #[test]
+    fn install_plugin_impl_threads_version_through_all_three_branches() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        write_plugin_manifest(&plugin_dir, br#"{"name": "myplugin", "version": "4.5.6"}"#);
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        write_steering_file(&plugin_dir, "steering/guide.md", "# guide\n");
+        write_translated_agent_file(&plugin_dir, "agents/reviewer.md", "reviewer", "Body.\n");
+        let project_path = make_kiro_project(dir.path());
+
+        let result = install_plugin_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("install with manifest version");
+
+        assert_eq!(result.version.as_deref(), Some("4.5.6"));
+
+        let project = KiroProject::new(std::path::PathBuf::from(&project_path));
+        let installed_skills = project.load_installed().expect("load installed skills");
+        assert_eq!(
+            installed_skills
+                .skills
+                .get("alpha")
+                .and_then(|m| m.version.as_deref()),
+            Some("4.5.6"),
+            "skills tracking must carry the manifest version"
+        );
+
+        let steering = project.load_installed_steering().expect("load steering");
+        assert_eq!(
+            steering
+                .files
+                .get(std::path::Path::new("guide.md"))
+                .and_then(|m| m.version.as_deref()),
+            Some("4.5.6"),
+            "steering tracking must carry the manifest version"
+        );
+
+        let agents = project.load_installed_agents().expect("load agents");
+        assert_eq!(
+            agents
+                .agents
+                .get("reviewer")
+                .and_then(|m| m.version.as_deref()),
+            Some("4.5.6"),
+            "agents tracking must carry the manifest version"
+        );
+    }
+
+    /// Unknown plugin must surface as `ErrorType::NotFound` from the
+    /// preamble (`resolve_plugin_install_context` inside
+    /// `MarketplaceService::install_plugin`). Mirrors the same assertion
+    /// in `steering.rs::tests` and `agents.rs::tests`.
+    #[test]
+    fn install_plugin_impl_returns_not_found_for_unknown_plugin() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("real-plugin", "plugins/real-plugin")];
+        let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let project_path = make_kiro_project(dir.path());
+
+        let err = install_plugin_impl(
+            &svc,
+            "mp1",
+            "does-not-exist",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("unknown plugin must error");
+
+        assert_eq!(err.error_type, ErrorType::NotFound);
+    }
+
+    /// `KiroProject::new` is infallible, so `install_plugin_impl` must
+    /// fail-fast on an empty `project_path` before the orchestrator
+    /// starts writing under `./.kiro/`. Pins the
+    /// `validate_kiro_project_path` call.
+    #[test]
+    fn install_plugin_impl_empty_project_path_returns_validation() {
+        let (_dir, svc) = temp_service();
+        let err = install_plugin_impl(&svc, "mp1", "myplugin", InstallMode::New, false, "")
+            .expect_err("empty project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+        assert!(
+            err.message.contains("project_path"),
+            "error message must name the offending field, got: {}",
+            err.message
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // list_installed_plugins
+    // -----------------------------------------------------------------------
+
+    /// A fresh `.kiro/` project with no installs returns an empty vec
+    /// (not an error). The aggregator must tolerate missing tracking
+    /// files via the underlying `load_installed*` methods' "treat absent
+    /// as empty" behavior.
+    #[tokio::test]
+    async fn list_installed_plugins_empty_for_fresh_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+
+        let plugins = list_installed_plugins(project_path)
+            .await
+            .expect("aggregator on fresh project");
+
+        assert!(
+            plugins.is_empty(),
+            "fresh project must aggregate to an empty list, got: {plugins:?}"
+        );
+    }
+
+    /// After [`install_plugin_impl`] seeds all three content types,
+    /// `list_installed_plugins` must surface a single
+    /// `(marketplace, plugin)` row whose counts reflect the install.
+    /// Locks the aggregator's grouping contract end-to-end through the
+    /// Tauri command boundary.
+    #[tokio::test]
+    async fn list_installed_plugins_aggregates_counts_after_install() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        write_steering_file(&plugin_dir, "steering/guide.md", "# guide\n");
+        write_translated_agent_file(&plugin_dir, "agents/reviewer.md", "reviewer", "Body.\n");
+        let project_path = make_kiro_project(dir.path());
+
+        install_plugin_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("seed via install_plugin_impl");
+
+        let plugins = list_installed_plugins(project_path)
+            .await
+            .expect("aggregator after install");
+
+        assert_eq!(
+            plugins.len(),
+            1,
+            "expected one plugin row, got: {plugins:?}"
+        );
+        let row = &plugins[0];
+        assert_eq!(row.marketplace, "mp1");
+        assert_eq!(row.plugin, "myplugin");
+        assert_eq!(row.skill_count, 1);
+        assert_eq!(row.steering_count, 1);
+        assert_eq!(row.agent_count, 1);
+        assert_eq!(row.installed_skills, vec!["alpha".to_string()]);
+        assert_eq!(row.installed_agents, vec!["reviewer".to_string()]);
+    }
+
+    /// An empty `project_path` must surface as `ErrorType::Validation`,
+    /// same as the install command. Without this, a frontend default-
+    /// constructed empty string would silently land at `./.kiro/...`
+    /// relative to the Tauri process cwd.
+    #[tokio::test]
+    async fn list_installed_plugins_empty_project_path_returns_validation() {
+        let err = list_installed_plugins(String::new())
+            .await
+            .expect_err("empty project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_plugin
+    // -----------------------------------------------------------------------
+
+    /// Removing a `(marketplace, plugin)` pair that was never installed
+    /// returns zeroed counts (not an error). The cascade's
+    /// "filter-then-remove" shape naturally produces zeros when no
+    /// tracking entries match.
+    #[tokio::test]
+    async fn remove_plugin_returns_zeros_for_nonexistent_pair() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+
+        let counts = remove_plugin(
+            "mp-absent".to_string(),
+            "plugin-absent".to_string(),
+            project_path,
+        )
+        .await
+        .expect("remove on empty project must succeed");
+
+        assert_eq!(counts.skills_removed, 0);
+        assert_eq!(counts.steering_removed, 0);
+        assert_eq!(counts.agents_removed, 0);
+    }
+
+    /// After [`install_plugin_impl`] seeds all three content types,
+    /// `remove_plugin` must report counts matching what was installed
+    /// AND the tracking files must reflect the removal.
+    #[tokio::test]
+    async fn remove_plugin_returns_expected_counts_after_install() {
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("myplugin", "plugins/myplugin")];
+        let marketplace_path = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
+        let plugin_dir = marketplace_path.join("plugins/myplugin");
+        make_plugin_with_skills(&marketplace_path, "myplugin", &["alpha"]);
+        write_steering_file(&plugin_dir, "steering/guide.md", "# guide\n");
+        write_translated_agent_file(&plugin_dir, "agents/reviewer.md", "reviewer", "Body.\n");
+        let project_path = make_kiro_project(dir.path());
+
+        install_plugin_impl(
+            &svc,
+            "mp1",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect("seed via install_plugin_impl");
+
+        let counts = remove_plugin(
+            "mp1".to_string(),
+            "myplugin".to_string(),
+            project_path.clone(),
+        )
+        .await
+        .expect("cascade remove");
+
+        assert_eq!(counts.skills_removed, 1);
+        assert_eq!(counts.steering_removed, 1);
+        assert_eq!(counts.agents_removed, 1);
+
+        let plugins_after = list_installed_plugins(project_path)
+            .await
+            .expect("aggregator after remove");
+        assert!(
+            plugins_after.is_empty(),
+            "all tracking entries must be gone after remove_plugin, got: {plugins_after:?}"
+        );
+    }
+
+    /// An empty `project_path` must surface as `ErrorType::Validation`,
+    /// same as the install / list commands.
+    #[tokio::test]
+    async fn remove_plugin_empty_project_path_returns_validation() {
+        let err = remove_plugin("mp1".to_string(), "myplugin".to_string(), String::new())
+            .await
+            .expect_err("empty project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+}

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -16,10 +16,9 @@
 //!   [`KiroProject::remove_plugin`] (Task 3). No `_impl` per A-19; same
 //!   project-only-read shape as `list_installed_plugins`.
 
-use std::path::PathBuf;
-
 use kiro_market_core::project::{InstalledPluginsView, KiroProject, RemovePluginResult};
 use kiro_market_core::service::{InstallMode, InstallPluginResult, MarketplaceService};
+use kiro_market_core::validation::validate_name;
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -64,8 +63,10 @@ fn install_plugin_impl(
     accept_mcp: bool,
     project_path: &str,
 ) -> Result<InstallPluginResult, CommandError> {
-    validate_kiro_project_path(project_path)?;
-    let project = KiroProject::new(PathBuf::from(project_path));
+    validate_name(marketplace)?;
+    validate_name(plugin)?;
+    let project_root = validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(project_root);
     svc.install_plugin(&project, marketplace, plugin, mode, accept_mcp)
         .map_err(CommandError::from)
 }
@@ -83,8 +84,8 @@ fn install_plugin_impl(
 pub async fn list_installed_plugins(
     project_path: String,
 ) -> Result<InstalledPluginsView, CommandError> {
-    validate_kiro_project_path(&project_path)?;
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(project_root);
     project.installed_plugins().map_err(CommandError::from)
 }
 
@@ -102,8 +103,10 @@ pub async fn remove_plugin(
     plugin: String,
     project_path: String,
 ) -> Result<RemovePluginResult, CommandError> {
-    validate_kiro_project_path(&project_path)?;
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    validate_name(&marketplace)?;
+    validate_name(&plugin)?;
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let project = KiroProject::new(project_root);
     project
         .remove_plugin(&marketplace, &plugin)
         .map_err(CommandError::from)
@@ -355,6 +358,46 @@ mod tests {
             "error message must name the offending field, got: {}",
             err.message
         );
+    }
+
+    // FE-supplied `marketplace = "../etc/passwd"` would otherwise reach
+    // `cache::marketplace_path(marketplace)` and force an FS access at
+    // `<registries_dir>/../etc/passwd` before the registry layer's own
+    // checks fire. The IPC-boundary `validate_name` guard rejects it
+    // before the service ever runs.
+    #[test]
+    fn install_plugin_impl_rejects_traversal_in_marketplace() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_impl(
+            &svc,
+            "../etc/passwd",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// NUL bytes truncate C-string conversions in syscalls; the
+    /// IPC-boundary `validate_name` guard must reject them before they
+    /// reach `cache::plugin_registry_path`.
+    #[test]
+    fn install_plugin_impl_rejects_nul_byte_in_plugin() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_impl(
+            &svc,
+            "mp1",
+            "evil\0plugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("NUL byte in plugin name must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -18,7 +18,7 @@
 
 use std::path::PathBuf;
 
-use kiro_market_core::project::{InstalledPluginInfo, KiroProject, RemovePluginResult};
+use kiro_market_core::project::{InstalledPluginsView, KiroProject, RemovePluginResult};
 use kiro_market_core::service::{InstallMode, InstallPluginResult, MarketplaceService};
 
 use crate::commands::{make_service, validate_kiro_project_path};
@@ -82,7 +82,7 @@ fn install_plugin_impl(
 #[specta::specta]
 pub async fn list_installed_plugins(
     project_path: String,
-) -> Result<Vec<InstalledPluginInfo>, CommandError> {
+) -> Result<InstalledPluginsView, CommandError> {
     validate_kiro_project_path(&project_path)?;
     let project = KiroProject::new(PathBuf::from(&project_path));
     project.installed_plugins().map_err(CommandError::from)
@@ -370,13 +370,18 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let project_path = make_kiro_project(dir.path());
 
-        let plugins = list_installed_plugins(project_path)
+        let view = list_installed_plugins(project_path)
             .await
             .expect("aggregator on fresh project");
 
         assert!(
-            plugins.is_empty(),
-            "fresh project must aggregate to an empty list, got: {plugins:?}"
+            view.plugins.is_empty(),
+            "fresh project must aggregate to an empty list, got: {view:?}"
+        );
+        assert!(
+            view.partial_load_warnings.is_empty(),
+            "fresh project: no warnings expected, got: {:?}",
+            view.partial_load_warnings
         );
     }
 
@@ -406,16 +411,16 @@ mod tests {
         )
         .expect("seed via install_plugin_impl");
 
-        let plugins = list_installed_plugins(project_path)
+        let view = list_installed_plugins(project_path)
             .await
             .expect("aggregator after install");
 
         assert_eq!(
-            plugins.len(),
+            view.plugins.len(),
             1,
-            "expected one plugin row, got: {plugins:?}"
+            "expected one plugin row, got: {view:?}"
         );
-        let row = &plugins[0];
+        let row = &view.plugins[0];
         assert_eq!(row.marketplace, "mp1");
         assert_eq!(row.plugin, "myplugin");
         assert_eq!(row.skill_count, 1);
@@ -423,6 +428,7 @@ mod tests {
         assert_eq!(row.agent_count, 1);
         assert_eq!(row.installed_skills, vec!["alpha".to_string()]);
         assert_eq!(row.installed_agents, vec!["reviewer".to_string()]);
+        assert!(view.partial_load_warnings.is_empty());
     }
 
     /// An empty `project_path` must surface as `ErrorType::Validation`,
@@ -499,12 +505,12 @@ mod tests {
         assert_eq!(counts.steering_removed, 1);
         assert_eq!(counts.agents_removed, 1);
 
-        let plugins_after = list_installed_plugins(project_path)
+        let view_after = list_installed_plugins(project_path)
             .await
             .expect("aggregator after remove");
         assert!(
-            plugins_after.is_empty(),
-            "all tracking entries must be gone after remove_plugin, got: {plugins_after:?}"
+            view_after.plugins.is_empty(),
+            "all tracking entries must be gone after remove_plugin, got: {view_after:?}"
         );
     }
 

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -78,18 +78,12 @@ mod tests {
     use std::fs;
 
     use kiro_market_core::service::test_support::{
-        relative_path_entry, seed_marketplace_with_registry, temp_service,
+        make_kiro_project, relative_path_entry, seed_marketplace_with_registry, temp_service,
     };
 
     use crate::error::ErrorType;
 
     use super::*;
-
-    fn make_kiro_project(dir: &std::path::Path) -> String {
-        let project_path = dir.join("kproj");
-        fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
-        project_path.to_str().expect("utf-8 path").to_owned()
-    }
 
     fn write_steering_file(plugin_dir: &std::path::Path, rel: &str, body: &str) {
         let p = plugin_dir.join(rel);

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -6,11 +6,10 @@
 //! is unit-testable against [`kiro_market_core::service::test_support`]
 //! fixtures without a Tauri runtime.
 
-use std::path::PathBuf;
-
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{InstallMode, MarketplaceService};
 use kiro_market_core::steering::{InstallSteeringResult, SteeringInstallContext};
+use kiro_market_core::validation::validate_name;
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -48,11 +47,13 @@ fn install_plugin_steering_impl(
     mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSteeringResult, CommandError> {
-    validate_kiro_project_path(project_path)?;
+    validate_name(marketplace)?;
+    validate_name(plugin)?;
+    let project_root = validate_kiro_project_path(project_path)?;
     let ctx = svc
         .resolve_plugin_install_context(marketplace, plugin)
         .map_err(CommandError::from)?;
-    let project = KiroProject::new(PathBuf::from(project_path));
+    let project = KiroProject::new(project_root);
 
     let install_ctx = SteeringInstallContext {
         mode,

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -1,5 +1,6 @@
 use kiro_market_core::error::{
     error_full_chain, Error as CoreError, MarketplaceError, PluginError, SkillError,
+    ValidationError,
 };
 use serde::Serialize;
 use tracing::warn;
@@ -106,6 +107,17 @@ impl From<String> for CommandError {
             message,
             error_type: ErrorType::Unknown,
         }
+    }
+}
+
+/// Map `ValidationError` straight to a `CommandError` so IPC-boundary
+/// guards (`validate_name`, `validate_relative_path`, ...) can use `?`
+/// without a manual `CoreError::from(...).into()` hop. Equivalent to
+/// `CommandError::from(CoreError::Validation(err))` but avoids the
+/// indirection at every call site.
+impl From<ValidationError> for CommandError {
+    fn from(err: ValidationError) -> Self {
+        Self::from(CoreError::from(err))
     }
 }
 

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::kiro_settings::set_kiro_setting,
         commands::kiro_settings::reset_kiro_setting,
         commands::steering::install_plugin_steering,
+        commands::agents::install_plugin_agents,
     ])
 }
 

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -35,6 +35,9 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::kiro_settings::reset_kiro_setting,
         commands::steering::install_plugin_steering,
         commands::agents::install_plugin_agents,
+        commands::plugins::install_plugin,
+        commands::plugins::list_installed_plugins,
+        commands::plugins::remove_plugin,
     ])
 }
 

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -106,6 +106,42 @@ export const commands = {
 	 *  runtime.
 	 */
 	installPluginAgents: (marketplace: string, plugin: string, force: boolean, acceptMcp: boolean, projectPath: string) => typedError<InstallAgentsResult_Serialize, CommandError>(__TAURI_INVOKE("install_plugin_agents", { marketplace, plugin, force, acceptMcp, projectPath })),
+	/**
+	 *  Install every skill, steering file, and agent declared by a plugin
+	 *  into the active project's `.kiro/` tree in one call.
+	 * 
+	 *  The wrapper exists only to construct a [`MarketplaceService`] from
+	 *  process globals and translate the FFI `force: bool` into an
+	 *  [`InstallMode`]; the install itself runs in [`install_plugin_impl`]
+	 *  so it can be tested without a Tauri runtime.
+	 * 
+	 *  `accept_mcp` is the per-call MCP opt-in gate (A-18). The Phase 1
+	 *  frontend hardcodes `false` at the call site until a user-toggle UI
+	 *  lands; the parameter is plumbed through so a later PR can flip it
+	 *  without touching this signature.
+	 */
+	installPlugin: (marketplace: string, plugin: string, force: boolean, acceptMcp: boolean, projectPath: string) => typedError<InstallPluginResult_Serialize, CommandError>(__TAURI_INVOKE("install_plugin", { marketplace, plugin, force, acceptMcp, projectPath })),
+	/**
+	 *  List every installed plugin in the project, aggregated by
+	 *  `(marketplace, plugin)` pair across the three tracking files.
+	 * 
+	 *  No `_impl` split (A-19): the body is inline in the wrapper because
+	 *  the command consumes `KiroProject` only — there's no
+	 *  `MarketplaceService` to thread through. Mirrors the existing
+	 *  [`crate::commands::installed::list_installed_skills`] shape; tests
+	 *  exercise the wrapper directly via `#[tokio::test]`.
+	 */
+	listInstalledPlugins: (projectPath: string) => typedError<InstalledPluginInfo[], CommandError>(__TAURI_INVOKE("list_installed_plugins", { projectPath })),
+	/**
+	 *  Remove every skill, steering file, and agent for a given
+	 *  `(marketplace, plugin)` pair from the project, returning per-content
+	 *  removal counts.
+	 * 
+	 *  No `_impl` split (A-19): same rationale as
+	 *  [`list_installed_plugins`] above — `KiroProject`-only read/write,
+	 *  no service.
+	 */
+	removePlugin: (marketplace: string, plugin: string, projectPath: string) => typedError<RemovePluginResult, CommandError>(__TAURI_INVOKE("remove_plugin", { marketplace, plugin, projectPath })),
 };
 
 /* Types */
@@ -460,6 +496,63 @@ export type InstallOutcomeKind =
  */
 "force_overwrote";
 
+/**
+ *  Aggregate result of [`MarketplaceService::install_plugin`] — the
+ *  outcome of running every install path a plugin declares (skills,
+ *  steering, agents) in one coordinated call.
+ * 
+ *  Sub-results are always populated. The underlying scan-path
+ *  fallbacks (`agent_scan_paths_for_plugin` /
+ *  `steering_scan_paths_for_plugin`) guarantee at least one attempt;
+ *  `install_skills` returns a fully-formed default for empty input.
+ *  Empty `installed` / `failed` vecs on a sub-result indicate "this
+ *  content type was attempted with nothing to do" — distinct from a
+ *  missing field.
+ */
+export type InstallPluginResult = InstallPluginResult_Serialize | InstallPluginResult_Deserialize;
+
+/**
+ *  Aggregate result of [`MarketplaceService::install_plugin`] — the
+ *  outcome of running every install path a plugin declares (skills,
+ *  steering, agents) in one coordinated call.
+ * 
+ *  Sub-results are always populated. The underlying scan-path
+ *  fallbacks (`agent_scan_paths_for_plugin` /
+ *  `steering_scan_paths_for_plugin`) guarantee at least one attempt;
+ *  `install_skills` returns a fully-formed default for empty input.
+ *  Empty `installed` / `failed` vecs on a sub-result indicate "this
+ *  content type was attempted with nothing to do" — distinct from a
+ *  missing field.
+ */
+export type InstallPluginResult_Deserialize = {
+	plugin: string,
+	version: string | null,
+	skills: InstallSkillsResult,
+	steering: InstallSteeringResult_Deserialize,
+	agents: InstallAgentsResult_Deserialize,
+};
+
+/**
+ *  Aggregate result of [`MarketplaceService::install_plugin`] — the
+ *  outcome of running every install path a plugin declares (skills,
+ *  steering, agents) in one coordinated call.
+ * 
+ *  Sub-results are always populated. The underlying scan-path
+ *  fallbacks (`agent_scan_paths_for_plugin` /
+ *  `steering_scan_paths_for_plugin`) guarantee at least one attempt;
+ *  `install_skills` returns a fully-formed default for empty input.
+ *  Empty `installed` / `failed` vecs on a sub-result indicate "this
+ *  content type was attempted with nothing to do" — distinct from a
+ *  missing field.
+ */
+export type InstallPluginResult_Serialize = {
+	plugin: string,
+	version: string | null,
+	skills: InstallSkillsResult,
+	steering: InstallSteeringResult_Serialize,
+	agents: InstallAgentsResult_Serialize,
+};
+
 // Outcome of installing a list of skill directories from one plugin.
 export type InstallSkillsResult = {
 	// Skill names successfully installed.
@@ -560,6 +653,39 @@ export type InstalledNativeCompanionsOutcome = {
 	kind: InstallOutcomeKind,
 	source_hash: string,
 	installed_hash: string,
+};
+
+/**
+ *  Aggregated view of a single installed plugin — the union of
+ *  what's tracked across `installed-skills.json`,
+ *  `installed-steering.json`, and `installed-agents.json` for a
+ *  given `(marketplace, plugin)` pair.
+ * 
+ *  Returned by [`KiroProject::installed_plugins`]. The frontend
+ *  renders one row per `InstalledPluginInfo`.
+ * 
+ *  `installed_version` is the version of the **most recent install**
+ *  by `installed_at` timestamp — not a lexicographic max. See A-6
+ *  in the plan amendments doc for why string-compare is wrong here.
+ * 
+ *  `earliest_install` and `latest_install` are RFC3339-formatted
+ *  strings to match the FFI shape used by `InstalledSkillInfo`
+ *  (specta's chrono feature isn't enabled in this crate).
+ */
+export type InstalledPluginInfo = {
+	marketplace: string,
+	plugin: string,
+	installed_version: string | null,
+	skill_count: number,
+	steering_count: number,
+	agent_count: number,
+	installed_skills: string[],
+	installed_steering: string[],
+	installed_agents: string[],
+	// RFC3339-formatted timestamp.
+	earliest_install: string,
+	// RFC3339-formatted timestamp.
+	latest_install: string,
 };
 
 // Information about a single installed skill.
@@ -731,6 +857,26 @@ export type ProjectInfo = {
  *  rejects traversal at parse time.
  */
 export type RelativePath = string;
+
+/**
+ *  Aggregated counts returned by
+ *  [`KiroProject::remove_plugin`] — one tally per content type so the
+ *  caller (CLI / Tauri) can render a one-line "removed N skills,
+ *  M steering files, K agents" summary without re-reading the tracking
+ *  files.
+ * 
+ *  Counts are post-cascade and include orphan-tracking recoveries
+ *  (A-12): a tracking entry with no on-disk file still counts as
+ *  "removed" because the cascade dropped the entry. The cascade
+ *  never partially succeeds — either every entry is removed and the
+ *  counts reflect the full work, or an error short-circuits before
+ *  the result returns.
+ */
+export type RemovePluginResult = {
+	skills_removed: number,
+	steering_removed: number,
+	agents_removed: number,
+};
 
 // Top-level category for a Kiro CLI setting.
 export type SettingCategory = "telemetry" | "chat" | "knowledge" | "key_bindings" | "features" | "api" | "mcp" | "environment";

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -95,6 +95,17 @@ export const commands = {
 	 *  runtime.
 	 */
 	installPluginSteering: (marketplace: string, plugin: string, force: boolean, projectPath: string) => typedError<InstallSteeringResult_Serialize, CommandError>(__TAURI_INVOKE("install_plugin_steering", { marketplace, plugin, force, projectPath })),
+	/**
+	 *  Install every agent declared by a plugin into the active project's
+	 *  `.kiro/agents/` directory.
+	 * 
+	 *  The wrapper exists only to construct a [`MarketplaceService`] from
+	 *  process globals and translate the FFI `force: bool` into an
+	 *  [`InstallMode`]; the install itself runs in
+	 *  [`install_plugin_agents_impl`] so it can be tested without a Tauri
+	 *  runtime.
+	 */
+	installPluginAgents: (marketplace: string, plugin: string, force: boolean, acceptMcp: boolean, projectPath: string) => typedError<InstallAgentsResult_Serialize, CommandError>(__TAURI_INVOKE("install_plugin_agents", { marketplace, plugin, force, acceptMcp, projectPath })),
 };
 
 /* Types */
@@ -146,6 +157,57 @@ export type DiscoveredProject = {
  *  unmapped-but-mundane errors.
  */
 export type ErrorType = "not_found" | "already_exists" | "validation" | "git_error" | "io_error" | "parse_error" | "internal" | "unknown";
+
+/**
+ *  An agent that failed to install, with the typed error.
+ * 
+ *  `name` is `Some` once parsing has identified the agent; pre-parse
+ *  failures use `source_path` as the fallback identifier. `error` is the
+ *  typed [`AgentError`] so frontends can branch on cause without
+ *  substring-matching the rendered message; a custom `Serialize` impl
+ *  projects it to the chain string for the wire format.
+ */
+export type FailedAgent = FailedAgent_Serialize | FailedAgent_Deserialize;
+
+/**
+ *  An agent that failed to install, with the typed error.
+ * 
+ *  `name` is `Some` once parsing has identified the agent; pre-parse
+ *  failures use `source_path` as the fallback identifier. `error` is the
+ *  typed [`AgentError`] so frontends can branch on cause without
+ *  substring-matching the rendered message; a custom `Serialize` impl
+ *  projects it to the chain string for the wire format.
+ */
+export type FailedAgent_Deserialize = {
+	name: string | null,
+	source_path: string,
+	/**
+	 *  Typed error. `Serialize` renders it as a string via
+	 *  [`crate::error::error_full_chain`] so the wire shape stays string;
+	 *  in-process consumers can match on the typed variants directly.
+	 */
+	error: string,
+};
+
+/**
+ *  An agent that failed to install, with the typed error.
+ * 
+ *  `name` is `Some` once parsing has identified the agent; pre-parse
+ *  failures use `source_path` as the fallback identifier. `error` is the
+ *  typed [`AgentError`] so frontends can branch on cause without
+ *  substring-matching the rendered message; a custom `Serialize` impl
+ *  projects it to the chain string for the wire format.
+ */
+export type FailedAgent_Serialize = {
+	name: string | null,
+	source_path: string,
+	/**
+	 *  Typed error. `Serialize` renders it as a string via
+	 *  [`crate::error::error_full_chain`] so the wire shape stays string;
+	 *  in-process consumers can match on the typed variants directly.
+	 */
+	error: string,
+};
 
 /**
  *  A skill that failed to install, with the reason.
@@ -272,6 +334,112 @@ export type GitProtocol =
 "ssh";
 
 /**
+ *  Outcome of installing the agents from one plugin.
+ * 
+ *  Mirrors [`InstallSkillsResult`]: per-agent successes and failures are
+ *  collected so a single broken agent never aborts the rest of the batch,
+ *  and accumulated warnings always reach the caller even when some agents
+ *  fail.
+ */
+export type InstallAgentsResult = InstallAgentsResult_Serialize | InstallAgentsResult_Deserialize;
+
+/**
+ *  Outcome of installing the agents from one plugin.
+ * 
+ *  Mirrors [`InstallSkillsResult`]: per-agent successes and failures are
+ *  collected so a single broken agent never aborts the rest of the batch,
+ *  and accumulated warnings always reach the caller even when some agents
+ *  fail.
+ */
+export type InstallAgentsResult_Deserialize = {
+	/**
+	 *  Agent names successfully installed (both translated and native paths
+	 *  populate this). Native idempotent reinstalls go to `skipped`.
+	 */
+	installed: string[],
+	/**
+	 *  Agent names that were already installed and left untouched.
+	 *  Native paths populate this for idempotent reinstalls
+	 *  (`kind == InstallOutcomeKind::Idempotent`).
+	 */
+	skipped: string[],
+	// Agents whose install attempt failed (parse, validation, or fs error).
+	failed: FailedAgent_Deserialize[],
+	/**
+	 *  Non-fatal issues (unmapped tools, skipped non-agent files,
+	 *  MCP-gated agents).
+	 */
+	warnings: InstallWarning[],
+	/**
+	 *  Per-native-agent rich outcome (`kind`, hashes). Empty for
+	 *  translated-only installs. Frontends that want the rich detail
+	 *  consume this; legacy presenters keep using `installed: Vec<String>`.
+	 * 
+	 *  `serde` `default` is kept for round-trip parsing of legacy JSON
+	 *  blobs that omit the field. `skip_serializing_if` was removed so
+	 *  the type can flow through Tauri/Specta bindings — `tauri-specta`
+	 *  2.0.0-rc.24's unified mode rejects conditional field omission.
+	 *  Mirrors [`InstallSkillsResult`] and [`crate::steering::InstallSteeringResult`],
+	 *  neither of which use `skip_serializing_if` either.
+	 */
+	installed_native?: InstalledNativeAgentOutcome[],
+	/**
+	 *  Per-plugin native companion bundle outcome. `None` for translated
+	 *  plugins or for native plugins with zero companion files. See
+	 *  [`Self::installed_native`] for why `skip_serializing_if` is absent.
+	 */
+	installed_companions?: InstalledNativeCompanionsOutcome | null,
+};
+
+/**
+ *  Outcome of installing the agents from one plugin.
+ * 
+ *  Mirrors [`InstallSkillsResult`]: per-agent successes and failures are
+ *  collected so a single broken agent never aborts the rest of the batch,
+ *  and accumulated warnings always reach the caller even when some agents
+ *  fail.
+ */
+export type InstallAgentsResult_Serialize = {
+	/**
+	 *  Agent names successfully installed (both translated and native paths
+	 *  populate this). Native idempotent reinstalls go to `skipped`.
+	 */
+	installed: string[],
+	/**
+	 *  Agent names that were already installed and left untouched.
+	 *  Native paths populate this for idempotent reinstalls
+	 *  (`kind == InstallOutcomeKind::Idempotent`).
+	 */
+	skipped: string[],
+	// Agents whose install attempt failed (parse, validation, or fs error).
+	failed: FailedAgent_Serialize[],
+	/**
+	 *  Non-fatal issues (unmapped tools, skipped non-agent files,
+	 *  MCP-gated agents).
+	 */
+	warnings: InstallWarning[],
+	/**
+	 *  Per-native-agent rich outcome (`kind`, hashes). Empty for
+	 *  translated-only installs. Frontends that want the rich detail
+	 *  consume this; legacy presenters keep using `installed: Vec<String>`.
+	 * 
+	 *  `serde` `default` is kept for round-trip parsing of legacy JSON
+	 *  blobs that omit the field. `skip_serializing_if` was removed so
+	 *  the type can flow through Tauri/Specta bindings — `tauri-specta`
+	 *  2.0.0-rc.24's unified mode rejects conditional field omission.
+	 *  Mirrors [`InstallSkillsResult`] and [`crate::steering::InstallSteeringResult`],
+	 *  neither of which use `skip_serializing_if` either.
+	 */
+	installed_native: InstalledNativeAgentOutcome[],
+	/**
+	 *  Per-plugin native companion bundle outcome. `None` for translated
+	 *  plugins or for native plugins with zero companion files. See
+	 *  [`Self::installed_native`] for why `skip_serializing_if` is absent.
+	 */
+	installed_companions: InstalledNativeCompanionsOutcome | null,
+};
+
+/**
  *  What happened during one native install call. Three states are
  *  distinct variants rather than a `(was_idempotent: bool,
  *  forced_overwrite: bool)` pair so that the contradictory
@@ -329,6 +497,69 @@ export type InstallSteeringResult_Serialize = {
 	installed: InstalledSteeringOutcome[],
 	failed: FailedSteeringFile_Serialize[],
 	warnings: SteeringWarning[],
+};
+
+/**
+ *  Non-fatal issue produced during install. Surfaced in install results
+ *  so the CLI / Tauri frontend can render them without blocking the install.
+ * 
+ *  Carries structured reason enums (not pre-rendered strings) so consumers
+ *  can switch on them — the CLI formats for a human, the Tauri frontend
+ *  can localize or map to its own UI states.
+ * 
+ *  Wire format: internally tagged on `kind` (`snake_case` discriminant) to
+ *  match the workspace convention for FFI-crossing enums (`SteeringWarning`,
+ *  `SkippedReason`, `FailedSkillReason`, `ParseFailure`). Enforced by the
+ *  `ffi-enum-serde-tag` plan-lint gate.
+ */
+export type InstallWarning = 
+/**
+ *  A source-declared tool had no Kiro equivalent and was dropped.
+ *  The emitted agent will inherit the full parent toolset for that slot.
+ */
+{ kind: "unmapped_tool"; agent: string; tool: string; reason: UnmappedReason } | 
+// An agent file could not be parsed; it was skipped.
+{ kind: "agent_parse_failed"; path: string; failure: ParseFailure } | 
+/**
+ *  An agent declares MCP servers but the install was not opted in
+ *  to MCP. The agent was skipped — its prompt would otherwise
+ *  install with a `mcpServers` block that runs subprocesses or
+ *  opens network connections without the user's explicit consent.
+ *  Listed transports help the user see the risk surface (e.g.
+ *  `["stdio", "stdio", "http"]`) before they re-run with the
+ *  `--accept-mcp` opt-in.
+ */
+{ kind: "mcp_servers_require_opt_in"; agent: string; transports: string[] };
+
+/**
+ *  In-memory outcome of one [`KiroProject::install_native_agent`] call.
+ * 
+ *  Carries enough detail for the service layer to render an install-summary
+ *  row without re-reading tracking — name, the resolved destination JSON
+ *  path, what kind of install happened, and both content hashes.
+ */
+export type InstalledNativeAgentOutcome = {
+	name: string,
+	json_path: string,
+	kind: InstallOutcomeKind,
+	source_hash: string,
+	installed_hash: string,
+};
+
+/**
+ *  In-memory outcome of one [`KiroProject::install_native_companions`] call.
+ * 
+ *  Plugin-scoped (companion bundles are owned per-plugin, not per-agent),
+ *  so callers see one entry for the whole bundle rather than one per file.
+ *  `files` is the absolute destination paths of every companion file
+ *  installed for this plugin.
+ */
+export type InstalledNativeCompanionsOutcome = {
+	plugin: string,
+	files: string[],
+	kind: InstallOutcomeKind,
+	source_hash: string,
+	installed_hash: string,
 };
 
 // Information about a single installed skill.
@@ -396,6 +627,63 @@ export type MarketplaceStorage =
  *  Edits to the source require re-adding the marketplace.
  */
 "copied";
+
+/**
+ *  Structured reason a source agent file could not be parsed.
+ * 
+ *  Replaces the pre-rendered `reason: String` that earlier versions carried
+ *  on `AgentError` and `InstallWarning`. Callers switch on variants
+ *  (e.g. to demote `MissingFrontmatter` to debug logs for README-style
+ *  files) rather than substring-matching on error text — which would
+ *  silently break the moment a message is reworded.
+ * 
+ *  Wire format: internally tagged on `kind` (`snake_case` discriminant)
+ *  to match the workspace convention for FFI-crossing enums
+ *  (`SteeringWarning`, `SkippedReason`, `FailedSkillReason`, …). All
+ *  payload-bearing variants use struct-style fields rather than tuple
+ *  fields because internal tagging requires named fields. Enforced by
+ *  the `ffi-enum-serde-tag` plan-lint gate.
+ */
+export type ParseFailure = 
+/**
+ *  No opening `---` fence. Usually a README or other prose file
+ *  accidentally scanned from the agents directory. Service layer
+ *  demotes this to a debug log.
+ */
+{ kind: "missing_frontmatter" } | 
+/**
+ *  Opening fence present but no closing fence — a broken file that
+ *  the user probably wants to hear about.
+ */
+{ kind: "unclosed_frontmatter" } | 
+// YAML parser rejected the frontmatter block.
+{ kind: "invalid_yaml"; reason: string } | 
+// Frontmatter parsed but lacks the required `name` key.
+{ kind: "missing_name" } | 
+/**
+ *  Frontmatter `name` failed validation (unsafe for use as a filename).
+ *  `reason` carries the validator's human-readable explanation.
+ */
+{ kind: "invalid_name"; reason: string } | 
+/**
+ *  File read failed (permission denied, not found during racy delete,
+ *  etc.). `reason` carries the rendered I/O error message.
+ */
+{ kind: "io_error"; reason: string } | 
+/**
+ *  The translated parser (`parse_agent_file`) was called with a file
+ *  whose detected dialect belongs on a different install code path.
+ *  Currently fires only for [`AgentDialect::Native`]: native agents are
+ *  installed via validate-and-copy through `parse_native_kiro_agent_file`,
+ *  not through `parse_agent_file`. The service routes by dialect
+ *  upstream, so this branch is a defensive sanity check rather than a
+ *  normal failure mode.
+ * 
+ *  Distinct from [`ParseFailure::IoError`] so callers branching on
+ *  "should I retry the I/O?" don't misclassify a routing bug as a
+ *  transient I/O failure.
+ */
+{ kind: "unsupported_dialect" };
 
 // Basic information about a plugin within a marketplace.
 export type PluginBasicInfo = {
@@ -736,6 +1024,15 @@ export type StructuredSource =
  *  exist in-memory — `RelativePath::new` is the only way in.
  */
 path: RelativePath; ref: string | null; sha: string | null };
+
+export type UnmappedReason = 
+// Claude `PascalCase` name with no Kiro equivalent (e.g. `NotebookEdit`).
+"NoKiroEquivalent" | 
+/**
+ *  Copilot bare name (e.g. `codebase`, `findTestFiles`) — internal Copilot
+ *  concept with no reliable Kiro mapping.
+ */
+"BareCopilotName";
 
 // Result of updating one or more marketplaces.
 export type UpdateResult = {

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -131,7 +131,7 @@ export const commands = {
 	 *  [`crate::commands::installed::list_installed_skills`] shape; tests
 	 *  exercise the wrapper directly via `#[tokio::test]`.
 	 */
-	listInstalledPlugins: (projectPath: string) => typedError<InstalledPluginInfo[], CommandError>(__TAURI_INVOKE("list_installed_plugins", { projectPath })),
+	listInstalledPlugins: (projectPath: string) => typedError<InstalledPluginsView, CommandError>(__TAURI_INVOKE("list_installed_plugins", { projectPath })),
 	/**
 	 *  Remove every skill, steering file, and agent for a given
 	 *  `(marketplace, plugin)` pair from the project, returning per-content
@@ -688,6 +688,41 @@ export type InstalledPluginInfo = {
 	latest_install: string,
 };
 
+/**
+ *  Wire-format wrapper around [`Vec<InstalledPluginInfo>`] that also
+ *  carries per-tracking-file load failures so the UI can render a
+ *  partial state when one of the three `installed-*.json` files is
+ *  corrupt or unreadable (I13).
+ * 
+ *  Rationale: previously, `installed_plugins()` failed the entire
+ *  aggregator on any `?`-chain load failure, leaving the user with
+ *  "zero installed plugins" even when two of three tracking files
+ *  loaded cleanly. The view here surfaces what loaded AND what
+ *  didn't, so the UI can show a "partial state — N tracking files
+ *  failed to load" banner instead of a misleading empty list.
+ */
+export type InstalledPluginsView = {
+	/**
+	 *  Per-`(marketplace, plugin)` rows assembled from the tracking
+	 *  files that loaded successfully. May be empty if every file
+	 *  failed; the [`Self::partial_load_warnings`] vec then carries
+	 *  the explanation.
+	 */
+	plugins: InstalledPluginInfo[],
+	/**
+	 *  One entry per `installed-*.json` whose load failed. The
+	 *  corresponding content type's contributions are missing from
+	 *  `plugins`. Empty on a clean state.
+	 * 
+	 *  `serde(default)` is kept for legacy-JSON tolerance.
+	 *  `skip_serializing_if` is intentionally absent — `tauri-specta`
+	 *  2.0.0-rc.24 unified mode rejects it (see A-25 in plan
+	 *  amendments). Empty Vec serializes as `[]` rather than being
+	 *  omitted, matching `InstallSkillsResult.failed` etc.
+	 */
+	partial_load_warnings?: TrackingLoadWarning[],
+};
+
 // Information about a single installed skill.
 export type InstalledSkillInfo = {
 	name: string,
@@ -859,23 +894,64 @@ export type ProjectInfo = {
 export type RelativePath = string;
 
 /**
+ *  One per-step failure recorded by [`KiroProject::remove_plugin`] when
+ *  a per-content removal fails mid-cascade. The cascade keeps going on
+ *  remaining content types; the caller surfaces these to the user as a
+ *  partial-failure summary.
+ */
+export type RemovePluginFailure = {
+	/**
+	 *  Which content type errored: `"skill"` / `"steering"` / `"agent"`
+	 *  / `"native_companions"`.
+	 */
+	content_type: string,
+	/**
+	 *  The item identifier — skill or agent name, or steering rel-path
+	 *  rendered via `Path::display()`. Empty string for the
+	 *  `"native_companions"` row, which is plugin-scoped rather than
+	 *  per-item.
+	 */
+	item: string,
+	/**
+	 *  Rendered error chain via [`crate::error::error_full_chain`] —
+	 *  wire format per CLAUDE.md "in any wire-format `reason`/`error:
+	 *  String` field that crosses the FFI, use `error_full_chain(&err)`".
+	 */
+	error: string,
+};
+
+/**
  *  Aggregated counts returned by
  *  [`KiroProject::remove_plugin`] — one tally per content type so the
  *  caller (CLI / Tauri) can render a one-line "removed N skills,
  *  M steering files, K agents" summary without re-reading the tracking
  *  files.
  * 
- *  Counts are post-cascade and include orphan-tracking recoveries
- *  (A-12): a tracking entry with no on-disk file still counts as
- *  "removed" because the cascade dropped the entry. The cascade
- *  never partially succeeds — either every entry is removed and the
- *  counts reflect the full work, or an error short-circuits before
- *  the result returns.
+ *  Counts are post-cascade across every per-content removal that
+ *  completed successfully. A per-step error during the cascade does
+ *  **not** abort the work — the cascade keeps going on the remaining
+ *  content types and records the failure in `failed`. Only "failed
+ *  to even read the initial tracking files" is surfaced as the
+ *  cascade's outer `Err` (I5). Orphan-tracking recoveries (A-12) still
+ *  count as "removed" because the per-content remove drops the
+ *  tracking row and treats the missing on-disk entry as success.
  */
 export type RemovePluginResult = {
 	skills_removed: number,
 	steering_removed: number,
 	agents_removed: number,
+	/**
+	 *  Per-step errors encountered during the cascade. The cascade
+	 *  keeps making progress on remaining content types when one
+	 *  step fails — same policy as `InstallPluginResult`'s sub-result
+	 *  `failed` vecs (A-15). Empty on a clean cascade.
+	 * 
+	 *  `serde(default)` is kept for legacy-JSON tolerance.
+	 *  `skip_serializing_if` is intentionally absent — `tauri-specta`
+	 *  2.0.0-rc.24 unified mode rejects it (A-25). Empty Vec serializes
+	 *  as `[]` rather than being omitted.
+	 */
+	failed?: RemovePluginFailure[],
 };
 
 // Top-level category for a Kiro CLI setting.
@@ -1170,6 +1246,26 @@ export type StructuredSource =
  *  exist in-memory — `RelativePath::new` is the only way in.
  */
 path: RelativePath; ref: string | null; sha: string | null };
+
+/**
+ *  Per-tracking-file load failure surfaced by
+ *  [`KiroProject::installed_plugins`] (I13).
+ */
+export type TrackingLoadWarning = {
+	/**
+	 *  Filename relative to `.kiro/`: `"installed-skills.json"` /
+	 *  `"installed-steering.json"` / `"installed-agents.json"`. Just
+	 *  the basename — the absolute path leaks layout information the
+	 *  frontend doesn't need.
+	 */
+	tracking_file: string,
+	/**
+	 *  Rendered error chain via [`crate::error::error_full_chain`] —
+	 *  wire format per CLAUDE.md "in any wire-format `reason`/`error:
+	 *  String` field that crosses the FFI, use `error_full_chain(&err)`".
+	 */
+	error: string,
+};
 
 export type UnmappedReason = 
 // Claude `PascalCase` name with no Kiro equivalent (e.g. `NotebookEdit`).

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -13,8 +13,6 @@
     MarketplaceInfo,
     PluginInfo,
     SkillInfo,
-    SkillCount,
-    SkippedReason,
     SkippedSkill,
     SteeringWarning,
   } from "$lib/bindings";

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -2,6 +2,12 @@
   import { onMount } from "svelte";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
+  import {
+    formatSkippedSkill,
+    formatSkippedSkillsForPlugin,
+    skillCountLabel,
+    skillCountTitle,
+  } from "$lib/format";
   import type {
     MarketplaceInfo,
     PluginInfo,
@@ -12,93 +18,6 @@
     SteeringWarning,
   } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
-
-  // Render a structured SkippedReason as a one-line string. Total over
-  // all eight variants (not just the six reachable via SkillCount) —
-  // TypeScript's exhaustiveness check forces full coverage. The two
-  // currently-unreachable variants (remote_source_not_local, no_skills)
-  // are reserved for future reuse with SkippedPlugin banners.
-  function formatSkippedReason(r: SkippedReason): string {
-    switch (r.kind) {
-      case "directory_missing":
-        return `plugin directory not found: ${r.path}`;
-      case "not_a_directory":
-        return `plugin path is not a directory: ${r.path}`;
-      case "symlink_refused":
-        return `plugin path is a symlink (refused): ${r.path}`;
-      case "directory_unreadable":
-        return `could not read ${r.path}: ${r.reason}`;
-      case "invalid_manifest":
-        return `malformed plugin.json at ${r.path}: ${r.reason}`;
-      case "manifest_read_failed":
-        return `could not read plugin.json at ${r.path}: ${r.reason}`;
-      case "remote_source_not_local":
-        return `plugin source is remote: ${r.plugin}`;
-      case "no_skills":
-        return `plugin declares no skills: ${r.path}`;
-    }
-  }
-
-  function skillCountLabel(sc: SkillCount): string {
-    switch (sc.state) {
-      case "known": return String(sc.count);
-      case "remote_not_counted": return "–";
-      case "manifest_failed": return "!";
-    }
-  }
-
-  function skillCountTitle(sc: SkillCount): string | undefined {
-    switch (sc.state) {
-      case "known":
-        return undefined;
-      case "remote_not_counted":
-        return "Remote plugin — skills cannot be counted without cloning";
-      case "manifest_failed":
-        return formatSkippedReason(sc.reason);
-    }
-  }
-
-  // Render a structured SkippedSkill as a one-line label for warning
-  // banners. Uses name_hint (Option<String> in core → string | null on
-  // the wire) with "<unnamed>" fallback so a skill whose directory name
-  // could not be extracted still shows up in the UI rather than being
-  // silently dropped — that silent drop is exactly the class of bug the
-  // SkippedSkill surfacing pattern is fighting across all three call
-  // sites that consume SkippedSkill.
-  function formatSkippedSkill(s: SkippedSkill): string {
-    const label = s.name_hint ?? "<unnamed>";
-    // SkippedSkillReason is a discriminated union on `kind`. A future
-    // variant would land here as an unknown kind with a generic
-    // "unreadable" label rather than a compile error — consistent with
-    // the Rust #[non_exhaustive] attribute on the enum.
-    let reason: string;
-    switch (s.reason.kind) {
-      case "read_failed":
-        reason = `could not read SKILL.md: ${s.reason.reason}`;
-        break;
-      case "frontmatter_invalid":
-        reason = `malformed frontmatter: ${s.reason.reason}`;
-        break;
-      default:
-        reason = "unreadable";
-    }
-    return `${label}: ${reason}`;
-  }
-
-  function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): string {
-    // Caller already filtered to entries for one plugin; compose a
-    // compact single-line banner body. Truncate at MAX entries and
-    // surface the remainder as a "+N more" count — a plugin with
-    // dozens of malformed SKILL.md files is a real failure mode, but
-    // the banner isn't the right place to dump the whole list.
-    const MAX = 5;
-    const parts = list.slice(0, MAX).map(formatSkippedSkill);
-    const overflow = list.length - parts.length;
-    const joined = parts.join("; ");
-    return overflow > 0
-      ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
-      : `${list.length} skill(s) failed to load — ${joined}`;
-  }
 
   // Render a SteeringWarning. The explicit `default` arm with a `never`
   // binding is the load-bearing exhaustiveness guard — if a new

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -8,6 +8,13 @@
     skillCountLabel,
     skillCountTitle,
   } from "$lib/format";
+  import {
+    DELIM,
+    pluginKey,
+    skillKey,
+    parsePluginKey,
+    parseSkillKey,
+  } from "$lib/keys";
   import type {
     InstalledPluginInfo,
     MarketplaceInfo,
@@ -44,22 +51,6 @@
   }
 
   let { projectPath }: { projectPath: string } = $props();
-
-  // Composite-key helpers. The ASCII Unit Separator (\u001f) is reserved for
-  // exactly this purpose and cannot occur in marketplace/plugin/skill names,
-  // so it never collides the way "/" or ":" would.
-  const DELIM = "\u001f";
-  const pluginKey = (mp: string, plugin: string) => `${mp}${DELIM}${plugin}`;
-  const skillKey = (mp: string, plugin: string, name: string) =>
-    `${mp}${DELIM}${plugin}${DELIM}${name}`;
-  const parsePluginKey = (key: string) => {
-    const [marketplace, plugin] = key.split(DELIM);
-    return { marketplace, plugin };
-  };
-  const parseSkillKey = (key: string) => {
-    const [marketplace, plugin, name] = key.split(DELIM);
-    return { marketplace, plugin, name };
-  };
 
   // Error-source key family. The `plugins\u001f` / `skills\u001f` /
   // `bulk-skills\u001f` prefixes embed DELIM so a marketplace literally

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -9,6 +9,7 @@
     skillCountTitle,
   } from "$lib/format";
   import type {
+    InstalledPluginInfo,
     MarketplaceInfo,
     PluginInfo,
     SkillInfo,
@@ -18,6 +19,9 @@
     SteeringWarning,
   } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
+  import PluginCard from "./PluginCard.svelte";
+
+  type BrowseView = "plugins" | "skills";
 
   // Render a SteeringWarning. The explicit `default` arm with a `never`
   // binding is the load-bearing exhaustiveness guard — if a new
@@ -108,6 +112,17 @@
   let forceInstall: boolean = $state(false);
   let popoverOpen: boolean = $state(false);
   let popRef: HTMLDivElement | undefined = $state();
+  let browseView: BrowseView = $state("plugins");
+
+  // Per-plugin in-flight tracker — pluginKey(marketplace, plugin) so two
+  // plugins can install in parallel without colliding (mirrors the shape
+  // of `pendingSteeringInstalls`).
+  let pendingPluginInstalls = new SvelteSet<string>();
+
+  let installedPlugins: InstalledPluginInfo[] = $state([]);
+  let installedPluginKeys = $derived(
+    new Set(installedPlugins.map((p) => pluginKey(p.marketplace, p.plugin))),
+  );
 
   let loadingMarketplaces: boolean = $state(false);
   // Single pending-fetch tracker keyed by ErrorSource — each in-flight fetch
@@ -387,6 +402,26 @@
     );
   }
 
+  async function fetchInstalledPlugins() {
+    if (!projectPath) {
+      installedPlugins = [];
+      return;
+    }
+    try {
+      const result = await commands.listInstalledPlugins(projectPath);
+      installedPlugins = result.status === "ok" ? result.data : [];
+    } catch (e) {
+      console.error("[BrowseTab] listInstalledPlugins rejected", e);
+      installedPlugins = [];
+    }
+  }
+
+  $effect(() => {
+    // Read projectPath to register the dependency.
+    void projectPath;
+    fetchInstalledPlugins();
+  });
+
   $effect(() => {
     for (const mp of selectedMarketplaces) fetchPluginsFor(mp);
   });
@@ -664,6 +699,65 @@
     }
   }
 
+  // Whole-plugin install — runs every install path the plugin declares
+  // (skills + steering + agents) in one coordinated call. Surfaces the
+  // aggregated outcome in installMessage / installError, same as the
+  // skill and steering flows.
+  async function installWholePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginInstalls.has(key)) return;
+    pendingPluginInstalls.add(key);
+    installError = null;
+    installMessage = null;
+
+    try {
+      // 4th arg is `acceptMcp` — Phase 1 hardcodes false. Phase 2 will
+      // wire a UI toggle so a user can opt into installing agents that
+      // declare MCP servers (subprocesses / network connections).
+      const result = await commands.installPlugin(
+        marketplace,
+        plugin,
+        forceInstall,
+        false,
+        projectPath,
+      );
+      if (result.status === "ok") {
+        const r = result.data;
+        const parts: string[] = [];
+        const sInstalled = r.skills.installed.length;
+        const sFailed = r.skills.failed.length;
+        const stInstalled = r.steering.installed.length;
+        const stFailed = r.steering.failed.length;
+        const aInstalled = r.agents.installed.length;
+        const aFailed = r.agents.failed.length;
+        if (sInstalled > 0) parts.push(`${sInstalled} skill${sInstalled === 1 ? "" : "s"}`);
+        if (sFailed > 0) parts.push(`${sFailed} skill${sFailed === 1 ? "" : "s"} failed`);
+        if (stInstalled > 0)
+          parts.push(`${stInstalled} steering file${stInstalled === 1 ? "" : "s"}`);
+        if (stFailed > 0) parts.push(`${stFailed} steering failed`);
+        if (aInstalled > 0) parts.push(`${aInstalled} agent${aInstalled === 1 ? "" : "s"}`);
+        if (aFailed > 0) parts.push(`${aFailed} agent${aFailed === 1 ? "" : "s"} failed`);
+
+        const anyFailed = sFailed + stFailed + aFailed > 0;
+        const anyInstalled = sInstalled + stInstalled + aInstalled > 0;
+        const summary = parts.length > 0 ? parts.join(" · ") : "nothing to install";
+        if (anyFailed && !anyInstalled) {
+          installError = `Plugin install failed for ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Plugin ${plugin}: ${summary}`;
+        }
+        await fetchInstalledPlugins();
+      } else {
+        installError = `Plugin install failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Plugin install failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginInstalls.delete(key);
+    }
+  }
+
   // Steering install operates on whole plugins, so the natural scope is
   // "exactly one plugin in focus." Sources of focus, in priority order:
   //   1. A plugin filter is active (visible chip at the top of the page).
@@ -707,6 +801,7 @@
 
   onMount(() => {
     loadMarketplaces();
+    fetchInstalledPlugins();
   });
 </script>
 
@@ -926,6 +1021,33 @@
     </div>
   {/if}
 
+  <div class="flex items-center gap-1 px-4 py-2 border-b border-kiro-muted bg-kiro-surface/30">
+    <div class="inline-flex rounded-md border border-kiro-muted bg-kiro-overlay overflow-hidden">
+      <button
+        type="button"
+        aria-pressed={browseView === "plugins"}
+        onclick={() => (browseView = "plugins")}
+        class="px-3 py-1.5 text-xs font-medium transition-colors
+          {browseView === 'plugins'
+            ? 'bg-kiro-accent-900/30 text-kiro-accent-300'
+            : 'text-kiro-text-secondary hover:bg-kiro-muted hover:text-kiro-text'}"
+      >
+        Plugins
+      </button>
+      <button
+        type="button"
+        aria-pressed={browseView === "skills"}
+        onclick={() => (browseView = "skills")}
+        class="px-3 py-1.5 text-xs font-medium transition-colors border-l border-kiro-muted
+          {browseView === 'skills'
+            ? 'bg-kiro-accent-900/30 text-kiro-accent-300'
+            : 'text-kiro-text-secondary hover:bg-kiro-muted hover:text-kiro-text'}"
+      >
+        Skills
+      </button>
+    </div>
+  </div>
+
   <div class="flex-1 overflow-y-auto p-4">
     {#if showLoadingSpinner}
       <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
@@ -943,54 +1065,8 @@
         </svg>
         <p class="text-sm">Failed to load marketplaces. See error above.</p>
       </div>
-    {:else if filteredSkills.length === 0}
-      {#if !filterText && availablePlugins.length > 0}
-        <!-- Skills are zero but plugins exist (e.g., a marketplace whose
-             plugins ship steering files but no skills). Surface the
-             plugins inline so the user has a direct install path —
-             without this they'd have to discover the filter popover to
-             scope the bottom-bar steering button. -->
-        <div class="flex flex-col gap-4">
-          <p class="text-sm text-kiro-subtle">
-            No skills in {selectedMarketplaces.size === 1 ? "this marketplace" : "these marketplaces"} —
-            install steering for a plugin below.
-          </p>
-          <div class="flex flex-col gap-2">
-            {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
-              {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
-              <div class="flex items-center gap-3 px-3 py-2.5 rounded-md border border-kiro-muted bg-kiro-overlay">
-                <div class="flex-1 min-w-0">
-                  <div class="text-sm font-medium text-kiro-text truncate">{ap.plugin.name}</div>
-                  {#if ap.plugin.description}
-                    <div class="text-xs text-kiro-subtle truncate">{ap.plugin.description}</div>
-                  {/if}
-                </div>
-                <span
-                  class="text-[11px] {ap.plugin.skill_count.state === 'manifest_failed' ? 'text-kiro-warning' : 'text-kiro-subtle'} flex-shrink-0"
-                  title={skillCountTitle(ap.plugin.skill_count)}
-                  aria-label={skillCountTitle(ap.plugin.skill_count)}
-                >{skillCountLabel(ap.plugin.skill_count)} skill{ap.plugin.skill_count.state === "known" && ap.plugin.skill_count.count === 1 ? "" : "s"}</span>
-                <button
-                  type="button"
-                  onclick={() => installSteering(ap.marketplace, ap.plugin.name)}
-                  disabled={!projectPath || pendingSteeringInstalls.has(key)}
-                  title={projectPath
-                    ? `Install steering files for ${ap.plugin.name}`
-                    : "Pick a project first"}
-                  aria-label="Install steering files for {ap.plugin.name}"
-                  aria-busy={pendingSteeringInstalls.has(key)}
-                  class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex-shrink-0
-                    {projectPath && !pendingSteeringInstalls.has(key)
-                      ? 'bg-kiro-overlay border border-kiro-muted text-kiro-accent-300 hover:bg-kiro-muted hover:text-kiro-accent-200'
-                      : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
-                >
-                  {pendingSteeringInstalls.has(key) ? "Installing…" : "Install steering"}
-                </button>
-              </div>
-            {/each}
-          </div>
-        </div>
-      {:else}
+    {:else if browseView === "skills"}
+      {#if filteredSkills.length === 0}
         <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
           <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -1002,22 +1078,43 @@
             {:else if fetchErrors.size > 0}
               Skills unavailable due to errors above
             {:else}
-              No skills available
+              No skills available — try the Plugins view to install plugins that ship steering.
             {/if}
           </p>
         </div>
+      {:else}
+        <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+          {#each filteredSkills as skill (skillKey(skill.marketplace, skill.plugin, skill.name))}
+            {@const key = skillKey(skill.marketplace, skill.plugin, skill.name)}
+            <SkillCard
+              {skill}
+              selected={selectedSkills.has(key)}
+              onToggle={() => toggleSkill(key)}
+            />
+          {/each}
+        </div>
       {/if}
     {:else}
-      <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
-        {#each filteredSkills as skill (skillKey(skill.marketplace, skill.plugin, skill.name))}
-          {@const key = skillKey(skill.marketplace, skill.plugin, skill.name)}
-          <SkillCard
-            {skill}
-            selected={selectedSkills.has(key)}
-            onToggle={() => toggleSkill(key)}
-          />
-        {/each}
-      </div>
+      <!-- browseView === "plugins" -->
+      {#if availablePlugins.length === 0}
+        <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+          <p class="text-sm">No plugins available — pick a marketplace from Filters.</p>
+        </div>
+      {:else}
+        <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+          {#each availablePlugins as ap (pluginKey(ap.marketplace, ap.plugin.name))}
+            {@const key = pluginKey(ap.marketplace, ap.plugin.name)}
+            <PluginCard
+              plugin={ap.plugin}
+              marketplace={ap.marketplace}
+              installed={installedPluginKeys.has(key)}
+              installing={pendingPluginInstalls.has(key)}
+              projectPicked={!!projectPath}
+              onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+            />
+          {/each}
+        </div>
+      {/if}
     {/if}
   </div>
 

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -3,8 +3,10 @@
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
   import {
+    formatInstallWarning,
     formatSkippedSkill,
     formatSkippedSkillsForPlugin,
+    formatSteeringWarning,
     skillCountLabel,
     skillCountTitle,
   } from "$lib/format";
@@ -21,34 +23,11 @@
     PluginInfo,
     SkillInfo,
     SkippedSkill,
-    SteeringWarning,
   } from "$lib/bindings";
   import SkillCard from "./SkillCard.svelte";
   import PluginCard from "./PluginCard.svelte";
 
   type BrowseView = "plugins" | "skills";
-
-  // Render a SteeringWarning. The explicit `default` arm with a `never`
-  // binding is the load-bearing exhaustiveness guard — if a new
-  // SteeringWarning variant lands in core (regenerating bindings.ts),
-  // the assignment fails to compile because the new variant isn't `never`.
-  // A return-type-narrowing approach (no default arm, function returns
-  // `string`) would also catch it via TS2366, but only as long as the
-  // return type stays non-`undefined` — refactoring to `void`-returning
-  // logging would silently disable the check. The assertNever pattern
-  // survives both.
-  function formatSteeringWarning(w: SteeringWarning): string {
-    switch (w.kind) {
-      case "scan_path_invalid":
-        return `invalid scan path '${w.path}': ${w.reason}`;
-      case "scan_dir_unreadable":
-        return `could not read steering dir '${w.path}': ${w.reason}`;
-      default: {
-        const _exhaustive: never = w;
-        throw new Error(`unhandled SteeringWarning variant: ${JSON.stringify(_exhaustive)}`);
-      }
-    }
-  }
 
   let { projectPath }: { projectPath: string } = $props();
 
@@ -60,8 +39,13 @@
   const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
   const BULK_SKILLS_ERR_PREFIX = `bulk-skills${DELIM}` as const;
   const ERR_MARKETPLACES = "marketplaces" as const;
+  // Standalone (non-prefixed) keys for top-level fetches that have no
+  // (marketplace, plugin) tuple. Adding more standalone keys later means
+  // extending the union in `ErrorSource` and the dispatch in `errLabel`.
+  const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
   type ErrorSource =
     | typeof ERR_MARKETPLACES
+    | typeof ERR_INSTALLED_PLUGINS
     | `${typeof PLUGINS_ERR_PREFIX}${string}`
     | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`
     | `${typeof BULK_SKILLS_ERR_PREFIX}${string}`;
@@ -79,6 +63,7 @@
   // enough context to disambiguate N stacked identical-looking controls.
   function errLabel(key: ErrorSource): string {
     if (key === ERR_MARKETPLACES) return "Dismiss marketplaces error";
+    if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins error";
     if (key.startsWith(PLUGINS_ERR_PREFIX)) {
       return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
     }
@@ -127,6 +112,12 @@
   let fetchErrors = new SvelteMap<ErrorSource, string>();
   let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
+  // Non-fatal install detail (skipped idempotent items, MCP-gated agents,
+  // unmapped tools, per-skill read failures, steering scan-path warnings).
+  // Distinct from `installError` (red, fatal) and `installMessage` (green,
+  // success summary) so the user sees BOTH "installed N items" AND "agent
+  // X requires --accept-mcp" simultaneously.
+  let installWarning: string | null = $state(null);
 
   let availablePlugins = $derived.by(() => {
     const out: { marketplace: string; plugin: PluginInfo }[] = [];
@@ -394,14 +385,48 @@
   async function fetchInstalledPlugins() {
     if (!projectPath) {
       installedPlugins = [];
+      fetchErrors.delete(ERR_INSTALLED_PLUGINS);
       return;
     }
     try {
       const result = await commands.listInstalledPlugins(projectPath);
-      installedPlugins = result.status === "ok" ? result.data : [];
+      if (result.status === "ok") {
+        // Wire format is `InstalledPluginsView` (I13) — read `.plugins`,
+        // not `.data` directly. Surfacing partial-load warnings via
+        // `fetchErrors` keeps them in the same banner stack as every
+        // other failure on this tab; a console-only log would let the
+        // user wonder why a plugin they just installed shows "Install"
+        // again instead of "Installed".
+        installedPlugins = result.data.plugins;
+        const warnings = result.data.partial_load_warnings ?? [];
+        if (warnings.length > 0) {
+          const summary = warnings
+            .map((w) => `${w.tracking_file}: ${w.error}`)
+            .join("; ");
+          fetchErrors.set(
+            ERR_INSTALLED_PLUGINS,
+            `Installed plugins partially loaded — ${summary}`,
+          );
+        } else {
+          fetchErrors.delete(ERR_INSTALLED_PLUGINS);
+        }
+      } else {
+        // Real Tauri-layer error (e.g. validate_kiro_project_path failed).
+        // Surface — don't silently fall back to an empty array, which
+        // would re-show "Install" buttons for plugins that may already
+        // be installed and re-enable double-installs.
+        console.error("[BrowseTab] listInstalledPlugins error", result.error);
+        fetchErrors.set(
+          ERR_INSTALLED_PLUGINS,
+          `Could not load installed plugins: ${result.error.message}`,
+        );
+      }
     } catch (e) {
       console.error("[BrowseTab] listInstalledPlugins rejected", e);
-      installedPlugins = [];
+      fetchErrors.set(
+        ERR_INSTALLED_PLUGINS,
+        `Could not load installed plugins: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 
@@ -519,6 +544,7 @@
     installing = true;
     installError = null;
     installMessage = null;
+    installWarning = null;
 
     type Group = { marketplace: string; plugin: string; names: string[] };
     const groups = new Map<string, Group>();
@@ -633,6 +659,7 @@
     pendingSteeringInstalls.add(key);
     installError = null;
     installMessage = null;
+    installWarning = null;
 
     try {
       const result = await commands.installPluginSteering(
@@ -690,14 +717,27 @@
 
   // Whole-plugin install — runs every install path the plugin declares
   // (skills + steering + agents) in one coordinated call. Surfaces the
-  // aggregated outcome in installMessage / installError, same as the
-  // skill and steering flows.
+  // aggregated outcome across THREE banner states:
+  //   - `installMessage` (green): success summary including idempotent skips
+  //   - `installError`   (red):   fatal — at least one failure and zero installs
+  //   - `installWarning` (amber): non-fatal detail (skipped_skills, steering
+  //                               scan warnings, MCP-gated agents, unmapped
+  //                               tools). Mirrors `installSelected`'s
+  //                               accumulation pattern.
+  //
+  // The MCP-gated path is the security-critical one: with `accept_mcp = false`
+  // an agent declaring `mcp_servers` produces `InstallWarning::McpServersRequireOptIn`
+  // and never lands in `installed` or `failed`. Previously the count would
+  // silently disappear ("1 of 2 agents installed" with no explanation); the
+  // new warning banner names the agent and lists its transports so the user
+  // can re-run with the opt-in if they want it.
   async function installWholePlugin(marketplace: string, plugin: string) {
     const key = pluginKey(marketplace, plugin);
     if (pendingPluginInstalls.has(key)) return;
     pendingPluginInstalls.add(key);
     installError = null;
     installMessage = null;
+    installWarning = null;
 
     try {
       // 4th arg is `acceptMcp` — Phase 1 hardcodes false. Phase 2 will
@@ -712,28 +752,92 @@
       );
       if (result.status === "ok") {
         const r = result.data;
-        const parts: string[] = [];
-        const sInstalled = r.skills.installed.length;
-        const sFailed = r.skills.failed.length;
-        const stInstalled = r.steering.installed.length;
-        const stFailed = r.steering.failed.length;
-        const aInstalled = r.agents.installed.length;
-        const aFailed = r.agents.failed.length;
-        if (sInstalled > 0) parts.push(`${sInstalled} skill${sInstalled === 1 ? "" : "s"}`);
-        if (sFailed > 0) parts.push(`${sFailed} skill${sFailed === 1 ? "" : "s"} failed`);
-        if (stInstalled > 0)
-          parts.push(`${stInstalled} steering file${stInstalled === 1 ? "" : "s"}`);
-        if (stFailed > 0) parts.push(`${stFailed} steering failed`);
-        if (aInstalled > 0) parts.push(`${aInstalled} agent${aInstalled === 1 ? "" : "s"}`);
-        if (aFailed > 0) parts.push(`${aFailed} agent${aFailed === 1 ? "" : "s"} failed`);
+        const summaryParts: string[] = [];
+        const warningParts: string[] = [];
 
-        const anyFailed = sFailed + stFailed + aFailed > 0;
-        const anyInstalled = sInstalled + stInstalled + aInstalled > 0;
-        const summary = parts.length > 0 ? parts.join(" · ") : "nothing to install";
+        // Skills: installed / failed / skipped (idempotent) / skipped_skills
+        // (per-file read or parse failures). `skipped_skills` is the
+        // structurally-distinct "couldn't even attempt to install" bucket.
+        {
+          const skills = r.skills;
+          if (skills.installed.length > 0) {
+            const noun = skills.installed.length === 1 ? "skill" : "skills";
+            summaryParts.push(`${skills.installed.length} ${noun}`);
+          }
+          if (skills.failed.length > 0) {
+            const noun = skills.failed.length === 1 ? "skill" : "skills";
+            summaryParts.push(`${skills.failed.length} ${noun} failed`);
+          }
+          if (skills.skipped.length > 0) {
+            const noun = skills.skipped.length === 1 ? "skill" : "skills";
+            summaryParts.push(`${skills.skipped.length} ${noun} already installed`);
+          }
+          if (skills.skipped_skills.length > 0) {
+            warningParts.push(formatSkippedSkillsForPlugin(skills.skipped_skills));
+          }
+        }
+
+        // Steering: idempotent reinstalls land in `installed` with
+        // `kind = idempotent` (not a separate `skipped` field — see
+        // `InstalledSteeringOutcome.kind`). Surfacing the breakdown is
+        // a Phase 2 follow-up; for now the count is the lump sum.
+        {
+          const steering = r.steering;
+          if (steering.installed.length > 0) {
+            const noun = steering.installed.length === 1 ? "file" : "files";
+            summaryParts.push(`${steering.installed.length} steering ${noun}`);
+          }
+          if (steering.failed.length > 0) {
+            summaryParts.push(`${steering.failed.length} steering failed`);
+          }
+          if (steering.warnings.length > 0) {
+            for (const w of steering.warnings) {
+              warningParts.push(formatSteeringWarning(w));
+            }
+          }
+        }
+
+        // Agents: includes `skipped` (idempotent native reinstalls) and
+        // `warnings` (MCP-gated, unmapped tools, parse failures on
+        // non-agent files in the scan dir). Without surfacing warnings
+        // here, `McpServersRequireOptIn` would silently drop agents.
+        {
+          const agents = r.agents;
+          if (agents.installed.length > 0) {
+            const noun = agents.installed.length === 1 ? "agent" : "agents";
+            summaryParts.push(`${agents.installed.length} ${noun}`);
+          }
+          if (agents.failed.length > 0) {
+            const noun = agents.failed.length === 1 ? "agent" : "agents";
+            summaryParts.push(`${agents.failed.length} ${noun} failed`);
+          }
+          if (agents.skipped.length > 0) {
+            const noun = agents.skipped.length === 1 ? "agent" : "agents";
+            summaryParts.push(`${agents.skipped.length} ${noun} already installed`);
+          }
+          if (agents.warnings.length > 0) {
+            for (const w of agents.warnings) {
+              warningParts.push(formatInstallWarning(w));
+            }
+          }
+        }
+
+        const anyFailed =
+          r.skills.failed.length + r.steering.failed.length + r.agents.failed.length > 0;
+        const anyInstalled =
+          r.skills.installed.length +
+            r.steering.installed.length +
+            r.agents.installed.length >
+          0;
+        const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to install";
+
         if (anyFailed && !anyInstalled) {
           installError = `Plugin install failed for ${plugin}: ${summary}`;
         } else {
           installMessage = `Plugin ${plugin}: ${summary}`;
+        }
+        if (warningParts.length > 0) {
+          installWarning = `Plugin ${plugin}: ${warningParts.join(" | ")}`;
         }
         await fetchInstalledPlugins();
       } else {
@@ -1007,6 +1111,23 @@
   {#if installMessage}
     <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
       <p class="text-sm text-kiro-success">{installMessage}</p>
+    </div>
+  {/if}
+
+  {#if installWarning}
+    <div
+      data-testid="install-warning"
+      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
+    >
+      <p class="text-sm text-kiro-warning flex-1">{installWarning}</p>
+      <button
+        type="button"
+        onclick={() => (installWarning = null)}
+        aria-label="Dismiss install warning"
+        class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
     </div>
   {/if}
 

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -1,215 +1,183 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { commands } from "$lib/bindings";
-  import type { InstalledSkillInfo } from "$lib/bindings";
-  import { SvelteSet } from "svelte/reactivity";
+  import type {
+    InstalledSkillInfo,
+    InstalledPluginInfo,
+  } from "$lib/bindings";
+  import { pluginKey } from "$lib/keys";
 
   let { projectPath }: { projectPath: string } = $props();
 
+  let plugins: InstalledPluginInfo[] = $state([]);
   let skills: InstalledSkillInfo[] = $state([]);
-  let selectedSkills = new SvelteSet<string>();
-  let filterText: string = $state("");
+  let loading: boolean = $state(true);
+  let loadError: string | null = $state(null);
+  // Single removal in flight at a time — `remove_plugin` reads/writes the
+  // installed-skills/steering/agents tracking files, so racing two removes
+  // could clobber each other. Disabling all Remove buttons while one is
+  // pending is the simplest correctness-preserving UI.
+  let removingKey: string | null = $state(null);
 
-  let loading: boolean = $state(false);
-  let removing: boolean = $state(false);
-  let error: string | null = $state(null);
-  let successMessage: string | null = $state(null);
-
-  let filteredSkills = $derived(
-    skills.filter(
-      (s) =>
-        s.name.toLowerCase().includes(filterText.toLowerCase()) ||
-        s.plugin.toLowerCase().includes(filterText.toLowerCase()) ||
-        s.marketplace.toLowerCase().includes(filterText.toLowerCase())
-    )
-  );
-
-  let selectedCount = $derived(selectedSkills.size);
-
-  async function loadSkills() {
+  async function refresh() {
     loading = true;
-    error = null;
-    const result = await commands.listInstalledSkills(projectPath);
-    if (result.status === "ok") {
-      skills = result.data;
-    } else {
-      error = result.error.message;
-    }
-    loading = false;
-  }
-
-  function toggleSkill(name: string) {
-    if (selectedSkills.has(name)) {
-      selectedSkills.delete(name);
-    } else {
-      selectedSkills.add(name);
-    }
-  }
-
-  function toggleAll() {
-    if (selectedSkills.size === filteredSkills.length) {
-      selectedSkills.clear();
-    } else {
-      for (const s of filteredSkills) {
-        selectedSkills.add(s.name);
-      }
-    }
-  }
-
-  async function removeSelected() {
-    if (selectedSkills.size === 0) return;
-    removing = true;
-    error = null;
-    successMessage = null;
-
-    const names = Array.from(selectedSkills);
-    const removed: string[] = [];
-    const failed: string[] = [];
-
-    for (const name of names) {
-      const result = await commands.removeSkill(name, projectPath);
-      if (result.status === "ok") {
-        removed.push(name);
+    loadError = null;
+    try {
+      const [pluginsResult, skillsResult] = await Promise.all([
+        commands.listInstalledPlugins(projectPath),
+        commands.listInstalledSkills(projectPath),
+      ]);
+      if (pluginsResult.status === "ok") {
+        plugins = pluginsResult.data;
       } else {
-        failed.push(`${name}: ${result.error.message}`);
+        loadError = pluginsResult.error.message;
       }
+      if (skillsResult.status === "ok") {
+        skills = skillsResult.data;
+      } else if (loadError === null) {
+        loadError = skillsResult.error.message;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      loadError = `Failed to load installed state: ${reason}`;
+    } finally {
+      loading = false;
     }
+  }
 
-    if (removed.length > 0) {
-      successMessage = `Removed: ${removed.join(", ")}`;
+  async function removePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (removingKey !== null) return;
+    removingKey = key;
+    try {
+      const result = await commands.removePlugin(marketplace, plugin, projectPath);
+      if (result.status === "ok") {
+        await refresh();
+      } else {
+        loadError = `Remove failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      loadError = `Remove failed for ${plugin}: ${reason}`;
+    } finally {
+      removingKey = null;
     }
-    if (failed.length > 0) {
-      error = `Failed to remove: ${failed.join("; ")}`;
-    }
-
-    selectedSkills.clear();
-    await loadSkills();
-    removing = false;
   }
 
   function formatDate(iso: string): string {
-    const date = new Date(iso);
-    if (isNaN(date.getTime())) {
-      console.warn(`Invalid date string from backend: "${iso}"`);
-      return iso;
-    }
-    return date.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
   }
 
+  function contentSummary(p: InstalledPluginInfo): string {
+    const parts: string[] = [];
+    if (p.skill_count > 0) parts.push(`${p.skill_count} skill${p.skill_count === 1 ? "" : "s"}`);
+    if (p.steering_count > 0) parts.push(`${p.steering_count} steering`);
+    if (p.agent_count > 0) parts.push(`${p.agent_count} agent${p.agent_count === 1 ? "" : "s"}`);
+    return parts.length > 0 ? parts.join(" · ") : "(empty)";
+  }
+
+  onMount(refresh);
+
+  // Re-fetch when the project changes. Reading projectPath registers the
+  // dependency; the void cast keeps lint happy about an unused expression.
   $effect(() => {
-    loadSkills();
+    void projectPath;
+    refresh();
   });
 </script>
 
 <div class="flex flex-col h-full">
-  <!-- Search bar -->
-  <div class="p-4 border-b border-kiro-muted">
-    <input
-      type="text"
-      placeholder="Filter by name, plugin, or marketplace..."
-      bind:value={filterText}
-      class="w-full px-3 py-2 text-sm rounded-md border border-kiro-muted bg-kiro-overlay text-kiro-text placeholder-kiro-subtle focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 focus:border-transparent"
-    />
-  </div>
-
-  <!-- Error display -->
-  {#if error}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
-      <p class="text-sm text-kiro-error">{error}</p>
-    </div>
-  {/if}
-
-  <!-- Success message -->
-  {#if successMessage}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
-      <p class="text-sm text-kiro-success">{successMessage}</p>
-    </div>
-  {/if}
-
-  <!-- Table -->
-  <div class="flex-1 overflow-y-auto">
+  <div class="flex-1 overflow-y-auto p-4">
     {#if loading}
       <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
         <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
         </svg>
-        <p class="text-sm">Loading installed skills...</p>
+        <p class="text-sm">Loading installed state...</p>
       </div>
-    {:else if filteredSkills.length === 0}
-      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
-        <svg class="w-10 h-10 text-kiro-accent-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-            d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-        </svg>
-        <p class="text-sm">
-          {filterText ? "No installed skills match the filter" : "No skills installed"}
-        </p>
+    {:else if loadError}
+      <div class="px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+        <p class="text-sm text-kiro-error">{loadError}</p>
       </div>
     {:else}
-      <table class="w-full text-sm text-left">
-        <thead class="text-xs text-kiro-subtle uppercase bg-kiro-surface sticky top-0">
-          <tr>
-            <th class="px-4 py-3 w-10">
-              <input
-                type="checkbox"
-                checked={selectedSkills.size === filteredSkills.length && filteredSkills.length > 0}
-                onchange={toggleAll}
-                class="h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
-              />
-            </th>
-            <th class="px-4 py-3">Name</th>
-            <th class="px-4 py-3">Plugin</th>
-            <th class="px-4 py-3">Marketplace</th>
-            <th class="px-4 py-3">Version</th>
-            <th class="px-4 py-3">Installed</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each filteredSkills as skill (skill.name)}
-            <tr
-              class="border-b border-kiro-muted/50 hover:bg-kiro-overlay transition-colors duration-100
-                {selectedSkills.has(skill.name) ? 'bg-kiro-accent-900/10' : ''}"
-            >
-              <td class="px-4 py-3">
-                <input
-                  type="checkbox"
-                  checked={selectedSkills.has(skill.name)}
-                  onchange={() => toggleSkill(skill.name)}
-                  class="h-4 w-4 rounded border-kiro-muted text-kiro-accent-500 focus:ring-kiro-accent-500"
-                />
-              </td>
-              <td class="px-4 py-3 font-medium text-kiro-text">{skill.name}</td>
-              <td class="px-4 py-3 text-kiro-text-secondary">{skill.plugin}</td>
-              <td class="px-4 py-3 text-kiro-text-secondary">{skill.marketplace}</td>
-              <td class="px-4 py-3 text-kiro-text-secondary">{skill.version ?? "---"}</td>
-              <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(skill.installed_at)}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </div>
+      <section class="mb-6">
+        <h2 class="text-sm font-semibold text-kiro-text mb-3">Installed plugins</h2>
+        {#if plugins.length === 0}
+          <p class="text-sm text-kiro-subtle">No plugins installed in this project.</p>
+        {:else}
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+                <th class="px-4 py-2">Plugin</th>
+                <th class="px-4 py-2">Marketplace</th>
+                <th class="px-4 py-2">Version</th>
+                <th class="px-4 py-2">Contents</th>
+                <th class="px-4 py-2">Installed</th>
+                <th class="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each plugins as p (pluginKey(p.marketplace, p.plugin))}
+                {@const key = pluginKey(p.marketplace, p.plugin)}
+                <tr class="border-b border-kiro-muted/50">
+                  <td class="px-4 py-3 font-medium text-kiro-text">{p.plugin}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{p.marketplace}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{p.installed_version ?? "—"}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{contentSummary(p)}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(p.latest_install)}</td>
+                  <td class="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onclick={() => removePlugin(p.marketplace, p.plugin)}
+                      disabled={removingKey !== null}
+                      aria-busy={removingKey === key}
+                      class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed"
+                    >
+                      {removingKey === key ? "Removing…" : "Remove"}
+                    </button>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </section>
 
-  <!-- Bottom bar -->
-  <div class="p-4 border-t border-kiro-muted bg-kiro-surface flex items-center justify-between">
-    <span class="text-sm text-kiro-subtle">
-      {skills.length} skill{skills.length === 1 ? "" : "s"} installed
-    </span>
-    <button
-      class="px-4 py-2 text-sm font-medium rounded-md text-white transition-colors duration-150
-        {selectedCount > 0 && !removing
-          ? 'bg-kiro-error hover:bg-kiro-error-hover'
-          : 'bg-kiro-muted text-kiro-subtle cursor-not-allowed'}"
-      disabled={selectedCount === 0 || removing}
-      onclick={removeSelected}
-    >
-      {removing ? "Removing..." : `Remove ${selectedCount} selected`}
-    </button>
+      <details class="mb-6">
+        <summary class="cursor-pointer text-sm font-medium text-kiro-text-secondary hover:text-kiro-text">
+          All installed skills (flat view)
+        </summary>
+        <div class="mt-3">
+          {#if skills.length === 0}
+            <p class="text-sm text-kiro-subtle">No skills installed.</p>
+          {:else}
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+                  <th class="px-4 py-2">Name</th>
+                  <th class="px-4 py-2">Marketplace</th>
+                  <th class="px-4 py-2">Plugin</th>
+                  <th class="px-4 py-2">Version</th>
+                  <th class="px-4 py-2">Installed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each skills as skill (skill.name)}
+                  <tr class="border-b border-kiro-muted/50">
+                    <td class="px-4 py-3 text-kiro-text">{skill.name}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.marketplace}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.plugin}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.version ?? "—"}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(skill.installed_at)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {/if}
+        </div>
+      </details>
+    {/if}
   </div>
 </div>

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -13,6 +13,10 @@
   let skills: InstalledSkillInfo[] = $state([]);
   let loading: boolean = $state(true);
   let loadError: string | null = $state(null);
+  // Non-fatal partial-load detail (one or more `installed-*.json` tracking
+  // files failed to parse; the others loaded). Distinct from `loadError`
+  // (red, fatal) — the table still has rows from the files that DID load.
+  let loadWarning: string | null = $state(null);
   // Single removal in flight at a time — `remove_plugin` reads/writes the
   // installed-skills/steering/agents tracking files, so racing two removes
   // could clobber each other. Disabling all Remove buttons while one is
@@ -22,13 +26,25 @@
   async function refresh() {
     loading = true;
     loadError = null;
+    loadWarning = null;
     try {
       const [pluginsResult, skillsResult] = await Promise.all([
         commands.listInstalledPlugins(projectPath),
         commands.listInstalledSkills(projectPath),
       ]);
       if (pluginsResult.status === "ok") {
-        plugins = pluginsResult.data;
+        // Wire format is `InstalledPluginsView` (I13): `.plugins` carries
+        // the rows, `.partial_load_warnings` carries per-tracking-file
+        // load failures (corrupt installed-*.json) so the table renders
+        // the partial state instead of a misleading empty list.
+        plugins = pluginsResult.data.plugins;
+        const warnings = pluginsResult.data.partial_load_warnings ?? [];
+        if (warnings.length > 0) {
+          const summary = warnings
+            .map((w) => `${w.tracking_file}: ${w.error}`)
+            .join("; ");
+          loadWarning = `Installed plugins partially loaded — ${summary}`;
+        }
       } else {
         loadError = pluginsResult.error.message;
       }
@@ -102,6 +118,22 @@
         <p class="text-sm text-kiro-error">{loadError}</p>
       </div>
     {:else}
+      {#if loadWarning}
+        <div
+          data-testid="installed-load-warning"
+          class="mb-4 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
+        >
+          <p class="text-sm text-kiro-warning flex-1">{loadWarning}</p>
+          <button
+            type="button"
+            onclick={() => (loadWarning = null)}
+            aria-label="Dismiss installed-plugins warning"
+            class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+          >
+            ×
+          </button>
+        </div>
+      {/if}
       <section class="mb-6">
         <h2 class="text-sm font-semibold text-kiro-text mb-3">Installed plugins</h2>
         {#if plugins.length === 0}

--- a/crates/kiro-control-center/src/lib/components/PluginCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/PluginCard.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import type { PluginInfo } from "$lib/bindings";
+  import { skillCountLabel, skillCountTitle } from "$lib/format";
+
+  type Props = {
+    plugin: PluginInfo;
+    marketplace: string;
+    installed: boolean;
+    installing: boolean;
+    projectPicked: boolean;
+    onInstall: () => void;
+  };
+
+  let {
+    plugin,
+    marketplace,
+    installed,
+    installing,
+    projectPicked,
+    onInstall,
+  }: Props = $props();
+
+  const title = $derived(
+    !projectPicked
+      ? "Pick a project first"
+      : installed
+        ? `${plugin.name} is already installed in this project`
+        : `Install ${plugin.name} (skills + steering + agents) into the active project`,
+  );
+</script>
+
+<div class="flex items-start gap-3 px-3 py-3 rounded-md border border-kiro-muted bg-kiro-overlay">
+  <div class="flex-1 min-w-0">
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="text-sm font-medium text-kiro-text truncate">{plugin.name}</span>
+      <span
+        class="text-[11px] {plugin.skill_count.state === 'manifest_failed'
+          ? 'text-kiro-warning'
+          : 'text-kiro-subtle'} flex-shrink-0"
+        title={skillCountTitle(plugin.skill_count)}
+        aria-label={skillCountTitle(plugin.skill_count)}
+      >
+        {skillCountLabel(plugin.skill_count)} skill{plugin.skill_count.state === "known" &&
+        plugin.skill_count.count === 1
+          ? ""
+          : "s"}
+      </span>
+    </div>
+    {#if plugin.description}
+      <div class="mt-1 text-xs text-kiro-subtle">{plugin.description}</div>
+    {/if}
+    <div class="mt-1.5 text-[10px] uppercase tracking-wider text-kiro-subtle">
+      {marketplace}
+    </div>
+  </div>
+
+  <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
+    {#if installed}
+      <span
+        class="px-2 py-0.5 text-[11px] font-medium text-kiro-success border border-kiro-success/40 rounded"
+      >
+        Installed
+      </span>
+    {:else}
+      <button
+        type="button"
+        onclick={onInstall}
+        disabled={!projectPicked || installing}
+        aria-busy={installing}
+        {title}
+        aria-label="Install {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+          {projectPicked && !installing
+            ? 'bg-kiro-overlay border border-kiro-muted text-kiro-accent-300 hover:bg-kiro-muted hover:text-kiro-accent-200'
+            : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
+      >
+        {installing ? "Installing…" : "Install"}
+      </button>
+    {/if}
+  </div>
+</div>

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -1,0 +1,88 @@
+import type { SkillCount, SkippedReason, SkippedSkill } from "$lib/bindings";
+
+// Render a structured SkippedReason as a one-line string. Total over
+// all eight variants (not just the six reachable via SkillCount) —
+// TypeScript's exhaustiveness check forces full coverage. The two
+// currently-unreachable variants (remote_source_not_local, no_skills)
+// are reserved for future reuse with SkippedPlugin banners.
+export function formatSkippedReason(r: SkippedReason): string {
+  switch (r.kind) {
+    case "directory_missing":
+      return `plugin directory not found: ${r.path}`;
+    case "not_a_directory":
+      return `plugin path is not a directory: ${r.path}`;
+    case "symlink_refused":
+      return `plugin path is a symlink (refused): ${r.path}`;
+    case "directory_unreadable":
+      return `could not read ${r.path}: ${r.reason}`;
+    case "invalid_manifest":
+      return `malformed plugin.json at ${r.path}: ${r.reason}`;
+    case "manifest_read_failed":
+      return `could not read plugin.json at ${r.path}: ${r.reason}`;
+    case "remote_source_not_local":
+      return `plugin source is remote: ${r.plugin}`;
+    case "no_skills":
+      return `plugin declares no skills: ${r.path}`;
+  }
+}
+
+export function skillCountLabel(sc: SkillCount): string {
+  switch (sc.state) {
+    case "known": return String(sc.count);
+    case "remote_not_counted": return "–";
+    case "manifest_failed": return "!";
+  }
+}
+
+export function skillCountTitle(sc: SkillCount): string | undefined {
+  switch (sc.state) {
+    case "known":
+      return undefined;
+    case "remote_not_counted":
+      return "Remote plugin — skills cannot be counted without cloning";
+    case "manifest_failed":
+      return formatSkippedReason(sc.reason);
+  }
+}
+
+// Render a structured SkippedSkill as a one-line label for warning
+// banners. Uses name_hint (Option<String> in core → string | null on
+// the wire) with "<unnamed>" fallback so a skill whose directory name
+// could not be extracted still shows up in the UI rather than being
+// silently dropped — that silent drop is exactly the class of bug the
+// SkippedSkill surfacing pattern is fighting across all three call
+// sites that consume SkippedSkill.
+export function formatSkippedSkill(s: SkippedSkill): string {
+  const label = s.name_hint ?? "<unnamed>";
+  // SkippedSkillReason is a discriminated union on `kind`. A future
+  // variant would land here as an unknown kind with a generic
+  // "unreadable" label rather than a compile error — consistent with
+  // the Rust #[non_exhaustive] attribute on the enum.
+  let reason: string;
+  switch (s.reason.kind) {
+    case "read_failed":
+      reason = `could not read SKILL.md: ${s.reason.reason}`;
+      break;
+    case "frontmatter_invalid":
+      reason = `malformed frontmatter: ${s.reason.reason}`;
+      break;
+    default:
+      reason = "unreadable";
+  }
+  return `${label}: ${reason}`;
+}
+
+export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): string {
+  // Caller already filtered to entries for one plugin; compose a
+  // compact single-line banner body. Truncate at MAX entries and
+  // surface the remainder as a "+N more" count — a plugin with
+  // dozens of malformed SKILL.md files is a real failure mode, but
+  // the banner isn't the right place to dump the whole list.
+  const MAX = 5;
+  const parts = list.slice(0, MAX).map(formatSkippedSkill);
+  const overflow = list.length - parts.length;
+  const joined = parts.join("; ");
+  return overflow > 0
+    ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
+    : `${list.length} skill(s) failed to load — ${joined}`;
+}

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -1,4 +1,11 @@
-import type { SkillCount, SkippedReason, SkippedSkill } from "$lib/bindings";
+import type {
+  InstallWarning,
+  ParseFailure,
+  SkillCount,
+  SkippedReason,
+  SkippedSkill,
+  SteeringWarning,
+} from "$lib/bindings";
 
 // Render a structured SkippedReason as a one-line string. Total over
 // all eight variants (not just the six reachable via SkillCount) —
@@ -54,10 +61,12 @@ export function skillCountTitle(sc: SkillCount): string | undefined {
 // sites that consume SkippedSkill.
 export function formatSkippedSkill(s: SkippedSkill): string {
   const label = s.name_hint ?? "<unnamed>";
-  // SkippedSkillReason is a discriminated union on `kind`. A future
-  // variant would land here as an unknown kind with a generic
-  // "unreadable" label rather than a compile error — consistent with
-  // the Rust #[non_exhaustive] attribute on the enum.
+  // SkippedSkillReason is a discriminated union on `kind`. The default
+  // arm uses an assertNever binding so a new variant lands as a
+  // compile-time error here rather than a silent "unreadable"
+  // collapse — `#[non_exhaustive]` on the Rust side is for runtime
+  // forward-compat, but the UI side benefits from the type system
+  // forcing a renderer update when bindings.ts grows.
   let reason: string;
   switch (s.reason.kind) {
     case "read_failed":
@@ -66,10 +75,89 @@ export function formatSkippedSkill(s: SkippedSkill): string {
     case "frontmatter_invalid":
       reason = `malformed frontmatter: ${s.reason.reason}`;
       break;
-    default:
-      reason = "unreadable";
+    default: {
+      const _exhaustive: never = s.reason;
+      throw new Error(
+        `unhandled SkippedSkillReason variant: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
   }
   return `${label}: ${reason}`;
+}
+
+// Render a SteeringWarning as a one-line label. Lifted from BrowseTab
+// once a second consumer (installWholePlugin) appeared — keeping it
+// inline would have meant two drift-prone copies of the assertNever
+// guard.
+export function formatSteeringWarning(w: SteeringWarning): string {
+  switch (w.kind) {
+    case "scan_path_invalid":
+      return `invalid scan path '${w.path}': ${w.reason}`;
+    case "scan_dir_unreadable":
+      return `could not read steering dir '${w.path}': ${w.reason}`;
+    default: {
+      const _exhaustive: never = w;
+      throw new Error(
+        `unhandled SteeringWarning variant: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+// Render an `InstallWarning` (from agent installs) as a one-line
+// label. The `mcp_servers_require_opt_in` variant is the
+// security-sensitive one — an agent declaring MCP servers was
+// refused because `accept_mcp` is false. Surfacing the listed
+// transports lets the user understand the risk surface before
+// re-running with the opt-in.
+export function formatInstallWarning(w: InstallWarning): string {
+  switch (w.kind) {
+    case "unmapped_tool":
+      return `agent '${w.agent}' dropped unmapped tool '${w.tool}' (${w.reason})`;
+    case "agent_parse_failed":
+      return `agent file '${w.path}' could not be parsed: ${formatParseFailure(w.failure)}`;
+    case "mcp_servers_require_opt_in": {
+      const transports = w.transports.length > 0
+        ? ` [${w.transports.join(", ")}]`
+        : "";
+      return `agent '${w.agent}' declares MCP servers${transports} — re-run with --accept-mcp to install`;
+    }
+    default: {
+      const _exhaustive: never = w;
+      throw new Error(
+        `unhandled InstallWarning variant: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+// Helper for `agent_parse_failed`. Kept module-private — the only
+// consumer today is `formatInstallWarning`, but the shape is the same
+// assertNever-guarded discriminated-union switch the other formatters
+// use, so a future caller can lift it without rework.
+function formatParseFailure(f: ParseFailure): string {
+  switch (f.kind) {
+    case "missing_frontmatter":
+      return "missing frontmatter fence";
+    case "unclosed_frontmatter":
+      return "unclosed frontmatter fence";
+    case "invalid_yaml":
+      return `invalid YAML: ${f.reason}`;
+    case "missing_name":
+      return "missing 'name' in frontmatter";
+    case "invalid_name":
+      return `invalid name: ${f.reason}`;
+    case "io_error":
+      return `I/O error: ${f.reason}`;
+    case "unsupported_dialect":
+      return "unsupported dialect for this code path";
+    default: {
+      const _exhaustive: never = f;
+      throw new Error(
+        `unhandled ParseFailure variant: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
 }
 
 export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): string {

--- a/crates/kiro-control-center/src/lib/keys.ts
+++ b/crates/kiro-control-center/src/lib/keys.ts
@@ -20,16 +20,31 @@ export const skillKey = (
   name: string,
 ): string => `${marketplace}${DELIM}${plugin}${DELIM}${name}`;
 
+// Throw on malformed input rather than returning `{ plugin: undefined }`
+// dressed up as `{ plugin: string }`. Every call site round-trips through
+// `pluginKey` / `skillKey`, so a malformed key is a programmer bug —
+// throwing makes the bug loud instead of silent (e.g. `fetchErrors.keys()`
+// later produces an `undefined` field that flows into a banner).
 export const parsePluginKey = (
   key: string,
 ): { marketplace: string; plugin: string } => {
-  const [marketplace, plugin] = key.split(DELIM);
-  return { marketplace, plugin };
+  const parts = key.split(DELIM);
+  if (parts.length !== 2 || parts[0] === "" || parts[1] === "") {
+    throw new Error(
+      `parsePluginKey: malformed key (expected exactly one DELIM separator): ${JSON.stringify(key)}`,
+    );
+  }
+  return { marketplace: parts[0], plugin: parts[1] };
 };
 
 export const parseSkillKey = (
   key: string,
 ): { marketplace: string; plugin: string; name: string } => {
-  const [marketplace, plugin, name] = key.split(DELIM);
-  return { marketplace, plugin, name };
+  const parts = key.split(DELIM);
+  if (parts.length !== 3 || parts.some((p) => p === "")) {
+    throw new Error(
+      `parseSkillKey: malformed key (expected exactly two DELIM separators): ${JSON.stringify(key)}`,
+    );
+  }
+  return { marketplace: parts[0], plugin: parts[1], name: parts[2] };
 };

--- a/crates/kiro-control-center/src/lib/keys.ts
+++ b/crates/kiro-control-center/src/lib/keys.ts
@@ -1,0 +1,35 @@
+// Composite-key helpers shared across BrowseTab and InstalledTab.
+//
+// The ASCII Unit Separator (\u001f) is reserved for exactly this purpose
+// and cannot occur in marketplace/plugin/skill names, so it never collides
+// the way "/" or ":" would. A marketplace named "foo" + plugin "bar"
+// produces a distinct key from marketplace "fooba" + plugin "r".
+//
+// Exported (not just module-private) so BrowseTab can build its typed
+// `ErrorSource` literal-union prefixes (`plugins${DELIM}`, `skills${DELIM}`,
+// `bulk-skills${DELIM}`) off the same constant — drift would silently
+// re-widen the ErrorSource type back to `string`.
+export const DELIM = "\u001f";
+
+export const pluginKey = (marketplace: string, plugin: string): string =>
+  `${marketplace}${DELIM}${plugin}`;
+
+export const skillKey = (
+  marketplace: string,
+  plugin: string,
+  name: string,
+): string => `${marketplace}${DELIM}${plugin}${DELIM}${name}`;
+
+export const parsePluginKey = (
+  key: string,
+): { marketplace: string; plugin: string } => {
+  const [marketplace, plugin] = key.split(DELIM);
+  return { marketplace, plugin };
+};
+
+export const parseSkillKey = (
+  key: string,
+): { marketplace: string; plugin: string; name: string } => {
+  const [marketplace, plugin, name] = key.split(DELIM);
+  return { marketplace, plugin, name };
+};

--- a/crates/kiro-control-center/tests/e2e/app.spec.ts
+++ b/crates/kiro-control-center/tests/e2e/app.spec.ts
@@ -110,12 +110,17 @@ test.describe("Marketplace workflow", () => {
   });
 
   test("install plugin from browse tab and verify in installed tab", async ({ page }) => {
-    await page.getByRole("button", { name: "Browse", exact: true }).click();
+    await page.goto("/");
 
     // The earlier "add local marketplace" test seeds FIXTURE_MARKETPLACE_PATH.
     // Skip if the fixture isn't available (matches the skill-install pattern).
+    // Pre-skip BEFORE clicking the Browse rail so a missing fixture doesn't
+    // race a hard-fail click against the skip — sibling tests at lines 91-110
+    // and 64-89 set the precedent.
     const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
     test.skip(!fixturePath, "FIXTURE_MARKETPLACE_PATH not set");
+
+    await page.getByRole("button", { name: "Browse", exact: true }).click();
 
     // Switch to the Plugins view if the toggle isn't already on it. The
     // Plugins button is the default per Task 7's BrowseView state, but

--- a/crates/kiro-control-center/tests/e2e/app.spec.ts
+++ b/crates/kiro-control-center/tests/e2e/app.spec.ts
@@ -109,6 +109,46 @@ test.describe("Marketplace workflow", () => {
     await expect(page.getByText(/test-skill/i).first()).toBeVisible();
   });
 
+  test("install plugin from browse tab and verify in installed tab", async ({ page }) => {
+    await page.getByRole("button", { name: "Browse", exact: true }).click();
+
+    // The earlier "add local marketplace" test seeds FIXTURE_MARKETPLACE_PATH.
+    // Skip if the fixture isn't available (matches the skill-install pattern).
+    const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+    test.skip(!fixturePath, "FIXTURE_MARKETPLACE_PATH not set");
+
+    // Switch to the Plugins view if the toggle isn't already on it. The
+    // Plugins button is the default per Task 7's BrowseView state, but
+    // switching defensively keeps the test robust to a future default change.
+    const pluginsToggle = page.getByRole("button", { name: "Plugins", exact: true });
+    if (await pluginsToggle.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await pluginsToggle.click();
+    }
+
+    // Find a plugin card with the test fixture's plugin name. PluginCard
+    // exposes "Install plugin" via aria-label="Install <name>".
+    const testPlugin = page.getByText(/test-plugin/i).first();
+    if (!(await testPlugin.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, "No marketplace with test-plugin available");
+    }
+
+    const installButton = page
+      .getByRole("button", { name: /install test-plugin/i })
+      .first();
+    await installButton.click();
+
+    // Wait for the success banner. Matches the success-banner pattern from
+    // the skill-install test.
+    await expect(page.getByText(/Plugin test-plugin/i)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Navigate to Installed tab and assert the plugin row appears.
+    await page.getByRole("button", { name: "Installed", exact: true }).click();
+    await expect(page.getByRole("heading", { name: /installed plugins/i })).toBeVisible();
+    await expect(page.getByText(/test-plugin/i).first()).toBeVisible();
+  });
+
   test("broken marketplace surfaces dismissible banner that clears on deselect", async ({ page }) => {
     const brokenPath = process.env.FIXTURE_BROKEN_MARKETPLACE_PATH;
     if (!brokenPath) {

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -23,9 +23,12 @@ pub struct PluginManifest {
     /// ([`crate::DEFAULT_AGENT_PATHS`]).
     #[serde(default)]
     pub agents: Vec<String>,
-    /// Authoring format for this plugin. See [`PluginFormat`].
+    /// Authoring format for this plugin. See [`PluginFormat`]. Omitted
+    /// fields default to [`PluginFormat::Translated`] via the type's
+    /// `Default` impl, matching the legacy "no `format` field means
+    /// markdown agents that need translation" behavior.
     #[serde(default)]
-    pub format: Option<PluginFormat>,
+    pub format: PluginFormat,
 
     /// Optional list of directories (relative to the plugin root) to scan
     /// for steering markdown files. Empty means "use the default scan
@@ -35,14 +38,29 @@ pub struct PluginManifest {
 }
 
 /// The plugin's native authoring format. Drives dispatch in
-/// `MarketplaceService::install_plugin_agents`: `KiroCli` skips
-/// parse-and-translate and validates-and-copies native JSON agents.
-/// Absent means the plugin uses Claude / Copilot markdown agents that
-/// require translation (the existing default flow).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+/// `MarketplaceService::install_plugin_agents`: [`PluginFormat::KiroCli`]
+/// skips parse-and-translate and validates-and-copies native JSON
+/// agents; [`PluginFormat::Translated`] (the default for plugins that
+/// don't declare a format) parses Claude / Copilot markdown agents and
+/// translates them.
+///
+/// Encoded as a real `Translated` variant rather than `None` so a
+/// future variant (e.g. `Cursor`) forces a compile-time decision at
+/// every dispatch site instead of silently routing through the
+/// translated path. Adding the explicit variant makes the
+/// `Option<PluginFormat>::None` == translated handshake unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum PluginFormat {
+    /// Claude / Copilot-style markdown agents (default for plugins
+    /// that don't declare a `format` field — preserves the legacy
+    /// install path).
+    #[default]
+    Translated,
+    /// Native Kiro CLI format (`agents/<name>.json` with optional
+    /// `agents/prompts/<name>.md` companion files).
     KiroCli,
 }
 
@@ -836,14 +854,25 @@ mod tests {
     fn manifest_parses_format_kiro_cli() {
         let json = br#"{"name": "p", "format": "kiro-cli"}"#;
         let manifest = PluginManifest::from_json(json).expect("should parse");
-        assert_eq!(manifest.format, Some(PluginFormat::KiroCli));
+        assert_eq!(manifest.format, PluginFormat::KiroCli);
     }
 
     #[test]
-    fn manifest_format_absent_is_none() {
+    fn manifest_format_absent_defaults_to_translated() {
+        // I8: omitted `format` field deserializes to
+        // `PluginFormat::Translated` via `#[serde(default)]` +
+        // `#[derive(Default)]`. Encodes "no format = translated" in
+        // the type instead of `Option<...>::None`.
         let json = br#"{"name": "p"}"#;
         let manifest = PluginManifest::from_json(json).expect("should parse");
-        assert!(manifest.format.is_none());
+        assert_eq!(manifest.format, PluginFormat::Translated);
+    }
+
+    #[test]
+    fn manifest_parses_format_translated() {
+        let json = br#"{"name": "p", "format": "translated"}"#;
+        let manifest = PluginManifest::from_json(json).expect("should parse");
+        assert_eq!(manifest.format, PluginFormat::Translated);
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -296,6 +296,26 @@ pub struct InstalledPluginInfo {
     pub latest_install: String,
 }
 
+/// Aggregated counts returned by
+/// [`KiroProject::remove_plugin`] — one tally per content type so the
+/// caller (CLI / Tauri) can render a one-line "removed N skills,
+/// M steering files, K agents" summary without re-reading the tracking
+/// files.
+///
+/// Counts are post-cascade and include orphan-tracking recoveries
+/// (A-12): a tracking entry with no on-disk file still counts as
+/// "removed" because the cascade dropped the entry. The cascade
+/// never partially succeeds — either every entry is removed and the
+/// counts reflect the full work, or an error short-circuits before
+/// the result returns.
+#[derive(Debug, Clone, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemovePluginResult {
+    pub skills_removed: u32,
+    pub steering_removed: u32,
+    pub agents_removed: u32,
+}
+
 /// Per-`(marketplace, plugin)` accumulator used by
 /// [`KiroProject::installed_plugins`] while folding the three tracking
 /// files into [`InstalledPluginInfo`] rows.
@@ -895,6 +915,336 @@ impl KiroProject {
                 }
             })
             .collect())
+    }
+
+    /// Remove a single installed steering file from
+    /// `installed-steering.json` and unlink the file under
+    /// `.kiro/steering/`.
+    ///
+    /// Defense in depth: even though `load_installed_steering` already
+    /// validates each tracking-file key against
+    /// [`validate_tracking_path_entry`], this method re-runs the same
+    /// check against `rel` before joining it onto the steering dir.
+    /// A future caller that constructs an `InstalledSteering` in
+    /// memory and bypasses the load path would otherwise be free to
+    /// reach `steering_dir.join("../../etc/passwd")`.
+    ///
+    /// # Errors
+    ///
+    /// - [`crate::steering::SteeringError::NotInstalled`] if `rel`
+    ///   has no entry in the tracking file. The cascade in
+    ///   [`Self::remove_plugin`] treats this as a recoverable
+    ///   orphan-tracking case (A-12).
+    /// - I/O / JSON failures from loading or writing the tracking
+    ///   file. A `NotFound` on the on-disk steering file itself is
+    ///   treated as success — the user may have hand-deleted the
+    ///   file before invoking remove.
+    pub fn remove_steering_file(&self, rel: &Path) -> crate::error::Result<()> {
+        if let Err(reason) = validate_tracking_path_entry(rel) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "refused to remove steering file with invalid path `{}`: {}",
+                    rel.display(),
+                    reason
+                ),
+            )
+            .into());
+        }
+
+        let tracking_path = self.steering_tracking_path();
+        crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
+            let mut installed = self.load_installed_steering()?;
+            if !installed.files.contains_key(rel) {
+                return Err(crate::steering::SteeringError::NotInstalled {
+                    rel: rel.to_path_buf(),
+                }
+                .into());
+            }
+
+            let dest = self.steering_dir().join(rel);
+            // Update tracking BEFORE unlinking so a crash between the
+            // two leaves a stray on-disk file (harmless) rather than a
+            // phantom tracking entry. Mirrors `remove_skill`'s ordering.
+            installed.files.remove(rel);
+            self.write_steering_tracking(&installed)?;
+
+            match fs::remove_file(&dest) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    debug!(
+                        path = %dest.display(),
+                        "steering file already absent on disk; tracking entry was orphan"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        rel = %rel.display(),
+                        path = %dest.display(),
+                        error = %e,
+                        "failed to unlink steering file after tracking update"
+                    );
+                    return Err(e.into());
+                }
+            }
+
+            debug!(rel = %rel.display(), "steering file removed");
+            Ok(())
+        })
+    }
+
+    /// Remove a single installed agent: drop the `installed-agents.json`
+    /// entry and unlink both on-disk files (`<name>.json` and
+    /// `prompts/<name>.md`). Mirrors [`Self::remove_steering_file`]'s
+    /// shape — tracking written before file ops, `NotFound` treated
+    /// as success.
+    ///
+    /// **Companions are not touched here.** A native plugin's
+    /// `native_companions` map entry is shared across all of that
+    /// plugin's agents; removing one agent must not nuke the plugin-wide
+    /// companion bundle. The cascade in [`Self::remove_plugin`] calls
+    /// [`Self::remove_native_companions_for_plugin`] separately after
+    /// per-agent cleanup completes.
+    ///
+    /// # Errors
+    ///
+    /// - [`AgentError::NotInstalled`] if `name` has no tracking entry.
+    /// - I/O / JSON failures from loading or writing the tracking file.
+    pub fn remove_agent(&self, name: &str) -> crate::error::Result<()> {
+        validation::validate_name(name)?;
+
+        let tracking_path = self.agent_tracking_path();
+        crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
+            let mut installed = self.load_installed_agents()?;
+            if !installed.agents.contains_key(name) {
+                return Err(AgentError::NotInstalled {
+                    name: name.to_owned(),
+                }
+                .into());
+            }
+
+            let json_target = self.agents_dir().join(format!("{name}.json"));
+            let prompt_target = self.agent_prompts_dir().join(format!("{name}.md"));
+
+            // Update tracking BEFORE unlinking so a crash between the
+            // two leaves stray on-disk files (harmless) rather than a
+            // phantom tracking entry.
+            installed.agents.remove(name);
+            self.write_agent_tracking(&installed)?;
+
+            for path in [&json_target, &prompt_target] {
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        debug!(
+                            path = %path.display(),
+                            "agent file already absent on disk; tracking entry was orphan"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            agent = name,
+                            path = %path.display(),
+                            error = %e,
+                            "failed to unlink agent file after tracking update"
+                        );
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            debug!(agent = name, "agent removed");
+            Ok(())
+        })
+    }
+
+    /// Remove the `native_companions` tracking entry for a given
+    /// `(plugin, marketplace)` pair and unlink every companion file
+    /// recorded under it.
+    ///
+    /// The companions map is keyed by **plugin name alone**
+    /// ([`InstalledAgents::native_companions`] is `HashMap<String, …>`),
+    /// but each value carries a `marketplace` field that
+    /// disambiguates same-named plugins across marketplaces (A-16).
+    /// This method only removes the entry when **both** match. An
+    /// entry belonging to a different marketplace, or no entry at
+    /// all, is treated as a no-op so the cascade in
+    /// [`Self::remove_plugin`] can call this unconditionally.
+    ///
+    /// On-disk companion files are unlinked best-effort via
+    /// [`Self::remove_companion_files_best_effort`] — companions are
+    /// installed at `agents_dir.join(rel)` (which can include
+    /// `prompts/` paths shared with per-agent prompts), so the
+    /// per-agent [`Self::remove_agent`] does not cover them.
+    ///
+    /// # Errors
+    ///
+    /// I/O or JSON failures from loading or writing
+    /// `installed-agents.json`. The on-disk unlink is best-effort and
+    /// does not propagate per-file failures.
+    pub fn remove_native_companions_for_plugin(
+        &self,
+        plugin: &str,
+        marketplace: &str,
+    ) -> crate::error::Result<()> {
+        let tracking_path = self.agent_tracking_path();
+        crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
+            let mut installed = self.load_installed_agents()?;
+            let should_remove = installed
+                .native_companions
+                .get(plugin)
+                .is_some_and(|meta| meta.marketplace == marketplace);
+            if !should_remove {
+                return Ok(());
+            }
+
+            // Take the entry so we can unlink the companion files
+            // referenced by it after the tracking write succeeds.
+            let Some(removed) = installed.native_companions.remove(plugin) else {
+                return Ok(());
+            };
+
+            self.write_agent_tracking(&installed)?;
+
+            // Best-effort on-disk cleanup — see
+            // `remove_companion_files_best_effort` for the symlink /
+            // reparse-point defense and the rationale for warn!-and-
+            // continue rather than propagating per-file failures.
+            Self::remove_companion_files_best_effort(&removed.files, &self.agents_dir(), plugin);
+
+            debug!(
+                plugin,
+                marketplace,
+                files = removed.files.len(),
+                "native companions tracking entry removed"
+            );
+            Ok(())
+        })
+    }
+
+    /// Cascade-remove every tracked entry from `(marketplace, plugin)`
+    /// across all three `installed-*.json` tracking files. Unlinks
+    /// the on-disk files, updates the tracking JSON files atomically,
+    /// and returns aggregated counts.
+    ///
+    /// **Orphan-tracking recovery (A-12).** If a tracking entry
+    /// references a path that no longer exists on disk (state
+    /// divergence: user ran `rm -rf .kiro/skills/<name>/` manually),
+    /// the per-content removal still completes successfully because
+    /// each `remove_*` treats on-disk `NotFound` as success. Only
+    /// genuine fs / parse / cross-plugin-clash error variants abort
+    /// the cascade.
+    ///
+    /// **`native_companions` cleanup (A-3 + A-16).** After per-agent
+    /// removals, the plugin-level `native_companions` entry is
+    /// dropped if its `marketplace` field matches `marketplace` (the
+    /// map is keyed by plugin name alone, so the marketplace check
+    /// disambiguates same-named plugins across marketplaces).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any non-`NotInstalled` error from the per-content
+    /// removals, plus I/O / JSON failures from the cascade's
+    /// initial tracking-file loads. The cascade does **not** roll
+    /// back partial progress — once a per-content `remove_*`
+    /// commits, that work stays committed even if a later step
+    /// fails.
+    pub fn remove_plugin(
+        &self,
+        marketplace: &str,
+        plugin: &str,
+    ) -> crate::error::Result<RemovePluginResult> {
+        let mut result = RemovePluginResult::default();
+
+        // Skills.
+        let skills = self.load_installed()?;
+        let skills_to_remove: Vec<String> = skills
+            .skills
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &skills_to_remove {
+            match self.remove_skill(name) {
+                Ok(()) => {
+                    result.skills_removed = result.skills_removed.saturating_add(1);
+                }
+                Err(crate::error::Error::Skill(SkillError::NotInstalled { .. })) => {
+                    warn!(
+                        skill = %name,
+                        plugin,
+                        marketplace,
+                        "remove_plugin: skill tracking entry had no on-disk directory; \
+                         treating as already-removed (A-12)"
+                    );
+                    result.skills_removed = result.skills_removed.saturating_add(1);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Steering files.
+        let steering = self.load_installed_steering()?;
+        let steering_to_remove: Vec<PathBuf> = steering
+            .files
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(rel, _)| rel.clone())
+            .collect();
+        for rel in &steering_to_remove {
+            match self.remove_steering_file(rel) {
+                Ok(()) => {
+                    result.steering_removed = result.steering_removed.saturating_add(1);
+                }
+                Err(crate::error::Error::Steering(
+                    crate::steering::SteeringError::NotInstalled { .. },
+                )) => {
+                    warn!(
+                        rel = %rel.display(),
+                        plugin,
+                        marketplace,
+                        "remove_plugin: steering tracking entry had no on-disk file; \
+                         treating as already-removed (A-12)"
+                    );
+                    result.steering_removed = result.steering_removed.saturating_add(1);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Agents.
+        let agents = self.load_installed_agents()?;
+        let agents_to_remove: Vec<String> = agents
+            .agents
+            .iter()
+            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &agents_to_remove {
+            match self.remove_agent(name) {
+                Ok(()) => {
+                    result.agents_removed = result.agents_removed.saturating_add(1);
+                }
+                Err(crate::error::Error::Agent(AgentError::NotInstalled { .. })) => {
+                    warn!(
+                        agent = %name,
+                        plugin,
+                        marketplace,
+                        "remove_plugin: agent tracking entry had no on-disk prompt; \
+                         treating as already-removed (A-12)"
+                    );
+                    result.agents_removed = result.agents_removed.saturating_add(1);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // native_companions cleanup (A-3 + A-16). Idempotent — the
+        // helper returns Ok even if the entry doesn't exist or
+        // belongs to a different marketplace.
+        self.remove_native_companions_for_plugin(plugin, marketplace)?;
+
+        Ok(result)
     }
 
     /// Persist the steering tracking file to disk atomically.
@@ -4180,6 +4530,583 @@ mod tests {
         assert!(
             msg.contains("invalid name"),
             "expected 'invalid name', got: {msg}"
+        );
+    }
+
+    // -- remove_steering_file ---------------------------------------------
+
+    #[test]
+    fn remove_steering_file_unlinks_and_updates_tracking() {
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir().join("steering")).expect("dirs");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "guide.md": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "source_hash": "feedface",
+                        "installed_hash": "feedface",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+        std::fs::write(project.kiro_dir().join("steering/guide.md"), "# guide\n")
+            .expect("write steering file");
+
+        project
+            .remove_steering_file(Path::new("guide.md"))
+            .expect("remove ok");
+
+        assert!(
+            !project.kiro_dir().join("steering/guide.md").exists(),
+            "on-disk steering file must be unlinked"
+        );
+        let tracking = project.load_installed_steering().expect("load post-remove");
+        assert!(
+            tracking.files.is_empty(),
+            "tracking entry must be gone after remove"
+        );
+    }
+
+    #[test]
+    fn remove_steering_file_returns_not_installed_for_unknown_rel() {
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let err = project
+            .remove_steering_file(Path::new("absent.md"))
+            .expect_err("expected NotInstalled");
+        assert!(
+            matches!(
+                err,
+                crate::error::Error::Steering(crate::steering::SteeringError::NotInstalled { .. })
+            ),
+            "expected SteeringError::NotInstalled, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn remove_steering_file_succeeds_when_on_disk_file_missing() {
+        // A-12 orphan-tracking case at the per-method granularity:
+        // tracking entry exists but on-disk file was hand-deleted.
+        // remove_steering_file must drop the tracking entry and return
+        // Ok(), letting the cascade count it as removed.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "orphan.md": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+        // Note: NO steering/orphan.md on disk.
+
+        project
+            .remove_steering_file(Path::new("orphan.md"))
+            .expect("orphan recovery: must NOT abort");
+
+        let tracking = project.load_installed_steering().expect("load post-remove");
+        assert!(
+            tracking.files.is_empty(),
+            "tracking entry must be gone even when on-disk file was orphan"
+        );
+    }
+
+    #[test]
+    fn remove_steering_file_rejects_path_traversal_argument() {
+        // Defense-in-depth: even though `load_installed_steering`
+        // already rejects traversal entries, a future caller might
+        // construct an `InstalledSteering` in memory and bypass the
+        // load path. `remove_steering_file` must independently
+        // refuse a traversal arg before joining onto `steering_dir`.
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let err = project
+            .remove_steering_file(Path::new("../../etc/passwd"))
+            .expect_err("traversal arg must be refused");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+                let msg = io_err.to_string();
+                assert!(
+                    msg.contains("../../etc/passwd"),
+                    "error must name the offending path, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::Io(InvalidData), got {other:?}"),
+        }
+    }
+
+    // -- remove_agent ------------------------------------------------------
+
+    #[test]
+    fn remove_agent_unlinks_files_and_updates_tracking() {
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.agent_prompts_dir()).expect("agents/prompts");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {
+                    "reviewer": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "dialect": "native",
+                        "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+        std::fs::write(project.agents_dir().join("reviewer.json"), b"{}\n").expect("write json");
+        std::fs::write(
+            project.agent_prompts_dir().join("reviewer.md"),
+            "# reviewer\n",
+        )
+        .expect("write prompt");
+
+        project.remove_agent("reviewer").expect("remove ok");
+
+        assert!(
+            !project.agents_dir().join("reviewer.json").exists(),
+            "agent JSON must be unlinked"
+        );
+        assert!(
+            !project.agent_prompts_dir().join("reviewer.md").exists(),
+            "agent prompt must be unlinked"
+        );
+        let tracking = project.load_installed_agents().expect("load");
+        assert!(
+            !tracking.agents.contains_key("reviewer"),
+            "tracking entry must be gone after remove"
+        );
+    }
+
+    #[test]
+    fn remove_agent_returns_not_installed_for_unknown_name() {
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let err = project
+            .remove_agent("missing")
+            .expect_err("expected NotInstalled");
+        assert!(
+            matches!(
+                err,
+                crate::error::Error::Agent(AgentError::NotInstalled { .. })
+            ),
+            "expected AgentError::NotInstalled, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn remove_agent_succeeds_when_on_disk_files_missing() {
+        // A-12 at per-method granularity for agents.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {
+                    "ghost": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": null,
+                        "installed_at": now,
+                        "dialect": "native",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+        // Note: NO ghost.json or prompts/ghost.md on disk.
+
+        project
+            .remove_agent("ghost")
+            .expect("orphan recovery: must NOT abort");
+
+        let tracking = project.load_installed_agents().expect("load");
+        assert!(
+            !tracking.agents.contains_key("ghost"),
+            "tracking entry must be gone even when on-disk files were orphan"
+        );
+    }
+
+    // -- remove_native_companions_for_plugin -------------------------------
+
+    #[test]
+    fn remove_native_companions_for_plugin_only_removes_matching_marketplace() {
+        // A-16: companions map is keyed by plugin name alone, but
+        // marketplace lives on the value. Removing mp-b's
+        // "code-reviewer" must NOT touch mp-a's record.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {},
+                "native_companions": {
+                    "code-reviewer": {
+                        "marketplace": "mp-a",
+                        "plugin": "code-reviewer",
+                        "version": null,
+                        "installed_at": now,
+                        "files": [],
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+
+        // mp-b's "code-reviewer" entry doesn't exist — no-op.
+        project
+            .remove_native_companions_for_plugin("code-reviewer", "mp-b")
+            .expect("remove ok (no-op)");
+
+        let tracking = project.load_installed_agents().expect("load");
+        assert!(
+            tracking.native_companions.contains_key("code-reviewer"),
+            "mp-a's record must remain — A-16 marketplace disambiguation"
+        );
+
+        // mp-a's removal takes the entry out.
+        project
+            .remove_native_companions_for_plugin("code-reviewer", "mp-a")
+            .expect("remove ok");
+        let tracking = project.load_installed_agents().expect("load");
+        assert!(
+            tracking.native_companions.is_empty(),
+            "matching marketplace must remove the entry"
+        );
+    }
+
+    #[test]
+    fn remove_native_companions_for_plugin_unlinks_companion_files() {
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.agent_prompts_dir()).expect("agents/prompts");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {},
+                "native_companions": {
+                    "p": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": null,
+                        "installed_at": now,
+                        "files": ["prompts/helper.md"],
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+        let companion = project.agents_dir().join("prompts/helper.md");
+        std::fs::write(&companion, b"# helper\n").expect("write companion file");
+
+        project
+            .remove_native_companions_for_plugin("p", "mp")
+            .expect("remove ok");
+
+        assert!(
+            !companion.exists(),
+            "companion file must be unlinked when its plugin entry is removed"
+        );
+    }
+
+    #[test]
+    fn remove_native_companions_for_plugin_is_noop_when_entry_absent() {
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        // No tracking file at all → load returns default → no entry.
+        project
+            .remove_native_companions_for_plugin("p", "mp")
+            .expect("must be a no-op when no tracking exists");
+    }
+
+    // -- remove_plugin cascade --------------------------------------------
+
+    #[test]
+    fn remove_plugin_cascades_through_skills_steering_agents_tracking() {
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir().join("steering")).expect("dirs");
+        std::fs::create_dir_all(project.skills_dir().join("alpha")).expect("skill dir");
+        std::fs::write(
+            project.skills_dir().join("alpha/SKILL.md"),
+            "---\nname: alpha\ndescription: A\n---\n",
+        )
+        .expect("skill file");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "skills": {
+                    "alpha": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "deadbeef",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("skills tracking");
+
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "guide.md": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "feedface", "installed_hash": "feedface",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("steering tracking");
+        std::fs::write(project.kiro_dir().join("steering/guide.md"), "# guide\n")
+            .expect("steering file");
+
+        let result = project.remove_plugin("mp", "p").expect("remove_plugin");
+        assert_eq!(result.skills_removed, 1);
+        assert_eq!(result.steering_removed, 1);
+        assert_eq!(result.agents_removed, 0);
+
+        let post = project
+            .installed_plugins()
+            .expect("installed_plugins post-remove");
+        assert!(
+            post.iter().all(|p| p.plugin != "p"),
+            "plugin p must be gone from the aggregated view"
+        );
+        assert!(
+            !project.skills_dir().join("alpha").exists(),
+            "skill dir must be unlinked"
+        );
+        assert!(
+            !project.kiro_dir().join("steering/guide.md").exists(),
+            "on-disk steering file must be unlinked"
+        );
+    }
+
+    #[test]
+    fn remove_plugin_only_removes_matching_marketplace_plugin_pair() {
+        // Same plugin name across two marketplaces: removing mp-a/p
+        // must NOT touch mp-b/p's entries.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir().join("steering")).expect("dirs");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "a.md": {
+                        "marketplace": "mp-a", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "1", "installed_hash": "1",
+                    },
+                    "b.md": {
+                        "marketplace": "mp-b", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "2", "installed_hash": "2",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("steering tracking");
+        std::fs::write(project.kiro_dir().join("steering/a.md"), "# a\n").expect("a");
+        std::fs::write(project.kiro_dir().join("steering/b.md"), "# b\n").expect("b");
+
+        let result = project.remove_plugin("mp-a", "p").expect("remove mp-a/p");
+        assert_eq!(result.steering_removed, 1, "only mp-a/p's entry");
+
+        let tracking = project.load_installed_steering().expect("load");
+        assert!(
+            tracking.files.contains_key(Path::new("b.md")),
+            "mp-b/p's entry must remain"
+        );
+        assert!(
+            project.kiro_dir().join("steering/b.md").exists(),
+            "mp-b/p's on-disk file must remain"
+        );
+        assert!(
+            !project.kiro_dir().join("steering/a.md").exists(),
+            "mp-a/p's on-disk file must be unlinked"
+        );
+    }
+
+    #[test]
+    fn remove_plugin_recovers_from_orphan_skill_tracking_entry() {
+        // A-12 regression at the cascade level: tracking entry exists
+        // but on-disk dir doesn't. The cascade must NOT abort; treat
+        // as already-removed.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "skills": {
+                    "orphan": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "deadbeef",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("skills tracking");
+        // Note: NO skills/orphan dir on disk.
+
+        let result = project
+            .remove_plugin("mp", "p")
+            .expect("orphan recovery: must NOT abort");
+        assert_eq!(
+            result.skills_removed, 1,
+            "orphan tracking entry counts as removed (A-12)"
+        );
+        // Note: remove_skill returns SkillError::NotInstalled when the
+        // on-disk directory is missing without dropping the tracking
+        // entry — that's the existing precedent. The cascade
+        // therefore can't drop the phantom skill tracking entry here.
+        // The orphan recovery contract per A-12 is "log + count as
+        // removed + continue", not "rewrite the tracking file." A
+        // future cleanup pass that makes remove_skill itself prune
+        // orphan tracking would tighten this — out of scope for the
+        // plugin-first install plan's Task 3.
+    }
+
+    #[test]
+    fn remove_plugin_propagates_load_time_path_traversal_error() {
+        // A-4 regression: the cascade reads tracking files via
+        // load_installed_steering, which validates path entries.
+        // A traversal entry must surface as a load-time Err and the
+        // cascade must propagate, not silently skip.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "../../etc/passwd": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "x", "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("steering tracking");
+
+        let err = project
+            .remove_plugin("mp", "p")
+            .expect_err("traversal entry must surface as Err");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+            }
+            other => {
+                panic!("expected Error::Io(InvalidData) from load-time validator, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn remove_plugin_drops_native_companions_entry_for_matching_marketplace() {
+        // A-3 + A-16: cascade must call
+        // remove_native_companions_for_plugin with the correct
+        // marketplace, and only matching entries get dropped.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {},
+                "native_companions": {
+                    "p": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": null,
+                        "installed_at": now,
+                        "files": [],
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("agents tracking");
+
+        project.remove_plugin("mp", "p").expect("remove_plugin");
+
+        let tracking = project.load_installed_agents().expect("load");
+        assert!(
+            tracking.native_companions.is_empty(),
+            "native_companions entry must be dropped for matching marketplace"
         );
     }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -263,6 +263,77 @@ pub struct InstalledNativeCompanionsOutcome {
     pub installed_hash: String,
 }
 
+/// Aggregated view of a single installed plugin — the union of
+/// what's tracked across `installed-skills.json`,
+/// `installed-steering.json`, and `installed-agents.json` for a
+/// given `(marketplace, plugin)` pair.
+///
+/// Returned by [`KiroProject::installed_plugins`]. The frontend
+/// renders one row per `InstalledPluginInfo`.
+///
+/// `installed_version` is the version of the **most recent install**
+/// by `installed_at` timestamp — not a lexicographic max. See A-6
+/// in the plan amendments doc for why string-compare is wrong here.
+///
+/// `earliest_install` and `latest_install` are RFC3339-formatted
+/// strings to match the FFI shape used by `InstalledSkillInfo`
+/// (specta's chrono feature isn't enabled in this crate).
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstalledPluginInfo {
+    pub marketplace: String,
+    pub plugin: String,
+    pub installed_version: Option<String>,
+    pub skill_count: u32,
+    pub steering_count: u32,
+    pub agent_count: u32,
+    pub installed_skills: Vec<String>,
+    pub installed_steering: Vec<std::path::PathBuf>,
+    pub installed_agents: Vec<String>,
+    /// RFC3339-formatted timestamp.
+    pub earliest_install: String,
+    /// RFC3339-formatted timestamp.
+    pub latest_install: String,
+}
+
+/// Per-`(marketplace, plugin)` accumulator used by
+/// [`KiroProject::installed_plugins`] while folding the three tracking
+/// files into [`InstalledPluginInfo`] rows.
+#[derive(Default)]
+struct Acc {
+    /// `(installed_at, version)` of the most recent tracking entry seen
+    /// across the three content types — the version of the latest
+    /// install, which is what the UI wants under "this plugin's
+    /// installed version."
+    latest: Option<(chrono::DateTime<chrono::Utc>, Option<String>)>,
+    earliest: Option<chrono::DateTime<chrono::Utc>>,
+    skills: Vec<String>,
+    steering: Vec<std::path::PathBuf>,
+    agents: Vec<String>,
+}
+
+fn update_latest(
+    acc: &mut Acc,
+    version: Option<&str>,
+    installed_at: chrono::DateTime<chrono::Utc>,
+) {
+    let new_version = version.map(str::to_string);
+    // `>` (not `>=`): on tied timestamps, first-seen wins. The
+    // aggregator iterates skills → steering → agents, so on equal
+    // timestamps the first of those three with a tracking entry
+    // contributes the displayed version. Stable across process
+    // restarts; `>=` would leak HashMap iteration order into the
+    // wire format.
+    let should_replace = acc
+        .latest
+        .as_ref()
+        .is_none_or(|(when, _)| installed_at > *when);
+    if should_replace {
+        acc.latest = Some((installed_at, new_version));
+    }
+    acc.earliest = Some(acc.earliest.map_or(installed_at, |e| e.min(installed_at)));
+}
+
 // ---------------------------------------------------------------------------
 // KiroProject
 // ---------------------------------------------------------------------------
@@ -749,6 +820,81 @@ impl KiroProject {
             }
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Aggregate the three `installed-*.json` tracking files into one
+    /// row per `(marketplace, plugin)` pair, the shape the
+    /// `InstalledTab` UI renders.
+    ///
+    /// The returned `installed_version` reflects the *most recent*
+    /// install across all three content types (skills, steering,
+    /// agents), measured by `installed_at`. Tied timestamps keep
+    /// the first-iterated version (skills → steering → agents) — see
+    /// [`update_latest`] for the rationale.
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O or JSON parse failures from the three
+    /// `load_installed*` methods.
+    pub fn installed_plugins(&self) -> crate::error::Result<Vec<InstalledPluginInfo>> {
+        use std::collections::BTreeMap;
+
+        let mut by_pair: BTreeMap<(String, String), Acc> = BTreeMap::new();
+
+        let skills = self.load_installed()?;
+        for (name, meta) in &skills.skills {
+            let acc = by_pair
+                .entry((meta.marketplace.clone(), meta.plugin.clone()))
+                .or_default();
+            acc.skills.push(name.clone());
+            update_latest(acc, meta.version.as_deref(), meta.installed_at);
+        }
+
+        let steering = self.load_installed_steering()?;
+        for (rel, meta) in &steering.files {
+            let acc = by_pair
+                .entry((meta.marketplace.clone(), meta.plugin.clone()))
+                .or_default();
+            acc.steering.push(rel.clone());
+            update_latest(acc, meta.version.as_deref(), meta.installed_at);
+        }
+
+        let agents = self.load_installed_agents()?;
+        for (name, meta) in &agents.agents {
+            let acc = by_pair
+                .entry((meta.marketplace.clone(), meta.plugin.clone()))
+                .or_default();
+            acc.agents.push(name.clone());
+            update_latest(acc, meta.version.as_deref(), meta.installed_at);
+        }
+
+        // Hoist `Utc::now()` out of the map closure (A-9): one syscall
+        // not N. Also makes the fallback substitution explicit at one
+        // site — a missing `installed_at` is a degenerate state the
+        // tracking file shouldn't produce; substituting "now" is a
+        // fallback the UI accepts but a future reader can scrutinize.
+        let now = chrono::Utc::now();
+        Ok(by_pair
+            .into_iter()
+            .map(|((marketplace, plugin), acc)| {
+                let (latest_install_dt, installed_version) =
+                    acc.latest.map_or_else(|| (now, None), |(t, v)| (t, v));
+                let earliest_install_dt = acc.earliest.unwrap_or(now);
+                InstalledPluginInfo {
+                    marketplace,
+                    plugin,
+                    installed_version,
+                    skill_count: u32::try_from(acc.skills.len()).unwrap_or(u32::MAX),
+                    steering_count: u32::try_from(acc.steering.len()).unwrap_or(u32::MAX),
+                    agent_count: u32::try_from(acc.agents.len()).unwrap_or(u32::MAX),
+                    installed_skills: acc.skills,
+                    installed_steering: acc.steering,
+                    installed_agents: acc.agents,
+                    earliest_install: earliest_install_dt.to_rfc3339(),
+                    latest_install: latest_install_dt.to_rfc3339(),
+                }
+            })
+            .collect())
     }
 
     /// Persist the steering tracking file to disk atomically.
@@ -2845,6 +2991,130 @@ mod tests {
         let loaded = project.load_installed_steering().unwrap();
         assert_eq!(loaded.files.len(), 1);
         assert!(loaded.files.contains_key(std::path::Path::new("guide.md")));
+    }
+
+    #[test]
+    fn installed_plugins_groups_skills_steering_agents_by_marketplace_plugin_pair() {
+        use chrono::Utc;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = KiroProject::new(dir.path().to_path_buf());
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        let skills_json = serde_json::json!({
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp",
+                    "plugin": "plug-a",
+                    "version": "1.0.0",
+                    "installed_at": now,
+                    "source_hash": "deadbeef"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-skills.json"),
+            serde_json::to_vec_pretty(&skills_json).expect("ser skills"),
+        )
+        .expect("skills tracking");
+
+        let steering_json = serde_json::json!({
+            "files": {
+                "guide.md": {
+                    "marketplace": "mp",
+                    "plugin": "plug-a",
+                    "version": "1.0.0",
+                    "installed_at": now,
+                    "source_hash": "cafebabe",
+                    "installed_hash": "cafebabe"
+                },
+                "review.md": {
+                    "marketplace": "mp",
+                    "plugin": "plug-b",
+                    "version": "0.5.0",
+                    "installed_at": now,
+                    "source_hash": "feedface",
+                    "installed_hash": "feedface"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&steering_json).expect("ser steering"),
+        )
+        .expect("steering tracking");
+
+        let result = project.installed_plugins().expect("installed_plugins");
+        assert_eq!(result.len(), 2, "two plugins expected");
+
+        let plug_a = result
+            .iter()
+            .find(|p| p.plugin == "plug-a")
+            .expect("plug-a present");
+        assert_eq!(plug_a.skill_count, 1);
+        assert_eq!(plug_a.steering_count, 1);
+        assert_eq!(plug_a.agent_count, 0);
+        assert_eq!(plug_a.installed_skills, vec!["alpha".to_string()]);
+        assert_eq!(plug_a.installed_version.as_deref(), Some("1.0.0"));
+
+        let plug_b = result
+            .iter()
+            .find(|p| p.plugin == "plug-b")
+            .expect("plug-b present");
+        assert_eq!(plug_b.skill_count, 0);
+        assert_eq!(plug_b.steering_count, 1);
+        assert_eq!(plug_b.agent_count, 0);
+    }
+
+    #[test]
+    fn installed_plugins_uses_strict_greater_for_latest_tie_break() {
+        use chrono::Utc;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = KiroProject::new(dir.path().to_path_buf());
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        // Same timestamp on skill (v1) and steering (v2). Skills are
+        // iterated first; `>` keeps skill's version. `>=` would let
+        // steering (iterated second) overwrite, producing v2.
+        let same_time = Utc::now();
+        let skills_json = serde_json::json!({
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": same_time,
+                    "source_hash": "deadbeef"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-skills.json"),
+            serde_json::to_vec_pretty(&skills_json).expect("ser"),
+        )
+        .expect("skills");
+
+        let steering_json = serde_json::json!({
+            "files": {
+                "guide.md": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "2.0.0", "installed_at": same_time,
+                    "source_hash": "cafebabe", "installed_hash": "cafebabe"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&steering_json).expect("ser"),
+        )
+        .expect("steering");
+
+        let result = project.installed_plugins().expect("installed_plugins");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].installed_version.as_deref(),
+            Some("1.0.0"),
+            "tied timestamps must keep first-iterated version (skills); \
+             got steering's 2.0.0 — A-17 `>` tie-break broken"
+        );
     }
 
     /// `rstest` fixture for steering install collision tests. Stages a

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -743,44 +743,64 @@ impl KiroProject {
 
     /// Remove an installed skill.
     ///
-    /// Deletes the skill directory and removes the entry from the tracking
-    /// file.
+    /// Drops the entry from `installed-skills.json` and unlinks the
+    /// skill directory. `NotInstalled` is reserved for "no tracking
+    /// entry" — a tracking row whose on-disk dir was hand-deleted is
+    /// recovered: the tracking row is dropped and the call returns
+    /// `Ok` (I3). Mirrors [`Self::remove_steering_file`] /
+    /// [`Self::remove_agent`]'s shape so the cascade in
+    /// [`Self::remove_plugin`] sees a uniform contract.
     ///
     /// # Errors
     ///
-    /// - [`SkillError::NotInstalled`] if the skill is not installed.
-    /// - I/O or JSON serialisation errors.
+    /// - [`SkillError::NotInstalled`] if `name` has no tracking entry.
+    /// - I/O or JSON serialisation errors. A `NotFound` on the
+    ///   on-disk directory itself is treated as success (orphan
+    ///   tracking row was just dropped).
     pub fn remove_skill(&self, name: &str) -> crate::error::Result<()> {
         validation::validate_name(name)?;
 
         crate::file_lock::with_file_lock(&self.tracking_path(), || -> crate::error::Result<()> {
             let dir = self.skill_dir(name);
 
-            if !dir.exists() {
-                return Err(SkillError::NotInstalled {
-                    name: name.to_owned(),
-                }
-                .into());
-            }
-
-            // Update tracking BEFORE deleting the directory so a crash
-            // between the two operations leaves the directory on disk
-            // (harmless) rather than a phantom tracking entry (confusing).
+            // Tracking-first removal (I3). Mirrors `remove_steering_file`
+            // and `remove_agent`: drop the tracking entry before any fs
+            // op so a crash between the two leaves the directory on
+            // disk (harmless) rather than a phantom tracking entry
+            // (which would resurrect the plugin in `installed_plugins()`).
             let mut installed = self.load_installed()?;
-            let saved_meta = installed.skills.remove(name);
+            let saved_meta =
+                installed
+                    .skills
+                    .remove(name)
+                    .ok_or_else(|| SkillError::NotInstalled {
+                        name: name.to_owned(),
+                    })?;
             self.write_tracking(&installed)?;
 
-            if let Err(e) = fs::remove_dir_all(&dir) {
-                // Directory delete failed after tracking was already updated.
-                // Re-insert the entry so the tracking file stays consistent.
-                warn!(
-                    name,
-                    error = %e,
-                    "failed to delete skill directory after tracking update; \
-                     restoring tracking entry"
-                );
-                if let Some(meta) = saved_meta {
-                    installed.skills.insert(name.to_owned(), meta);
+            match fs::remove_dir_all(&dir) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Orphan recovery: tracking row dropped, dir was
+                    // already gone (user hand-deleted it). I3 closes
+                    // the gap that previously made the cascade's
+                    // A-12 path leave persistent orphans.
+                    debug!(
+                        name,
+                        path = %dir.display(),
+                        "skill dir already absent on disk; orphan tracking row dropped"
+                    );
+                }
+                Err(e) => {
+                    // Restore tracking on non-NotFound fs failure so
+                    // the file system stays consistent with tracking.
+                    warn!(
+                        name,
+                        error = %e,
+                        "failed to delete skill directory after tracking update; \
+                         restoring tracking entry"
+                    );
+                    installed.skills.insert(name.to_owned(), saved_meta);
                     if let Err(restore_err) = self.write_tracking(&installed) {
                         warn!(
                             name,
@@ -789,14 +809,8 @@ impl KiroProject {
                              untracked on disk"
                         );
                     }
-                } else {
-                    debug!(
-                        name,
-                        "skill directory exists on disk but had no tracking \
-                         entry; no restore needed"
-                    );
+                    return Err(e.into());
                 }
-                return Err(e.into());
             }
 
             Ok(())
@@ -1065,18 +1079,16 @@ impl KiroProject {
         let tracking_path = self.steering_tracking_path();
         crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
             let mut installed = self.load_installed_steering()?;
-            if !installed.files.contains_key(rel) {
-                return Err(crate::steering::SteeringError::NotInstalled {
+            let saved_meta = installed.files.remove(rel).ok_or_else(|| {
+                crate::steering::SteeringError::NotInstalled {
                     rel: rel.to_path_buf(),
                 }
-                .into());
-            }
+            })?;
 
             let dest = self.steering_dir().join(rel);
             // Update tracking BEFORE unlinking so a crash between the
             // two leaves a stray on-disk file (harmless) rather than a
             // phantom tracking entry. Mirrors `remove_skill`'s ordering.
-            installed.files.remove(rel);
             self.write_steering_tracking(&installed)?;
 
             match fs::remove_file(&dest) {
@@ -1088,12 +1100,26 @@ impl KiroProject {
                     );
                 }
                 Err(e) => {
+                    // I4: restore tracking on non-NotFound fs failure
+                    // so the tracking file stays consistent with the
+                    // file system (and a retry will see the same
+                    // tracking entry).
                     warn!(
                         rel = %rel.display(),
                         path = %dest.display(),
                         error = %e,
-                        "failed to unlink steering file after tracking update"
+                        "failed to unlink steering file after tracking update; \
+                         restoring tracking entry"
                     );
+                    installed.files.insert(rel.to_path_buf(), saved_meta);
+                    if let Err(restore_err) = self.write_steering_tracking(&installed) {
+                        warn!(
+                            rel = %rel.display(),
+                            error = %restore_err,
+                            "failed to restore steering tracking entry — \
+                             file may be untracked on disk"
+                        );
+                    }
                     return Err(e.into());
                 }
             }
@@ -1126,12 +1152,13 @@ impl KiroProject {
         let tracking_path = self.agent_tracking_path();
         crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
             let mut installed = self.load_installed_agents()?;
-            if !installed.agents.contains_key(name) {
-                return Err(AgentError::NotInstalled {
-                    name: name.to_owned(),
-                }
-                .into());
-            }
+            let saved_meta =
+                installed
+                    .agents
+                    .remove(name)
+                    .ok_or_else(|| AgentError::NotInstalled {
+                        name: name.to_owned(),
+                    })?;
 
             let json_target = self.agents_dir().join(format!("{name}.json"));
             let prompt_target = self.agent_prompts_dir().join(format!("{name}.md"));
@@ -1139,7 +1166,6 @@ impl KiroProject {
             // Update tracking BEFORE unlinking so a crash between the
             // two leaves stray on-disk files (harmless) rather than a
             // phantom tracking entry.
-            installed.agents.remove(name);
             self.write_agent_tracking(&installed)?;
 
             for path in [&json_target, &prompt_target] {
@@ -1152,12 +1178,29 @@ impl KiroProject {
                         );
                     }
                     Err(e) => {
+                        // I4: restore tracking on non-NotFound fs
+                        // failure. The dual-file unlink can be
+                        // half-successful — one file unlinked, the
+                        // other failed. Restoring tracking keeps the
+                        // file system consistent with tracking, even
+                        // though the on-disk state is now partial.
+                        // The caller can retry or inspect.
                         warn!(
                             agent = name,
                             path = %path.display(),
                             error = %e,
-                            "failed to unlink agent file after tracking update"
+                            "failed to unlink agent file after tracking update; \
+                             restoring tracking entry"
                         );
+                        installed.agents.insert(name.to_owned(), saved_meta);
+                        if let Err(restore_err) = self.write_agent_tracking(&installed) {
+                            warn!(
+                                agent = name,
+                                error = %restore_err,
+                                "failed to restore agent tracking entry — \
+                                 agent may be untracked on disk"
+                            );
+                        }
                         return Err(e.into());
                     }
                 }
@@ -1237,28 +1280,35 @@ impl KiroProject {
     /// the on-disk files, updates the tracking JSON files atomically,
     /// and returns aggregated counts.
     ///
-    /// **Orphan-tracking recovery (A-12).** If a tracking entry
+    /// **Orphan-tracking recovery (A-12 + I3).** If a tracking entry
     /// references a path that no longer exists on disk (state
     /// divergence: user ran `rm -rf .kiro/skills/<name>/` manually),
-    /// the per-content removal still completes successfully because
-    /// each `remove_*` treats on-disk `NotFound` as success. Only
-    /// genuine fs / parse / cross-plugin-clash error variants abort
-    /// the cascade.
+    /// the per-content `remove_*` drops the tracking row and treats
+    /// the missing on-disk file as success. The cascade therefore
+    /// counts the orphan as removed AND the tracking row no longer
+    /// resurrects the plugin in `installed_plugins()`.
+    ///
+    /// **Per-step failures (I5).** A per-content removal that fails
+    /// mid-cascade does NOT abort. The failure is recorded in
+    /// `result.failed`; the cascade keeps going on the remaining
+    /// content types so partial progress isn't lost. Same policy as
+    /// `InstallPluginResult`'s sub-result `failed` vecs (A-15).
     ///
     /// **`native_companions` cleanup (A-3 + A-16).** After per-agent
     /// removals, the plugin-level `native_companions` entry is
     /// dropped if its `marketplace` field matches `marketplace` (the
     /// map is keyed by plugin name alone, so the marketplace check
-    /// disambiguates same-named plugins across marketplaces).
+    /// disambiguates same-named plugins across marketplaces). A
+    /// failure here also lands in `result.failed` rather than
+    /// short-circuiting the cascade.
     ///
     /// # Errors
     ///
-    /// Propagates any non-`NotInstalled` error from the per-content
-    /// removals, plus I/O / JSON failures from the cascade's
-    /// initial tracking-file loads. The cascade does **not** roll
-    /// back partial progress — once a per-content `remove_*`
-    /// commits, that work stays committed even if a later step
-    /// fails.
+    /// Reserved for "failed to even read the initial tracking files"
+    /// (the three `load_installed*()` calls). Per-step errors during
+    /// the loop go into `result.failed`. Tracking-file loads can fail
+    /// with I/O errors, JSON parse errors, or path-traversal
+    /// validation errors (A-4).
     pub fn remove_plugin(
         &self,
         marketplace: &str,
@@ -1279,17 +1329,25 @@ impl KiroProject {
                 Ok(()) => {
                     result.skills_removed = result.skills_removed.saturating_add(1);
                 }
-                Err(crate::error::Error::Skill(SkillError::NotInstalled { .. })) => {
+                Err(e) => {
+                    // I5: collect, don't abort. I3 closed the orphan-
+                    // tracking gap so `SkillError::NotInstalled` from
+                    // here is now "no tracking entry" — which the
+                    // cascade's `filter` already excluded. So this
+                    // arm is for genuine fs / serialisation failures.
                     warn!(
                         skill = %name,
                         plugin,
                         marketplace,
-                        "remove_plugin: skill tracking entry had no on-disk directory; \
-                         treating as already-removed (A-12)"
+                        error = %e,
+                        "remove_plugin: skill removal failed; recording in `failed`"
                     );
-                    result.skills_removed = result.skills_removed.saturating_add(1);
+                    result.failed.push(RemovePluginFailure {
+                        content_type: "skill".to_string(),
+                        item: name.clone(),
+                        error: crate::error::error_full_chain(&e),
+                    });
                 }
-                Err(e) => return Err(e),
             }
         }
 
@@ -1306,19 +1364,20 @@ impl KiroProject {
                 Ok(()) => {
                     result.steering_removed = result.steering_removed.saturating_add(1);
                 }
-                Err(crate::error::Error::Steering(
-                    crate::steering::SteeringError::NotInstalled { .. },
-                )) => {
+                Err(e) => {
                     warn!(
                         rel = %rel.display(),
                         plugin,
                         marketplace,
-                        "remove_plugin: steering tracking entry had no on-disk file; \
-                         treating as already-removed (A-12)"
+                        error = %e,
+                        "remove_plugin: steering removal failed; recording in `failed`"
                     );
-                    result.steering_removed = result.steering_removed.saturating_add(1);
+                    result.failed.push(RemovePluginFailure {
+                        content_type: "steering".to_string(),
+                        item: rel.display().to_string(),
+                        error: crate::error::error_full_chain(&e),
+                    });
                 }
-                Err(e) => return Err(e),
             }
         }
 
@@ -1335,24 +1394,40 @@ impl KiroProject {
                 Ok(()) => {
                     result.agents_removed = result.agents_removed.saturating_add(1);
                 }
-                Err(crate::error::Error::Agent(AgentError::NotInstalled { .. })) => {
+                Err(e) => {
                     warn!(
                         agent = %name,
                         plugin,
                         marketplace,
-                        "remove_plugin: agent tracking entry had no on-disk prompt; \
-                         treating as already-removed (A-12)"
+                        error = %e,
+                        "remove_plugin: agent removal failed; recording in `failed`"
                     );
-                    result.agents_removed = result.agents_removed.saturating_add(1);
+                    result.failed.push(RemovePluginFailure {
+                        content_type: "agent".to_string(),
+                        item: name.clone(),
+                        error: crate::error::error_full_chain(&e),
+                    });
                 }
-                Err(e) => return Err(e),
             }
         }
 
         // native_companions cleanup (A-3 + A-16). Idempotent — the
         // helper returns Ok even if the entry doesn't exist or
-        // belongs to a different marketplace.
-        self.remove_native_companions_for_plugin(plugin, marketplace)?;
+        // belongs to a different marketplace. Per I5 a failure here
+        // also lands in `result.failed` rather than aborting.
+        if let Err(e) = self.remove_native_companions_for_plugin(plugin, marketplace) {
+            warn!(
+                plugin,
+                marketplace,
+                error = %e,
+                "remove_plugin: native_companions cleanup failed; recording in `failed`"
+            );
+            result.failed.push(RemovePluginFailure {
+                content_type: "native_companions".to_string(),
+                item: String::new(),
+                error: crate::error::error_full_chain(&e),
+            });
+        }
 
         Ok(result)
     }
@@ -4872,6 +4947,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn remove_skill_drops_tracking_on_orphan_dir() {
+        // I3: when the on-disk skill dir is missing but a tracking
+        // entry exists, `remove_skill` must drop the tracking row and
+        // return `Ok(())`. Closes A-24 — the cascade's A-12 path no
+        // longer creates persistent orphans because the per-method
+        // contract now drives to absence.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "skills": {
+                    "orphan": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "deadbeef",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("skills tracking");
+        // Note: NO skills/orphan dir on disk.
+
+        project
+            .remove_skill("orphan")
+            .expect("orphan removal must succeed");
+
+        let installed = project.load_installed().expect("reload");
+        assert!(
+            installed.skills.is_empty(),
+            "I3: orphan tracking row must be dropped on remove_skill"
+        );
+    }
+
     // -- remove_steering_file ---------------------------------------------
 
     #[test]
@@ -4971,6 +5085,55 @@ mod tests {
         assert!(
             tracking.files.is_empty(),
             "tracking entry must be gone even when on-disk file was orphan"
+        );
+    }
+
+    #[test]
+    fn remove_steering_file_restores_tracking_on_unlink_failure() {
+        // I4: when fs::remove_file fails with a non-NotFound error,
+        // the tracking entry must be restored so the file system
+        // and tracking stay consistent. Trick: stage a directory at
+        // the destination path, so `remove_file` returns EISDIR
+        // (kind Other / IsADirectory) — not NotFound — which the
+        // restore branch handles.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir().join("steering/guide.md"))
+            .expect("stage directory at destination so unlink fails with EISDIR");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "guide.md": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+
+        let err = project
+            .remove_steering_file(Path::new("guide.md"))
+            .expect_err("EISDIR must surface as Err");
+        assert!(
+            matches!(err, crate::error::Error::Io(_)),
+            "expected Error::Io, got {err:?}"
+        );
+
+        let tracking = project
+            .load_installed_steering()
+            .expect("reload steering tracking");
+        assert!(
+            tracking.files.contains_key(Path::new("guide.md")),
+            "I4: tracking entry must be restored after unlink failure"
         );
     }
 
@@ -5102,6 +5265,64 @@ mod tests {
         assert!(
             !tracking.agents.contains_key("ghost"),
             "tracking entry must be gone even when on-disk files were orphan"
+        );
+    }
+
+    #[test]
+    fn remove_agent_restores_tracking_on_unlink_failure() {
+        // I4: stage a directory at the agent JSON destination so
+        // `fs::remove_file` returns EISDIR; the tracking row must be
+        // restored. This exercises the half-success case (one file
+        // unlinks, the other fails) by relying on the JSON path
+        // being unlinkable as a directory.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        // Create the parent so we can stage a directory at the JSON path.
+        std::fs::create_dir_all(project.agents_dir().join("reviewer.json"))
+            .expect("stage directory at agent JSON path so unlink fails with EISDIR");
+        std::fs::create_dir_all(project.agent_prompts_dir()).expect("agents/prompts dir");
+        // Empty prompt file so the second unlink would succeed —
+        // the failure must come from the directory at reviewer.json.
+        std::fs::write(
+            project.agent_prompts_dir().join("reviewer.md"),
+            "# reviewer\n",
+        )
+        .expect("write prompt");
+
+        let now = Utc::now();
+        std::fs::write(
+            project.agent_tracking_path(),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "agents": {
+                    "reviewer": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "dialect": "native",
+                        "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write tracking");
+
+        let err = project
+            .remove_agent("reviewer")
+            .expect_err("EISDIR must surface as Err");
+        assert!(
+            matches!(err, crate::error::Error::Io(_)),
+            "expected Error::Io, got {err:?}"
+        );
+
+        let tracking = project
+            .load_installed_agents()
+            .expect("reload agent tracking");
+        assert!(
+            tracking.agents.contains_key("reviewer"),
+            "I4: tracking entry must be restored after unlink failure"
         );
     }
 
@@ -5329,9 +5550,10 @@ mod tests {
 
     #[test]
     fn remove_plugin_recovers_from_orphan_skill_tracking_entry() {
-        // A-12 regression at the cascade level: tracking entry exists
-        // but on-disk dir doesn't. The cascade must NOT abort; treat
-        // as already-removed.
+        // A-12 + I3 regression at the cascade level: tracking entry
+        // exists but on-disk dir doesn't. The cascade must NOT abort
+        // AND the tracking row must be dropped so the plugin doesn't
+        // resurrect on the next `installed_plugins()` call.
         use chrono::Utc;
         let (_dir, project) = temp_project();
         std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
@@ -5360,15 +5582,116 @@ mod tests {
             result.skills_removed, 1,
             "orphan tracking entry counts as removed (A-12)"
         );
-        // Note: remove_skill returns SkillError::NotInstalled when the
-        // on-disk directory is missing without dropping the tracking
-        // entry — that's the existing precedent. The cascade
-        // therefore can't drop the phantom skill tracking entry here.
-        // The orphan recovery contract per A-12 is "log + count as
-        // removed + continue", not "rewrite the tracking file." A
-        // future cleanup pass that makes remove_skill itself prune
-        // orphan tracking would tighten this — out of scope for the
-        // plugin-first install plan's Task 3.
+        assert!(
+            result.failed.is_empty(),
+            "I3: orphan recovery is no longer a `failed` entry; remove_skill \
+             drops the tracking row and treats missing on-disk dir as success"
+        );
+        // I3: remove_skill now drops the tracking row on the orphan
+        // path, so installed_plugins() must NOT surface this plugin
+        // anymore. Closes A-24.
+        let installed = project.load_installed().expect("reload skills tracking");
+        assert!(
+            installed.skills.is_empty(),
+            "I3: orphan tracking row must be dropped post-cascade"
+        );
+        let plugins = project.installed_plugins().expect("installed_plugins");
+        assert!(
+            plugins.is_empty(),
+            "I3: cleared tracking means `installed_plugins()` reports nothing — \
+             plugin no longer resurrects after a `Remove` click"
+        );
+    }
+
+    #[test]
+    fn remove_plugin_partial_failure_collects_failed_and_keeps_succeeded() {
+        // I5: stage one removable skill plus a steering tracking row
+        // whose unlink fails (directory at destination). The cascade
+        // must:
+        //   - count the skill as removed
+        //   - record the steering failure in `result.failed` (NOT
+        //     short-circuit)
+        //   - still return Ok(result)
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        // Removable skill: install a real one so remove_skill drives
+        // to absence cleanly.
+        let src = tempfile::tempdir().expect("skill tempdir");
+        std::fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: removable\ndescription: Goes away\n---\n",
+        )
+        .expect("write skill");
+        project
+            .install_skill_from_dir(
+                "removable",
+                src.path(),
+                InstalledSkillMeta {
+                    marketplace: "mp".into(),
+                    plugin: "p".into(),
+                    version: Some("1.0.0".into()),
+                    installed_at: Utc::now(),
+                    source_hash: Some("deadbeef".into()),
+                    installed_hash: Some("deadbeef".into()),
+                },
+            )
+            .expect("install skill");
+
+        // Stage steering tracking entry whose dest is a directory →
+        // remove_file returns EISDIR → I5 captures the failure.
+        std::fs::create_dir_all(project.kiro_dir().join("steering/guide.md"))
+            .expect("stage directory at steering destination");
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "guide.md": {
+                        "marketplace": "mp",
+                        "plugin": "p",
+                        "version": "1.0.0",
+                        "installed_at": now,
+                        "source_hash": "x",
+                        "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser"),
+        )
+        .expect("write steering tracking");
+
+        let result = project
+            .remove_plugin("mp", "p")
+            .expect("I5: cascade returns Ok even with per-step failures");
+
+        assert_eq!(
+            result.skills_removed, 1,
+            "I5: skill removal succeeded and counted"
+        );
+        assert_eq!(
+            result.steering_removed, 0,
+            "I5: steering removal failed — count must NOT increment"
+        );
+        assert_eq!(
+            result.failed.len(),
+            1,
+            "I5: exactly one failed entry expected, got {:?}",
+            result.failed
+        );
+        assert_eq!(
+            result.failed[0].content_type, "steering",
+            "I5: content_type must identify which sub-step errored"
+        );
+        assert_eq!(
+            result.failed[0].item, "guide.md",
+            "I5: item must identify which entry errored"
+        );
+        assert!(
+            !result.failed[0].error.is_empty(),
+            "I5: error string must be populated via error_full_chain"
+        );
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -296,6 +296,48 @@ pub struct InstalledPluginInfo {
     pub latest_install: String,
 }
 
+/// Wire-format wrapper around [`Vec<InstalledPluginInfo>`] that also
+/// carries per-tracking-file load failures so the UI can render a
+/// partial state when one of the three `installed-*.json` files is
+/// corrupt or unreadable (I13).
+///
+/// Rationale: previously, `installed_plugins()` failed the entire
+/// aggregator on any `?`-chain load failure, leaving the user with
+/// "zero installed plugins" even when two of three tracking files
+/// loaded cleanly. The view here surfaces what loaded AND what
+/// didn't, so the UI can show a "partial state — N tracking files
+/// failed to load" banner instead of a misleading empty list.
+#[derive(Debug, Clone, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstalledPluginsView {
+    /// Per-`(marketplace, plugin)` rows assembled from the tracking
+    /// files that loaded successfully. May be empty if every file
+    /// failed; the [`Self::partial_load_warnings`] vec then carries
+    /// the explanation.
+    pub plugins: Vec<InstalledPluginInfo>,
+    /// One entry per `installed-*.json` whose load failed. The
+    /// corresponding content type's contributions are missing from
+    /// `plugins`. Empty on a clean state.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub partial_load_warnings: Vec<TrackingLoadWarning>,
+}
+
+/// Per-tracking-file load failure surfaced by
+/// [`KiroProject::installed_plugins`] (I13).
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct TrackingLoadWarning {
+    /// Filename relative to `.kiro/`: `"installed-skills.json"` /
+    /// `"installed-steering.json"` / `"installed-agents.json"`. Just
+    /// the basename — the absolute path leaks layout information the
+    /// frontend doesn't need.
+    pub tracking_file: String,
+    /// Rendered error chain via [`crate::error::error_full_chain`] —
+    /// wire format per CLAUDE.md "in any wire-format `reason`/`error:
+    /// String` field that crosses the FFI, use `error_full_chain(&err)`".
+    pub error: String,
+}
+
 /// Aggregated counts returned by
 /// [`KiroProject::remove_plugin`] — one tally per content type so the
 /// caller (CLI / Tauri) can render a one-line "removed N skills,
@@ -967,16 +1009,40 @@ impl KiroProject {
     /// the first-iterated version (skills → steering → agents) — see
     /// [`update_latest`] for the rationale.
     ///
+    /// # Partial-load tolerance (I13)
+    ///
+    /// A failure to load one of the three tracking files is recorded
+    /// in [`InstalledPluginsView::partial_load_warnings`] and the
+    /// other two files still contribute. Previously a single corrupt
+    /// tracking file would surface as the user seeing zero installed
+    /// plugins; the view now lets the UI render the partial state with
+    /// an explicit "N tracking files failed to load" banner.
+    ///
     /// # Errors
     ///
-    /// Propagates I/O or JSON parse failures from the three
-    /// `load_installed*` methods.
-    pub fn installed_plugins(&self) -> crate::error::Result<Vec<InstalledPluginInfo>> {
+    /// Infallible at the function level — even if every tracking
+    /// file fails to load, the returned view carries the warnings
+    /// and an empty `plugins` Vec. The `Result` return type is
+    /// preserved purely for API stability and future-proofing
+    /// (a panic-on-corrupt-tempdir style failure would fit there).
+    pub fn installed_plugins(&self) -> crate::error::Result<InstalledPluginsView> {
         use std::collections::BTreeMap;
 
         let mut by_pair: BTreeMap<(String, String), Acc> = BTreeMap::new();
+        let mut warnings: Vec<TrackingLoadWarning> = Vec::new();
 
-        let skills = self.load_installed()?;
+        // I13: each tracking-file load failure is recorded as a
+        // warning; the other two files still contribute. The
+        // `unwrap_or_else` shape is a deliberate fall-back to the
+        // `Default` value (empty maps) so the rest of the fold
+        // doesn't have to special-case missing data.
+        let skills = self.load_installed().unwrap_or_else(|e| {
+            warnings.push(TrackingLoadWarning {
+                tracking_file: INSTALLED_SKILLS_FILE.to_string(),
+                error: crate::error::error_full_chain(&e),
+            });
+            InstalledSkills::default()
+        });
         for (name, meta) in &skills.skills {
             let acc = by_pair
                 .entry((meta.marketplace.clone(), meta.plugin.clone()))
@@ -985,7 +1051,13 @@ impl KiroProject {
             update_latest(acc, meta.version.as_deref(), meta.installed_at);
         }
 
-        let steering = self.load_installed_steering()?;
+        let steering = self.load_installed_steering().unwrap_or_else(|e| {
+            warnings.push(TrackingLoadWarning {
+                tracking_file: INSTALLED_STEERING_FILE.to_string(),
+                error: crate::error::error_full_chain(&e),
+            });
+            InstalledSteering::default()
+        });
         for (rel, meta) in &steering.files {
             let acc = by_pair
                 .entry((meta.marketplace.clone(), meta.plugin.clone()))
@@ -994,7 +1066,13 @@ impl KiroProject {
             update_latest(acc, meta.version.as_deref(), meta.installed_at);
         }
 
-        let agents = self.load_installed_agents()?;
+        let agents = self.load_installed_agents().unwrap_or_else(|e| {
+            warnings.push(TrackingLoadWarning {
+                tracking_file: INSTALLED_AGENTS_FILE.to_string(),
+                error: crate::error::error_full_chain(&e),
+            });
+            InstalledAgents::default()
+        });
         for (name, meta) in &agents.agents {
             let acc = by_pair
                 .entry((meta.marketplace.clone(), meta.plugin.clone()))
@@ -1009,7 +1087,7 @@ impl KiroProject {
         // tracking file shouldn't produce; substituting "now" is a
         // fallback the UI accepts but a future reader can scrutinize.
         let now = chrono::Utc::now();
-        Ok(by_pair
+        let plugins: Vec<InstalledPluginInfo> = by_pair
             .into_iter()
             .map(|((marketplace, plugin), mut acc)| {
                 let (latest_install_dt, installed_version) =
@@ -1038,7 +1116,11 @@ impl KiroProject {
                     latest_install: latest_install_dt.to_rfc3339(),
                 }
             })
-            .collect())
+            .collect();
+        Ok(InstalledPluginsView {
+            plugins,
+            partial_load_warnings: warnings,
+        })
     }
 
     /// Remove a single installed steering file from
@@ -3702,9 +3784,14 @@ mod tests {
         .expect("steering tracking");
 
         let result = project.installed_plugins().expect("installed_plugins");
-        assert_eq!(result.len(), 2, "two plugins expected");
+        assert_eq!(result.plugins.len(), 2, "two plugins expected");
+        assert!(
+            result.partial_load_warnings.is_empty(),
+            "clean state must produce no warnings"
+        );
 
         let plug_a = result
+            .plugins
             .iter()
             .find(|p| p.plugin == "plug-a")
             .expect("plug-a present");
@@ -3715,6 +3802,7 @@ mod tests {
         assert_eq!(plug_a.installed_version.as_deref(), Some("1.0.0"));
 
         let plug_b = result
+            .plugins
             .iter()
             .find(|p| p.plugin == "plug-b")
             .expect("plug-b present");
@@ -3765,9 +3853,9 @@ mod tests {
         .expect("steering");
 
         let result = project.installed_plugins().expect("installed_plugins");
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.plugins.len(), 1);
         assert_eq!(
-            result[0].installed_version.as_deref(),
+            result.plugins[0].installed_version.as_deref(),
             Some("1.0.0"),
             "tied timestamps must keep first-iterated version (skills); \
              got steering's 2.0.0 — A-17 `>` tie-break broken"
@@ -3855,14 +3943,14 @@ mod tests {
         .expect("agents");
 
         let result = project.installed_plugins().expect("installed_plugins");
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.plugins.len(), 1);
         assert_eq!(
-            result[0].installed_skills,
+            result.plugins[0].installed_skills,
             vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()],
             "skills must be sorted post-fold; HashMap iteration order leak"
         );
         assert_eq!(
-            result[0].installed_steering,
+            result.plugins[0].installed_steering,
             vec![
                 std::path::PathBuf::from("a-guide.md"),
                 std::path::PathBuf::from("m-guide.md"),
@@ -3871,13 +3959,94 @@ mod tests {
             "steering must be sorted post-fold"
         );
         assert_eq!(
-            result[0].installed_agents,
+            result.plugins[0].installed_agents,
             vec![
                 "alpha-agent".to_string(),
                 "mid-agent".to_string(),
                 "zeta".to_string(),
             ],
             "agents must be sorted post-fold"
+        );
+    }
+
+    #[test]
+    fn installed_plugins_returns_full_view_with_empty_warnings_on_clean_state() {
+        // I13 regression: a clean (no tracking files) state must
+        // surface as an empty view with no warnings — not as an error.
+        let (_dir, project) = temp_project();
+
+        let view = project.installed_plugins().expect("clean state");
+        assert!(
+            view.plugins.is_empty(),
+            "no plugins installed yet, got: {:?}",
+            view.plugins
+        );
+        assert!(
+            view.partial_load_warnings.is_empty(),
+            "missing tracking files are NOT corruption — warnings must be empty, got: {:?}",
+            view.partial_load_warnings
+        );
+    }
+
+    #[test]
+    fn installed_plugins_returns_partial_view_when_one_tracking_file_corrupt() {
+        // I13 regression: a corrupt tracking file (invalid JSON) must
+        // NOT abort the aggregator. The other two tracking files
+        // contribute their plugins; the corruption is recorded as a
+        // `partial_load_warnings` entry so the UI can render a banner.
+        use chrono::Utc;
+        let (_dir, project) = temp_project();
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        // Steering: clean — must contribute its plugin to the view.
+        let now = Utc::now();
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "files": {
+                    "guide.md": {
+                        "marketplace": "mp", "plugin": "p",
+                        "version": "1.0.0", "installed_at": now,
+                        "source_hash": "x", "installed_hash": "x",
+                    }
+                }
+            }))
+            .expect("ser steering"),
+        )
+        .expect("write steering");
+
+        // Skills: corrupt JSON — must surface as a load warning,
+        // not abort the aggregator.
+        std::fs::write(
+            project.kiro_dir().join("installed-skills.json"),
+            "{ this is not valid JSON",
+        )
+        .expect("write corrupt skills");
+
+        let view = project.installed_plugins().expect("partial-load tolerant");
+        assert_eq!(
+            view.plugins.len(),
+            1,
+            "steering loaded; one plugin expected, got: {:?}",
+            view.plugins
+        );
+        assert_eq!(view.plugins[0].plugin, "p");
+        assert_eq!(view.plugins[0].steering_count, 1);
+        assert_eq!(view.plugins[0].skill_count, 0);
+
+        assert_eq!(
+            view.partial_load_warnings.len(),
+            1,
+            "expected one warning for corrupt skills tracking, got: {:?}",
+            view.partial_load_warnings
+        );
+        assert_eq!(
+            view.partial_load_warnings[0].tracking_file, "installed-skills.json",
+            "warning must identify which tracking file failed"
+        );
+        assert!(
+            !view.partial_load_warnings[0].error.is_empty(),
+            "warning's error string must be populated via error_full_chain"
         );
     }
 
@@ -5486,7 +5655,7 @@ mod tests {
             .installed_plugins()
             .expect("installed_plugins post-remove");
         assert!(
-            post.iter().all(|p| p.plugin != "p"),
+            post.plugins.iter().all(|p| p.plugin != "p"),
             "plugin p must be gone from the aggregated view"
         );
         assert!(
@@ -5597,7 +5766,7 @@ mod tests {
         );
         let plugins = project.installed_plugins().expect("installed_plugins");
         assert!(
-            plugins.is_empty(),
+            plugins.plugins.is_empty(),
             "I3: cleared tracking means `installed_plugins()` reports nothing — \
              plugin no longer resurrects after a `Remove` click"
         );

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -3699,6 +3699,21 @@ mod tests {
         );
     }
 
+    /// Build a tracking JSON map with three entries keyed by `keys`,
+    /// where each value is a tracking-meta object built by `value_for`.
+    /// Used by [`installed_plugins_returns_sorted_vecs_per_plugin`] to
+    /// keep the test under clippy's `too_many_lines` threshold.
+    fn build_tracking_map<F>(keys: [&str; 3], value_for: F) -> serde_json::Value
+    where
+        F: Fn() -> serde_json::Value,
+    {
+        let mut map = serde_json::Map::new();
+        for k in keys {
+            map.insert(k.to_string(), value_for());
+        }
+        serde_json::Value::Object(map)
+    }
+
     #[test]
     fn installed_plugins_returns_sorted_vecs_per_plugin() {
         // I1 regression: per-plugin Vecs (`installed_skills`,
@@ -3714,75 +3729,50 @@ mod tests {
         std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
 
         let now = Utc::now();
+        let skill_meta = || {
+            serde_json::json!({
+                "marketplace": "mp", "plugin": "p",
+                "version": "1.0.0", "installed_at": now,
+                "source_hash": "x"
+            })
+        };
+        let steering_meta = || {
+            serde_json::json!({
+                "marketplace": "mp", "plugin": "p",
+                "version": "1.0.0", "installed_at": now,
+                "source_hash": "x", "installed_hash": "x"
+            })
+        };
+        let agent_meta = || {
+            serde_json::json!({
+                "marketplace": "mp", "plugin": "p",
+                "version": "1.0.0", "installed_at": now,
+                "dialect": "claude"
+            })
+        };
+
+        // Non-alphabetic order on every tracking file — exercises
+        // the sort-post-fold contract regardless of HashMap order.
         let skills_json = serde_json::json!({
-            "skills": {
-                "gamma": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x"
-                },
-                "alpha": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x"
-                },
-                "beta": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x"
-                }
-            }
+            "skills": build_tracking_map(["gamma", "alpha", "beta"], skill_meta),
         });
+        let steering_json = serde_json::json!({
+            "files": build_tracking_map(["z-guide.md", "a-guide.md", "m-guide.md"], steering_meta),
+        });
+        let agents_json = serde_json::json!({
+            "agents": build_tracking_map(["zeta", "alpha-agent", "mid-agent"], agent_meta),
+        });
+
         std::fs::write(
             project.kiro_dir().join("installed-skills.json"),
             serde_json::to_vec_pretty(&skills_json).expect("ser skills"),
         )
         .expect("skills");
-
-        let steering_json = serde_json::json!({
-            "files": {
-                "z-guide.md": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x", "installed_hash": "x"
-                },
-                "a-guide.md": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x", "installed_hash": "x"
-                },
-                "m-guide.md": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "source_hash": "x", "installed_hash": "x"
-                }
-            }
-        });
         std::fs::write(
             project.kiro_dir().join("installed-steering.json"),
             serde_json::to_vec_pretty(&steering_json).expect("ser steering"),
         )
         .expect("steering");
-
-        let agents_json = serde_json::json!({
-            "agents": {
-                "zeta": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "dialect": "claude"
-                },
-                "alpha-agent": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "dialect": "claude"
-                },
-                "mid-agent": {
-                    "marketplace": "mp", "plugin": "p",
-                    "version": "1.0.0", "installed_at": now,
-                    "dialect": "claude"
-                }
-            }
-        });
         std::fs::write(
             project.kiro_dir().join("installed-agents.json"),
             serde_json::to_vec_pretty(&agents_json).expect("ser agents"),
@@ -3793,7 +3783,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].installed_skills,
-            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string(),],
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()],
             "skills must be sorted post-fold; HashMap iteration order leak"
         );
         assert_eq!(

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -302,18 +302,47 @@ pub struct InstalledPluginInfo {
 /// M steering files, K agents" summary without re-reading the tracking
 /// files.
 ///
-/// Counts are post-cascade and include orphan-tracking recoveries
-/// (A-12): a tracking entry with no on-disk file still counts as
-/// "removed" because the cascade dropped the entry. The cascade
-/// never partially succeeds — either every entry is removed and the
-/// counts reflect the full work, or an error short-circuits before
-/// the result returns.
+/// Counts are post-cascade across every per-content removal that
+/// completed successfully. A per-step error during the cascade does
+/// **not** abort the work — the cascade keeps going on the remaining
+/// content types and records the failure in `failed`. Only "failed
+/// to even read the initial tracking files" is surfaced as the
+/// cascade's outer `Err` (I5). Orphan-tracking recoveries (A-12) still
+/// count as "removed" because the per-content remove drops the
+/// tracking row and treats the missing on-disk entry as success.
 #[derive(Debug, Clone, Default, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct RemovePluginResult {
     pub skills_removed: u32,
     pub steering_removed: u32,
     pub agents_removed: u32,
+    /// Per-step errors encountered during the cascade. The cascade
+    /// keeps making progress on remaining content types when one
+    /// step fails — same policy as `InstallPluginResult`'s sub-result
+    /// `failed` vecs (A-15). Empty on a clean cascade.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<RemovePluginFailure>,
+}
+
+/// One per-step failure recorded by [`KiroProject::remove_plugin`] when
+/// a per-content removal fails mid-cascade. The cascade keeps going on
+/// remaining content types; the caller surfaces these to the user as a
+/// partial-failure summary.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemovePluginFailure {
+    /// Which content type errored: `"skill"` / `"steering"` / `"agent"`
+    /// / `"native_companions"`.
+    pub content_type: String,
+    /// The item identifier — skill or agent name, or steering rel-path
+    /// rendered via `Path::display()`. Empty string for the
+    /// `"native_companions"` row, which is plugin-scoped rather than
+    /// per-item.
+    pub item: String,
+    /// Rendered error chain via [`crate::error::error_full_chain`] —
+    /// wire format per CLAUDE.md "in any wire-format `reason`/`error:
+    /// String` field that crosses the FFI, use `error_full_chain(&err)`".
+    pub error: String,
 }
 
 /// Per-`(marketplace, plugin)` accumulator used by
@@ -564,6 +593,76 @@ fn validate_tracking_companion_files(
     Ok(())
 }
 
+/// Validate every name key in a freshly-loaded [`InstalledSkills`]
+/// tracking record. Tracking files are user-owned; a tampered or
+/// hand-edited entry containing `../../etc/passwd` as a skill name
+/// would, without this check, flow into `skills_dir.join(name)` at
+/// removal time (`fs::remove_dir_all`) and delete files outside the
+/// install boundary. Mirrors [`validate_tracking_steering_files`]'s
+/// shape.
+fn validate_tracking_skill_keys(
+    installed: &InstalledSkills,
+    tracking_path: &Path,
+) -> crate::error::Result<()> {
+    for name in installed.skills.keys() {
+        if let Err(reason) = validation::validate_name(name) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "tracking file {} has invalid skill name `{}`: {}",
+                    tracking_path.display(),
+                    name,
+                    reason
+                ),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+/// Validate every name key in a freshly-loaded [`InstalledAgents`]
+/// tracking record — both per-agent (`agents`) and per-plugin
+/// (`native_companions`). Same rationale as
+/// [`validate_tracking_skill_keys`]: a tampered name reaches
+/// `agents_dir.join(format!("{name}.json"))` /
+/// `agent_prompts_dir.join(format!("{name}.md"))` at removal time,
+/// or shows up unfiltered in `installed_plugins()` on the wire.
+fn validate_tracking_agent_keys(
+    installed: &InstalledAgents,
+    tracking_path: &Path,
+) -> crate::error::Result<()> {
+    for name in installed.agents.keys() {
+        if let Err(reason) = validation::validate_name(name) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "tracking file {} has invalid agent name `{}`: {}",
+                    tracking_path.display(),
+                    name,
+                    reason
+                ),
+            )
+            .into());
+        }
+    }
+    for plugin in installed.native_companions.keys() {
+        if let Err(reason) = validation::validate_name(plugin) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "tracking file {} has invalid native_companions plugin key `{}`: {}",
+                    tracking_path.display(),
+                    plugin,
+                    reason
+                ),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
 /// Validate every relative path key in a freshly-loaded
 /// [`InstalledSteering`] tracking record. Same rationale as
 /// [`validate_tracking_companion_files`]: a tampered key like
@@ -631,6 +730,7 @@ impl KiroProject {
         match fs::read(&path) {
             Ok(bytes) => {
                 let installed: InstalledSkills = serde_json::from_slice(&bytes)?;
+                validate_tracking_skill_keys(&installed, &path)?;
                 Ok(installed)
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -779,6 +879,7 @@ impl KiroProject {
         match fs::read(&path) {
             Ok(bytes) => {
                 let installed: InstalledAgents = serde_json::from_slice(&bytes)?;
+                validate_tracking_agent_keys(&installed, &path)?;
                 validate_tracking_companion_files(&installed, &path)?;
                 Ok(installed)
             }
@@ -896,10 +997,19 @@ impl KiroProject {
         let now = chrono::Utc::now();
         Ok(by_pair
             .into_iter()
-            .map(|((marketplace, plugin), acc)| {
+            .map(|((marketplace, plugin), mut acc)| {
                 let (latest_install_dt, installed_version) =
                     acc.latest.map_or_else(|| (now, None), |(t, v)| (t, v));
                 let earliest_install_dt = acc.earliest.unwrap_or(now);
+                // Sort the per-plugin item Vecs (I1) so the wire-format
+                // ordering doesn't depend on HashMap iteration order.
+                // Without this, the same tracking files could yield
+                // different `installed_skills` orderings across runs —
+                // breaks UI snapshot tests and confuses humans reading
+                // the JSON.
+                acc.skills.sort();
+                acc.steering.sort();
+                acc.agents.sort();
                 InstalledPluginInfo {
                     marketplace,
                     plugin,
@@ -3274,6 +3384,128 @@ mod tests {
     }
 
     #[test]
+    fn load_installed_rejects_path_traversal_in_skills_key() {
+        // I9 regression: a tampered `installed-skills.json` containing
+        // a path-traversal key like `../../etc` as a skill name would,
+        // without validation, flow into `skills_dir.join(name)` at
+        // removal time (`fs::remove_dir_all`) and escape the install
+        // boundary. Mirrors
+        // [`load_installed_steering_rejects_path_traversal_in_files_key`].
+        let (_dir, project) = temp_project();
+        let tracking_path = project.root.join(".kiro/installed-skills.json");
+        fs::create_dir_all(tracking_path.parent().unwrap()).unwrap();
+        let tampered = serde_json::json!({
+            "skills": {
+                "../../etc": {
+                    "marketplace": "m",
+                    "plugin": "p",
+                    "version": null,
+                    "installed_at": chrono::Utc::now(),
+                    "source_hash": "blake3:abc",
+                }
+            }
+        });
+        fs::write(&tracking_path, tampered.to_string()).unwrap();
+
+        let err = project
+            .load_installed()
+            .expect_err("traversal must be refused at load time");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+                let msg = io_err.to_string();
+                assert!(
+                    msg.contains("../../etc"),
+                    "error must name the offending key, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::Io(InvalidData), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_installed_agents_rejects_path_traversal_in_agents_key() {
+        // I9 regression: a tampered `installed-agents.json` containing
+        // a path-traversal key like `../../etc` as an agent name
+        // would, without validation, flow into both
+        // `agents_dir.join(format!("{name}.json"))` and
+        // `agent_prompts_dir.join(format!("{name}.md"))` at removal
+        // time, escaping the install boundary.
+        let (_dir, project) = temp_project();
+        let tracking_path = project.root.join(".kiro/installed-agents.json");
+        fs::create_dir_all(tracking_path.parent().unwrap()).unwrap();
+        let tampered = serde_json::json!({
+            "agents": {
+                "../../etc": {
+                    "marketplace": "m",
+                    "plugin": "p",
+                    "version": null,
+                    "installed_at": chrono::Utc::now(),
+                    "dialect": "claude",
+                }
+            }
+        });
+        fs::write(&tracking_path, tampered.to_string()).unwrap();
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("traversal must be refused at load time");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+                let msg = io_err.to_string();
+                assert!(
+                    msg.contains("../../etc"),
+                    "error must name the offending agent name, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::Io(InvalidData), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_installed_agents_rejects_path_traversal_in_native_companions_key() {
+        // I9 regression: a tampered `installed-agents.json` whose
+        // `native_companions` map keys (plugin names) contain a
+        // traversal entry would, without validation, flow into
+        // `installed_plugins()` on the wire and corrupt downstream
+        // marketplace/plugin string handling.
+        let (_dir, project) = temp_project();
+        let tracking_path = project.root.join(".kiro/installed-agents.json");
+        fs::create_dir_all(tracking_path.parent().unwrap()).unwrap();
+        let tampered = serde_json::json!({
+            "agents": {},
+            "native_companions": {
+                "../../evil": {
+                    "marketplace": "m",
+                    "plugin": "evil",
+                    "version": null,
+                    "installed_at": chrono::Utc::now(),
+                    "files": [],
+                    "source_hash": "blake3:abc",
+                    "installed_hash": "blake3:abc",
+                }
+            }
+        });
+        fs::write(&tracking_path, tampered.to_string()).unwrap();
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("traversal must be refused at load time");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+                let msg = io_err.to_string();
+                assert!(
+                    msg.contains("../../evil"),
+                    "error must name the offending plugin key, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::Io(InvalidData), got {other:?}"),
+        }
+    }
+
+    #[test]
     fn load_installed_agents_rejects_path_traversal_in_companion_files() {
         // Closes marketplace-security-reviewer Important finding: a
         // tampered `installed-agents.json` containing a traversal entry
@@ -3464,6 +3696,123 @@ mod tests {
             Some("1.0.0"),
             "tied timestamps must keep first-iterated version (skills); \
              got steering's 2.0.0 — A-17 `>` tie-break broken"
+        );
+    }
+
+    #[test]
+    fn installed_plugins_returns_sorted_vecs_per_plugin() {
+        // I1 regression: per-plugin Vecs (`installed_skills`,
+        // `installed_steering`, `installed_agents`) are pushed in
+        // HashMap iteration order, which is nondeterministic. Sorting
+        // post-fold gives a stable wire format. Seed three skills,
+        // three steering files, and three agents in non-alphabetic
+        // tracking order; the result Vecs must be alphabetically
+        // sorted regardless of which order the HashMap chose to yield.
+        use chrono::Utc;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = KiroProject::new(dir.path().to_path_buf());
+        std::fs::create_dir_all(project.kiro_dir()).expect("kiro dir");
+
+        let now = Utc::now();
+        let skills_json = serde_json::json!({
+            "skills": {
+                "gamma": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x"
+                },
+                "alpha": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x"
+                },
+                "beta": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-skills.json"),
+            serde_json::to_vec_pretty(&skills_json).expect("ser skills"),
+        )
+        .expect("skills");
+
+        let steering_json = serde_json::json!({
+            "files": {
+                "z-guide.md": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x", "installed_hash": "x"
+                },
+                "a-guide.md": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x", "installed_hash": "x"
+                },
+                "m-guide.md": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "source_hash": "x", "installed_hash": "x"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-steering.json"),
+            serde_json::to_vec_pretty(&steering_json).expect("ser steering"),
+        )
+        .expect("steering");
+
+        let agents_json = serde_json::json!({
+            "agents": {
+                "zeta": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "dialect": "claude"
+                },
+                "alpha-agent": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "dialect": "claude"
+                },
+                "mid-agent": {
+                    "marketplace": "mp", "plugin": "p",
+                    "version": "1.0.0", "installed_at": now,
+                    "dialect": "claude"
+                }
+            }
+        });
+        std::fs::write(
+            project.kiro_dir().join("installed-agents.json"),
+            serde_json::to_vec_pretty(&agents_json).expect("ser agents"),
+        )
+        .expect("agents");
+
+        let result = project.installed_plugins().expect("installed_plugins");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].installed_skills,
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string(),],
+            "skills must be sorted post-fold; HashMap iteration order leak"
+        );
+        assert_eq!(
+            result[0].installed_steering,
+            vec![
+                std::path::PathBuf::from("a-guide.md"),
+                std::path::PathBuf::from("m-guide.md"),
+                std::path::PathBuf::from("z-guide.md"),
+            ],
+            "steering must be sorted post-fold"
+        );
+        assert_eq!(
+            result[0].installed_agents,
+            vec![
+                "alpha-agent".to_string(),
+                "mid-agent".to_string(),
+                "zeta".to_string(),
+            ],
+            "agents must be sorted post-fold"
         );
     }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -318,7 +318,13 @@ pub struct InstalledPluginsView {
     /// One entry per `installed-*.json` whose load failed. The
     /// corresponding content type's contributions are missing from
     /// `plugins`. Empty on a clean state.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ///
+    /// `serde(default)` is kept for legacy-JSON tolerance.
+    /// `skip_serializing_if` is intentionally absent — `tauri-specta`
+    /// 2.0.0-rc.24 unified mode rejects it (see A-25 in plan
+    /// amendments). Empty Vec serializes as `[]` rather than being
+    /// omitted, matching `InstallSkillsResult.failed` etc.
+    #[serde(default)]
     pub partial_load_warnings: Vec<TrackingLoadWarning>,
 }
 
@@ -362,7 +368,12 @@ pub struct RemovePluginResult {
     /// keeps making progress on remaining content types when one
     /// step fails — same policy as `InstallPluginResult`'s sub-result
     /// `failed` vecs (A-15). Empty on a clean cascade.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ///
+    /// `serde(default)` is kept for legacy-JSON tolerance.
+    /// `skip_serializing_if` is intentionally absent — `tauri-specta`
+    /// 2.0.0-rc.24 unified mode rejects it (A-25). Empty Vec serializes
+    /// as `[]` rather than being omitted.
+    #[serde(default)]
     pub failed: Vec<RemovePluginFailure>,
 }
 

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -395,10 +395,17 @@ pub struct PluginInstallContext {
     /// [`MarketplaceService::install_plugin_steering`].
     pub steering_scan_paths: Vec<String>,
     /// Authoring format declared by the plugin manifest. Drives dispatch
-    /// in [`MarketplaceService::install_plugin_agents`]: `Some(KiroCli)`
-    /// validates-and-copies native JSON; `None` (legacy) parses-and-translates
-    /// markdown agents.
-    pub format: Option<crate::plugin::PluginFormat>,
+    /// in [`MarketplaceService::install_plugin_agents`]:
+    /// [`PluginFormat::KiroCli`] validates-and-copies native JSON;
+    /// [`PluginFormat::Translated`] parses-and-translates markdown
+    /// agents. Plugins that omit the `format` field default to
+    /// [`PluginFormat::Translated`] via [`PluginFormat`]'s `Default`
+    /// impl, preserving the legacy install path.
+    ///
+    /// [`PluginFormat`]: crate::plugin::PluginFormat
+    /// [`PluginFormat::KiroCli`]: crate::plugin::PluginFormat::KiroCli
+    /// [`PluginFormat::Translated`]: crate::plugin::PluginFormat::Translated
+    pub format: crate::plugin::PluginFormat,
 }
 
 // Compile-time lock for the "Do not add `Serialize`" invariant on
@@ -781,7 +788,12 @@ impl MarketplaceService {
         let skill_dirs = discover_skills_for_plugin(plugin_dir, manifest.as_ref());
         let agent_scan_paths = agent_scan_paths_for_plugin(manifest.as_ref());
         let steering_scan_paths = steering_scan_paths_for_plugin(manifest.as_ref());
-        let format = manifest.as_ref().and_then(|m| m.format);
+        // I8: omitted `format` defaults to `PluginFormat::Translated`
+        // via the type's `Default` impl. `unwrap_or_default()` here
+        // (vs. `and_then`) makes the Option<...> → enum collapse
+        // explicit and lets the dispatch in `install_plugin_agents`
+        // be exhaustive.
+        let format = manifest.as_ref().map(|m| m.format).unwrap_or_default();
         Ok(PluginInstallContext {
             plugin_dir: plugin_dir.to_path_buf(),
             version,
@@ -3002,11 +3014,16 @@ mod tests {
 
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("happy path");
-        assert_eq!(ctx.format, Some(crate::plugin::PluginFormat::KiroCli));
+        assert_eq!(ctx.format, crate::plugin::PluginFormat::KiroCli);
     }
 
     #[test]
-    fn resolve_plugin_install_context_format_absent_is_none() {
+    fn resolve_plugin_install_context_format_absent_defaults_to_translated() {
+        // I8 regression: a plugin manifest with no `format` field
+        // routes to `PluginFormat::Translated` via the type's
+        // `Default` impl. Preserves the legacy "no format means
+        // translated agents" behavior, but encodes the default in
+        // the type rather than as `Option<...>::None`.
         let (dir, _svc) = temp_service();
         let plugin_dir = dir.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
@@ -3014,6 +3031,17 @@ mod tests {
 
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
             .expect("happy path");
-        assert!(ctx.format.is_none());
+        assert_eq!(ctx.format, crate::plugin::PluginFormat::Translated);
+    }
+
+    #[test]
+    fn plugin_manifest_defaults_to_translated_when_format_omitted() {
+        // I8 regression at the manifest deserialization boundary:
+        // a `plugin.json` with no `format` field deserializes to
+        // `PluginFormat::Translated` via `#[serde(default)]` on the
+        // field combined with `#[derive(Default)]` on the enum.
+        let manifest =
+            crate::plugin::PluginManifest::from_json(br#"{"name": "p"}"#).expect("parse");
+        assert_eq!(manifest.format, crate::plugin::PluginFormat::Translated);
     }
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -400,11 +400,19 @@ pub struct InstallAgentsResult {
     /// Per-native-agent rich outcome (`kind`, hashes). Empty for
     /// translated-only installs. Frontends that want the rich detail
     /// consume this; legacy presenters keep using `installed: Vec<String>`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ///
+    /// `serde` `default` is kept for round-trip parsing of legacy JSON
+    /// blobs that omit the field. `skip_serializing_if` was removed so
+    /// the type can flow through Tauri/Specta bindings — `tauri-specta`
+    /// 2.0.0-rc.24's unified mode rejects conditional field omission.
+    /// Mirrors [`InstallSkillsResult`] and [`crate::steering::InstallSteeringResult`],
+    /// neither of which use `skip_serializing_if` either.
+    #[serde(default)]
     pub installed_native: Vec<crate::project::InstalledNativeAgentOutcome>,
     /// Per-plugin native companion bundle outcome. `None` for translated
-    /// plugins or for native plugins with zero companion files.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// plugins or for native plugins with zero companion files. See
+    /// [`Self::installed_native`] for why `skip_serializing_if` is absent.
+    #[serde(default)]
     pub installed_companions: Option<crate::project::InstalledNativeCompanionsOutcome>,
 }
 

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1329,14 +1329,20 @@ impl MarketplaceService {
         project: &crate::project::KiroProject,
         plugin_dir: &Path,
         scan_paths: &[String],
-        format: Option<crate::plugin::PluginFormat>,
+        format: crate::plugin::PluginFormat,
         ctx: AgentInstallContext<'_>,
     ) -> InstallAgentsResult {
+        // I8: exhaustive match on the explicit `Translated` variant
+        // (vs. `Option<PluginFormat>::None`) so a future variant
+        // (e.g. `Cursor`) forces a compile-time decision here instead
+        // of silently routing through the translated path.
         match format {
-            Some(crate::plugin::PluginFormat::KiroCli) => {
+            crate::plugin::PluginFormat::KiroCli => {
                 Self::install_native_kiro_cli_agents_inner(project, plugin_dir, scan_paths, ctx)
             }
-            None => Self::install_translated_agents_inner(project, plugin_dir, scan_paths, ctx),
+            crate::plugin::PluginFormat::Translated => {
+                Self::install_translated_agents_inner(project, plugin_dir, scan_paths, ctx)
+            }
         }
     }
 
@@ -2182,7 +2188,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // existing fixtures don't carry MCP servers
@@ -2261,7 +2267,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2309,7 +2315,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2364,7 +2370,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2413,7 +2419,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // gate must fire
@@ -2468,7 +2474,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: true, // gate is bypassed
@@ -2537,7 +2543,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2593,7 +2599,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::Force, // force, but...
                 accept_mcp: false,        // accept_mcp = false should still gate
@@ -2634,7 +2640,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2651,7 +2657,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2690,7 +2696,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2714,7 +2720,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::Force,
                 accept_mcp: false,
@@ -2780,7 +2786,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            None,
+            crate::plugin::PluginFormat::Translated,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
@@ -2842,7 +2848,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            Some(crate::plugin::PluginFormat::KiroCli),
+            crate::plugin::PluginFormat::KiroCli,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // fixture has no MCP servers
@@ -2911,7 +2917,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string()],
-            Some(crate::plugin::PluginFormat::KiroCli),
+            crate::plugin::PluginFormat::KiroCli,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // gate fires
@@ -2971,7 +2977,7 @@ mod tests {
             &project,
             plugin_tmp.path(),
             &["./agents/".to_string(), "./extras/".to_string()],
-            Some(crate::plugin::PluginFormat::KiroCli),
+            crate::plugin::PluginFormat::KiroCli,
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -408,6 +408,27 @@ pub struct InstallAgentsResult {
     pub installed_companions: Option<crate::project::InstalledNativeCompanionsOutcome>,
 }
 
+/// Aggregate result of [`MarketplaceService::install_plugin`] — the
+/// outcome of running every install path a plugin declares (skills,
+/// steering, agents) in one coordinated call.
+///
+/// Sub-results are always populated. The underlying scan-path
+/// fallbacks (`agent_scan_paths_for_plugin` /
+/// `steering_scan_paths_for_plugin`) guarantee at least one attempt;
+/// `install_skills` returns a fully-formed default for empty input.
+/// Empty `installed` / `failed` vecs on a sub-result indicate "this
+/// content type was attempted with nothing to do" — distinct from a
+/// missing field.
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallPluginResult {
+    pub plugin: String,
+    pub version: Option<String>,
+    pub skills: InstallSkillsResult,
+    pub steering: crate::steering::InstallSteeringResult,
+    pub agents: InstallAgentsResult,
+}
+
 /// An agent that failed to install, with the typed error.
 ///
 /// `name` is `Some` once parsing has identified the agent; pre-parse
@@ -1884,6 +1905,83 @@ impl MarketplaceService {
             }
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Install every content type a plugin declares — skills, steering,
+    /// and agents — in one coordinated call. Replaces the per-frontend
+    /// "resolve context, then call three install paths in sequence" loop
+    /// that CLI and Tauri previously duplicated.
+    ///
+    /// Sub-results are always populated. `install_skills` returns a
+    /// fully-formed default for empty `skill_dirs`; the agent and steering
+    /// scan-path fallbacks guarantee at least one attempt each. Per-item
+    /// failures live in the relevant sub-result's `failed` field — a
+    /// single broken file never aborts the whole plugin install.
+    ///
+    /// `accept_mcp` plumbs through to [`Self::install_plugin_agents`]'s
+    /// MCP opt-in gate. Default-deny: agents that bring MCP servers are
+    /// skipped with a warning unless the caller explicitly opts in.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only for unrecoverable preamble failures — registry
+    /// lookup, plugin-directory resolution, or `plugin.json` parse — as
+    /// surfaced by [`Self::resolve_plugin_install_context`]. Once the
+    /// context resolves, every per-content-type call collects per-item
+    /// failures into its sub-result rather than propagating.
+    pub fn install_plugin(
+        &self,
+        project: &crate::project::KiroProject,
+        marketplace: &str,
+        plugin: &str,
+        mode: InstallMode,
+        accept_mcp: bool,
+    ) -> Result<InstallPluginResult, Error> {
+        let ctx = self.resolve_plugin_install_context(marketplace, plugin)?;
+
+        let skills = self.install_skills(
+            project,
+            &ctx.skill_dirs,
+            &InstallFilter::All,
+            mode,
+            marketplace,
+            plugin,
+            ctx.version.as_deref(),
+        );
+
+        let steering = Self::install_plugin_steering(
+            project,
+            &ctx.plugin_dir,
+            &ctx.steering_scan_paths,
+            crate::steering::SteeringInstallContext {
+                mode,
+                marketplace,
+                plugin,
+                version: ctx.version.as_deref(),
+            },
+        );
+
+        let agents = Self::install_plugin_agents(
+            project,
+            &ctx.plugin_dir,
+            &ctx.agent_scan_paths,
+            ctx.format,
+            AgentInstallContext {
+                mode,
+                accept_mcp,
+                marketplace,
+                plugin,
+                version: ctx.version.as_deref(),
+            },
+        );
+
+        Ok(InstallPluginResult {
+            plugin: plugin.to_string(),
+            version: ctx.version,
+            skills,
+            steering,
+            agents,
+        })
     }
 }
 
@@ -4600,6 +4698,127 @@ mod tests {
             matches!(result.failed[0].kind, FailedSkillReason::InstallFailed),
             "expected InstallFailed, got: {:?}",
             result.failed[0].kind
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // install_plugin orchestrator
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn install_plugin_runs_skills_steering_agents_in_one_call() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::create_dir_all(&plugin_dir).expect("plugin dir");
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name": "p", "version": "1.0.0"}"#,
+        )
+        .expect("write plugin.json");
+        fs::create_dir_all(plugin_dir.join("steering")).expect("steering dir");
+        fs::write(plugin_dir.join("steering/guide.md"), "# guide\n").expect("steering");
+        fs::create_dir_all(plugin_dir.join("agents")).expect("agents dir");
+        fs::write(
+            plugin_dir.join("agents/reviewer.md"),
+            "---\nname: reviewer\ndescription: Reviews\n---\nBody.\n",
+        )
+        .expect("agent");
+
+        let project_dir = tempfile::tempdir().expect("project tempdir");
+        let project = KiroProject::new(project_dir.path().to_path_buf());
+
+        let result = svc
+            .install_plugin(&project, "mp", "p", InstallMode::New, false)
+            .expect("install_plugin happy path");
+
+        assert_eq!(result.plugin, "p");
+        assert_eq!(result.version.as_deref(), Some("1.0.0"));
+        assert_eq!(result.skills.installed, vec!["alpha".to_string()]);
+        assert_eq!(
+            result.steering.installed.len(),
+            1,
+            "steering: {:?}",
+            result.steering
+        );
+        assert_eq!(
+            result.agents.installed.len(),
+            1,
+            "agents: {:?}",
+            result.agents
+        );
+    }
+
+    /// Wire-format lock for `InstallPluginResult`. Sub-result fields are
+    /// non-Optional structs (per Task 1 amendment A-15) — they always
+    /// serialize as nested objects, never as `null` or missing keys.
+    /// Frontend code that branches on `result.skills.installed.length`
+    /// relies on this shape.
+    #[test]
+    fn install_plugin_result_json_shape_locks_default_subresults() {
+        let result = InstallPluginResult {
+            plugin: "p".into(),
+            version: Some("1.0.0".into()),
+            skills: InstallSkillsResult::default(),
+            steering: crate::steering::InstallSteeringResult::default(),
+            agents: InstallAgentsResult::default(),
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["plugin"], "p");
+        assert_eq!(json["version"], "1.0.0");
+        assert!(
+            json["skills"].is_object(),
+            "skills must serialize as nested object, got: {}",
+            json["skills"]
+        );
+        assert!(
+            json["steering"].is_object(),
+            "steering must serialize as nested object, got: {}",
+            json["steering"]
+        );
+        assert!(
+            json["agents"].is_object(),
+            "agents must serialize as nested object, got: {}",
+            json["agents"]
+        );
+    }
+
+    /// Companion to the default-shape lock: a populated sub-result must
+    /// keep nesting under its key (no accidental `#[serde(flatten)]`
+    /// on `InstallPluginResult`). Pin one populated field so a future
+    /// flatten regression breaks the assertion immediately.
+    #[test]
+    fn install_plugin_result_json_shape_with_populated_subresult() {
+        let result = InstallPluginResult {
+            plugin: "p".into(),
+            version: Some("1.0.0".into()),
+            skills: InstallSkillsResult {
+                installed: vec!["alpha".into()],
+                ..InstallSkillsResult::default()
+            },
+            steering: crate::steering::InstallSteeringResult::default(),
+            agents: InstallAgentsResult::default(),
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        let skills = json.pointer("/skills").expect("skills field exists");
+        assert!(
+            skills.is_object(),
+            "must serialize as nested object, not flatten: {skills}"
+        );
+        assert_eq!(
+            skills
+                .pointer("/installed")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(1),
         );
     }
 }

--- a/crates/kiro-market-core/src/service/test_support.rs
+++ b/crates/kiro-market-core/src/service/test_support.rs
@@ -108,6 +108,31 @@ pub fn relative_path_entry(name: &str, rel: &str) -> PluginEntry {
     }
 }
 
+/// Build a `.kiro/`-rooted project directory under `dir` and return its
+/// path as a UTF-8 string ready to pass through the Tauri FFI.
+///
+/// Mirrors the inline helper that previously lived in three Tauri
+/// `commands/*::tests` modules (`steering.rs`, `browse.rs`, `agents.rs`).
+/// Hoisted here so new command files (`plugins.rs`) can reuse the same
+/// project-shape contract that
+/// [`crate::commands::validate_kiro_project_path`](../../../../kiro-control-center/src-tauri/src/commands/mod.rs)
+/// expects.
+///
+/// The created path is `<dir>/kproj/` with a `.kiro/` subdirectory; the
+/// returned `String` points at `<dir>/kproj/`.
+///
+/// # Panics
+///
+/// Panics if directory creation fails or the path is not valid UTF-8
+/// (the latter can't happen on `tempdir()`-rooted callers but is asserted
+/// for symmetry with the original inline helpers). Test infrastructure only.
+#[must_use]
+pub fn make_kiro_project(dir: &Path) -> String {
+    let project_path = dir.join("kproj");
+    std::fs::create_dir_all(project_path.join(".kiro")).expect("create .kiro dir");
+    project_path.to_str().expect("utf-8 path").to_owned()
+}
+
 /// Seed a marketplace's plugin registry directly to disk, bypassing
 /// the real `marketplace.json` + fetch flow. Returns the marketplace
 /// root path as a convenience for tests that then place plugin

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -113,6 +113,17 @@ pub enum SteeringError {
     #[non_exhaustive]
     #[error("steering tracking JSON malformed at `{path}`: {reason}")]
     TrackingMalformed { path: PathBuf, reason: String },
+
+    /// The steering file is not tracked in `installed-steering.json`.
+    /// Returned by `KiroProject::remove_steering_file` when the caller
+    /// asks to remove a `rel` path that has no tracking entry. Mirrors
+    /// [`crate::error::SkillError::NotInstalled`] /
+    /// [`crate::error::AgentError::NotInstalled`] so the
+    /// `remove_plugin` cascade can match on a uniform "tracking entry
+    /// missing" shape across all three content types.
+    #[non_exhaustive]
+    #[error("steering file `{rel}` is not tracked in installed-steering.json")]
+    NotInstalled { rel: PathBuf },
 }
 
 /// Construct a [`SteeringError::TrackingMalformed`] from a `serde_json::Error`,
@@ -329,6 +340,35 @@ mod tests {
              SkippedReason / FailedSkillReason / InstallOutcomeKind. Frontend code \
              writes `if (warning.kind === \"scan_path_invalid\")` — reverting this \
              attribute would silently break that pattern."
+        );
+    }
+
+    /// `SteeringError::NotInstalled` is the cascade-uniform "missing
+    /// tracking entry" variant used by
+    /// [`crate::project::KiroProject::remove_steering_file`] and the
+    /// `remove_plugin` cascade. The variant carries no `#[source]` —
+    /// the orphaned-tracking case isn't an underlying I/O / parse
+    /// failure, just a state mismatch. Locking that here keeps a
+    /// future variant addition from accidentally introducing a chain.
+    #[test]
+    fn not_installed_renders_rel_and_exposes_no_source_chain() {
+        use std::error::Error as _;
+        let err = SteeringError::NotInstalled {
+            rel: PathBuf::from("guide.md"),
+        };
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("guide.md"),
+            "rendered message must name the offending rel path, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("not tracked"),
+            "rendered message must convey the not-tracked semantic, got: {rendered}"
+        );
+        assert!(
+            err.source().is_none(),
+            "NotInstalled is a state mismatch, not an underlying I/O failure — \
+             must not expose a source chain"
         );
     }
 

--- a/crates/kiro-market-core/tests/integration_native_install.rs
+++ b/crates/kiro-market-core/tests/integration_native_install.rs
@@ -54,7 +54,7 @@ impl IntegrationHarness {
         marketplace: &str,
         plugin: &str,
         mode: InstallMode,
-    ) -> (Option<PluginFormat>, InstallAgentsResult) {
+    ) -> (PluginFormat, InstallAgentsResult) {
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(plugin_dir)
             .expect("resolve plugin install context");
         let install_ctx = AgentInstallContext {
@@ -220,7 +220,7 @@ fn end_to_end_native_plugin_with_agents_and_companions(harness: IntegrationHarne
         "fake-reviewers",
         InstallMode::New,
     );
-    assert_eq!(format, Some(PluginFormat::KiroCli));
+    assert_eq!(format, PluginFormat::KiroCli);
 
     assert!(result.failed.is_empty(), "no failures: {:?}", result.failed);
     assert_eq!(result.installed.len(), 3);
@@ -281,7 +281,11 @@ fn end_to_end_translated_plugin_unaffected_by_native_dispatch(harness: Integrati
         stage_translated_plugin(harness.plugin_root.path(), "translated-plugin", "rev");
 
     let (format, result) = harness.install(&plugin_dir, "m", "translated-plugin", InstallMode::New);
-    assert!(format.is_none(), "translated plugin has no format field");
+    assert_eq!(
+        format,
+        PluginFormat::Translated,
+        "translated plugin defaults to PluginFormat::Translated when format field omitted (I8)"
+    );
 
     assert!(result.failed.is_empty(), "no failures: {:?}", result.failed);
     assert_eq!(result.installed, vec!["rev".to_string()]);
@@ -346,7 +350,7 @@ fn end_to_end_native_plugin_with_agents_companions_and_steering(harness: Integra
         "fake-reviewers",
         InstallMode::New,
     );
-    assert_eq!(format, Some(PluginFormat::KiroCli));
+    assert_eq!(format, PluginFormat::KiroCli);
     assert!(
         agent_result.failed.is_empty(),
         "no agent failures: {:?}",

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -196,7 +196,7 @@ fn run_agent_install(
     plugin_dir: &Path,
     agent_scan_paths: &[String],
     skill_filter: Option<&str>,
-    format: Option<kiro_market_core::plugin::PluginFormat>,
+    format: kiro_market_core::plugin::PluginFormat,
     ctx: kiro_market_core::service::AgentInstallContext<'_>,
 ) -> InstallAgentsResult {
     // A `--skill <name>` filter narrows the install to one skill and never

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -1475,7 +1475,24 @@ pub installed_companions: Option<crate::project::InstalledNativeCompanionsOutcom
 
 ---
 
-## A-24 — Implementation finding: `remove_skill`'s `NotInstalled` leaves tracking row stale; A-12 cascade counts but doesn't truly drive to absence
+## A-24 — [CLOSED in PR #94 review fixup] Implementation finding: `remove_skill`'s `NotInstalled` leaves tracking row stale; A-12 cascade counts but doesn't truly drive to absence
+
+**Status.** Closed via PR #94's I3 review-fixup commit. The fix
+is option 1 from the original "two equally valid future fixes" list:
+`remove_skill` now drops the tracking row before any fs op and treats
+`fs::remove_dir_all` `NotFound` as success. The cascade's match arms
+were simultaneously reworked under I5 (per-step failures collected
+into `RemovePluginResult.failed`) so the orphan path is no longer
+even an exceptional case — `remove_skill` returns `Ok(())` and the
+cascade increments `skills_removed` like any other clean removal.
+
+Regression locks:
+- `remove_skill_drops_tracking_on_orphan_dir` — per-method contract.
+- `remove_plugin_recovers_from_orphan_skill_tracking_entry` —
+  expanded to assert tracking is empty post-cascade AND
+  `installed_plugins()` returns `[]` (no resurrection).
+
+The original A-24 narrative is preserved below for audit trail.
 
 **Surfaced during.** Task 3 implementation (commit `7a4718d`). Captured per the "forward motion + audit trail" rule from the Phase 1 execution session — not actioned in Task 3.
 

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -1441,6 +1441,30 @@ lesson so future plan-reviews start with the right tool.
 
 ---
 
+## A-24 — Implementation finding: `remove_skill`'s `NotInstalled` leaves tracking row stale; A-12 cascade counts but doesn't truly drive to absence
+
+**Surfaced during.** Task 3 implementation (commit `7a4718d`). Captured per the "forward motion + audit trail" rule from the Phase 1 execution session — not actioned in Task 3.
+
+**Drift.** A-12's "log + count + continue" recipe assumes that catching `*Error::NotInstalled` from a per-content remove is equivalent to "the entry is now gone." That holds for `remove_steering_file` and `remove_agent` (Tasks 3b/3c — both methods drop the tracking entry as the FIRST step, then unlink, so a missing on-disk file is still success and the tracking row is gone). It does NOT hold for the existing `remove_skill` (`project.rs:562`): when `!skill_dir.exists()`, `remove_skill` returns `Err(SkillError::NotInstalled)` *without* mutating `installed-skills.json`. The orphan tracking row persists.
+
+**User-visible effect.** A user clicks "Remove plugin" on a plugin whose `.kiro/skills/<name>/` was hand-deleted. The cascade reports `skills_removed: 1` and the UI redraws as "removed." But `installed_plugins()` will still surface that orphan tracking row on the next list call — the plugin reappears.
+
+**Why out-of-scope for Task 3.** Fixing `remove_skill` is a behavioral change to a pre-existing public API on `KiroProject` — the asymmetry vs. `remove_steering_file` / `remove_agent` (which Task 3 introduced) is a pre-existing design quirk. Tightening it touches the existing `remove_skill_*` test suite and may surface invariants we'd rather not change mid-implementation.
+
+**Two equally valid future fixes — pick during follow-up:**
+
+1. **Tighten `remove_skill`** to drop the tracking entry on `!dir.exists()` instead of returning `NotInstalled`. Symmetric with the new sibling methods. Risk: a caller relying on the current "tracking unchanged on NotInstalled" contract would break — needs a grep for `SkillError::NotInstalled` consumers to gauge the blast radius.
+
+2. **Tighten the cascade** to manually drop the skill tracking entry when it catches `SkillError::NotInstalled`, via direct `with_file_lock` + `load_installed` + remove + save. The `remove_skill` API stays unchanged; only the cascade's recovery path becomes complete. Risk: the cascade gains intimate knowledge of tracking-file shape that lives elsewhere.
+
+**Recommendation:** option 1, tracked for a Phase 1.5 follow-up PR after Phase 1 ships. The orphan-skill scenario is real but rare (user manually `rm -rf`'d a skill), and the user can recover by clicking "Remove" again after a `Refresh` (which would now show no entry — wait, no, the entry persists; never mind, *the user can hand-edit the tracking JSON*, which is the documented escape hatch per CLAUDE.md "tracking files are user-owned").
+
+The Task 3 orphan-recovery test (`remove_plugin_recovers_from_orphan_skill_tracking_entry`) was written as a regression lock for the cascade's no-abort behavior — NOT as a "drives to absence" test. The test asserts `result.skills_removed == 1` and that the cascade returns `Ok`. It does NOT assert that the tracking is empty afterward, because today it isn't. Future-fix PR should expand that test once `remove_skill` (or the cascade) is tightened.
+
+**Rationale.** Captured for audit trail per the "23 amendments + forward motion" rule. The implementer correctly chose to leave `remove_skill` alone — A-12's recipe didn't mandate "drive to absence," only "log + count + continue." The semantic gap is real but doesn't block Phase 1 from shipping; Phase 1.5 can close it.
+
+---
+
 ## Summary of changes
 
 - A-1: Single line fix in Task 1 step 4 (`self.` → `Self::`).
@@ -1512,6 +1536,11 @@ lesson so future plan-reviews start with the right tool.
   boundary, matching the existing `InstalledSkillInfo.installed_at`
   precedent. `PathBuf` survives — verified `InstalledSteeringOutcome`
   uses it under specta::Type today.
+- A-24: Implementation finding from Task 3. `remove_skill`'s
+  `NotInstalled` doesn't drop the tracking row, so the cascade's
+  A-12 "count as removed" path leaves stale tracking. Out of scope
+  for Phase 1; deferred to Phase 1.5 follow-up. Captured here as
+  audit trail per the "forward motion + amendments" execution rule.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
+++ b/docs/plans/2026-04-29-plugin-first-install-plan-amendments.md
@@ -1441,6 +1441,40 @@ lesson so future plan-reviews start with the right tool.
 
 ---
 
+## A-25 — Implementation finding: `tauri-specta` 2.0.0-rc.24 rejects `skip_serializing_if` on FFI types
+
+**Surfaced during.** Task 4 implementation (commit `34c96e0`). Hit when registering `install_plugin_agents` triggered the binding-gen pass.
+
+**Drift.** `InstallAgentsResult` (in `service/mod.rs:387`) had `#[serde(default, skip_serializing_if = "Vec::is_empty")]` on `installed_native` and `#[serde(default, skip_serializing_if = "Option::is_none")]` on `installed_companions`. These pre-dated the type crossing FFI. Registering it as a Tauri command return failed validation:
+
+```
+Specta Serde validation failed for command 'install_plugin_agents' result:
+Invalid phased type usage at 'InstallAgentsResult_Serialize.installed_native':
+`skip_serializing_if` requires `apply_phases` because unified mode cannot
+represent conditional omission
+```
+
+**Why `tauri-specta` rejects this.** Unified mode generates one TypeScript type that has to be valid for both serialization and deserialization. `skip_serializing_if` makes a field's *presence* conditional — meaning the deserialization input may have fewer fields than the serialization output. The unified TS type can't represent that without phase-splitting (`InstallAgentsResult_Serialize` vs `_Deserialize`), which `apply_phases` would enable but the project doesn't currently configure.
+
+**Wire-format peers don't have this issue.** `InstallSkillsResult` and `InstallSteeringResult` — both already exported through `bindings.ts` since PRs 83 and 92 — don't use `skip_serializing_if` on any field. The pattern at this codebase is "always serialize, always deserialize, default values for missing fields." `InstallAgentsResult`'s `skip_serializing_if` was an outlier predating its FFI exposure.
+
+**Amended.** Drop `skip_serializing_if` from both fields. Keep `serde(default)` for legacy-JSON tolerance:
+
+```rust
+#[serde(default)]
+pub installed_native: Vec<crate::project::InstalledNativeAgentOutcome>,
+#[serde(default)]
+pub installed_companions: Option<crate::project::InstalledNativeCompanionsOutcome>,
+```
+
+**Wire format change.** Empty `installed_native` now serializes as `[]` instead of being omitted; `installed_companions: None` now serializes as `null` instead of being omitted. No Rust callers asserted on the omitted shape; no tests asserted on the omitted shape. The runtime contract for Rust consumers is preserved. The TypeScript wire shape becomes consistent with the sibling result types.
+
+**Forward-looking rule.** Validation/result types that flow through Tauri must avoid `skip_serializing_if` — match `InstallSkillsResult`'s shape. This is a sibling rule to CLAUDE.md's existing "validation newtypes flowing through Tauri bindings need `#[cfg_attr(feature = "specta", derive(specta::Type))]`" guidance. Worth adding to CLAUDE.md once Phase 1 ships.
+
+**Rationale.** Captured as audit trail per the "forward motion + amendments" execution rule. The implementer correctly identified the root cause, made the minimal fix, and preserved the legacy-JSON tolerance contract. The amendment names the rule for future reviewers.
+
+---
+
 ## A-24 — Implementation finding: `remove_skill`'s `NotInstalled` leaves tracking row stale; A-12 cascade counts but doesn't truly drive to absence
 
 **Surfaced during.** Task 3 implementation (commit `7a4718d`). Captured per the "forward motion + audit trail" rule from the Phase 1 execution session — not actioned in Task 3.
@@ -1541,6 +1575,13 @@ The Task 3 orphan-recovery test (`remove_plugin_recovers_from_orphan_skill_track
   A-12 "count as removed" path leaves stale tracking. Out of scope
   for Phase 1; deferred to Phase 1.5 follow-up. Captured here as
   audit trail per the "forward motion + amendments" execution rule.
+- A-25: Implementation finding from Task 4. `tauri-specta` 2.0.0-rc.24
+  rejects `skip_serializing_if` on Tauri-exposed result types in
+  unified mode. Drop the directives from `InstallAgentsResult.installed_native`
+  and `InstallAgentsResult.installed_companions`; the wire format
+  becomes `[]`/`null` for empty/None instead of omitted, matching
+  `InstallSkillsResult` and `InstallSteeringResult`. Forward-looking
+  rule worth adding to CLAUDE.md.
 
 No design-doc revisions required. The amendments are all execution-time
 corrections; the architecture in

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -352,13 +352,13 @@ const ALLOWED_SITES: &[AllowedSite] = &[
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 50,
+        line: 54,
         reason: "Tauri scaffolding pattern — debug-only `specta_typescript::Typescript::default().export(...)` failure at app startup. Refactoring to `?` propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 61,
+        line: 65,
         reason: "Tauri scaffolding pattern — `tauri::Builder::run` failure at app startup. Replacing with Result propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
 ];

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -1306,7 +1306,7 @@ mod tests {
     fn is_allowed_matches_gate_path_and_line_exactly() {
         let f = Finding {
             path: "crates/kiro-control-center/src-tauri/src/lib.rs".to_string(),
-            line: 50,
+            line: 54,
             qualified_name: "run".to_string(),
             signature: Some("expect".to_string()),
         };


### PR DESCRIPTION
## Summary

Implements Phase 1 of the plugin-first install architecture from the design doc + plan merged in #93. Plugins become the first-class user-facing object in BrowseTab and InstalledTab, while backend stays content-type-first (separate `installed-skills.json` / `installed-steering.json` / `installed-agents.json`).

**Backend** (`kiro-market-core` + Tauri):
- `MarketplaceService::install_plugin` — orchestrator that runs skills + steering + agents in one coordinated call. Returns `InstallPluginResult` with non-Optional sub-results (per A-15).
- `KiroProject::installed_plugins` — aggregator grouping the three tracking files by `(marketplace, plugin)`, returning `Vec<InstalledPluginInfo>`.
- `KiroProject::remove_plugin` — cascade removal with orphan-recovery (A-12), marketplace-aware `native_companions` cleanup (A-3 + A-16), and reuse of the existing `validate_tracking_path_entry` helper (A-4).
- New supporting methods: `remove_steering_file`, `remove_agent`, `remove_native_companions_for_plugin` (Tasks 3a / 3b / 3b.5). New typed variant: `SteeringError::NotInstalled` (A-13).
- Four new Tauri commands: `install_plugin_agents`, `install_plugin`, `list_installed_plugins`, `remove_plugin`.

**Frontend** (Svelte 5):
- New `PluginCard.svelte` reusable component.
- New `\$lib/format.ts` (lifted helpers — `formatSkippedReason`, `skillCountLabel`, `skillCountTitle`, `formatSkippedSkill`, `formatSkippedSkillsForPlugin`).
- New `\$lib/keys.ts` (lifted `pluginKey` / `skillKey` / `parsePluginKey` with collision-safe ASCII Unit Separator delim, per A-10).
- BrowseTab: `[Plugins | Skills]` view toggle with Plugins as default; PR 92's empty-state plugin-card branch retired (A-11).
- InstalledTab: \"Installed plugins\" primary table with Remove cascade, plus collapsible `<details>` flat-skills view for backward compat.
- New Playwright e2e: `install plugin from browse tab and verify in installed tab`.

## Amendments folded in

This PR executes the plan with **all 25 amendments** applied (A-1 through A-25). A-1 through A-23 were captured during plan review. A-24 and A-25 surfaced during implementation and were captured as audit-trail commits before continuing forward:

- **A-24**: `remove_skill` returns `NotInstalled` without dropping the tracking row, so the cascade's A-12 \"count as removed\" path leaves stale tracking. Documented; deferred to a Phase 1.5 follow-up (out of scope for the cascade itself).
- **A-25**: `tauri-specta` 2.0.0-rc.24 unified mode rejects `skip_serializing_if` on FFI-exposed result types. Dropped the directives from `InstallAgentsResult.installed_native` / `installed_companions` to match the `InstallSkillsResult` / `InstallSteeringResult` precedent. Wire format becomes `[]` / `null` for empty/None instead of omitted.

## What's NOT in this PR

- Phase 2 (update detection / per-plugin update action) — design-only in the design doc; no Phase 2 tasks in this PR.
- Plugin-uninstall confirmation dialog (just a button for now).
- Per-content-type install customization (rejected for v1; bundle install is the contract).
- The Phase 1.5 follow-up tightening `remove_skill`'s orphan-tracking behavior (A-24).
- An `accept_mcp` UI toggle — Phase 1 hardcodes `false` at the BrowseTab call site, plumbed through the wrapper signature per A-18.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — 889 tests pass (701 in `kiro-market-core` alone, including 13+ new tests in `project.rs`)
- [x] `npm run check` clean (292 files, 0 errors, 0 warnings) in `crates/kiro-control-center/`
- [x] `bindings.ts` regenerated with the four new Tauri commands and three new exported types (`InstallPluginResult`, `InstalledPluginInfo`, `RemovePluginResult`)
- [x] New Playwright e2e test compiles and is listed by `npx playwright test --list`
- [ ] CI plan-lint (gate-4-external-error-boundary + no-unwrap-in-production) — couldn't run locally without `tethys` on PATH; CI is authoritative
- [ ] Manual smoke against `dwalleck/kiro-starter-kit`: click Install on a plugin card, verify banner, switch to InstalledTab, verify row, click Remove, verify cleanup

## References

- Design doc: `docs/plans/2026-04-29-plugin-first-install-design.md` (merged in #93)
- Plan: `docs/plans/2026-04-29-plugin-first-install-plan.md` (merged in #93)
- Amendments: `docs/plans/2026-04-29-plugin-first-install-plan-amendments.md` (A-1 through A-25)
- Prior PRs: #83 (steering install backend), #91 (plan-lint tag gate), #92 (steering install UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)