### PR TITLE
feat: type-safety hardening — MarketplaceName/PluginName newtypes (Phase 1.5)

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -443,4 +443,54 @@ mod tests {
             "rendered error must mention the agent name, got: {rendered}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // install_plugin_agents_impl — IPC-boundary newtype rejection (I2 from
+    // PR #95 8-reviewer review). Mirrors `install_plugin_impl` tests in
+    // `commands/plugins.rs::tests:368-401` so each install `_impl` carries
+    // symmetric adversarial coverage; otherwise the `MarketplaceName::new`
+    // / `PluginName::new` guard is only exercised on one of four install
+    // paths.
+    // -----------------------------------------------------------------------
+
+    /// FE-supplied `marketplace = "../etc/passwd"` would otherwise reach
+    /// `cache::marketplace_path(marketplace)` via the
+    /// `resolve_plugin_install_context` lookup and force an FS read at
+    /// `<registries_dir>/../etc/passwd`. The IPC-boundary
+    /// `MarketplaceName::new` constructor rejects it before the service
+    /// ever runs.
+    #[test]
+    fn install_plugin_agents_impl_rejects_traversal_in_marketplace() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_agents_impl(
+            &svc,
+            "../etc/passwd",
+            "myplugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// NUL bytes truncate C-string conversions in syscalls; the
+    /// IPC-boundary `PluginName::new` constructor must reject them
+    /// before they reach `cache::plugin_registry_path`.
+    #[test]
+    fn install_plugin_agents_impl_rejects_nul_byte_in_plugin() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_agents_impl(
+            &svc,
+            "mp1",
+            "evil\0plugin",
+            InstallMode::New,
+            false,
+            &project_path,
+        )
+        .expect_err("NUL byte in plugin name must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -17,7 +17,7 @@ use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{
     AgentInstallContext, InstallAgentsResult, InstallMode, MarketplaceService,
 };
-use kiro_market_core::validation::validate_name;
+use kiro_market_core::validation::{MarketplaceName, PluginName};
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -58,11 +58,11 @@ fn install_plugin_agents_impl(
     accept_mcp: bool,
     project_path: &str,
 ) -> Result<InstallAgentsResult, CommandError> {
-    validate_name(marketplace)?;
-    validate_name(plugin)?;
     let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let ctx = svc
-        .resolve_plugin_install_context(marketplace, plugin)
+        .resolve_plugin_install_context(&marketplace, &plugin)
         .map_err(CommandError::from)?;
     let project = KiroProject::new(project_root);
 
@@ -74,8 +74,8 @@ fn install_plugin_agents_impl(
         AgentInstallContext {
             mode,
             accept_mcp,
-            marketplace,
-            plugin,
+            marketplace: &marketplace,
+            plugin: &plugin,
             version: ctx.version.as_deref(),
         },
     ))

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -662,6 +662,54 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // install_skills_impl — IPC-boundary newtype rejection (I2 from PR #95
+    // 8-reviewer review). Mirrors the `install_plugin_impl` rejection tests
+    // in `commands/plugins.rs::tests` so each `_impl` siblings the same
+    // adversarial coverage; without this every newtype constructor we add
+    // would only be exercised on one of the four install paths.
+    // -----------------------------------------------------------------------
+
+    /// FE-supplied `marketplace = "../etc/passwd"` would otherwise reach
+    /// `cache::marketplace_path(marketplace)` and force an FS read at
+    /// `<registries_dir>/../etc/passwd`. The IPC-boundary
+    /// `MarketplaceName::new` constructor rejects it before the service
+    /// ever runs.
+    #[test]
+    fn install_skills_impl_rejects_traversal_in_marketplace() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_skills_impl(
+            &svc,
+            "../etc/passwd",
+            "myplugin",
+            &[],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// NUL bytes truncate C-string conversions in syscalls; the
+    /// IPC-boundary `PluginName::new` constructor must reject them
+    /// before they reach `cache::plugin_registry_path`.
+    #[test]
+    fn install_skills_impl_rejects_nul_byte_in_plugin() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_skills_impl(
+            &svc,
+            "mp1",
+            "evil\0plugin",
+            &[],
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("NUL byte in plugin name must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    // -----------------------------------------------------------------------
     // list_available_skills / list_all_skills_for_marketplace — IPC-boundary
     // newtype rejection (I1 follow-on from PR #95 review). The Phase 1.5
     // wrappers were the only `String`-typed marketplace/plugin entry points

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -141,6 +141,17 @@ pub async fn list_plugins(marketplace: String) -> Result<Vec<PluginInfo>, Comman
 /// per-skill failures vanished into `warn!` logs, leaving the frontend to
 /// wonder why the count shrank; surfacing them structurally lets the UI
 /// show "N skills failed to load" with a drill-down.
+///
+/// The IPC-boundary [`MarketplaceName::new`] / [`PluginName::new`]
+/// constructors plus [`validate_kiro_project_path`] gate the wrapper
+/// before any service or filesystem access. Without these guards a
+/// frontend-supplied `marketplace = "../etc/passwd"` would reach
+/// [`MarketplaceService::marketplace_path`] (`cache::marketplace_path`)
+/// via a bare path join and force an FS read at
+/// `<registries_dir>/../etc/passwd` — the read-side analogue of the
+/// install-side hardening from PR #94's I10. Validation runs *before*
+/// [`make_service`] so rejection paths never touch `$HOME` / the cache
+/// directory.
 #[tauri::command]
 #[specta::specta]
 pub async fn list_available_skills(
@@ -148,10 +159,16 @@ pub async fn list_available_skills(
     plugin: String,
     project_path: String,
 ) -> Result<PluginSkillsResult, CommandError> {
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let svc = make_service()?;
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    // Phase 1.5: `list_skills_for_plugin` keeps its `&str` signature by
+    // design (only the install API migrates to newtypes). The `as_str()`
+    // bridges below are permanent.
+    let project = KiroProject::new(project_root);
     let installed = load_installed_or_error(&project, &project_path)?;
-    svc.list_skills_for_plugin(&marketplace, &plugin, &installed)
+    svc.list_skills_for_plugin(marketplace.as_str(), plugin.as_str(), &installed)
         .map_err(CommandError::from)
 }
 
@@ -162,16 +179,23 @@ pub async fn list_available_skills(
 /// plugin filter is active. The returned [`BulkSkillsResult::skipped`]
 /// carries plugin-level errors (missing directory, malformed manifest,
 /// remote source) so the frontend can surface a partial-listing warning.
+///
+/// The IPC-boundary [`MarketplaceName::new`] plus
+/// [`validate_kiro_project_path`] gate the wrapper before any service or
+/// filesystem access — same defense-in-depth contract as
+/// [`list_available_skills`].
 #[tauri::command]
 #[specta::specta]
 pub async fn list_all_skills_for_marketplace(
     marketplace: String,
     project_path: String,
 ) -> Result<BulkSkillsResult, CommandError> {
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
     let svc = make_service()?;
-    let project = KiroProject::new(PathBuf::from(&project_path));
+    let project = KiroProject::new(project_root);
     let installed = load_installed_or_error(&project, &project_path)?;
-    svc.list_all_skills(&marketplace, &installed)
+    svc.list_all_skills(marketplace.as_str(), &installed)
         .map_err(CommandError::from)
 }
 
@@ -634,6 +658,66 @@ mod tests {
         )
         .expect_err("remote source must refuse local install");
 
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    // -----------------------------------------------------------------------
+    // list_available_skills / list_all_skills_for_marketplace — IPC-boundary
+    // newtype rejection (I1 follow-on from PR #95 review). The Phase 1.5
+    // wrappers were the only `String`-typed marketplace/plugin entry points
+    // that bypassed validation; these tests pin the rejection behaviour now
+    // that `MarketplaceName::new` / `PluginName::new` gate the wrapper.
+    // -----------------------------------------------------------------------
+
+    /// `list_available_skills` reaches `MarketplaceService::marketplace_path`
+    /// (cache::marketplace_path) via a bare path join. Without the
+    /// IPC-boundary `MarketplaceName::new` guard, `marketplace = "../etc"`
+    /// would force an FS read outside the cache root.
+    #[tokio::test]
+    async fn list_available_skills_rejects_traversal_in_marketplace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+        let err = list_available_skills("../etc".to_string(), "myplugin".to_string(), project_path)
+            .await
+            .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// NUL bytes truncate C-string conversions in syscalls; the IPC-boundary
+    /// `PluginName::new` guard must reject them before they reach
+    /// `list_skills_for_plugin`.
+    #[tokio::test]
+    async fn list_available_skills_rejects_nul_byte_in_plugin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+        let err =
+            list_available_skills("mp1".to_string(), "evil\0plugin".to_string(), project_path)
+                .await
+                .expect_err("NUL byte in plugin must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// Bulk listing must reject a traversal marketplace name before the
+    /// service iterates plugin entries; mirrors the per-plugin variant.
+    #[tokio::test]
+    async fn list_all_skills_for_marketplace_rejects_traversal_in_marketplace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+        let err = list_all_skills_for_marketplace("../etc".to_string(), project_path)
+            .await
+            .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// Bulk listing only takes a marketplace name (no per-plugin arg);
+    /// the NUL-byte adversarial case targets that single string field.
+    #[tokio::test]
+    async fn list_all_skills_for_marketplace_rejects_nul_byte_in_marketplace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+        let err = list_all_skills_for_marketplace("evil\0mp".to_string(), project_path)
+            .await
+            .expect_err("NUL byte in marketplace must error");
         assert_eq!(err.error_type, ErrorType::Validation);
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -13,7 +13,7 @@ use kiro_market_core::service::{
     BulkSkillsResult, InstallFilter, InstallMode, InstallSkillsResult, MarketplaceService,
     PluginSkillsResult, SkillCount,
 };
-use kiro_market_core::validation::validate_name;
+use kiro_market_core::validation::{MarketplaceName, PluginName};
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::{CommandError, ErrorType};
@@ -109,11 +109,14 @@ pub async fn list_marketplaces() -> Result<Vec<MarketplaceInfo>, CommandError> {
 #[tauri::command]
 #[specta::specta]
 pub async fn list_plugins(marketplace: String) -> Result<Vec<PluginInfo>, CommandError> {
-    validate_name(&marketplace)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
     let svc = make_service()?;
-    let marketplace_path = svc.marketplace_path(&marketplace);
+    // Phase 1.5: `marketplace_path` and `list_plugin_entries` remain
+    // `&str`-typed by design — only the install API migrates to the
+    // newtypes. The `as_str()` bridges below are permanent.
+    let marketplace_path = svc.marketplace_path(marketplace.as_str());
     let plugin_entries = svc
-        .list_plugin_entries(&marketplace)
+        .list_plugin_entries(marketplace.as_str())
         .map_err(CommandError::from)?;
 
     let mut results = Vec::with_capacity(plugin_entries.len());
@@ -212,11 +215,11 @@ fn install_skills_impl(
     mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSkillsResult, CommandError> {
-    validate_name(marketplace)?;
-    validate_name(plugin)?;
     let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let ctx = svc
-        .resolve_plugin_install_context(marketplace, plugin)
+        .resolve_plugin_install_context(&marketplace, &plugin)
         .map_err(CommandError::from)?;
     let project = KiroProject::new(project_root);
     Ok(svc.install_skills(
@@ -224,8 +227,8 @@ fn install_skills_impl(
         &ctx.skill_dirs,
         &InstallFilter::Names(skills),
         mode,
-        marketplace,
-        plugin,
+        &marketplace,
+        &plugin,
         ctx.version.as_deref(),
     ))
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -43,8 +43,8 @@ pub async fn list_installed_skills(
         .into_iter()
         .map(|(name, meta)| InstalledSkillInfo {
             name,
-            marketplace: meta.marketplace,
-            plugin: meta.plugin,
+            marketplace: meta.marketplace.into_inner(),
+            plugin: meta.plugin.into_inner(),
             version: meta.version,
             installed_at: meta.installed_at.to_rfc3339(),
         })
@@ -73,6 +73,7 @@ pub async fn remove_skill(name: String, project_path: String) -> Result<(), Comm
 mod tests {
     use chrono::Utc;
     use kiro_market_core::project::{InstalledSkillMeta, KiroProject};
+    use kiro_market_core::validation::{MarketplaceName, PluginName};
 
     use super::*;
 
@@ -80,8 +81,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let project = KiroProject::new(dir.path().to_path_buf());
         let meta = InstalledSkillMeta {
-            marketplace: "test-market".into(),
-            plugin: "test-plugin".into(),
+            marketplace: MarketplaceName::new("test-market").expect("valid marketplace"),
+            plugin: PluginName::new("test-plugin").expect("valid plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
             source_hash: None,
@@ -108,8 +109,8 @@ mod tests {
 
         for name in &["zulu-skill", "alpha-skill", "mike-skill"] {
             let meta = InstalledSkillMeta {
-                marketplace: "test-market".into(),
-                plugin: "test-plugin".into(),
+                marketplace: MarketplaceName::new("test-market").expect("valid marketplace"),
+                plugin: PluginName::new("test-plugin").expect("valid plugin"),
                 version: Some("1.0.0".into()),
                 installed_at: Utc::now(),
                 source_hash: None,

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -363,8 +363,9 @@ mod tests {
     // FE-supplied `marketplace = "../etc/passwd"` would otherwise reach
     // `cache::marketplace_path(marketplace)` and force an FS access at
     // `<registries_dir>/../etc/passwd` before the registry layer's own
-    // checks fire. The IPC-boundary `validate_name` guard rejects it
-    // before the service ever runs.
+    // checks fire. The IPC-boundary `MarketplaceName::new` constructor
+    // (which routes through `validate_name`) rejects it before the
+    // service ever runs.
     #[test]
     fn install_plugin_impl_rejects_traversal_in_marketplace() {
         let (dir, svc) = temp_service();
@@ -382,8 +383,9 @@ mod tests {
     }
 
     /// NUL bytes truncate C-string conversions in syscalls; the
-    /// IPC-boundary `validate_name` guard must reject them before they
-    /// reach `cache::plugin_registry_path`.
+    /// IPC-boundary `PluginName::new` constructor (which routes through
+    /// `validate_name`) must reject them before they reach
+    /// `cache::plugin_registry_path`.
     #[test]
     fn install_plugin_impl_rejects_nul_byte_in_plugin() {
         let (dir, svc) = temp_service();

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -18,7 +18,7 @@
 
 use kiro_market_core::project::{InstalledPluginsView, KiroProject, RemovePluginResult};
 use kiro_market_core::service::{InstallMode, InstallPluginResult, MarketplaceService};
-use kiro_market_core::validation::validate_name;
+use kiro_market_core::validation::{MarketplaceName, PluginName};
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -63,11 +63,11 @@ fn install_plugin_impl(
     accept_mcp: bool,
     project_path: &str,
 ) -> Result<InstallPluginResult, CommandError> {
-    validate_name(marketplace)?;
-    validate_name(plugin)?;
     let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let project = KiroProject::new(project_root);
-    svc.install_plugin(&project, marketplace, plugin, mode, accept_mcp)
+    svc.install_plugin(&project, &marketplace, &plugin, mode, accept_mcp)
         .map_err(CommandError::from)
 }
 
@@ -103,9 +103,9 @@ pub async fn remove_plugin(
     plugin: String,
     project_path: String,
 ) -> Result<RemovePluginResult, CommandError> {
-    validate_name(&marketplace)?;
-    validate_name(&plugin)?;
     let project_root = validate_kiro_project_path(&project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let project = KiroProject::new(project_root);
     project
         .remove_plugin(&marketplace, &plugin)

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -9,7 +9,7 @@
 use kiro_market_core::project::KiroProject;
 use kiro_market_core::service::{InstallMode, MarketplaceService};
 use kiro_market_core::steering::{InstallSteeringResult, SteeringInstallContext};
-use kiro_market_core::validation::validate_name;
+use kiro_market_core::validation::{MarketplaceName, PluginName};
 
 use crate::commands::{make_service, validate_kiro_project_path};
 use crate::error::CommandError;
@@ -47,18 +47,18 @@ fn install_plugin_steering_impl(
     mode: InstallMode,
     project_path: &str,
 ) -> Result<InstallSteeringResult, CommandError> {
-    validate_name(marketplace)?;
-    validate_name(plugin)?;
     let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = MarketplaceName::new(marketplace)?;
+    let plugin = PluginName::new(plugin)?;
     let ctx = svc
-        .resolve_plugin_install_context(marketplace, plugin)
+        .resolve_plugin_install_context(&marketplace, &plugin)
         .map_err(CommandError::from)?;
     let project = KiroProject::new(project_root);
 
     let install_ctx = SteeringInstallContext {
         mode,
-        marketplace,
-        plugin,
+        marketplace: &marketplace,
+        plugin: &plugin,
         version: ctx.version.as_deref(),
     };
 

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -458,4 +458,52 @@ mod tests {
             err.message
         );
     }
+
+    // -----------------------------------------------------------------------
+    // install_plugin_steering_impl — IPC-boundary newtype rejection (I2 from
+    // PR #95 8-reviewer review). Mirrors `install_plugin_impl` tests in
+    // `commands/plugins.rs::tests:368-401` so each install `_impl` carries
+    // symmetric adversarial coverage; otherwise the `MarketplaceName::new`
+    // / `PluginName::new` guard is only exercised on one of four install
+    // paths.
+    // -----------------------------------------------------------------------
+
+    /// FE-supplied `marketplace = "../etc/passwd"` would otherwise reach
+    /// `cache::marketplace_path(marketplace)` via the
+    /// `resolve_plugin_install_context` lookup and force an FS read at
+    /// `<registries_dir>/../etc/passwd`. The IPC-boundary
+    /// `MarketplaceName::new` constructor rejects it before the service
+    /// ever runs.
+    #[test]
+    fn install_plugin_steering_impl_rejects_traversal_in_marketplace() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_steering_impl(
+            &svc,
+            "../etc/passwd",
+            "myplugin",
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("traversal in marketplace must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    /// NUL bytes truncate C-string conversions in syscalls; the
+    /// IPC-boundary `PluginName::new` constructor must reject them
+    /// before they reach `cache::plugin_registry_path`.
+    #[test]
+    fn install_plugin_steering_impl_rejects_nul_byte_in_plugin() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let err = install_plugin_steering_impl(
+            &svc,
+            "mp1",
+            "evil\0plugin",
+            InstallMode::New,
+            &project_path,
+        )
+        .expect_err("NUL byte in plugin name must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
 }

--- a/crates/kiro-control-center/src-tauri/src/error.rs
+++ b/crates/kiro-control-center/src-tauri/src/error.rs
@@ -111,10 +111,20 @@ impl From<String> for CommandError {
 }
 
 /// Map `ValidationError` straight to a `CommandError` so IPC-boundary
-/// guards (`validate_name`, `validate_relative_path`, ...) can use `?`
-/// without a manual `CoreError::from(...).into()` hop. Equivalent to
-/// `CommandError::from(CoreError::Validation(err))` but avoids the
-/// indirection at every call site.
+/// guards can use `?` without a manual `CoreError::from(...).into()`
+/// hop. Two families of caller depend on this conversion:
+///
+/// - the freestanding helpers (`validate_name`,
+///   `validate_relative_path`, `validate_kiro_project_path`) used at
+///   the top of `#[tauri::command]` wrappers;
+/// - the validating constructors (`MarketplaceName::new`,
+///   `PluginName::new`, `RelativePath::new`, `AgentName::new`) which
+///   are now the dominant users after Phase 1.5's newtype migration —
+///   every install-side wrapper threads marketplace/plugin strings
+///   through these constructors before calling the service.
+///
+/// Equivalent to `CommandError::from(CoreError::Validation(err))` but
+/// avoids the indirection at every call site.
 impl From<ValidationError> for CommandError {
     fn from(err: ValidationError) -> Self {
         Self::from(CoreError::from(err))

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -508,6 +508,14 @@ export type InstallOutcomeKind =
  *  Empty `installed` / `failed` vecs on a sub-result indicate "this
  *  content type was attempted with nothing to do" — distinct from a
  *  missing field.
+ * 
+ *  Phase 1.5 (A1+A4): the `marketplace` and `plugin` fields are typed
+ *  newtypes (`MarketplaceName` / `PluginName`) — `serde(transparent)`
+ *  in the wire format, so the JSON shape stays plain strings while the
+ *  in-memory contract is parse-don't-validate. `Default` is intentionally
+ *  not derived: the newtypes don't derive `Default`, and no consumer
+ *  constructs an `InstallPluginResult::default()` — `install_plugin` is
+ *  the only origin and always populates every field.
  */
 export type InstallPluginResult = InstallPluginResult_Serialize | InstallPluginResult_Deserialize;
 
@@ -523,9 +531,18 @@ export type InstallPluginResult = InstallPluginResult_Serialize | InstallPluginR
  *  Empty `installed` / `failed` vecs on a sub-result indicate "this
  *  content type was attempted with nothing to do" — distinct from a
  *  missing field.
+ * 
+ *  Phase 1.5 (A1+A4): the `marketplace` and `plugin` fields are typed
+ *  newtypes (`MarketplaceName` / `PluginName`) — `serde(transparent)`
+ *  in the wire format, so the JSON shape stays plain strings while the
+ *  in-memory contract is parse-don't-validate. `Default` is intentionally
+ *  not derived: the newtypes don't derive `Default`, and no consumer
+ *  constructs an `InstallPluginResult::default()` — `install_plugin` is
+ *  the only origin and always populates every field.
  */
 export type InstallPluginResult_Deserialize = {
-	plugin: string,
+	marketplace: MarketplaceName,
+	plugin: PluginName,
 	version: string | null,
 	skills: InstallSkillsResult,
 	steering: InstallSteeringResult_Deserialize,
@@ -544,9 +561,18 @@ export type InstallPluginResult_Deserialize = {
  *  Empty `installed` / `failed` vecs on a sub-result indicate "this
  *  content type was attempted with nothing to do" — distinct from a
  *  missing field.
+ * 
+ *  Phase 1.5 (A1+A4): the `marketplace` and `plugin` fields are typed
+ *  newtypes (`MarketplaceName` / `PluginName`) — `serde(transparent)`
+ *  in the wire format, so the JSON shape stays plain strings while the
+ *  in-memory contract is parse-don't-validate. `Default` is intentionally
+ *  not derived: the newtypes don't derive `Default`, and no consumer
+ *  constructs an `InstallPluginResult::default()` — `install_plugin` is
+ *  the only origin and always populates every field.
  */
 export type InstallPluginResult_Serialize = {
-	plugin: string,
+	marketplace: MarketplaceName,
+	plugin: PluginName,
 	version: string | null,
 	skills: InstallSkillsResult,
 	steering: InstallSteeringResult_Serialize,
@@ -673,8 +699,8 @@ export type InstalledNativeCompanionsOutcome = {
  *  (specta's chrono feature isn't enabled in this crate).
  */
 export type InstalledPluginInfo = {
-	marketplace: string,
-	plugin: string,
+	marketplace: MarketplaceName,
+	plugin: PluginName,
 	installed_version: string | null,
 	skill_count: number,
 	steering_count: number,
@@ -774,6 +800,26 @@ export type MarketplaceInfo = {
 	load_error: string | null,
 };
 
+/**
+ *  Validated marketplace name. Routes through [`validate_name`] at construction
+ *  — non-empty, no NUL/control bytes, no path-traversal, no Windows-reserved
+ *  names. The `serde(transparent)` representation keeps the JSON wire format
+ *  byte-identical to a plain string; `Deserialize` is routed through `new` so
+ *  `serde_json::from_slice` rejects malformed names at parse time.
+ * 
+ *  Deliberately does NOT derive `Default` — `MarketplaceName::default()` would
+ *  return `MarketplaceName(String::new())` which `validate_name` rejects.
+ *  Matches the existing `RelativePath` / `AgentName` / `GitRef` precedent.
+ * 
+ *  `Ord`/`PartialOrd` are derived for use as `BTreeMap` keys in
+ *  `installed_plugins`'s aggregator (see `project.rs`). Lexicographic ordering
+ *  on the inner string is well-defined and semantically equivalent to
+ *  `String`'s ordering. Deviates from `RelativePath` / `AgentName` / `GitRef`
+ *  (which don't derive `Ord`) because none of those types are used as map keys
+ *  today.
+ */
+export type MarketplaceName = string;
+
 // How a registered marketplace's contents are stored on disk.
 export type MarketplaceStorage = 
 // Cloned from a remote git repository.
@@ -859,6 +905,12 @@ export type PluginInfo = {
 	skill_count: SkillCount,
 	source_type: SourceType,
 };
+
+/**
+ *  Validated plugin name. Same shape as [`MarketplaceName`]; see that type's
+ *  documentation for the construction, serde, and Ord-derive contracts.
+ */
+export type PluginName = string;
 
 /**
  *  Result of [`MarketplaceService::list_skills_for_plugin`]. Mirrors

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -16,6 +16,7 @@ use crate::agent::tools::MappedTool;
 use crate::agent::{AgentDefinition, AgentDialect};
 use crate::error::{AgentError, SkillError};
 use crate::validation;
+use crate::validation::{MarketplaceName, PluginName};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,10 +25,14 @@ use crate::validation;
 /// Metadata recorded for each installed skill.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledSkillMeta {
-    /// Name of the marketplace the skill came from.
-    pub marketplace: String,
-    /// Name of the plugin that owns the skill.
-    pub plugin: String,
+    /// Name of the marketplace the skill came from. Routed through
+    /// [`MarketplaceName::Deserialize`] so a tampered tracking file with
+    /// a malformed marketplace value is rejected at `serde_json::from_slice`
+    /// time, not later via a follow-up walker.
+    pub marketplace: MarketplaceName,
+    /// Name of the plugin that owns the skill. Same parse-time validation
+    /// as [`Self::marketplace`].
+    pub plugin: PluginName,
     /// Optional version string from the plugin manifest.
     pub version: Option<String>,
     /// Timestamp when the skill was installed.
@@ -55,10 +60,11 @@ pub struct InstalledSkills {
 /// Metadata recorded for each installed agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledAgentMeta {
-    /// Name of the marketplace the agent came from.
-    pub marketplace: String,
+    /// Name of the marketplace the agent came from. See
+    /// [`InstalledSkillMeta::marketplace`] for the parse-time validation contract.
+    pub marketplace: MarketplaceName,
     /// Name of the plugin that owns the agent.
-    pub plugin: String,
+    pub plugin: PluginName,
     /// Optional version string from the plugin manifest.
     pub version: Option<String>,
     /// Timestamp when the agent was installed.
@@ -94,8 +100,14 @@ pub struct InstalledAgentMeta {
 /// tracks the union of files installed for one plugin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledNativeCompanionsMeta {
-    pub marketplace: String,
-    pub plugin: String,
+    /// Marketplace the bundle was installed from. See
+    /// [`InstalledSkillMeta::marketplace`] for the parse-time validation
+    /// contract. Disambiguates same-named plugins across marketplaces — the
+    /// outer `HashMap<String, _>` is keyed by plugin name alone, so the
+    /// `marketplace` field is what makes A-16's "only-removes-matching-
+    /// marketplace" comparison correct.
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
     pub version: Option<String>,
     pub installed_at: DateTime<Utc>,
     /// Relative paths under `.kiro/agents/` of every companion file owned
@@ -129,8 +141,11 @@ pub struct InstalledAgents {
 /// always equal because there is no parse-and-translate step.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstalledSteeringMeta {
-    pub marketplace: String,
-    pub plugin: String,
+    /// Marketplace the file was installed from. See
+    /// [`InstalledSkillMeta::marketplace`] for the parse-time validation
+    /// contract.
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
     pub version: Option<String>,
     pub installed_at: DateTime<Utc>,
     pub source_hash: String,
@@ -232,8 +247,8 @@ pub struct NativeCompanionsInput<'a> {
     /// `prompts/reviewer.md`). Also the relative paths under
     /// `.kiro/agents/` they install to.
     pub rel_paths: &'a [PathBuf],
-    pub marketplace: &'a str,
-    pub plugin: &'a str,
+    pub marketplace: &'a MarketplaceName,
+    pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
     pub source_hash: &'a str,
     pub mode: crate::service::InstallMode,
@@ -281,8 +296,8 @@ pub struct InstalledNativeCompanionsOutcome {
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct InstalledPluginInfo {
-    pub marketplace: String,
-    pub plugin: String,
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
     pub installed_version: Option<String>,
     pub skill_count: u32,
     pub steering_count: u32,
@@ -562,8 +577,8 @@ pub struct KiroProject {
 /// caller — which still holds the `(json_target, prompt_target, backups)`
 /// from the promote phase — is the right place to restore on error.
 struct CompanionInput<'a> {
-    marketplace: &'a str,
-    plugin: &'a str,
+    marketplace: &'a MarketplaceName,
+    plugin: &'a PluginName,
     version: Option<&'a str>,
     agents_root: &'a Path,
     prompt_rel: &'a Path,
@@ -1039,7 +1054,11 @@ impl KiroProject {
     pub fn installed_plugins(&self) -> crate::error::Result<InstalledPluginsView> {
         use std::collections::BTreeMap;
 
-        let mut by_pair: BTreeMap<(String, String), Acc> = BTreeMap::new();
+        // Newtype keys: both `MarketplaceName` and `PluginName` derive `Ord`
+        // (added in Phase 1.5 Task 1) so the lexicographic ordering is
+        // identical to a `(String, String)` key — wire-format ordering is
+        // preserved across the migration.
+        let mut by_pair: BTreeMap<(MarketplaceName, PluginName), Acc> = BTreeMap::new();
         let mut warnings: Vec<TrackingLoadWarning> = Vec::new();
 
         // I13: each tracking-file load failure is recorded as a
@@ -1330,23 +1349,28 @@ impl KiroProject {
     /// does not propagate per-file failures.
     pub fn remove_native_companions_for_plugin(
         &self,
-        plugin: &str,
-        marketplace: &str,
+        plugin: &PluginName,
+        marketplace: &MarketplaceName,
     ) -> crate::error::Result<()> {
         let tracking_path = self.agent_tracking_path();
         crate::file_lock::with_file_lock(&tracking_path, || -> crate::error::Result<()> {
             let mut installed = self.load_installed_agents()?;
+            // The companions map is keyed by plugin NAME (a `String` —
+            // out of scope per Phase 1.5 design — HashMap key migration
+            // would require a follow-up). Look up by `plugin.as_str()`.
+            // The marketplace check below uses newtype `PartialEq` to
+            // stay A-16-correct.
             let should_remove = installed
                 .native_companions
-                .get(plugin)
-                .is_some_and(|meta| meta.marketplace == marketplace);
+                .get(plugin.as_str())
+                .is_some_and(|meta| meta.marketplace == *marketplace);
             if !should_remove {
                 return Ok(());
             }
 
             // Take the entry so we can unlink the companion files
             // referenced by it after the tracking write succeeds.
-            let Some(removed) = installed.native_companions.remove(plugin) else {
+            let Some(removed) = installed.native_companions.remove(plugin.as_str()) else {
                 return Ok(());
             };
 
@@ -1359,8 +1383,8 @@ impl KiroProject {
             Self::remove_companion_files_best_effort(&removed.files, &self.agents_dir(), plugin);
 
             debug!(
-                plugin,
-                marketplace,
+                plugin = plugin.as_str(),
+                marketplace = marketplace.as_str(),
                 files = removed.files.len(),
                 "native companions tracking entry removed"
             );
@@ -1404,17 +1428,19 @@ impl KiroProject {
     /// validation errors (A-4).
     pub fn remove_plugin(
         &self,
-        marketplace: &str,
-        plugin: &str,
+        marketplace: &MarketplaceName,
+        plugin: &PluginName,
     ) -> crate::error::Result<RemovePluginResult> {
         let mut result = RemovePluginResult::default();
 
-        // Skills.
+        // Skills. The A-16 marketplace check is preserved by the newtype
+        // `PartialEq` impl (see also the `native_companions` cleanup at
+        // the bottom of this method).
         let skills = self.load_installed()?;
         let skills_to_remove: Vec<String> = skills
             .skills
             .iter()
-            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
             .map(|(name, _)| name.clone())
             .collect();
         for name in &skills_to_remove {
@@ -1430,8 +1456,8 @@ impl KiroProject {
                     // arm is for genuine fs / serialisation failures.
                     warn!(
                         skill = %name,
-                        plugin,
-                        marketplace,
+                        plugin = plugin.as_str(),
+                        marketplace = marketplace.as_str(),
                         error = %e,
                         "remove_plugin: skill removal failed; recording in `failed`"
                     );
@@ -1449,7 +1475,7 @@ impl KiroProject {
         let steering_to_remove: Vec<PathBuf> = steering
             .files
             .iter()
-            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
             .map(|(rel, _)| rel.clone())
             .collect();
         for rel in &steering_to_remove {
@@ -1460,8 +1486,8 @@ impl KiroProject {
                 Err(e) => {
                     warn!(
                         rel = %rel.display(),
-                        plugin,
-                        marketplace,
+                        plugin = plugin.as_str(),
+                        marketplace = marketplace.as_str(),
                         error = %e,
                         "remove_plugin: steering removal failed; recording in `failed`"
                     );
@@ -1479,7 +1505,7 @@ impl KiroProject {
         let agents_to_remove: Vec<String> = agents
             .agents
             .iter()
-            .filter(|(_, meta)| meta.marketplace == marketplace && meta.plugin == plugin)
+            .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
             .map(|(name, _)| name.clone())
             .collect();
         for name in &agents_to_remove {
@@ -1490,8 +1516,8 @@ impl KiroProject {
                 Err(e) => {
                     warn!(
                         agent = %name,
-                        plugin,
-                        marketplace,
+                        plugin = plugin.as_str(),
+                        marketplace = marketplace.as_str(),
                         error = %e,
                         "remove_plugin: agent removal failed; recording in `failed`"
                     );
@@ -1510,8 +1536,8 @@ impl KiroProject {
         // also lands in `result.failed` rather than aborting.
         if let Err(e) = self.remove_native_companions_for_plugin(plugin, marketplace) {
             warn!(
-                plugin,
-                marketplace,
+                plugin = plugin.as_str(),
+                marketplace = marketplace.as_str(),
                 error = %e,
                 "remove_plugin: native_companions cleanup failed; recording in `failed`"
             );
@@ -1696,13 +1722,13 @@ impl KiroProject {
     fn classify_steering_collision(
         installed: &InstalledSteering,
         rel_path: &Path,
-        plugin: &str,
+        plugin: &PluginName,
         source_hash: &str,
         dest: &Path,
         mode: crate::service::InstallMode,
     ) -> Result<CollisionDecision<SteeringIdempotentEcho>, crate::steering::SteeringError> {
         match installed.files.get(rel_path) {
-            Some(existing) if existing.plugin == plugin => {
+            Some(existing) if existing.plugin == *plugin => {
                 if existing.source_hash == source_hash {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         SteeringIdempotentEcho {
@@ -1725,7 +1751,9 @@ impl KiroProject {
                 if !mode.is_force() {
                     return Err(crate::steering::SteeringError::PathOwnedByOtherPlugin {
                         rel: rel_path.to_path_buf(),
-                        owner: existing.plugin.clone(),
+                        // `owner` is the wire-format `String` field; project
+                        // the newtype to its string view via `Display`.
+                        owner: existing.plugin.to_string(),
                     });
                 }
                 Ok(CollisionDecision::Proceed {
@@ -1847,6 +1875,14 @@ impl KiroProject {
         source_hash: &str,
         ctx: crate::steering::SteeringInstallContext<'_>,
     ) -> crate::error::Result<crate::steering::InstalledSteeringOutcome> {
+        // Wrap the still-`&str` ctx fields once (Task 3 transient shim).
+        // Task 4 migrates `SteeringInstallContext` to carry the newtypes
+        // directly; until then the strings come in pre-validated from
+        // the marketplace catalog, so `from_internal_unchecked` is sound
+        // — same precedent as `RelativePath::from_internal_unchecked`.
+        let plugin_name = PluginName::from_internal_unchecked(ctx.plugin.to_owned());
+        let marketplace_name = MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
+
         let tracking_path = self.steering_tracking_path();
         let mut installed = self.load_installed_steering().map_err(|e| match e {
             // A malformed installed-steering.json is a distinct condition
@@ -1864,7 +1900,7 @@ impl KiroProject {
         let forced_overwrite = match Self::classify_steering_collision(
             &installed,
             rel_path,
-            ctx.plugin,
+            &plugin_name,
             source_hash,
             dest,
             ctx.mode,
@@ -1897,7 +1933,7 @@ impl KiroProject {
         // If we're transferring ownership from another plugin, scrub the
         // prior owner's entry so the same path isn't tracked twice.
         if let Some(existing) = installed.files.get(rel_path)
-            && existing.plugin != ctx.plugin
+            && existing.plugin != plugin_name
         {
             installed.files.remove(rel_path);
         }
@@ -1905,8 +1941,8 @@ impl KiroProject {
         installed.files.insert(
             rel_path.to_path_buf(),
             InstalledSteeringMeta {
-                marketplace: ctx.marketplace.to_owned(),
-                plugin: ctx.plugin.to_owned(),
+                marketplace: marketplace_name,
+                plugin: plugin_name,
                 version: ctx.version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 source_hash: source_hash.to_owned(),
@@ -2345,12 +2381,16 @@ impl KiroProject {
         // Hash semantics: source_hash == installed_hash because the
         // translated path does not separately track original .md source
         // files; both equal the hash over the prompt-bundle bytes.
+        //
+        // The HashMap key is still `String` (out of scope per Phase 1.5
+        // design); only the meta-value's `marketplace`/`plugin` fields
+        // adopt the newtypes.
         let companion_entry = installed
             .native_companions
-            .entry(input.plugin.to_owned())
+            .entry(input.plugin.as_str().to_owned())
             .or_insert_with(|| InstalledNativeCompanionsMeta {
-                marketplace: input.marketplace.to_owned(),
-                plugin: input.plugin.to_owned(),
+                marketplace: input.marketplace.clone(),
+                plugin: input.plugin.clone(),
                 version: input.version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 files: Vec::new(),
@@ -2358,9 +2398,7 @@ impl KiroProject {
                 installed_hash: String::new(),
             });
         // Refresh marketplace/version/timestamp on every install.
-        input
-            .marketplace
-            .clone_into(&mut companion_entry.marketplace);
+        companion_entry.marketplace = input.marketplace.clone();
         companion_entry.version = input.version.map(str::to_owned);
         companion_entry.installed_at = chrono::Utc::now();
         if !companion_entry
@@ -2394,13 +2432,13 @@ impl KiroProject {
     fn classify_native_collision(
         installed: &InstalledAgents,
         agent_name: &str,
-        plugin: &str,
+        plugin: &PluginName,
         source_hash: &str,
         json_target: &Path,
         mode: crate::service::InstallMode,
     ) -> crate::error::Result<CollisionDecision<InstalledNativeAgentOutcome>> {
         match installed.agents.get(agent_name) {
-            Some(existing) if existing.plugin == plugin => {
+            Some(existing) if existing.plugin == *plugin => {
                 if existing.source_hash.as_deref() == Some(source_hash) {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         InstalledNativeAgentOutcome {
@@ -2426,7 +2464,11 @@ impl KiroProject {
                 if !mode.is_force() {
                     return Err(AgentError::NameClashWithOtherPlugin {
                         name: agent_name.to_owned(),
-                        owner: existing.plugin.clone(),
+                        // `owner` is the wire-format `String` field on
+                        // `AgentError`. We project the newtype to its
+                        // string view via `Display` so consumers see the
+                        // same value they did before the migration.
+                        owner: existing.plugin.to_string(),
                     }
                     .into());
                 }
@@ -2501,8 +2543,8 @@ impl KiroProject {
     pub fn install_native_agent(
         &self,
         bundle: &crate::agent::NativeAgentBundle,
-        marketplace: &str,
-        plugin: &str,
+        marketplace: &MarketplaceName,
+        plugin: &PluginName,
         version: Option<&str>,
         source_hash: &str,
         mode: crate::service::InstallMode,
@@ -2543,8 +2585,8 @@ impl KiroProject {
                 installed.agents.insert(
                     agent_name.clone(),
                     InstalledAgentMeta {
-                        marketplace: marketplace.to_string(),
-                        plugin: plugin.to_string(),
+                        marketplace: marketplace.clone(),
+                        plugin: plugin.clone(),
                         version: version.map(String::from),
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
@@ -2824,10 +2866,13 @@ impl KiroProject {
             Self::diff_prior_companion_files(&installed, input.plugin, input.rel_paths);
 
         installed.native_companions.insert(
-            input.plugin.to_string(),
+            // HashMap key remains `String` (out of scope per Phase 1.5
+            // design — only the meta-value's `plugin: PluginName` field
+            // gets the newtype).
+            input.plugin.as_str().to_owned(),
             InstalledNativeCompanionsMeta {
-                marketplace: input.marketplace.to_string(),
-                plugin: input.plugin.to_string(),
+                marketplace: input.marketplace.clone(),
+                plugin: input.plugin.clone(),
                 version: input.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 files: input.rel_paths.to_vec(),
@@ -2897,7 +2942,9 @@ impl KiroProject {
         let mut forced_overwrite = false;
 
         // Same-plugin check first — idempotent or content-changed.
-        if let Some(existing) = installed.native_companions.get(input.plugin) {
+        // The HashMap key is still `String` (out of scope), so look up
+        // by string view; equality below uses the same shape.
+        if let Some(existing) = installed.native_companions.get(input.plugin.as_str()) {
             if existing.source_hash == input.source_hash {
                 return Ok(CollisionDecision::Idempotent(Box::new(
                     InstalledNativeCompanionsOutcome {
@@ -2921,7 +2968,7 @@ impl KiroProject {
         // Cross-plugin path conflict + orphan-on-disk checks.
         for rel in input.rel_paths {
             for (other_plugin, other_meta) in &installed.native_companions {
-                if other_plugin == input.plugin {
+                if other_plugin.as_str() == input.plugin.as_str() {
                     continue;
                 }
                 if other_meta.files.contains(rel) {
@@ -2962,12 +3009,12 @@ impl KiroProject {
     /// Returns `(staging_dir, installed_hash)` on success.
     fn stage_native_companion_files(
         &self,
-        plugin: &str,
+        plugin: &PluginName,
         scan_root: &Path,
         rel_paths: &[PathBuf],
     ) -> crate::error::Result<(tempfile::TempDir, String)> {
         let staging = tempfile::Builder::new()
-            .prefix(&format!("_installing-companions-{plugin}-"))
+            .prefix(&format!("_installing-companions-{}-", plugin.as_str()))
             .tempdir_in(self.kiro_dir())?;
 
         for rel in rel_paths {
@@ -3011,7 +3058,7 @@ impl KiroProject {
             Ok(h) => h,
             Err(e) => {
                 warn!(
-                    plugin,
+                    plugin = plugin.as_str(),
                     error = %e,
                     "installed_hash computation failed on staging; removing staging dir"
                 );
@@ -3143,16 +3190,18 @@ impl KiroProject {
     /// promotion since this happens AFTER promote.
     fn strip_transferred_paths_from_other_plugins(
         installed: &mut InstalledAgents,
-        plugin: &str,
+        plugin: &PluginName,
         rel_paths: &[PathBuf],
         agents_dir: &Path,
     ) -> crate::error::Result<()> {
         let new_set: std::collections::HashSet<&Path> =
             rel_paths.iter().map(PathBuf::as_path).collect();
+        // HashMap key on `installed.native_companions` is still `String`,
+        // so the filter compares plugin-name string-views.
         let other_plugins: Vec<String> = installed
             .native_companions
             .keys()
-            .filter(|p| p.as_str() != plugin)
+            .filter(|p| p.as_str() != plugin.as_str())
             .cloned()
             .collect();
         let mut modified: Vec<String> = Vec::new();
@@ -3193,10 +3242,10 @@ impl KiroProject {
     /// half.
     fn diff_prior_companion_files(
         installed: &InstalledAgents,
-        plugin: &str,
+        plugin: &PluginName,
         rel_paths: &[PathBuf],
     ) -> Vec<PathBuf> {
-        let Some(prior) = installed.native_companions.get(plugin) else {
+        let Some(prior) = installed.native_companions.get(plugin.as_str()) else {
             return Vec::new();
         };
         let new_set: std::collections::HashSet<&Path> =
@@ -3227,13 +3276,17 @@ impl KiroProject {
     /// `fs::remove_file` would remove the symlink itself, not the
     /// target — operationally fine but the audit trail is murkier.
     /// Skipping with a warn! makes the unusual state visible.
-    fn remove_companion_files_best_effort(rel_paths: &[PathBuf], agents_dir: &Path, plugin: &str) {
+    fn remove_companion_files_best_effort(
+        rel_paths: &[PathBuf],
+        agents_dir: &Path,
+        plugin: &PluginName,
+    ) {
         for rel in rel_paths {
             let abs = agents_dir.join(rel);
             match fs::symlink_metadata(&abs) {
                 Ok(md) if crate::platform::is_reparse_or_symlink(&md) => {
                     warn!(
-                        plugin,
+                        plugin = plugin.as_str(),
                         path = %abs.display(),
                         "tracked companion is a symlink/reparse point; skipping orphan-removal"
                     );
@@ -3246,7 +3299,7 @@ impl KiroProject {
                 }
                 Err(e) => {
                     warn!(
-                        plugin,
+                        plugin = plugin.as_str(),
                         path = %abs.display(),
                         error = %e,
                         "failed to stat orphaned prior companion file; skipping"
@@ -3258,7 +3311,7 @@ impl KiroProject {
                 && e.kind() != std::io::ErrorKind::NotFound
             {
                 warn!(
-                    plugin,
+                    plugin = plugin.as_str(),
                     path = %abs.display(),
                     error = %e,
                     "failed to remove orphaned prior companion file post-success"
@@ -3394,6 +3447,7 @@ impl KiroProject {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::test_support::{mp, pn};
 
     fn temp_project() -> (tempfile::TempDir, KiroProject) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -3403,8 +3457,8 @@ mod tests {
 
     fn sample_meta() -> InstalledSkillMeta {
         InstalledSkillMeta {
-            marketplace: "test-market".into(),
-            plugin: "test-plugin".into(),
+            marketplace: mp("test-market"),
+            plugin: pn("test-plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
             source_hash: None,
@@ -3415,8 +3469,8 @@ mod tests {
     #[test]
     fn installed_agent_meta_roundtrips_json() {
         let meta = InstalledAgentMeta {
-            marketplace: "mp".into(),
-            plugin: "pr-review-toolkit".into(),
+            marketplace: mp("mp"),
+            plugin: pn("pr-review-toolkit"),
             version: Some("1.2.3".into()),
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
@@ -3437,8 +3491,8 @@ mod tests {
     #[test]
     fn installed_agent_meta_roundtrips_copilot_dialect() {
         let meta = InstalledAgentMeta {
-            marketplace: "mp".into(),
-            plugin: "p".into(),
+            marketplace: mp("mp"),
+            plugin: pn("p"),
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
@@ -3471,8 +3525,8 @@ mod tests {
         steering.files.insert(
             std::path::PathBuf::from("review-process.md"),
             InstalledSteeringMeta {
-                marketplace: "m".into(),
-                plugin: "p".into(),
+                marketplace: mp("m"),
+                plugin: pn("p"),
                 version: Some("0.1.0".into()),
                 installed_at: chrono::Utc::now(),
                 source_hash: "blake3:abc".into(),
@@ -3728,8 +3782,8 @@ mod tests {
         to_save.files.insert(
             PathBuf::from("guide.md"),
             InstalledSteeringMeta {
-                marketplace: "m".into(),
-                plugin: "p".into(),
+                marketplace: mp("m"),
+                plugin: pn("p"),
                 version: None,
                 installed_at: chrono::Utc::now(),
                 source_hash: "blake3:abc".into(),
@@ -4406,8 +4460,8 @@ mod tests {
 
     fn sample_agent_meta() -> InstalledAgentMeta {
         InstalledAgentMeta {
-            marketplace: "mp".into(),
-            plugin: "p".into(),
+            marketplace: mp("mp"),
+            plugin: pn("p"),
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
@@ -4894,7 +4948,7 @@ mod tests {
         let src_a = write_agent(src_tmp.path(), "shared", "---\nname: shared\n---\nfrom A\n");
         let (def_a, mapped_a) = parse_and_map(&src_a);
         let mut meta_a = sample_agent_meta();
-        "plugin-a".clone_into(&mut meta_a.plugin);
+        meta_a.plugin = pn("plugin-a");
         project
             .install_agent(&def_a, &mapped_a, meta_a, None)
             .expect("plugin-a install");
@@ -4915,7 +4969,7 @@ mod tests {
         fs::write(&src_b, "---\nname: shared\n---\nfrom B\n").unwrap();
         let (def_b, mapped_b) = parse_and_map(&src_b);
         let mut meta_b = sample_agent_meta();
-        "plugin-b".clone_into(&mut meta_b.plugin);
+        meta_b.plugin = pn("plugin-b");
         project
             .install_agent_force(&def_b, &mapped_b, meta_b, None)
             .expect("plugin-b force install");
@@ -4975,12 +5029,14 @@ mod tests {
             PathBuf::from("prompts/transfer.md"),
         ];
         let h_a = crate::hash::hash_artifact(&scan_a, &rel_paths_a).unwrap();
+        let mp_m = mp("m");
+        let pn_a = pn("plugin-a");
         project
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_a,
                 rel_paths: &rel_paths_a,
-                marketplace: "m",
-                plugin: "plugin-a",
+                marketplace: &mp_m,
+                plugin: &pn_a,
                 version: None,
                 source_hash: &h_a,
                 mode: crate::service::InstallMode::New,
@@ -5003,12 +5059,13 @@ mod tests {
         fs::write(scan_b.join("prompts/transfer.md"), b"b-transfer").unwrap();
         let rel_paths_b = vec![PathBuf::from("prompts/transfer.md")];
         let h_b = crate::hash::hash_artifact(&scan_b, &rel_paths_b).unwrap();
+        let pn_b = pn("plugin-b");
         project
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_b,
                 rel_paths: &rel_paths_b,
-                marketplace: "m",
-                plugin: "plugin-b",
+                marketplace: &mp_m,
+                plugin: &pn_b,
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::Force,
@@ -5540,7 +5597,7 @@ mod tests {
 
         // mp-b's "code-reviewer" entry doesn't exist — no-op.
         project
-            .remove_native_companions_for_plugin("code-reviewer", "mp-b")
+            .remove_native_companions_for_plugin(&pn("code-reviewer"), &mp("mp-b"))
             .expect("remove ok (no-op)");
 
         let tracking = project.load_installed_agents().expect("load");
@@ -5551,7 +5608,7 @@ mod tests {
 
         // mp-a's removal takes the entry out.
         project
-            .remove_native_companions_for_plugin("code-reviewer", "mp-a")
+            .remove_native_companions_for_plugin(&pn("code-reviewer"), &mp("mp-a"))
             .expect("remove ok");
         let tracking = project.load_installed_agents().expect("load");
         assert!(
@@ -5590,7 +5647,7 @@ mod tests {
         std::fs::write(&companion, b"# helper\n").expect("write companion file");
 
         project
-            .remove_native_companions_for_plugin("p", "mp")
+            .remove_native_companions_for_plugin(&pn("p"), &mp("mp"))
             .expect("remove ok");
 
         assert!(
@@ -5606,7 +5663,7 @@ mod tests {
 
         // No tracking file at all → load returns default → no entry.
         project
-            .remove_native_companions_for_plugin("p", "mp")
+            .remove_native_companions_for_plugin(&pn("p"), &mp("mp"))
             .expect("must be a no-op when no tracking exists");
     }
 
@@ -5657,7 +5714,9 @@ mod tests {
         std::fs::write(project.kiro_dir().join("steering/guide.md"), "# guide\n")
             .expect("steering file");
 
-        let result = project.remove_plugin("mp", "p").expect("remove_plugin");
+        let result = project
+            .remove_plugin(&mp("mp"), &pn("p"))
+            .expect("remove_plugin");
         assert_eq!(result.skills_removed, 1);
         assert_eq!(result.steering_removed, 1);
         assert_eq!(result.agents_removed, 0);
@@ -5710,7 +5769,9 @@ mod tests {
         std::fs::write(project.kiro_dir().join("steering/a.md"), "# a\n").expect("a");
         std::fs::write(project.kiro_dir().join("steering/b.md"), "# b\n").expect("b");
 
-        let result = project.remove_plugin("mp-a", "p").expect("remove mp-a/p");
+        let result = project
+            .remove_plugin(&mp("mp-a"), &pn("p"))
+            .expect("remove mp-a/p");
         assert_eq!(result.steering_removed, 1, "only mp-a/p's entry");
 
         let tracking = project.load_installed_steering().expect("load");
@@ -5756,7 +5817,7 @@ mod tests {
         // Note: NO skills/orphan dir on disk.
 
         let result = project
-            .remove_plugin("mp", "p")
+            .remove_plugin(&mp("mp"), &pn("p"))
             .expect("orphan recovery: must NOT abort");
         assert_eq!(
             result.skills_removed, 1,
@@ -5809,8 +5870,8 @@ mod tests {
                 "removable",
                 src.path(),
                 InstalledSkillMeta {
-                    marketplace: "mp".into(),
-                    plugin: "p".into(),
+                    marketplace: mp("mp"),
+                    plugin: pn("p"),
                     version: Some("1.0.0".into()),
                     installed_at: Utc::now(),
                     source_hash: Some("deadbeef".into()),
@@ -5843,7 +5904,7 @@ mod tests {
         .expect("write steering tracking");
 
         let result = project
-            .remove_plugin("mp", "p")
+            .remove_plugin(&mp("mp"), &pn("p"))
             .expect("I5: cascade returns Ok even with per-step failures");
 
         assert_eq!(
@@ -5901,7 +5962,7 @@ mod tests {
         .expect("steering tracking");
 
         let err = project
-            .remove_plugin("mp", "p")
+            .remove_plugin(&mp("mp"), &pn("p"))
             .expect_err("traversal entry must surface as Err");
         match err {
             crate::error::Error::Io(io_err) => {
@@ -5943,7 +6004,9 @@ mod tests {
         )
         .expect("agents tracking");
 
-        project.remove_plugin("mp", "p").expect("remove_plugin");
+        project
+            .remove_plugin(&mp("mp"), &pn("p"))
+            .expect("remove_plugin");
 
         let tracking = project.load_installed_agents().expect("load");
         assert!(
@@ -6454,8 +6517,8 @@ mod tests {
     #[test]
     fn installed_native_companions_meta_round_trips_through_serde() {
         let meta = InstalledNativeCompanionsMeta {
-            marketplace: "m".into(),
-            plugin: "p".into(),
+            marketplace: mp("m"),
+            plugin: pn("p"),
             version: Some("0.1.0".into()),
             installed_at: chrono::Utc::now(),
             files: vec![
@@ -6498,8 +6561,8 @@ mod tests {
         fs::write(skill_src.join("SKILL.md"), b"# test skill\n\nbody").unwrap();
 
         let meta = InstalledSkillMeta {
-            marketplace: "m".into(),
-            plugin: "p".into(),
+            marketplace: mp("m"),
+            plugin: pn("p"),
             version: Some("1.0.0".into()),
             installed_at: chrono::Utc::now(),
             source_hash: None,
@@ -6575,7 +6638,7 @@ mod tests {
         // `prompts/rev.md` in the native_companions map.
         let companion = installed
             .native_companions
-            .get(&plugin_name)
+            .get(plugin_name.as_str())
             .expect("native_companions entry synthesized");
         assert!(
             companion
@@ -6618,7 +6681,7 @@ mod tests {
         let installed = project.load_installed_agents().unwrap();
         let companion = installed
             .native_companions
-            .get(&plugin_name)
+            .get(plugin_name.as_str())
             .expect("entry exists");
         assert_eq!(companion.files.len(), 2);
         assert!(
@@ -6718,8 +6781,12 @@ mod tests {
         plugin: &str,
         mode: crate::service::InstallMode,
     ) -> Result<InstalledNativeAgentOutcome, AgentError> {
+        // Wrap once at the helper boundary so the test bodies stay
+        // string-literal-friendly (they pass `"m"`, `"plugin-a"` etc.).
+        let marketplace = mp(marketplace);
+        let plugin = pn(plugin);
         f.project
-            .install_native_agent(&f.bundle, marketplace, plugin, None, &f.source_hash, mode)
+            .install_native_agent(&f.bundle, &marketplace, &plugin, None, &f.source_hash, mode)
     }
 
     #[test]
@@ -6741,8 +6808,8 @@ mod tests {
         let outcome = project
             .install_native_agent(
                 &bundle,
-                "marketplace-x",
-                "plugin-y",
+                &mp("marketplace-x"),
+                &pn("plugin-y"),
                 Some("0.1.0"),
                 &source_hash,
                 crate::service::InstallMode::New,
@@ -6921,8 +6988,8 @@ mod tests {
         let outcome = project
             .install_native_agent(
                 &bundle,
-                "m",
-                "p",
+                &mp("m"),
+                &pn("p"),
                 None,
                 &source_hash,
                 crate::service::InstallMode::New,
@@ -6954,8 +7021,8 @@ mod tests {
         project
             .install_native_agent(
                 &bundle_v1,
-                "m",
-                "p",
+                &mp("m"),
+                &pn("p"),
                 None,
                 &h_v1,
                 crate::service::InstallMode::New,
@@ -6987,8 +7054,8 @@ mod tests {
         let err = project
             .install_native_agent(
                 &bundle_v2,
-                "m",
-                "p",
+                &mp("m"),
+                &pn("p"),
                 None,
                 &h_v2,
                 crate::service::InstallMode::Force,
@@ -7111,12 +7178,14 @@ mod tests {
         let (scan_root, rel_paths, source_hash) =
             stage_companion_source(dir.path(), &[("a.md", b"prompt a"), ("b.md", b"prompt b")]);
 
+        let mp_x = mp("marketplace-x");
+        let pn_y = pn("plugin-y");
         let outcome = project
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &rel_paths,
-                marketplace: "marketplace-x",
-                plugin: "plugin-y",
+                marketplace: &mp_x,
+                plugin: &pn_y,
                 version: Some("0.1.0"),
                 source_hash: &source_hash,
                 mode: crate::service::InstallMode::New,
@@ -7163,8 +7232,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &[],
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
                 source_hash: "blake3:empty",
                 mode: crate::service::InstallMode::New,
@@ -7207,8 +7276,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &rel_paths,
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
                 source_hash: &h,
                 mode: crate::service::InstallMode::New,
@@ -7251,8 +7320,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &rel_paths_v1,
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
                 source_hash: &h_v1,
                 mode: crate::service::InstallMode::New,
@@ -7284,8 +7353,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &rel_paths_v2,
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
                 source_hash: &h_v2,
                 mode: crate::service::InstallMode::Force,
@@ -7341,8 +7410,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scan_root,
                 rel_paths: &rel_paths,
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
                 source_hash: &source_hash,
                 mode: crate::service::InstallMode::New,
@@ -7413,11 +7482,15 @@ mod tests {
         plugin: &str,
         mode: crate::service::InstallMode,
     ) -> Result<InstalledNativeCompanionsOutcome, AgentError> {
+        // Wrap once at the helper boundary; tests pass `"m"`, `"plugin-a"`
+        // etc. and the wrap stays internal.
+        let marketplace = mp(marketplace);
+        let plugin = pn(plugin);
         f.project.install_native_companions(&NativeCompanionsInput {
             scan_root: &f.scan_root,
             rel_paths: &f.rel_paths,
-            marketplace,
-            plugin,
+            marketplace: &marketplace,
+            plugin: &plugin,
             version: None,
             source_hash: &f.source_hash,
             mode,
@@ -7585,8 +7658,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scratch_b,
                 rel_paths: &rel_paths_b,
-                marketplace: "m",
-                plugin: "plugin-b",
+                marketplace: &mp("m"),
+                plugin: &pn("plugin-b"),
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::New,
@@ -7608,8 +7681,8 @@ mod tests {
             .install_native_companions(&NativeCompanionsInput {
                 scan_root: &scratch_b,
                 rel_paths: &rel_paths_b,
-                marketplace: "m",
-                plugin: "plugin-b",
+                marketplace: &mp("m"),
+                plugin: &pn("plugin-b"),
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::Force,

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -1751,9 +1751,7 @@ impl KiroProject {
                 if !mode.is_force() {
                     return Err(crate::steering::SteeringError::PathOwnedByOtherPlugin {
                         rel: rel_path.to_path_buf(),
-                        // `owner` is the wire-format `String` field; project
-                        // the newtype to its string view via `Display`.
-                        owner: existing.plugin.to_string(),
+                        owner: existing.plugin.clone(),
                     });
                 }
                 Ok(CollisionDecision::Proceed {
@@ -1875,14 +1873,6 @@ impl KiroProject {
         source_hash: &str,
         ctx: crate::steering::SteeringInstallContext<'_>,
     ) -> crate::error::Result<crate::steering::InstalledSteeringOutcome> {
-        // Wrap the still-`&str` ctx fields once (Task 3 transient shim).
-        // Task 4 migrates `SteeringInstallContext` to carry the newtypes
-        // directly; until then the strings come in pre-validated from
-        // the marketplace catalog, so `from_internal_unchecked` is sound
-        // — same precedent as `RelativePath::from_internal_unchecked`.
-        let plugin_name = PluginName::from_internal_unchecked(ctx.plugin.to_owned());
-        let marketplace_name = MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
-
         let tracking_path = self.steering_tracking_path();
         let mut installed = self.load_installed_steering().map_err(|e| match e {
             // A malformed installed-steering.json is a distinct condition
@@ -1900,7 +1890,7 @@ impl KiroProject {
         let forced_overwrite = match Self::classify_steering_collision(
             &installed,
             rel_path,
-            &plugin_name,
+            ctx.plugin,
             source_hash,
             dest,
             ctx.mode,
@@ -1933,7 +1923,7 @@ impl KiroProject {
         // If we're transferring ownership from another plugin, scrub the
         // prior owner's entry so the same path isn't tracked twice.
         if let Some(existing) = installed.files.get(rel_path)
-            && existing.plugin != plugin_name
+            && existing.plugin != *ctx.plugin
         {
             installed.files.remove(rel_path);
         }
@@ -1941,8 +1931,8 @@ impl KiroProject {
         installed.files.insert(
             rel_path.to_path_buf(),
             InstalledSteeringMeta {
-                marketplace: marketplace_name,
-                plugin: plugin_name,
+                marketplace: ctx.marketplace.clone(),
+                plugin: ctx.plugin.clone(),
                 version: ctx.version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 source_hash: source_hash.to_owned(),
@@ -4158,13 +4148,15 @@ mod tests {
             source: f.source_path(),
             scan_root: f.scan_root.clone(),
         };
+        let mp_name = mp("m");
+        let pn_name = pn(plugin);
         f.project.install_steering_file(
             &discovered,
             &f.source_hash,
             crate::steering::SteeringInstallContext {
                 mode,
-                marketplace: "m",
-                plugin,
+                marketplace: &mp_name,
+                plugin: &pn_name,
                 version: None,
             },
         )
@@ -4265,6 +4257,8 @@ mod tests {
             scan_root: scan_b.clone(),
         };
 
+        let mp_name = mp("m");
+        let pn_name = pn("plugin-b");
         let err = steering_file
             .project
             .install_steering_file(
@@ -4272,8 +4266,8 @@ mod tests {
                 &source_hash_b,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::New,
-                    marketplace: "m",
-                    plugin: "plugin-b",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: None,
                 },
             )
@@ -4294,8 +4288,8 @@ mod tests {
                 &source_hash_b,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::Force,
-                    marketplace: "m",
-                    plugin: "plugin-b",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: None,
                 },
             )
@@ -4335,6 +4329,8 @@ mod tests {
             scan_root: steering_file.scan_root.clone(),
         };
 
+        let mp_name = mp("m");
+        let pn_name = pn("p");
         let err = steering_file
             .project
             .install_steering_file(
@@ -4342,8 +4338,8 @@ mod tests {
                 &source_hash,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::New,
-                    marketplace: "m",
-                    plugin: "p",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: None,
                 },
             )
@@ -4410,14 +4406,16 @@ mod tests {
             scan_root: scan_root.clone(),
         };
 
+        let mp_name = mp("marketplace-x");
+        let pn_name = pn("plugin-y");
         let outcome = project
             .install_steering_file(
                 &discovered,
                 &source_hash,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::New,
-                    marketplace: "marketplace-x",
-                    plugin: "plugin-y",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: Some("0.1.0"),
                 },
             )
@@ -7090,14 +7088,16 @@ mod tests {
             source: scan_root.join("guide.md"),
             scan_root: scan_root.clone(),
         };
+        let mp_name = mp("m");
+        let pn_name = pn("p");
         project
             .install_steering_file(
                 &discovered,
                 &h_v1,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::New,
-                    marketplace: "m",
-                    plugin: "p",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: None,
                 },
             )
@@ -7122,8 +7122,8 @@ mod tests {
                 &h_v2,
                 crate::steering::SteeringInstallContext {
                     mode: crate::service::InstallMode::Force,
-                    marketplace: "m",
-                    plugin: "p",
+                    marketplace: &mp_name,
+                    plugin: &pn_name,
                     version: None,
                 },
             )

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1790,13 +1790,14 @@ mod tests {
         use chrono::Utc;
 
         use crate::project::InstalledSkillMeta;
+        use crate::service::test_support::{mp, pn};
 
         let mut skills = HashMap::new();
         skills.insert(
             skill_name.to_owned(),
             InstalledSkillMeta {
-                marketplace: marketplace.to_owned(),
-                plugin: plugin.to_owned(),
+                marketplace: mp(marketplace),
+                plugin: pn(plugin),
                 version: None,
                 installed_at: Utc::now(),
                 source_hash: None,

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -745,18 +745,21 @@ impl MarketplaceService {
     /// failures, not skips.
     pub fn resolve_plugin_install_context(
         &self,
-        marketplace: &str,
-        plugin: &str,
+        marketplace: &crate::validation::MarketplaceName,
+        plugin: &crate::validation::PluginName,
     ) -> Result<PluginInstallContext, Error> {
-        let marketplace_path = self.marketplace_path(marketplace);
-        let plugin_entries = self.list_plugin_entries(marketplace)?;
+        // Phase 1.5: `marketplace_path` and `list_plugin_entries` remain
+        // `&str`-typed by design — only the install API migrates to the
+        // newtypes. The `as_str()` bridges below are permanent.
+        let marketplace_path = self.marketplace_path(marketplace.as_str());
+        let plugin_entries = self.list_plugin_entries(marketplace.as_str())?;
         let plugin_entry = plugin_entries
             .iter()
-            .find(|p| p.name == plugin)
+            .find(|p| p.name == plugin.as_str())
             .ok_or_else(|| {
                 Error::Plugin(PluginError::NotFound {
-                    plugin: plugin.to_owned(),
-                    marketplace: marketplace.to_owned(),
+                    plugin: plugin.as_str().to_owned(),
+                    marketplace: marketplace.as_str().to_owned(),
                 })
             })?;
         let plugin_dir = self.resolve_local_plugin_dir(plugin_entry, &marketplace_path)?;
@@ -1144,7 +1147,8 @@ mod tests {
     use super::*;
     use crate::marketplace::{PluginSource, StructuredSource};
     use crate::service::test_support::{
-        make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry, temp_service,
+        make_plugin_with_skills, mp, pn, relative_path_entry, seed_marketplace_with_registry,
+        temp_service,
     };
 
     /// Build an `io::Error` whose Custom repr wraps a two-link error chain.
@@ -2638,7 +2642,7 @@ mod tests {
         .expect("write plugin.json");
 
         let ctx = svc
-            .resolve_plugin_install_context("mp1", "myplugin")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("myplugin"))
             .expect("happy path");
         assert_eq!(
             ctx.plugin_dir,
@@ -2685,7 +2689,7 @@ mod tests {
         .expect("write plugin.json");
 
         let ctx = svc
-            .resolve_plugin_install_context("mp1", "lonely")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("lonely"))
             .expect("happy path");
         assert_eq!(ctx.version.as_deref(), Some("0.1.0"));
         assert!(ctx.skill_dirs.is_empty());
@@ -2707,7 +2711,7 @@ mod tests {
         .expect("write plugin.json");
 
         let ctx = svc
-            .resolve_plugin_install_context("mp1", "nover")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("nover"))
             .expect("happy path");
         assert!(
             ctx.version.is_none(),
@@ -2740,7 +2744,7 @@ mod tests {
         .expect("write plugin.json");
 
         let ctx = svc
-            .resolve_plugin_install_context("mp1", "withcustom")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("withcustom"))
             .expect("happy path");
         assert_eq!(ctx.version.as_deref(), Some("0.1.0"));
         assert_eq!(
@@ -2782,7 +2786,7 @@ mod tests {
     fn resolve_plugin_install_context_errors_on_unknown_marketplace() {
         let (_dir, svc) = temp_service();
         let err = svc
-            .resolve_plugin_install_context("does-not-exist", "anyplugin")
+            .resolve_plugin_install_context(&mp("does-not-exist"), &pn("anyplugin"))
             .expect_err("unknown marketplace must error");
         // The inner MarketplaceError variant is an implementation detail
         // of list_plugin_entries; pin only the top-level Error::Marketplace
@@ -2801,7 +2805,7 @@ mod tests {
         let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
-            .resolve_plugin_install_context("mp1", "does-not-exist")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("does-not-exist"))
             .expect_err("unknown plugin must error");
         assert!(
             matches!(
@@ -2823,7 +2827,7 @@ mod tests {
         let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
-            .resolve_plugin_install_context("mp1", "ghost")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("ghost"))
             .expect_err("missing plugin_dir must error");
         assert!(
             matches!(err, Error::Plugin(PluginError::DirectoryMissing { .. })),
@@ -2841,7 +2845,7 @@ mod tests {
         fs::write(plugin_dir.join("plugin.json"), b"{not json").expect("write plugin.json");
 
         let err = svc
-            .resolve_plugin_install_context("mp1", "broken")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("broken"))
             .expect_err("malformed plugin.json must error");
         assert!(
             matches!(err, Error::Plugin(PluginError::InvalidManifest { .. })),
@@ -2864,7 +2868,7 @@ mod tests {
         let _ = seed_marketplace_with_registry(dir.path(), &svc, "mp1", &entries);
 
         let err = svc
-            .resolve_plugin_install_context("mp1", "remote-plugin")
+            .resolve_plugin_install_context(&mp("mp1"), &pn("remote-plugin"))
             .expect_err("remote source must refuse local resolution");
         assert!(
             matches!(err, Error::Plugin(PluginError::RemoteSourceNotLocal { .. })),

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1108,8 +1108,16 @@ impl MarketplaceService {
             processed.insert(frontmatter.name.clone());
 
             let meta = crate::project::InstalledSkillMeta {
-                marketplace: marketplace.to_owned(),
-                plugin: plugin.to_owned(),
+                // Phase 1.5 Task 3 transient shim: the surrounding fn
+                // still takes `marketplace: &str, plugin: &str`. Names
+                // came in via the validated marketplace catalog, so
+                // `from_internal_unchecked` is sound (RelativePath
+                // precedent). Task 5 strips the shim by migrating the
+                // surrounding fn signatures to take the newtypes directly.
+                marketplace: crate::validation::MarketplaceName::from_internal_unchecked(
+                    marketplace.to_owned(),
+                ),
+                plugin: crate::validation::PluginName::from_internal_unchecked(plugin.to_owned()),
                 version: version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 source_hash: None,
@@ -1508,8 +1516,16 @@ impl MarketplaceService {
             }
 
             let meta = crate::project::InstalledAgentMeta {
-                marketplace: ctx.marketplace.to_string(),
-                plugin: ctx.plugin.to_string(),
+                // Phase 1.5 Task 3 transient shim — see equivalent
+                // construction in `install_skills` for rationale. Task 5
+                // migrates `AgentInstallContext` so this collapses to
+                // `ctx.marketplace.clone()` / `ctx.plugin.clone()`.
+                marketplace: crate::validation::MarketplaceName::from_internal_unchecked(
+                    ctx.marketplace.to_string(),
+                ),
+                plugin: crate::validation::PluginName::from_internal_unchecked(
+                    ctx.plugin.to_string(),
+                ),
                 version: ctx.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
@@ -1672,10 +1688,18 @@ impl MarketplaceService {
             }
         };
 
+        // Phase 1.5 Task 3 transient shims: project.install_native_agent
+        // now takes `&MarketplaceName`/`&PluginName`. ctx still carries
+        // `&str` (Task 5 migrates `AgentInstallContext`). The strings are
+        // pre-validated at the marketplace catalog layer.
+        let marketplace_name =
+            crate::validation::MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
+        let plugin_name =
+            crate::validation::PluginName::from_internal_unchecked(ctx.plugin.to_owned());
         match project.install_native_agent(
             &bundle,
-            ctx.marketplace,
-            ctx.plugin,
+            &marketplace_name,
+            &plugin_name,
             ctx.version,
             &source_hash,
             ctx.mode,
@@ -1744,11 +1768,19 @@ impl MarketplaceService {
             }
         };
 
+        // Phase 1.5 Task 3 transient shims — see equivalent in
+        // `install_native_kiro_cli_one_agent`. Task 5 migrates
+        // `AgentInstallContext` so this collapses back to passing
+        // `ctx.marketplace` / `ctx.plugin` directly.
+        let marketplace_name =
+            crate::validation::MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
+        let plugin_name =
+            crate::validation::PluginName::from_internal_unchecked(ctx.plugin.to_owned());
         match project.install_native_companions(&crate::project::NativeCompanionsInput {
             scan_root: &scan_root,
             rel_paths: &rel_paths,
-            marketplace: ctx.marketplace,
-            plugin: ctx.plugin,
+            marketplace: &marketplace_name,
+            plugin: &plugin_name,
             version: ctx.version,
             source_hash: &source_hash,
             mode: ctx.mode,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1960,11 +1960,7 @@ impl MarketplaceService {
         mode: InstallMode,
         accept_mcp: bool,
     ) -> Result<InstallPluginResult, Error> {
-        // Phase 1.5 Task 5 bridge: `resolve_plugin_install_context` still
-        // accepts `&str`; Task 6 migrates it to take the newtypes and
-        // strips the `.as_str()` calls below. Once that lands, this hop
-        // becomes `self.resolve_plugin_install_context(marketplace, plugin)`.
-        let ctx = self.resolve_plugin_install_context(marketplace.as_str(), plugin.as_str())?;
+        let ctx = self.resolve_plugin_install_context(marketplace, plugin)?;
 
         let skills = self.install_skills(
             project,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1995,14 +1995,24 @@ impl MarketplaceService {
             ctx.version.as_deref(),
         );
 
+        // Phase 1.5 Task 4 transient shim — Task 5 strips this when
+        // MarketplaceService::install_plugin migrates to take
+        // &MarketplaceName / &PluginName. The strings reach here
+        // pre-validated at the marketplace catalog parse layer, so
+        // from_internal_unchecked is sound — same precedent as
+        // RelativePath::from_internal_unchecked.
+        let marketplace_name =
+            crate::validation::MarketplaceName::from_internal_unchecked(marketplace.to_owned());
+        let plugin_name = crate::validation::PluginName::from_internal_unchecked(plugin.to_owned());
+
         let steering = Self::install_plugin_steering(
             project,
             &ctx.plugin_dir,
             &ctx.steering_scan_paths,
             crate::steering::SteeringInstallContext {
                 mode,
-                marketplace,
-                plugin,
+                marketplace: &marketplace_name,
+                plugin: &plugin_name,
                 version: ctx.version.as_deref(),
             },
         );
@@ -3151,10 +3161,12 @@ mod tests {
         let project = crate::project::KiroProject::new(project_tmp.path().to_path_buf());
 
         let scan_paths = vec!["./steering/".to_string()];
+        let mp_name = crate::service::test_support::mp("marketplace-x");
+        let pn_name = crate::service::test_support::pn("p");
         let ctx = crate::steering::SteeringInstallContext {
             mode: InstallMode::New,
-            marketplace: "marketplace-x",
-            plugin: "p",
+            marketplace: &mp_name,
+            plugin: &pn_name,
             version: None,
         };
 
@@ -3211,10 +3223,12 @@ mod tests {
         // the legitimate one still installs, the traversal surfaces as
         // a warning without aborting the batch.
         let scan_paths = vec!["./steering/".to_string(), "../escape/".to_string()];
+        let mp_name = crate::service::test_support::mp("m");
+        let pn_name = crate::service::test_support::pn("p");
         let ctx = crate::steering::SteeringInstallContext {
             mode: InstallMode::New,
-            marketplace: "m",
-            plugin: "p",
+            marketplace: &mp_name,
+            plugin: &pn_name,
             version: None,
         };
 
@@ -3281,10 +3295,12 @@ mod tests {
         let project = crate::project::KiroProject::new(project_tmp.path().to_path_buf());
 
         let scan_paths = vec!["./a/".to_string(), "./b/".to_string()];
+        let mp_name = crate::service::test_support::mp("m");
+        let pn_name = crate::service::test_support::pn("p");
         let ctx = crate::steering::SteeringInstallContext {
             mode: InstallMode::New,
-            marketplace: "m",
-            plugin: "p",
+            marketplace: &mp_name,
+            plugin: &pn_name,
             version: None,
         };
 

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -371,8 +371,8 @@ pub struct AgentInstallContext<'a> {
     /// servers (subprocess / network capability). Default-deny; flip via
     /// `--accept-mcp` or its frontend equivalent.
     pub accept_mcp: bool,
-    pub marketplace: &'a str,
-    pub plugin: &'a str,
+    pub marketplace: &'a crate::validation::MarketplaceName,
+    pub plugin: &'a crate::validation::PluginName,
     pub version: Option<&'a str>,
 }
 
@@ -427,10 +427,19 @@ pub struct InstallAgentsResult {
 /// Empty `installed` / `failed` vecs on a sub-result indicate "this
 /// content type was attempted with nothing to do" — distinct from a
 /// missing field.
-#[derive(Debug, Default, Serialize)]
+///
+/// Phase 1.5 (A1+A4): the `marketplace` and `plugin` fields are typed
+/// newtypes (`MarketplaceName` / `PluginName`) — `serde(transparent)`
+/// in the wire format, so the JSON shape stays plain strings while the
+/// in-memory contract is parse-don't-validate. `Default` is intentionally
+/// not derived: the newtypes don't derive `Default`, and no consumer
+/// constructs an `InstallPluginResult::default()` — `install_plugin` is
+/// the only origin and always populates every field.
+#[derive(Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct InstallPluginResult {
-    pub plugin: String,
+    pub marketplace: crate::validation::MarketplaceName,
+    pub plugin: crate::validation::PluginName,
     pub version: Option<String>,
     pub skills: InstallSkillsResult,
     pub steering: crate::steering::InstallSteeringResult,
@@ -1053,8 +1062,8 @@ impl MarketplaceService {
         skill_dirs: &[PathBuf],
         filter: &InstallFilter<'_>,
         mode: InstallMode,
-        marketplace: &str,
-        plugin: &str,
+        marketplace: &crate::validation::MarketplaceName,
+        plugin: &crate::validation::PluginName,
         version: Option<&str>,
     ) -> InstallSkillsResult {
         let mut result = InstallSkillsResult::default();
@@ -1071,7 +1080,7 @@ impl MarketplaceService {
                         "failed to read SKILL.md, skipping"
                     );
                     result.skipped_skills.push(browse::SkippedSkill {
-                        plugin: plugin.to_owned(),
+                        plugin: plugin.as_str().to_owned(),
                         name_hint: browse::name_hint_from_skill_dir(skill_dir),
                         path: skill_md_path,
                         reason: browse::SkippedSkillReason::ReadFailed {
@@ -1091,7 +1100,7 @@ impl MarketplaceService {
                         "failed to parse SKILL.md frontmatter, skipping"
                     );
                     result.skipped_skills.push(browse::SkippedSkill {
-                        plugin: plugin.to_owned(),
+                        plugin: plugin.as_str().to_owned(),
                         name_hint: browse::name_hint_from_skill_dir(skill_dir),
                         path: skill_md_path,
                         reason: browse::SkippedSkillReason::FrontmatterInvalid {
@@ -1108,16 +1117,8 @@ impl MarketplaceService {
             processed.insert(frontmatter.name.clone());
 
             let meta = crate::project::InstalledSkillMeta {
-                // Phase 1.5 Task 3 transient shim: the surrounding fn
-                // still takes `marketplace: &str, plugin: &str`. Names
-                // came in via the validated marketplace catalog, so
-                // `from_internal_unchecked` is sound (RelativePath
-                // precedent). Task 5 strips the shim by migrating the
-                // surrounding fn signatures to take the newtypes directly.
-                marketplace: crate::validation::MarketplaceName::from_internal_unchecked(
-                    marketplace.to_owned(),
-                ),
-                plugin: crate::validation::PluginName::from_internal_unchecked(plugin.to_owned()),
+                marketplace: marketplace.clone(),
+                plugin: plugin.clone(),
                 version: version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 source_hash: None,
@@ -1157,10 +1158,10 @@ impl MarketplaceService {
         if let InstallFilter::Names(requested) = *filter {
             for name in requested {
                 if !processed.contains(name) {
-                    warn!(skill = %name, plugin = %plugin, "requested skill not found in plugin");
+                    warn!(skill = %name, plugin = %plugin.as_str(), "requested skill not found in plugin");
                     result.failed.push(FailedSkill::requested_but_not_found(
                         name.clone(),
-                        plugin.to_owned(),
+                        plugin.as_str().to_owned(),
                     ));
                 }
             }
@@ -1516,16 +1517,8 @@ impl MarketplaceService {
             }
 
             let meta = crate::project::InstalledAgentMeta {
-                // Phase 1.5 Task 3 transient shim — see equivalent
-                // construction in `install_skills` for rationale. Task 5
-                // migrates `AgentInstallContext` so this collapses to
-                // `ctx.marketplace.clone()` / `ctx.plugin.clone()`.
-                marketplace: crate::validation::MarketplaceName::from_internal_unchecked(
-                    ctx.marketplace.to_string(),
-                ),
-                plugin: crate::validation::PluginName::from_internal_unchecked(
-                    ctx.plugin.to_string(),
-                ),
+                marketplace: ctx.marketplace.clone(),
+                plugin: ctx.plugin.clone(),
                 version: ctx.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
@@ -1688,18 +1681,10 @@ impl MarketplaceService {
             }
         };
 
-        // Phase 1.5 Task 3 transient shims: project.install_native_agent
-        // now takes `&MarketplaceName`/`&PluginName`. ctx still carries
-        // `&str` (Task 5 migrates `AgentInstallContext`). The strings are
-        // pre-validated at the marketplace catalog layer.
-        let marketplace_name =
-            crate::validation::MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
-        let plugin_name =
-            crate::validation::PluginName::from_internal_unchecked(ctx.plugin.to_owned());
         match project.install_native_agent(
             &bundle,
-            &marketplace_name,
-            &plugin_name,
+            ctx.marketplace,
+            ctx.plugin,
             ctx.version,
             &source_hash,
             ctx.mode,
@@ -1768,19 +1753,11 @@ impl MarketplaceService {
             }
         };
 
-        // Phase 1.5 Task 3 transient shims — see equivalent in
-        // `install_native_kiro_cli_one_agent`. Task 5 migrates
-        // `AgentInstallContext` so this collapses back to passing
-        // `ctx.marketplace` / `ctx.plugin` directly.
-        let marketplace_name =
-            crate::validation::MarketplaceName::from_internal_unchecked(ctx.marketplace.to_owned());
-        let plugin_name =
-            crate::validation::PluginName::from_internal_unchecked(ctx.plugin.to_owned());
         match project.install_native_companions(&crate::project::NativeCompanionsInput {
             scan_root: &scan_root,
             rel_paths: &rel_paths,
-            marketplace: &marketplace_name,
-            plugin: &plugin_name,
+            marketplace: ctx.marketplace,
+            plugin: ctx.plugin,
             version: ctx.version,
             source_hash: &source_hash,
             mode: ctx.mode,
@@ -1978,12 +1955,16 @@ impl MarketplaceService {
     pub fn install_plugin(
         &self,
         project: &crate::project::KiroProject,
-        marketplace: &str,
-        plugin: &str,
+        marketplace: &crate::validation::MarketplaceName,
+        plugin: &crate::validation::PluginName,
         mode: InstallMode,
         accept_mcp: bool,
     ) -> Result<InstallPluginResult, Error> {
-        let ctx = self.resolve_plugin_install_context(marketplace, plugin)?;
+        // Phase 1.5 Task 5 bridge: `resolve_plugin_install_context` still
+        // accepts `&str`; Task 6 migrates it to take the newtypes and
+        // strips the `.as_str()` calls below. Once that lands, this hop
+        // becomes `self.resolve_plugin_install_context(marketplace, plugin)`.
+        let ctx = self.resolve_plugin_install_context(marketplace.as_str(), plugin.as_str())?;
 
         let skills = self.install_skills(
             project,
@@ -1995,24 +1976,14 @@ impl MarketplaceService {
             ctx.version.as_deref(),
         );
 
-        // Phase 1.5 Task 4 transient shim — Task 5 strips this when
-        // MarketplaceService::install_plugin migrates to take
-        // &MarketplaceName / &PluginName. The strings reach here
-        // pre-validated at the marketplace catalog parse layer, so
-        // from_internal_unchecked is sound — same precedent as
-        // RelativePath::from_internal_unchecked.
-        let marketplace_name =
-            crate::validation::MarketplaceName::from_internal_unchecked(marketplace.to_owned());
-        let plugin_name = crate::validation::PluginName::from_internal_unchecked(plugin.to_owned());
-
         let steering = Self::install_plugin_steering(
             project,
             &ctx.plugin_dir,
             &ctx.steering_scan_paths,
             crate::steering::SteeringInstallContext {
                 mode,
-                marketplace: &marketplace_name,
-                plugin: &plugin_name,
+                marketplace,
+                plugin,
                 version: ctx.version.as_deref(),
             },
         );
@@ -2032,7 +2003,8 @@ impl MarketplaceService {
         );
 
         Ok(InstallPluginResult {
-            plugin: plugin.to_string(),
+            marketplace: marketplace.clone(),
+            plugin: plugin.clone(),
             version: ctx.version,
             skills,
             steering,
@@ -2087,6 +2059,7 @@ mod tests {
     use crate::cache::CacheDir;
     use crate::error::GitError;
     use crate::git::CloneOptions;
+    use crate::service::test_support::{mp, pn};
 
     #[test]
     fn install_warning_unmapped_tool_renders_with_reason() {
@@ -2234,8 +2207,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // existing fixtures don't carry MCP servers
-                marketplace: "mp",
-                plugin: "plugin-x",
+                marketplace: &mp("mp"),
+                plugin: &pn("plugin-x"),
                 version: None,
             },
         );
@@ -2313,8 +2286,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2361,8 +2334,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2416,8 +2389,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2465,8 +2438,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // gate must fire
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2520,8 +2493,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: true, // gate is bypassed
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2589,8 +2562,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2645,8 +2618,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::Force, // force, but...
                 accept_mcp: false,        // accept_mcp = false should still gate
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2686,8 +2659,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2703,8 +2676,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2742,8 +2715,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: Some("1.0.0"),
             },
         );
@@ -2766,8 +2739,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::Force,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: Some("2.0.0"),
             },
         );
@@ -2832,8 +2805,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "mp",
-                plugin: "p",
+                marketplace: &mp("mp"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2894,8 +2867,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // fixture has no MCP servers
-                marketplace: "marketplace-x",
-                plugin: "p",
+                marketplace: &mp("marketplace-x"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -2963,8 +2936,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false, // gate fires
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -3023,8 +2996,8 @@ mod tests {
             AgentInstallContext {
                 mode: InstallMode::New,
                 accept_mcp: false,
-                marketplace: "m",
-                plugin: "p",
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
                 version: None,
             },
         );
@@ -4529,8 +4502,8 @@ mod tests {
             &skill_dirs,
             &InstallFilter::All,
             InstallMode::New,
-            "mp1",
-            "plug1",
+            &mp("mp1"),
+            &pn("plug1"),
             None,
         );
 
@@ -4578,8 +4551,8 @@ mod tests {
             &[only_dir],
             &InstallFilter::Names(&requested),
             InstallMode::New,
-            "mp1",
-            "plug1",
+            &mp("mp1"),
+            &pn("plug1"),
             None,
         );
 
@@ -4670,8 +4643,8 @@ mod tests {
             std::slice::from_ref(&skill_dir),
             &InstallFilter::All,
             InstallMode::New,
-            "mp1",
-            "plug1",
+            &mp("mp1"),
+            &pn("plug1"),
             None,
         );
         // Restore permissions BEFORE assertions so tempdir cleanup can
@@ -4733,8 +4706,8 @@ mod tests {
             &[skill_dir],
             &InstallFilter::All,
             InstallMode::New,
-            "mp1",
-            "plug1",
+            &mp("mp1"),
+            &pn("plug1"),
             None,
         );
 
@@ -4799,9 +4772,10 @@ mod tests {
         let project = KiroProject::new(project_dir.path().to_path_buf());
 
         let result = svc
-            .install_plugin(&project, "mp", "p", InstallMode::New, false)
+            .install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
             .expect("install_plugin happy path");
 
+        assert_eq!(result.marketplace, "mp");
         assert_eq!(result.plugin, "p");
         assert_eq!(result.version.as_deref(), Some("1.0.0"));
         assert_eq!(result.skills.installed, vec!["alpha".to_string()]);
@@ -4824,17 +4798,30 @@ mod tests {
     /// serialize as nested objects, never as `null` or missing keys.
     /// Frontend code that branches on `result.skills.installed.length`
     /// relies on this shape.
+    ///
+    /// Phase 1.5 (A4): also pins that the new `marketplace` field
+    /// serializes as a plain string via `serde(transparent)` on
+    /// `MarketplaceName`, and that `plugin` likewise stays a plain
+    /// string after the `String` -> `PluginName` swap.
     #[test]
     fn install_plugin_result_json_shape_locks_default_subresults() {
         let result = InstallPluginResult {
-            plugin: "p".into(),
+            marketplace: mp("mp"),
+            plugin: pn("p"),
             version: Some("1.0.0".into()),
             skills: InstallSkillsResult::default(),
             steering: crate::steering::InstallSteeringResult::default(),
             agents: InstallAgentsResult::default(),
         };
         let json = serde_json::to_value(&result).expect("serialize");
-        assert_eq!(json["plugin"], "p");
+        assert_eq!(
+            json["marketplace"], "mp",
+            "MarketplaceName is serde(transparent); wire format must be a plain string"
+        );
+        assert_eq!(
+            json["plugin"], "p",
+            "PluginName is serde(transparent); wire format must be a plain string"
+        );
         assert_eq!(json["version"], "1.0.0");
         assert!(
             json["skills"].is_object(),
@@ -4860,7 +4847,8 @@ mod tests {
     #[test]
     fn install_plugin_result_json_shape_with_populated_subresult() {
         let result = InstallPluginResult {
-            plugin: "p".into(),
+            marketplace: mp("mp"),
+            plugin: pn("p"),
             version: Some("1.0.0".into()),
             skills: InstallSkillsResult {
                 installed: vec!["alpha".into()],
@@ -4882,5 +4870,11 @@ mod tests {
                 .map(Vec::len),
             Some(1),
         );
+        // A4: marketplace field serializes as a plain string via
+        // serde(transparent) — pin alongside a populated sub-result so
+        // a future regression that breaks ordering or transparency
+        // surfaces in this test, not just the default-shape lock.
+        assert_eq!(json["marketplace"], "mp");
+        assert_eq!(json["plugin"], "p");
     }
 }

--- a/crates/kiro-market-core/src/service/test_support.rs
+++ b/crates/kiro-market-core/src/service/test_support.rs
@@ -163,3 +163,33 @@ pub fn seed_marketplace_with_registry(
         .expect("write plugin registry");
     marketplace_path
 }
+
+/// Test helper: construct a [`MarketplaceName`](crate::validation::MarketplaceName)
+/// from a string literal, panicking on validation failure. Test fixtures pass
+/// `"mp"`, `"plug-a"`, etc. — values controlled by the test author, not user
+/// input. A fixture failure is a bug, not an error to handle.
+///
+/// # Panics
+///
+/// Panics if `s` is not a valid marketplace name. Test infrastructure only —
+/// callers pass known-good literals.
+#[cfg(any(test, feature = "test-support"))]
+#[must_use]
+pub fn mp(s: &str) -> crate::validation::MarketplaceName {
+    crate::validation::MarketplaceName::new(s)
+        .unwrap_or_else(|e| panic!("test fixture: invalid marketplace name {s:?}: {e}"))
+}
+
+/// Test helper: construct a [`PluginName`](crate::validation::PluginName) from
+/// a string literal. See [`mp`] for the contract.
+///
+/// # Panics
+///
+/// Panics if `s` is not a valid plugin name. Test infrastructure only —
+/// callers pass known-good literals.
+#[cfg(any(test, feature = "test-support"))]
+#[must_use]
+pub fn pn(s: &str) -> crate::validation::PluginName {
+    crate::validation::PluginName::new(s)
+        .unwrap_or_else(|e| panic!("test fixture: invalid plugin name {s:?}: {e}"))
+}

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 
 use crate::project::InstallOutcomeKind;
 use crate::service::InstallMode;
+use crate::validation::{MarketplaceName, PluginName};
 
 /// Bundled non-source-specific install identity threaded through the
 /// per-file steering install chain. Mirrors
@@ -26,8 +27,8 @@ use crate::service::InstallMode;
 #[derive(Debug, Clone, Copy)]
 pub struct SteeringInstallContext<'a> {
     pub mode: InstallMode,
-    pub marketplace: &'a str,
-    pub plugin: &'a str,
+    pub marketplace: &'a MarketplaceName,
+    pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
 }
 
@@ -57,7 +58,7 @@ pub enum SteeringError {
         "steering file `{rel}` would clobber a file owned by plugin `{owner}`; \
          pass --force to transfer ownership"
     )]
-    PathOwnedByOtherPlugin { rel: PathBuf, owner: String },
+    PathOwnedByOtherPlugin { rel: PathBuf, owner: PluginName },
 
     #[non_exhaustive]
     #[error(

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -247,6 +247,23 @@ impl MarketplaceName {
         Ok(MarketplaceName(value))
     }
 
+    /// Construct from a value the caller has already validated upstream.
+    /// `pub(crate)` so external callers cannot bypass [`validate_name`].
+    ///
+    /// **Caller contract:** `value` must already satisfy [`validate_name`].
+    /// Used inside `kiro-market-core` as a transient shim while the surrounding
+    /// function signatures are still `&str` (the names came in via the validated
+    /// marketplace catalog and would otherwise need re-validation here). The
+    /// `debug_assert!` below catches a contract violation in tests. Mirrors
+    /// [`RelativePath::from_internal_unchecked`].
+    pub(crate) fn from_internal_unchecked(value: String) -> Self {
+        debug_assert!(
+            validate_name(&value).is_ok(),
+            "MarketplaceName::from_internal_unchecked called with invalid name: {value:?}"
+        );
+        MarketplaceName(value)
+    }
+
     /// View the validated name as a `&str`.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -328,6 +345,17 @@ impl PluginName {
         let value = value.into();
         validate_name(&value)?;
         Ok(PluginName(value))
+    }
+
+    /// Construct from a value the caller has already validated upstream.
+    /// `pub(crate)` so external callers cannot bypass [`validate_name`].
+    /// See [`MarketplaceName::from_internal_unchecked`] for the contract.
+    pub(crate) fn from_internal_unchecked(value: String) -> Self {
+        debug_assert!(
+            validate_name(&value).is_ok(),
+            "PluginName::from_internal_unchecked called with invalid name: {value:?}"
+        );
+        PluginName(value)
     }
 
     /// View the validated name as a `&str`.

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -1107,4 +1107,54 @@ mod tests {
         let json = serde_json::to_string(&name).expect("serialize");
         assert_eq!(json, r#""p""#);
     }
+
+    // The five tests below mirror the corresponding `marketplace_name_*`
+    // tests at lines 991, 1018, 1031, 1039, 1046. PR #95's review
+    // (finding I4) flagged the asymmetry: PluginName lacked parallel
+    // accessor / empty-deserialize / round-trip / Ord coverage, which
+    // would let a regression slip through one type but not the other.
+    // The Ord lock in particular is load-bearing: if `PluginName` ever
+    // becomes a `BTreeMap` key (it isn't today, but `MarketplaceName`
+    // already is), an inconsistent comparator would silently misorder
+    // entries. Locking the contract symmetrically prevents that.
+
+    #[test]
+    fn plugin_name_accessors_round_trip() {
+        let name = PluginName::new("p").expect("valid");
+        let s = name.clone().into_inner();
+        assert_eq!(s, "p");
+        assert_eq!(name.as_str(), "p");
+    }
+
+    #[test]
+    fn deserialize_plugin_name_rejects_empty() {
+        let result: Result<PluginNameWrapper, _> = serde_json::from_str(r#"{"name":""}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn plugin_name_round_trips_through_serde_json() {
+        let name = PluginName::new("kiro-code-reviewer").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        let parsed: PluginName = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, name);
+    }
+
+    #[test]
+    fn plugin_name_ord_is_lexicographic_on_inner() {
+        let a = PluginName::new("alpha").expect("valid");
+        let b = PluginName::new("bravo").expect("valid");
+        assert!(a < b);
+    }
+
+    #[test]
+    fn plugin_name_ord_matches_inner_string_ord() {
+        let a = PluginName::new("alpha").expect("valid");
+        let b = PluginName::new("bravo").expect("valid");
+        assert_eq!(
+            a.cmp(&b),
+            a.as_str().cmp(b.as_str()),
+            "PluginName::cmp must match inner String::cmp byte-for-byte"
+        );
+    }
 }

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -247,23 +247,6 @@ impl MarketplaceName {
         Ok(MarketplaceName(value))
     }
 
-    /// Construct from a value the caller has already validated upstream.
-    /// `pub(crate)` so external callers cannot bypass [`validate_name`].
-    ///
-    /// **Caller contract:** `value` must already satisfy [`validate_name`].
-    /// Used inside `kiro-market-core` as a transient shim while the surrounding
-    /// function signatures are still `&str` (the names came in via the validated
-    /// marketplace catalog and would otherwise need re-validation here). The
-    /// `debug_assert!` below catches a contract violation in tests. Mirrors
-    /// [`RelativePath::from_internal_unchecked`].
-    pub(crate) fn from_internal_unchecked(value: String) -> Self {
-        debug_assert!(
-            validate_name(&value).is_ok(),
-            "MarketplaceName::from_internal_unchecked called with invalid name: {value:?}"
-        );
-        MarketplaceName(value)
-    }
-
     /// View the validated name as a `&str`.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -345,17 +328,6 @@ impl PluginName {
         let value = value.into();
         validate_name(&value)?;
         Ok(PluginName(value))
-    }
-
-    /// Construct from a value the caller has already validated upstream.
-    /// `pub(crate)` so external callers cannot bypass [`validate_name`].
-    /// See [`MarketplaceName::from_internal_unchecked`] for the contract.
-    pub(crate) fn from_internal_unchecked(value: String) -> Self {
-        debug_assert!(
-            validate_name(&value).is_ok(),
-            "PluginName::from_internal_unchecked called with invalid name: {value:?}"
-        );
-        PluginName(value)
     }
 
     /// View the validated name as a `&str`.

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -213,6 +213,186 @@ impl<'de> Deserialize<'de> for AgentName {
     }
 }
 
+/// Validated marketplace name. Routes through [`validate_name`] at construction
+/// — non-empty, no NUL/control bytes, no path-traversal, no Windows-reserved
+/// names. The `serde(transparent)` representation keeps the JSON wire format
+/// byte-identical to a plain string; `Deserialize` is routed through `new` so
+/// `serde_json::from_slice` rejects malformed names at parse time.
+///
+/// Deliberately does NOT derive `Default` — `MarketplaceName::default()` would
+/// return `MarketplaceName(String::new())` which `validate_name` rejects.
+/// Matches the existing `RelativePath` / `AgentName` / `GitRef` precedent.
+///
+/// `Ord`/`PartialOrd` are derived for use as `BTreeMap` keys in
+/// `installed_plugins`'s aggregator (see `project.rs`). Lexicographic ordering
+/// on the inner string is well-defined and semantically equivalent to
+/// `String`'s ordering. Deviates from `RelativePath` / `AgentName` / `GitRef`
+/// (which don't derive `Ord`) because none of those types are used as map keys
+/// today.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct MarketplaceName(String);
+
+impl MarketplaceName {
+    /// Construct after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidName`] if the input fails
+    /// [`validate_name`].
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        validate_name(&value)?;
+        Ok(MarketplaceName(value))
+    }
+
+    /// View the validated name as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the newtype and return the inner `String`.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for MarketplaceName {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for MarketplaceName {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for MarketplaceName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MarketplaceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl PartialEq<str> for MarketplaceName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for MarketplaceName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'de> Deserialize<'de> for MarketplaceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validated plugin name. Same shape as [`MarketplaceName`]; see that type's
+/// documentation for the construction, serde, and Ord-derive contracts.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct PluginName(String);
+
+impl PluginName {
+    /// Construct after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidName`] if the input fails
+    /// [`validate_name`].
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        validate_name(&value)?;
+        Ok(PluginName(value))
+    }
+
+    /// View the validated name as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the newtype and return the inner `String`.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for PluginName {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for PluginName {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for PluginName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PluginName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl PartialEq<str> for PluginName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for PluginName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'de> Deserialize<'de> for PluginName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Names reserved by Windows for legacy device handles. Trying to create
 /// a file or directory with one of these names (with or without extension)
 /// fails on Windows in interesting ways: the OS short-circuits the path to
@@ -774,5 +954,157 @@ mod tests {
         let wire = serde_json::to_string(&original).expect("ser");
         let parsed: AgentName = serde_json::from_str(&wire).expect("de");
         assert_eq!(parsed, original);
+    }
+
+    // ──── MarketplaceName ────────────────────────────────────────────────
+
+    #[test]
+    fn marketplace_name_new_accepts_valid() {
+        let name = MarketplaceName::new("kiro-starter-kit").expect("valid");
+        assert_eq!(name.as_str(), "kiro-starter-kit");
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_empty() {
+        assert!(MarketplaceName::new("").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_traversal() {
+        assert!(MarketplaceName::new("../etc").is_err());
+        assert!(MarketplaceName::new("..").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_nul_byte() {
+        assert!(MarketplaceName::new("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_partial_eq_against_str_and_ref_str() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        assert_eq!(name, *"mp");
+        assert_eq!(name, "mp");
+    }
+
+    #[test]
+    fn marketplace_name_accessors_round_trip() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        let s = name.clone().into_inner();
+        assert_eq!(s, "mp");
+        assert_eq!(name.as_str(), "mp");
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct MarketplaceNameWrapper {
+        name: MarketplaceName,
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_accepts_valid() {
+        let w: MarketplaceNameWrapper =
+            serde_json::from_str(r#"{"name":"kiro-starter-kit"}"#).expect("valid");
+        assert_eq!(w.name.as_str(), "kiro-starter-kit");
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_rejects_traversal() {
+        let result: Result<MarketplaceNameWrapper, _> =
+            serde_json::from_str(r#"{"name":"../etc"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_rejects_empty() {
+        let result: Result<MarketplaceNameWrapper, _> = serde_json::from_str(r#"{"name":""}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn serialize_marketplace_name_is_transparent_string() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        assert_eq!(json, r#""mp""#);
+    }
+
+    #[test]
+    fn marketplace_name_round_trips_through_serde_json() {
+        let name = MarketplaceName::new("kiro-starter-kit").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        let parsed: MarketplaceName = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, name);
+    }
+
+    #[test]
+    fn marketplace_name_ord_is_lexicographic_on_inner() {
+        let a = MarketplaceName::new("alpha").expect("valid");
+        let b = MarketplaceName::new("bravo").expect("valid");
+        assert!(a < b);
+    }
+
+    #[test]
+    fn marketplace_name_ord_matches_inner_string_ord() {
+        let a = MarketplaceName::new("alpha").expect("valid");
+        let b = MarketplaceName::new("bravo").expect("valid");
+        assert_eq!(
+            a.cmp(&b),
+            a.as_str().cmp(b.as_str()),
+            "MarketplaceName::cmp must match inner String::cmp byte-for-byte"
+        );
+    }
+
+    // ──── PluginName ────────────────────────────────────────────────────
+
+    #[test]
+    fn plugin_name_new_accepts_valid() {
+        let name = PluginName::new("kiro-code-reviewer").expect("valid");
+        assert_eq!(name.as_str(), "kiro-code-reviewer");
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_empty() {
+        assert!(PluginName::new("").is_err());
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_traversal() {
+        assert!(PluginName::new("../etc").is_err());
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_nul_byte() {
+        assert!(PluginName::new("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn plugin_name_partial_eq_against_str_and_ref_str() {
+        let name = PluginName::new("p").expect("valid");
+        assert_eq!(name, *"p");
+        assert_eq!(name, "p");
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct PluginNameWrapper {
+        name: PluginName,
+    }
+
+    #[test]
+    fn deserialize_plugin_name_accepts_valid() {
+        let w: PluginNameWrapper =
+            serde_json::from_str(r#"{"name":"kiro-code-reviewer"}"#).expect("valid");
+        assert_eq!(w.name.as_str(), "kiro-code-reviewer");
+    }
+
+    #[test]
+    fn deserialize_plugin_name_rejects_traversal() {
+        let result: Result<PluginNameWrapper, _> = serde_json::from_str(r#"{"name":"../etc"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn serialize_plugin_name_is_transparent_string() {
+        let name = PluginName::new("p").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        assert_eq!(json, r#""p""#);
     }
 }

--- a/crates/kiro-market-core/tests/integration_native_install.rs
+++ b/crates/kiro-market-core/tests/integration_native_install.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use kiro_market_core::agent::AgentDialect;
 use kiro_market_core::plugin::PluginFormat;
 use kiro_market_core::project::{InstallOutcomeKind, KiroProject};
-use kiro_market_core::service::test_support::temp_service;
+use kiro_market_core::service::test_support::{mp, pn, temp_service};
 use kiro_market_core::service::{
     AgentInstallContext, InstallAgentsResult, InstallMode, MarketplaceService,
 };
@@ -86,10 +86,12 @@ impl IntegrationHarness {
     ) -> InstallSteeringResult {
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(plugin_dir)
             .expect("resolve plugin install context");
+        let mp_name = mp(marketplace);
+        let pn_name = pn(plugin);
         let steering_ctx = SteeringInstallContext {
             mode,
-            marketplace,
-            plugin,
+            marketplace: &mp_name,
+            plugin: &pn_name,
             version: None,
         };
         MarketplaceService::install_plugin_steering(

--- a/crates/kiro-market-core/tests/integration_native_install.rs
+++ b/crates/kiro-market-core/tests/integration_native_install.rs
@@ -57,11 +57,13 @@ impl IntegrationHarness {
     ) -> (PluginFormat, InstallAgentsResult) {
         let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(plugin_dir)
             .expect("resolve plugin install context");
+        let mp_name = mp(marketplace);
+        let pn_name = pn(plugin);
         let install_ctx = AgentInstallContext {
             mode,
             accept_mcp: false, // fixtures never carry MCP servers
-            marketplace,
-            plugin,
+            marketplace: &mp_name,
+            plugin: &pn_name,
             version: None,
         };
         let result = MarketplaceService::install_plugin_agents(

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -11,6 +11,7 @@ use kiro_market_core::service::{
     InstallAgentsResult, InstallFilter, InstallMode, InstallSkillsResult, MarketplaceService,
 };
 use kiro_market_core::steering::InstallSteeringResult;
+use kiro_market_core::validation::{MarketplaceName, PluginName};
 use tracing::{debug, warn};
 
 use crate::cli;
@@ -30,24 +31,33 @@ pub fn run(
     accept_mcp: bool,
 ) -> Result<()> {
     let mode = InstallMode::from(force);
-    let (plugin_name, marketplace_name) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
+    let (plugin_str, marketplace_str) = cli::parse_plugin_ref(plugin_ref).with_context(|| {
         format!("invalid plugin reference '{plugin_ref}': expected plugin@marketplace")
     })?;
 
+    // Construct validated newtypes once at the IPC boundary; downstream
+    // service APIs accept `&MarketplaceName` / `&PluginName` and can no
+    // longer be called with the args swapped (the convergent Critical
+    // finding from PR #94's 8-reviewer aggregated review).
+    let marketplace = MarketplaceName::new(marketplace_str)
+        .with_context(|| format!("invalid marketplace name: {marketplace_str}"))?;
+    let plugin = PluginName::new(plugin_str)
+        .with_context(|| format!("invalid plugin name: {plugin_str}"))?;
+
     let cache = CacheDir::default_location()
         .context("could not determine data directory; is $HOME set?")?;
-    let marketplace_path = cache.marketplace_path(marketplace_name);
+    let marketplace_path = cache.marketplace_path(marketplace.as_str());
     if !marketplace_path.exists() {
         bail!(
             "marketplace '{}' not found. Run {} first.",
-            marketplace_name,
+            marketplace,
             "kiro-market marketplace add".bold()
         );
     }
 
-    let protocol = load_protocol(&cache, marketplace_name);
+    let protocol = load_protocol(&cache, marketplace.as_str());
     let plugin_entry =
-        super::common::find_plugin_entry(&marketplace_path, plugin_name, marketplace_name)?;
+        super::common::find_plugin_entry(&marketplace_path, plugin.as_str(), marketplace.as_str())?;
 
     // One service instance drives plugin-dir resolution plus the install
     // loops; no second `GixCliBackend` needed.
@@ -56,13 +66,13 @@ pub fn run(
         &svc,
         &plugin_entry,
         &marketplace_path,
-        marketplace_name,
-        plugin_name,
+        marketplace.as_str(),
+        plugin.as_str(),
         protocol,
     )?;
 
     let ctx = MarketplaceService::resolve_plugin_install_context_from_dir(&plugin_dir)
-        .with_context(|| format!("failed to resolve install context for '{plugin_name}'"))?;
+        .with_context(|| format!("failed to resolve install context for '{plugin}'"))?;
 
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let project = KiroProject::new(cwd);
@@ -73,8 +83,8 @@ pub fn run(
         &ctx.skill_dirs,
         skill_filter,
         mode,
-        marketplace_name,
-        plugin_name,
+        &marketplace,
+        &plugin,
         ctx.version.as_deref(),
     );
     print_install_outcome(plugin_ref, &skill_result);
@@ -82,8 +92,8 @@ pub fn run(
     let install_ctx = kiro_market_core::service::AgentInstallContext {
         mode,
         accept_mcp,
-        marketplace: marketplace_name,
-        plugin: plugin_name,
+        marketplace: &marketplace,
+        plugin: &plugin,
         version: ctx.version.as_deref(),
     };
     let agent_result = run_agent_install(
@@ -98,8 +108,8 @@ pub fn run(
 
     let steering_ctx = kiro_market_core::steering::SteeringInstallContext {
         mode,
-        marketplace: marketplace_name,
-        plugin: plugin_name,
+        marketplace: &marketplace,
+        plugin: &plugin,
         version: ctx.version.as_deref(),
     };
     let steering_result = run_steering_install(
@@ -169,8 +179,8 @@ fn run_skill_install(
     skill_dirs: &[PathBuf],
     skill_filter: Option<&str>,
     mode: InstallMode,
-    marketplace_name: &str,
-    plugin_name: &str,
+    marketplace: &MarketplaceName,
+    plugin: &PluginName,
     version: Option<&str>,
 ) -> InstallSkillsResult {
     if skill_dirs.is_empty() {
@@ -185,8 +195,8 @@ fn run_skill_install(
         skill_dirs,
         &filter,
         mode,
-        marketplace_name,
-        plugin_name,
+        marketplace,
+        plugin,
         version,
     )
 }

--- a/crates/kiro-market/tests/cli_tests.rs
+++ b/crates/kiro-market/tests/cli_tests.rs
@@ -142,6 +142,60 @@ fn install_missing_marketplace_fails() {
     );
 }
 
+/// CLI-side defense-in-depth: a `plugin@../etc/passwd` reference must
+/// surface as `invalid marketplace name` from the IPC-boundary
+/// `MarketplaceName::new(...).with_context(...)` guard at
+/// `commands/install.rs:42-43` *before* the cache directory is touched.
+/// Without this test, a regression that dropped the `with_context` would
+/// only surface as a downstream `marketplace not found` error — masking
+/// the validation gate.
+#[test]
+fn install_rejects_traversal_in_marketplace() {
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["install", "myplugin@../etc/passwd"]);
+
+    assert!(
+        !output.status.success(),
+        "traversal in marketplace must fail"
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid marketplace name"),
+        "stderr must surface the IPC-boundary validation message, got:\n{err}"
+    );
+}
+
+/// CLI-side defense-in-depth: a path separator in the plugin name must
+/// surface as `invalid plugin name` from the IPC-boundary
+/// `PluginName::new(...).with_context(...)` guard at
+/// `commands/install.rs:44-45`. Path separators in plugin names would
+/// otherwise let the install code build paths like
+/// `<plugin_registry>/foo/bar` and target a directory the user never
+/// intended.
+///
+/// The other adversarial cases (`..`, NUL byte, control characters) can't
+/// reach the CLI: `..` collides with shell globbing, NUL bytes are
+/// rejected by `Command::args` at the OS level (`InvalidInput: nul byte
+/// found in provided data`), and control characters get filtered by the
+/// shell. The path-separator branch is the right CLI-layer adversarial
+/// case to lock; the other branches are covered by the
+/// `PluginName::new` unit tests in `validation.rs`.
+#[test]
+fn install_rejects_invalid_plugin_name() {
+    let dir = TempDir::new().expect("temp dir");
+    let output = run_in_dir(dir.path(), &["install", "evil/plugin@mp"]);
+
+    assert!(
+        !output.status.success(),
+        "path separator in plugin must fail"
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid plugin name"),
+        "stderr must surface the IPC-boundary validation message, got:\n{err}"
+    );
+}
+
 #[test]
 fn marketplace_add_rejects_http_url_by_default() {
     // End-to-end coverage of the http:// gate: the CLI must surface the

--- a/docs/plans/2026-04-30-phase-1-5-session-start.md
+++ b/docs/plans/2026-04-30-phase-1-5-session-start.md
@@ -1,0 +1,50 @@
+# Phase 1.5 — Session-Start Prompt
+
+> Paste this verbatim into a fresh Claude Code session to start Phase 1.5 implementation. Self-contained briefing.
+
+---
+
+Context: I'm starting Phase 1.5 implementation of the plugin-first install architecture for the kiro-control-center desktop app. Phase 1 (PR #94) shipped 23 commits with an 8-reviewer aggregated review whose Critical convergent finding was the swap-arg footgun on `marketplace`/`plugin` strings across 7+ public APIs. Phase 1.5 closes that footgun with validated `MarketplaceName` / `PluginName` newtypes (A1) plus the missing `marketplace` field on `InstallPluginResult` (A4).
+
+Worktree: /home/dwalleck/repos/kiro-marketplace-cli-phase-1-5
+Branch: feat/phase-1-5-types (tracks origin/main, already at the post-#94 state, plus 4 design+plan+amendments commits)
+
+Required reading, in order, before touching any code:
+
+1. docs/plans/2026-04-30-phase-1-5-type-safety-design.md — architecture and user-locked decisions (newtypes are *Name not *Id, no Default derive, A2/A3 deferred, scope is strictly the install/remove cascade family).
+
+2. docs/plans/2026-04-30-phase-1-5-type-safety-plan.md — 8 tasks. Tasks 3 and 5 are heavy (project.rs and service/mod.rs); Tasks 1, 2, 4, 6 are focused; Tasks 7-8 trail the migration through Tauri + CLI + bindings.ts + final sweep + open PR.
+
+3. docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md — 5 amendments (P1.5-1 through P1.5-5) from the 5-gates plan-review pass. Two are real compile-error fixes (P1.5-1, P1.5-2 — both Task 6 step 1, comparison shape and PluginError variant fields), the rest are clarity. Fold them at the relevant task; don't skip.
+
+4. docs/plans/2026-04-29-plugin-first-install-plan-amendments.md — Phase 1's 25 amendments (A-1 through A-25). NOT all relevant, but A-1/A-14/A-21 (associated-fn drift), A-12/A-24 (orphan recovery — A-24 was closed in PR #94), A-25 (tauri-specta skip_serializing_if rule) are useful precedents you'll cross-reference.
+
+Conventions you must follow (from CLAUDE.md and Phase 1 precedent):
+
+- Edition 2024, rust-version 1.85.0
+- thiserror in libs, anyhow in bins
+- Zero-tolerance in production: no .unwrap() / .expect() / let _ = ... discarding Result / #[allow(...)] (tests exempt)
+- Validation newtypes flowing through Tauri bindings need #[cfg_attr(feature = "specta", derive(specta::Type))]
+- Map external errors at the adapter boundary (no #[source] serde_json::Error etc. on pub types)
+- Tauri commands split into thin wrapper + private fn <name>_impl that takes &MarketplaceService. Project-only reads (list_installed_plugins, remove_plugin, list_installed_skills, remove_skill) follow the no-_impl precedent — body inline.
+- Pre-commit: cargo fmt --all --check, cargo test --workspace, cargo clippy --workspace --tests -- -D warnings, npm run check (in crates/kiro-control-center/), and TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+
+Use the LSP tool first when researching code structure (per memory feedback_lsp_first.md and A-8 in Phase 1's amendments). Grep is fallback. The LSP-first discipline caught P1.5-1 and P1.5-2 in the plan-review pass; it'll catch similar drift during execution.
+
+Execution model — subagent-driven-development:
+
+Use the superpowers:subagent-driven-development skill. Dispatch a fresh subagent per task, with the design + plan + amendments docs as required context. Read the diff yourself between tasks; optionally dispatch pr-review-toolkit:code-reviewer for a deeper pass after every 2-3 tasks (Phase 1 used this rhythm).
+
+Don't redo plan-time review. The plan has 5 amendments; trust them and the compiler. If a finding does come up during implementation, capture it as P1.5-6+ in the amendments doc (audit trail) — but the goal is forward motion, not more review. Phase 1 captured A-24 and A-25 mid-execution this way.
+
+Don't try to compile or run from /home/dwalleck/repos/kiro-marketplace-cli (main repo). Always work in /home/dwalleck/repos/kiro-marketplace-cli-phase-1-5. The worktree has its own target/ and node_modules/. Memory file feedback_review_worktree.md explains why.
+
+When you dispatch review-agent subagents (later, when checking convergence with deeper review), pass the worktree absolute path explicitly and warn against reading the main repo — Phase 1 had a wrong-directory review that produced phantom dead-code findings.
+
+Heavy lifts to anticipate:
+- Task 3 (project.rs): 4 meta types + InstalledPluginInfo + KiroProject removal/install API + free helpers + ~30 test fixtures. Single coherent commit (or with as_str() shims for sub-commits). After Task 3 the workspace doesn't compile — Tasks 5-7 fix the ripple.
+- Task 5 (service/mod.rs): AgentInstallContext + InstallPluginResult + A4 marketplace field + drop Default + MarketplaceService install API. ~12 test fixtures.
+
+After Phase 1.5 is done (8 tasks), open a PR titled "feat: type-safety hardening — MarketplaceName/PluginName newtypes (Phase 1.5)" referencing PR #94 in the body. The plan's Task 8 step 7 has the full PR body template.
+
+First action: cd to the worktree, read the three plan docs (design + plan + amendments) plus the relevant parts of Phase 1's amendments (A-8 LSP discipline, A-25 skip_serializing_if rule), then start Task 1 (define MarketplaceName + PluginName) via a fresh subagent.

--- a/docs/plans/2026-04-30-phase-1-5-type-safety-design.md
+++ b/docs/plans/2026-04-30-phase-1-5-type-safety-design.md
@@ -1,0 +1,261 @@
+# Phase 1.5 — Type-Safety Hardening — Design
+
+> **Status:** design draft. Implementation plan to be written next via the `superpowers:writing-plans` skill once this design is approved.
+
+## Problem
+
+PR #94 (Phase 1, plugin-first install) shipped 23 commits and 909 tests, with an 8-reviewer aggregated review producing 3 Critical and 13 Important findings — all addressed before merge. Three of those findings converged on a single underlying weakness in `kiro-market-core`: **the `marketplace` and `plugin` strings are unstructured `&str` / `String`**, accepted by 7+ public API entry points in argument-order pairs that the type system cannot enforce.
+
+Concretely:
+
+```rust
+pub fn remove_plugin(&self, marketplace: &str, plugin: &str) -> Result<RemovePluginResult, Error>;
+pub fn remove_native_companions_for_plugin(&self, plugin: &str, marketplace: &str) -> Result<()>;
+```
+
+The two functions order their arguments differently. A caller that swaps them silently writes the marketplace string into the plugin slot. The compiler is mute. The same shape repeats across `install_plugin`, `install_skills`, `install_plugin_steering`, `install_plugin_agents`, `resolve_plugin_install_context`, plus the tracking-file meta types' `marketplace: String` and `plugin: String` fields.
+
+Phase 1 worked around this surface in three places:
+
+1. **I9 walkers** (`validate_tracking_skill_keys`, `validate_tracking_agent_keys`) walk HashMap keys after deserialization to reject path-traversal entries.
+2. **I10 IPC validation** (`validate_name(marketplace)?` calls in every Tauri `_impl`) rejects malformed FE-supplied names at the boundary.
+3. **A-12 / A-24 cascade orphan recovery** assumes the cascade can drop tracking entries it received valid pairs for — a `(marketplace, plugin)` swap would silently drop the wrong tracking row.
+
+These are runtime gates. The type system gives no help. Phase 2 — update detection — would inherit the same surface (`detect_plugin_updates(marketplace, plugin)`), propagating the footgun.
+
+## Approach
+
+**Encode the marketplace/plugin string invariant in the type system.** Two newtypes — `MarketplaceName` and `PluginName` — replace `String` / `&str` at every internal boundary in `kiro-market-core`. Construction goes through a fallible `new` that routes to the existing `validate_name`. Tracking-file struct fields adopt the newtypes too, so `serde_json::from_slice` rejects malformed names at parse time (parse-don't-validate per CLAUDE.md template). `serde(transparent)` keeps the JSON wire format identical to today's strings — no migration of installed projects' tracking files.
+
+The Tauri command surface keeps its `String` parameters (frontend callers naturally pass strings; specta-aliased newtypes don't enforce nominal types in TypeScript without branded patterns). The IPC `_impl`s construct the newtype early via `MarketplaceName::new(...)?`, replacing the I10 `validate_name(...)?` calls — same effective gate, but the resulting handle proves provenance for the rest of the function body.
+
+This is mechanical, rippling work. Argument-swap bugs become compile errors. The I9 walkers stay (they validate HashMap *keys*, which Phase 1.5 doesn't touch); when a future phase newtypes the keys themselves, those walkers retire.
+
+## User-locked decisions
+
+These came out of the `2026-04-30` brainstorming conversation. Documented here so they don't drift during implementation:
+
+1. **Phase 1.5 is pure polish/hardening.** Phase 2 (update detection) ships separately as its own feature PR after 1.5 lands. Rationale: type-design is *Phase 1 completeness* — the swap-arg footgun would propagate into Phase 2's `detect_plugin_updates(marketplace, plugin)` if not closed first. Phase 2 is a coherent feature with its own design surface; bundling dilutes review focus.
+
+2. **Type-safety hardening is the anchor.** Of the four review-deferral themes (type-safety, security, UX polish, testing infra), type-safety is the highest-conviction work — three reviewers convergent on the swap-arg risk, and the CLAUDE.md template (`RelativePath` / `AgentName` precedent) is ready to apply. Security work (CSP, TOCTOU) is more disruptive and gets its own focused phase later. Testing infra is foundational but doesn't block Phase 2.
+
+3. **Subset within type-safety: A1 + A4.** The full type-design bucket has four items:
+   - **A1.** `MarketplaceName` / `PluginName` newtypes — the meat
+   - **A2.** `RemovePluginResult` shape symmetry (drop `_count: u32`, return `Vec<String>`) — wire-format change with frontend ripples
+   - **A3.** `InstallAgentsResult` dual-track collapse (`installed: Vec<String>` + `installed_native: Vec<...>`) — annotated as legacy-presenter scaffolding, low conviction
+   - **A4.** `InstallPluginResult` add `marketplace` field — trivial, rides for free
+
+   Phase 1.5 is **A1 + A4**. A2 defers to a UI-touching phase (likely bundled with Phase 2's "Update available" indicator work where the result-shape change can land alongside frontend updates). A3 defers indefinitely; the dual-track is documented tech debt, not a bug source.
+
+4. **Naming: `*Name`, not `*Id`.** Matches the existing `AgentName` precedent in `validation.rs`. The strings ARE names (used in path joining, log output, tracking-file keys); `MarketplaceId` / `PluginId` would imply opaque identifiers which they aren't.
+
+5. **Default impl: degenerate empty-string.** `MarketplaceName::default()` returns `MarketplaceName(String::new())`. The struct derives `Default` for test ergonomics — `InstallPluginResult` derives `Default` for two JSON-shape rstests (`install_plugin_result_json_shape_locks_default_subresults` and the populated-subresult companion), and `InstallPluginResult::default()` requires the field types to be `Default`-constructible. **This is a NEW pattern for `kiro-market-core`** — existing newtypes (`RelativePath`, `AgentName`, `GitRef`) deliberately don't derive `Default`. The trade-off: degenerate values bypass `new`'s validator, but they can't escape because (a) production paths always route through `MarketplaceName::new(...)?`, and (b) downstream uses of an empty name fail predictably (path joins produce no-op paths, tracking-file lookups find nothing). Alternative: drop `Default` from `InstallPluginResult` and update the two test sites to construct manually — preserves the existing-newtypes precedent at the cost of slightly more verbose tests. **See "Open question" below for the call-out.**
+
+## Phase 1.5 architecture
+
+### New types
+
+Two newtypes added to `crates/kiro-market-core/src/validation.rs` next to the existing `RelativePath` / `AgentName`:
+
+```rust
+/// Marketplace name as it appears in `marketplace.json` and tracking files.
+/// Validated against the existing `validate_name` rules at construction:
+/// non-empty, no NUL/control bytes, no path-traversal, no Windows-reserved names.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct MarketplaceName(String);
+
+impl MarketplaceName {
+    /// Construct after validation. Routes through [`validate_name`].
+    pub fn new(s: impl Into<String>) -> Result<Self, ValidationError> {
+        let s = s.into();
+        validate_name(&s)?;
+        Ok(MarketplaceName(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for MarketplaceName {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Display for MarketplaceName { /* delegates to inner */ }
+impl AsRef<str> for MarketplaceName { /* delegates */ }
+impl PartialEq<str> for MarketplaceName { /* for ergonomic comparisons */ }
+impl PartialEq<&str> for MarketplaceName { /* same */ }
+```
+
+`PluginName` has the same shape. Both compile to a wire-format string, fail-loud at construction or deserialization, and prove provenance once instantiated.
+
+### Propagation scope
+
+| Surface | Today | Phase 1.5 | Reasoning |
+|---|---|---|---|
+| Tracking-file meta types (`InstalledSkillMeta.marketplace`, etc.) | `String` | `MarketplaceName` / `PluginName` | Parse-don't-validate at `serde_json::from_slice` — malformed entries reject at load |
+| Core function signatures (`install_plugin`, `remove_plugin`, etc.) | `&str, &str` | `&MarketplaceName, &PluginName` | Compiler enforces argument order |
+| Result type fields (`InstalledPluginInfo.marketplace`, `InstalledPluginInfo.plugin`, `InstallPluginResult.plugin`, new `InstallPluginResult.marketplace` from A4) | `String` | `MarketplaceName` / `PluginName` | Wire format stays string via `serde(transparent)` |
+| Tauri command wrapper signatures (`install_plugin(marketplace: String, plugin: String, ...)`) | `String` | `String` (unchanged) | FE callers naturally pass strings |
+| Tauri `_impl` interior | `validate_name(marketplace)?` then pass `&str` | `let marketplace = MarketplaceName::new(marketplace)?;` then pass `&marketplace` | Construction at IPC boundary supersedes I10 |
+| Frontend (`bindings.ts`, BrowseTab, InstalledTab) | `string` | `string` (specta emits aliases but TS doesn't enforce nominal) | No frontend code change |
+
+**HashMap keys** (`InstalledSkills.skills: HashMap<String, InstalledSkillMeta>` keyed by skill name) stay `String`. The I9 walkers (`validate_tracking_skill_keys`, `validate_tracking_agent_keys`) shipped in PR #94 continue to validate keys at load. Newtyping the keys themselves (`SkillName`, etc.) is a separate, larger scope and out of Phase 1.5.
+
+### A4: `marketplace` field on `InstallPluginResult`
+
+```rust
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallPluginResult {
+    pub marketplace: MarketplaceName,   // NEW (A4)
+    pub plugin: PluginName,             // changed from String per A1
+    pub version: Option<String>,
+    pub skills: InstallSkillsResult,
+    pub steering: InstallSteeringResult,
+    pub agents: InstallAgentsResult,
+}
+```
+
+`MarketplaceService::install_plugin` already accepts `marketplace: &MarketplaceName` (post-A1); assign `marketplace.clone()` to the new field. Symmetric with `InstalledPluginInfo` which already carries both fields.
+
+The frontend's install banner currently reads `"Plugin ${plugin}: ..."`. With `marketplace` available, BrowseTab could optionally render `"${marketplace}/${plugin}"` for disambiguation. Marked **optional polish** — install banners are per-card so the marketplace is visually adjacent already, and forcing a frontend touch into a backend-only PR would expand scope.
+
+## Migration strategy
+
+The newtype change ripples broadly. Implementation work in this order avoids intermediate-state breakage. Each step ends with `cargo test --workspace` green.
+
+| Step | Files | Effect |
+|---|---|---|
+| 1. Define `MarketplaceName` + `PluginName` | `validation.rs` (+1 unit) | Adds types; nothing uses them yet |
+| 2. Migrate tracking-file meta types | `project.rs` (`InstalledSkillMeta`, `InstalledSteeringMeta`, `InstalledAgentMeta`, `InstalledNativeCompanionsMeta`) | Parse-validated at load. `serde(transparent)` accepts existing JSON unchanged. Internal users update via `as_str()` / `Display` |
+| 3. Migrate `installed_plugins` aggregator + `InstalledPluginInfo` field types | `project.rs` | Result types use newtypes |
+| 4. Migrate `KiroProject` removal API (`remove_plugin`, `remove_skill`, `remove_steering_file`, `remove_agent`, `remove_native_companions_for_plugin`) | `project.rs` | Function signatures use `&MarketplaceName` / `&PluginName`. Internal callers updated |
+| 5. Migrate `MarketplaceService` install API (`install_plugin`, `install_skills`, `install_plugin_steering`, `install_plugin_agents`, `resolve_plugin_install_context`) | `service/mod.rs`, `service/browse.rs` | Function signatures + `PluginInstallContext` field types. **A4 lands here** |
+| 6. Update Tauri `_impl`s | `commands/{agents,plugins,steering,browse,installed}.rs` | Replace `validate_name(x)?` with `let x = MarketplaceName::new(x)?;`. Pass `&x` to core |
+| 7. Regenerate `bindings.ts` | `crates/kiro-control-center/src/lib/bindings.ts` | Emits `MarketplaceName` / `PluginName` as TS string aliases |
+| 8. Verify I10 cleanup | `commands/*.rs` | The `validate_name` calls from Phase 1's I10 are now redundant (step 6 replaced them) |
+
+**Critical: I9 walkers stay.** `validate_tracking_skill_keys` and `validate_tracking_agent_keys` in `project.rs` validate HashMap *keys*, which step 2 doesn't touch. Don't delete them.
+
+## Testing strategy
+
+### New tests (`validation.rs::tests`)
+
+- `marketplace_name_rejects_empty`
+- `marketplace_name_rejects_traversal` (`..`, `../etc`, etc.)
+- `marketplace_name_rejects_nul_byte`
+- `marketplace_name_rejects_control_chars`
+- `marketplace_name_rejects_windows_reserved` (`CON`, `NUL`, etc., per existing `validate_name` rules)
+- `marketplace_name_round_trips_through_serde` (serialize → deserialize → equal)
+- `marketplace_name_deserialize_rejects_malformed_via_parse_dont_validate` — feed malformed JSON to `serde_json::from_str::<MarketplaceName>(...)`, assert `Err`
+- `plugin_name_*` — same set
+
+### New tests (`project.rs::tests`)
+
+- `installed_skills_deserialize_rejects_malformed_marketplace_in_meta` — locks the parse-don't-validate contract at the tracking-file boundary. The point of the newtype is that the I9 walkers become belt-and-suspenders rather than load-bearing.
+
+### Wire-format JSON-shape locks (existing tests modified)
+
+`install_plugin_result_json_shape_locks_default_subresults` and `install_plugin_result_json_shape_with_populated_subresult` (added in PR #94 per A-5) need updates to reflect the new `marketplace` field. Both should continue to assert that `marketplace` and `plugin` serialize as plain strings (the `serde(transparent)` contract).
+
+### Existing tests modified
+
+~30 sites currently passing `"mp"` / `"p"` literals to core APIs need `MarketplaceName::new("mp").expect("test fixture")`. Add helpers to `crates/kiro-market-core/src/service/test_support.rs`:
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+pub fn mp(s: &str) -> MarketplaceName {
+    MarketplaceName::new(s).expect("test marketplace name")
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub fn pn(s: &str) -> PluginName {
+    PluginName::new(s).expect("test plugin name")
+}
+```
+
+Test fixtures become `mp("mp")` / `pn("p")` — readable and idiomatic.
+
+## Out of scope
+
+Documented here so they don't drift into the plan:
+
+- **A2 `RemovePluginResult` shape symmetry** (drop `_count: u32`, return `Vec<String>` per content type) — defer to a UI-touching phase, likely bundled with Phase 2's "Update available" work where the result-shape change can land alongside frontend updates.
+- **A3 `InstallAgentsResult` dual-track collapse** — defer indefinitely; the dual-track is annotated as legacy-presenter scaffolding, not a bug source.
+- **HashMap-key newtypes** (`SkillName`, etc.) — keys stay `String`; I9 walkers continue to validate. Newtype-the-keys is bigger scope; leave for a future "tracking-file types" phase.
+- **`*Error::NotInstalled { name: String }` variants** — stay `String`. Refactoring every error site to carry `PluginName` is high-churn for low gain since error messages are wire-projected to strings anyway.
+- **Frontend nominal-type migration** — `bindings.ts` will emit `MarketplaceName` / `PluginName` as TS string aliases via `specta::Type`, but BrowseTab / InstalledTab code stays `string`-typed. TypeScript doesn't enforce nominal types ergonomically without branded patterns; the value of newtypes is at the Rust boundary.
+- **Phase 2 (updates)** — `detect_plugin_updates`, "Update available" UI, `force=true` re-install wiring. Separate feature PR after 1.5 lands.
+- **`csp: null` hardening, TOCTOU lock-spanning, vitest setup** — these were the bucket (b)/(c)/(d) themes not chosen for 1.5. Track for a future hardening phase.
+- **A4 frontend banner uplift** — render `${marketplace}/${plugin}` in install banners. Optional polish; the marketplace is visually adjacent on the plugin card, so the banner doesn't strictly need it.
+
+## 5-Gates self-review
+
+### Gate 1 — Grounding
+
+**Real incident driving this work?** Yes. PR #94's 8-reviewer aggregated review had **3 reviewers convergent** on the swap-arg footgun (`remove_plugin(marketplace: &str, plugin: &str)` accepts swapped args silently). The type-design reviewer flagged it as Critical with concrete reasoning: `remove_native_companions_for_plugin(plugin: &str, marketplace: &str)` already orders its arguments differently, the bug is latent, and there are 19+ sites where the same string-typed pair appears. The CLAUDE.md `validation.rs` template (`RelativePath` / `AgentName` precedent) is ready to apply.
+
+### Gate 2 — Threat Model
+
+**Untrusted inputs:**
+
+- **Tracking-file content** (`InstalledSkillMeta.marketplace`, etc.) — A1 makes these parse-validated at `serde_json::from_slice`. Closes the gap PR #94's I9 walkers cover via post-load walking; the walkers remain belt-and-suspenders for HashMap keys (out of scope) but become structurally redundant for meta fields.
+- **Tauri command FE strings** — `MarketplaceName::new(marketplace)?` at the IPC boundary supersedes PR #94's I10 `validate_name(marketplace)?` calls. Same effective gate, with a typed handle proving provenance for the rest of the function body.
+- **Plugin manifest fields** — already validated by existing core parsers (`PluginManifest`, `RelativePath`, etc.); Phase 1.5 doesn't introduce new untrusted parse points.
+
+### Gate 3 — Wire Format / FFI
+
+**`serde(transparent)` keeps the wire format identical to today's strings.** JSON tracking files round-trip without migration. `bindings.ts` emits TypeScript string aliases via `specta::Type` — the TS shape is unchanged for consumers who don't opt into nominal typing.
+
+**Existing JSON-shape rstest locks** continue to pin the contract. New tests assert the parse-don't-validate behavior at deserialization (a malformed `marketplace` in tracking JSON fails to deserialize, surfacing at `load_installed*()` rather than reaching the cascade).
+
+**Action item:** verify the existing `InstallPluginResult` JSON-shape rstests (added in PR #94 per A-5: `install_plugin_result_json_shape_locks_default_subresults` and the populated-subresult companion) and the `installed_plugins_groups_skills_steering_agents_by_marketplace_plugin_pair` aggregator test continue to pass after the field-type change. The newtype fields under `serde(transparent)` should serialize byte-identically to the prior String fields.
+
+### Gate 4 — External Type Boundary
+
+**No new external errors introduced.** `MarketplaceName::new` returns `ValidationError` — typed, internal to `kiro-market-core`. The existing plan-lint gate `cargo xtask plan-lint --gate gate-4-external-error-boundary` will continue to pass.
+
+### Gate 5 — Type Design
+
+**This phase IS the Gate 5 work.** It encodes the "this is a validated marketplace/plugin name, not a raw string" invariant in the type system — making argument-order swap-safe at compile time, eliminating the swap-arg bug class entirely. The newtypes use a private inner field (per CLAUDE.md template) so degenerate values can't be constructed without going through `new`.
+
+The `Default` impl returning empty-string is the one caveat. It exists for test ergonomics — `InstallPluginResult::default()` is called by JSON-shape rstests. Production code never constructs `MarketplaceName::default()`; every real-world instance flows through `MarketplaceName::new(...)?`. **Note:** this is a new pattern for `kiro-market-core` — the existing newtypes (`RelativePath`, `AgentName`, `GitRef`) don't derive `Default`. Mitigation: empty-string would fail downstream uses anyway (path joining with `""` produces a deterministic-but-meaningless path; tracking-file lookups for `""` find nothing). The alternative — drop `Default` from `InstallPluginResult` — preserves the existing precedent at the cost of slightly more verbose test construction. See open question below.
+
+## Open question
+
+**Should `MarketplaceName` / `PluginName` derive `Default`?**
+
+- **Yes (current design):** `InstallPluginResult` keeps its `Default` derive; the two JSON-shape rstests stay terse via `InstallPluginResult::default()`. New pattern for kiro-market-core.
+- **No (alternative):** Drop `Default` from both newtypes AND from `InstallPluginResult`. Two test sites construct manually with `mp("...")` / `pn("...")` helpers. Matches existing `RelativePath` / `AgentName` / `GitRef` precedent (none derive Default).
+
+The first review pass picked "Yes" before discovering the precedent mismatch. Re-confirm before the implementation plan is written, since the choice ripples to ~3 sites: the two newtypes' `derive(...)` lists, `InstallPluginResult`'s `derive(...)` line, and two rstest call sites.
+
+## Module map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/validation.rs` | Modify | Add `MarketplaceName`, `PluginName` |
+| `crates/kiro-market-core/src/project.rs` | Modify | Migrate `Installed*Meta` field types, removal API signatures, aggregator |
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | Migrate install API signatures, `InstallPluginResult` field types (incl. A4 `marketplace`) |
+| `crates/kiro-market-core/src/service/browse.rs` | Modify | Migrate `PluginInstallContext` field types, `resolve_plugin_install_context*` signatures |
+| `crates/kiro-market-core/src/service/test_support.rs` | Modify | Add `mp(&str) -> MarketplaceName` and `pn(&str) -> PluginName` helpers |
+| `crates/kiro-control-center/src-tauri/src/commands/{agents,plugins,steering,browse,installed}.rs` | Modify | Replace `validate_name(...)?` with `MarketplaceName::new(...)?` in `_impl`s |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | Auto-generated; emits `MarketplaceName` / `PluginName` TS aliases |
+| `crates/kiro-market-core/tests/integration_native_install.rs` | Modify | Test fixture sites — `mp("mp")` / `pn("p")` |
+| `crates/kiro-market/src/commands/install.rs` | Modify | CLI signature update to construct newtypes from clap-parsed strings |
+
+## References
+
+- `2026-04-29-plugin-first-install-design.md` — Phase 1 design
+- `2026-04-29-plugin-first-install-plan.md` — Phase 1 plan (10 tasks)
+- `2026-04-29-plugin-first-install-plan-amendments.md` — 25 amendments (A-1 through A-25; A-24 closed in PR #94 per the I3 fix)
+- PR #94 — Phase 1 implementation (23 commits, merged `9ff4e7b`)
+- PR #94's 8-reviewer aggregated review (in conversation; convergent finding on swap-arg footgun across type-design / silent-failure / comment-analyzer)
+- CLAUDE.md `validation.rs` template — `RelativePath`, `AgentName`, `GitRef` precedents
+- `docs/plan-review-checklist.md` — 5-gates self-review used above

--- a/docs/plans/2026-04-30-phase-1-5-type-safety-design.md
+++ b/docs/plans/2026-04-30-phase-1-5-type-safety-design.md
@@ -49,7 +49,7 @@ These came out of the `2026-04-30` brainstorming conversation. Documented here s
 
 4. **Naming: `*Name`, not `*Id`.** Matches the existing `AgentName` precedent in `validation.rs`. The strings ARE names (used in path joining, log output, tracking-file keys); `MarketplaceId` / `PluginId` would imply opaque identifiers which they aren't.
 
-5. **Default impl: degenerate empty-string.** `MarketplaceName::default()` returns `MarketplaceName(String::new())`. The struct derives `Default` for test ergonomics — `InstallPluginResult` derives `Default` for two JSON-shape rstests (`install_plugin_result_json_shape_locks_default_subresults` and the populated-subresult companion), and `InstallPluginResult::default()` requires the field types to be `Default`-constructible. **This is a NEW pattern for `kiro-market-core`** — existing newtypes (`RelativePath`, `AgentName`, `GitRef`) deliberately don't derive `Default`. The trade-off: degenerate values bypass `new`'s validator, but they can't escape because (a) production paths always route through `MarketplaceName::new(...)?`, and (b) downstream uses of an empty name fail predictably (path joins produce no-op paths, tracking-file lookups find nothing). Alternative: drop `Default` from `InstallPluginResult` and update the two test sites to construct manually — preserves the existing-newtypes precedent at the cost of slightly more verbose tests. **See "Open question" below for the call-out.**
+5. **No `Default` derive on the newtypes.** Verified by `grep`: `InstallPluginResult::default()` is never called anywhere — the two JSON-shape rstests construct the struct field-by-field, and `MarketplaceService::install_plugin` at `service/mod.rs:1992` does the same. Phase 1's implementer added `Default` to `InstallPluginResult`'s derive list but no consumer uses it. Phase 1.5 drops `Default` from `InstallPluginResult` and does NOT derive `Default` on the newtypes. Matches existing precedent (`RelativePath`, `AgentName`, `GitRef` deliberately don't derive `Default`); avoids the degenerate-state hazard (`MarketplaceName(String::new())` would be a value the type's own validator rejects); zero test churn. A future reader who tries `InstallPluginResult::default()` will see a compile error rather than silently construct a degenerate value.
 
 ## Phase 1.5 architecture
 
@@ -61,7 +61,11 @@ Two newtypes added to `crates/kiro-market-core/src/validation.rs` next to the ex
 /// Marketplace name as it appears in `marketplace.json` and tracking files.
 /// Validated against the existing `validate_name` rules at construction:
 /// non-empty, no NUL/control bytes, no path-traversal, no Windows-reserved names.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
+///
+/// Deliberately does NOT derive `Default` — `MarketplaceName::default()` would
+/// have to return `MarketplaceName(String::new())`, which `validate_name` rejects.
+/// Matches the existing `RelativePath` / `AgentName` / `GitRef` precedent.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct MarketplaceName(String);
@@ -110,7 +114,8 @@ impl PartialEq<&str> for MarketplaceName { /* same */ }
 ### A4: `marketplace` field on `InstallPluginResult`
 
 ```rust
-#[derive(Debug, Default, Serialize)]
+// `Default` derive dropped — never called; A1 newtypes don't derive Default.
+#[derive(Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct InstallPluginResult {
     pub marketplace: MarketplaceName,   // NEW (A4)
@@ -225,16 +230,7 @@ Documented here so they don't drift into the plan:
 
 **This phase IS the Gate 5 work.** It encodes the "this is a validated marketplace/plugin name, not a raw string" invariant in the type system — making argument-order swap-safe at compile time, eliminating the swap-arg bug class entirely. The newtypes use a private inner field (per CLAUDE.md template) so degenerate values can't be constructed without going through `new`.
 
-The `Default` impl returning empty-string is the one caveat. It exists for test ergonomics — `InstallPluginResult::default()` is called by JSON-shape rstests. Production code never constructs `MarketplaceName::default()`; every real-world instance flows through `MarketplaceName::new(...)?`. **Note:** this is a new pattern for `kiro-market-core` — the existing newtypes (`RelativePath`, `AgentName`, `GitRef`) don't derive `Default`. Mitigation: empty-string would fail downstream uses anyway (path joining with `""` produces a deterministic-but-meaningless path; tracking-file lookups for `""` find nothing). The alternative — drop `Default` from `InstallPluginResult` — preserves the existing precedent at the cost of slightly more verbose test construction. See open question below.
-
-## Open question
-
-**Should `MarketplaceName` / `PluginName` derive `Default`?**
-
-- **Yes (current design):** `InstallPluginResult` keeps its `Default` derive; the two JSON-shape rstests stay terse via `InstallPluginResult::default()`. New pattern for kiro-market-core.
-- **No (alternative):** Drop `Default` from both newtypes AND from `InstallPluginResult`. Two test sites construct manually with `mp("...")` / `pn("...")` helpers. Matches existing `RelativePath` / `AgentName` / `GitRef` precedent (none derive Default).
-
-The first review pass picked "Yes" before discovering the precedent mismatch. Re-confirm before the implementation plan is written, since the choice ripples to ~3 sites: the two newtypes' `derive(...)` lists, `InstallPluginResult`'s `derive(...)` line, and two rstest call sites.
+**No `Default` derive** on the newtypes — verified by grep that `InstallPluginResult::default()` is never called anywhere. Phase 1.5 drops `Default` from `InstallPluginResult` and does NOT derive `Default` on the newtypes. The newtypes can only be constructed via `new` (which validates) or `Deserialize` (which routes through `new`). Degenerate empty-string values are unrepresentable. Matches existing precedent for the validation newtypes in this crate.
 
 ## Module map
 

--- a/docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md
+++ b/docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md
@@ -201,6 +201,73 @@ The plan's note is technically right but reads as if even kiro-market-core might
 
 ---
 
+## P1.5-6 — Implementation finding: Task 3's intra-crate ripple is wider than the plan anticipated
+
+**Surfaced during.** Task 3 implementation (commit `9fbbfd9`). The plan's Task 3 step 7 said only the workspace crates (`kiro-control-center`, `kiro-market`) would fail to compile after Task 3, with `kiro-market-core` itself going green. In practice, three meta-construction sites *inside* `kiro-market-core` also have to be migrated in Task 3 (because the crate must compile end-to-end as a unit):
+
+- `crates/kiro-market-core/src/service/mod.rs::install_skills` (around line 1110) — builds `InstalledSkillMeta` from `marketplace: &str, plugin: &str` parameters that won't be migrated until Task 5 changes `MarketplaceService::install_skills`'s signature.
+- `crates/kiro-market-core/src/service/mod.rs::install_translated_agent` (around line 1519) — builds `InstalledAgentMeta` from `ctx: AgentInstallContext<'_>` whose `marketplace`/`plugin` fields stay `&str` until Task 5 migrates `AgentInstallContext`.
+- `crates/kiro-market-core/src/service/mod.rs::install_one_native_agent` and `install_native_companions_for_plugin` (around lines 1691, 1771) — same shape, take `ctx: AgentInstallContext<'_>` whose fields are still `&str` pre-Task-5.
+
+Plus one inside `project.rs` itself: `install_steering_file_locked` (around line 1878) holds a `SteeringInstallContext<'_>` whose fields stay `&str` until Task 4 migrates that struct.
+
+**Why the plan missed it.** The plan correctly identified the *call sites that change in each task* but didn't trace the *meta-construction sites that consume those parameters*. An `InstalledSkillMeta` construction inside `install_skills` is downstream of `install_skills`'s parameter type — when we change the meta type's field type in Task 3, the construction site has to be updated even if its surrounding fn's signature doesn't change until Task 5.
+
+**Mitigation chosen.** Task 3 added two `pub(crate) fn from_internal_unchecked` constructors on `MarketplaceName` and `PluginName` (mirroring the existing `RelativePath::from_internal_unchecked` precedent at `validation.rs:56` — `debug_assert!` validation, no panic in release, identical recipe). The four shim sites use them with explicit "Phase 1.5 Task 3 transient shim — Task 4/5 strips" comments. Task 4's `SteeringInstallContext` migration strips the `project.rs` shim; Task 5's `AgentInstallContext` + `MarketplaceService::install_skills` migrations strip the three `service/mod.rs` shims.
+
+**Forward-looking rule.** When a plan migrates a struct field type (X), the plan should also enumerate the *construction sites* of that struct, not just the *call sites of the function holding it*. Construction sites and parameter sites are separate axes of ripple.
+
+**Rationale.** Captured as audit trail per "forward motion + amendments" execution rule. The implementer correctly identified the intra-crate ripple, applied the existing `from_internal_unchecked` recipe (not a new pattern), and marked every shim site for Task 4/5 to strip. No design-doc revision needed.
+
+---
+
+## P1.5-7 — Implementation finding: `from_internal_unchecked` constructors added to both newtypes
+
+**Surfaced during.** Task 3 implementation (commit `9fbbfd9`). Coupled to P1.5-6 — these are the constructors that enable the transient shim sites to compile without introducing `unwrap`/`expect` in production code.
+
+**Drift.** The plan's Task 1 spec defined `MarketplaceName::new` and `PluginName::new` as the only public constructors. Task 3's intra-crate ripple (P1.5-6) needed a way to construct the newtypes from strings that *had already been validated upstream* (at the marketplace catalog parse layer) without re-running validation or returning a `Result`.
+
+**Resolved by.** Adding `pub(crate) fn from_internal_unchecked(value: String) -> Self` to both newtypes:
+
+```rust
+/// See [`RelativePath::from_internal_unchecked`].
+pub(crate) fn from_internal_unchecked(value: String) -> Self {
+    debug_assert!(
+        validate_name(&value).is_ok(),
+        "MarketplaceName::from_internal_unchecked called with invalid name: {value:?}"
+    );
+    MarketplaceName(value)
+}
+```
+
+This mirrors the **existing** `RelativePath::from_internal_unchecked` precedent at `crates/kiro-market-core/src/validation.rs:56`. It's not a new pattern — it's the codebase's established recipe for "internal post-validation construction without re-validating." `pub(crate)` keeps it off the public API; `debug_assert!` catches bugs in dev/test builds.
+
+**Forward-looking expectation.** The four `from_internal_unchecked` call sites (3 in `service/mod.rs`, 1 in `project.rs`) are TRANSIENT — Tasks 4 and 5 strip them when the surrounding context structs (`SteeringInstallContext`, `AgentInstallContext`) and `MarketplaceService::install_skills` migrate to take the newtypes directly. The constructors themselves stay (they're general infrastructure matching `RelativePath`'s shape), but the call sites should disappear.
+
+**Verification expectation.** After Task 5 lands, `grep -rn "from_internal_unchecked" crates/kiro-market-core/src/` should return only the `validation.rs` definition lines and the `RelativePath` precedent — no call sites in `service/mod.rs` (or anywhere else). If any survive past Task 5, that's a finding to capture.
+
+**Site-count drift.** Tasks 1-4 deep review (`9a3b297..a80455c`) found that the actual call-site count is 5 (not 4): all in `service/mod.rs` after Task 4 stripped the `project.rs` site. Lines 1117/1120 (`install_skills`), 1523/1526 (`install_translated_agent`), 1696/1698 (`install_one_native_agent`), 1776/1778 (`install_native_companions_for_plugin`), 2005/2006 (`install_plugin`'s `SteeringInstallContext` construction added by Task 4). Task 5 strips all five.
+
+**IMPORTANT — release-build exposure pre-Task-5.** Two of the five shim sites (`install_skills` 1117/1120 and `install_plugin` 2005/2006) are reached via PUBLIC `MarketplaceService` methods that still take `marketplace: &str, plugin: &str`. `from_internal_unchecked`'s `debug_assert!` is stripped in release builds, so a release-build CLI consumer that doesn't pre-validate could plant a malformed name into a tracking file. The Tauri direction is safe (callers do `validate_name(...)?` first); the CLI direction is not (`crates/kiro-market/src/commands/install.rs` parses but doesn't `validate_name`). Closing this is a Task 5 hard requirement — Task 5 must migrate `MarketplaceService::install_skills` and `install_plugin`'s public signatures to `&MarketplaceName, &PluginName` so the shim sites disappear by construction. No interim mitigation needed since Task 5 is the next dispatched task.
+
+**Rationale.** Captured as audit trail. The implementer correctly invoked the existing precedent rather than introducing a new pattern, and the constructors will continue to be useful infrastructure even after the Phase 1.5 shim sites disappear (any future internal post-validation construction can reach for the same recipe).
+
+---
+
+## P1.5-8 — Implementation finding: Task 5 removed `from_internal_unchecked` from `MarketplaceName` / `PluginName` instead of keeping them as infrastructure
+
+**Surfaced during.** Task 5 implementation. P1.5-7 said the `pub(crate) fn from_internal_unchecked` constructors on `MarketplaceName` and `PluginName` would stay as general infrastructure even after their Phase 1.5 shim call sites disappeared. In practice, leaving them as dead code triggered `dead_code` warnings, which `cargo clippy --tests -- -D warnings` (the project's pre-commit gate) treats as errors. CLAUDE.md's zero-tolerance policy on `#[allow(...)]` directives forecloses the warning-suppression escape hatch.
+
+**Resolved by.** Removing both `pub(crate) fn from_internal_unchecked` definitions from `validation.rs` (along with their doc comments). The `RelativePath::from_internal_unchecked` precedent at `validation.rs:56` is unaffected — it has a real call site (`plugin.rs:133` via `DiscoveredPlugin::as_relative_path`) so it stays.
+
+**Forward-looking expectation.** If a future task needs to construct a `MarketplaceName` or `PluginName` from an already-validated string without re-running validation, re-adding the constructor is a 7-line edit and the `RelativePath` precedent is right there. The deletion is reversible. The decision rule going forward: a `pub(crate) fn from_internal_unchecked` on a newtype that has no callers is a code smell, not infrastructure.
+
+**Asymmetry left in place — `AgentError::PathOwnedByOtherPlugin.owner: String`.** Task 4 migrated `SteeringError::PathOwnedByOtherPlugin.owner` to `PluginName`. The sibling variant `AgentError::PathOwnedByOtherPlugin.owner` (at `error.rs:332`) still carries `String`. The construction site at `project.rs:2966` reads from a `&String` HashMap key — the in-design choice was to keep `HashMap<String, _>` keys as `String` rather than `PluginName`. Migrating just the error variant would either (a) require adding a NEW `from_internal_unchecked` shim site (defeating Task 5's purpose) or (b) require migrating the HashMap key (out of scope per the design doc). Task 5 leaves the asymmetry in place. If a follow-up wants to close it, the shape is "migrate the HashMap key first, then the variant." Logged here so the asymmetry is auditable rather than accidental.
+
+**Rationale.** Captured as audit trail per "forward motion + amendments" execution rule. The deletion is the right call given the project's clippy posture; the forward-looking note keeps the door open for re-introduction if a future need actually materializes.
+
+---
+
 ## Gates not flagged
 
 - **Gate 2 (Threat Model)** — pass. The plan migrates existing surface; no new untrusted byte sources. The newtype's `Deserialize` adds defensive validation at parse time, strengthening the existing trust model. PR #94's I9 walkers + the new newtype `Deserialize` gives belt-and-suspenders for tracking-file content.
@@ -215,6 +282,9 @@ The plan's note is technically right but reads as if even kiro-market-core might
 - **P1.5-3**: Add inline rationale comment on `Ord/PartialOrd` derive, plus a regression test asserting cmp matches inner String cmp.
 - **P1.5-4**: One-line note in Task 7 step 1 citing Phase 1 I10's `From<ValidationError> for CommandError`.
 - **P1.5-5**: Tighter wording in Task 3 step 7 separating crate-level vs workspace-level compile boundaries.
+- **P1.5-6** (implementation finding): Task 3's intra-crate ripple wider than plan anticipated; 4 transient shim sites added with `from_internal_unchecked` per P1.5-7.
+- **P1.5-7** (implementation finding): `pub(crate) fn from_internal_unchecked` added to `MarketplaceName` and `PluginName` mirroring the existing `RelativePath::from_internal_unchecked` precedent. Tasks 4-5 strip the call sites; the constructors themselves stay as infrastructure.
+- **P1.5-8** (implementation finding): Task 5 removed the `from_internal_unchecked` constructors (no remaining callers triggered `dead_code`; CLAUDE.md's no-`#[allow]` rule blocked suppression). Reversible if a future task needs them. Also documents the deliberate `AgentError::PathOwnedByOtherPlugin.owner: String` asymmetry that Task 5 chose to leave in place.
 
 No design-doc revisions required. The amendments are execution-time corrections; the architecture in `2026-04-30-phase-1-5-type-safety-design.md` stands as written.
 

--- a/docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md
+++ b/docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md
@@ -1,0 +1,225 @@
+# Phase 1.5 — Plan Amendments
+
+> **Status:** plan-review pass per `docs/plan-review-checklist.md`.
+> Fixes drift between `2026-04-30-phase-1-5-type-safety-plan.md` and the
+> actual SHA at `9ff4e7b` (post-PR-#94 `main`). Format follows the
+> precedent set by `2026-04-29-plugin-first-install-plan-amendments.md`.
+
+5-gates pass via LSP-first discipline (per A-8 in the Phase 1
+amendments doc). Gates 2, 3, 4, and most of Gate 5 pass clean — the
+plan's design carried through. Gate 1 (grounding) found 4 specific
+drift points; Gate 5 found one rationale gap worth documenting inline.
+
+Each amendment cites the gate that fired, names the original plan
+text, gives the amended text, and explains the rationale. Apply
+during execution; they don't require re-opening the design conversation.
+
+---
+
+## P1.5-1 — Gate 1: Task 6 step 1 comparison `p.name == *plugin` won't compile
+
+**Original (plan Task 6 step 1):**
+
+```rust
+let entry = plugin_entries
+    .iter()
+    .find(|p| p.name == *plugin)        // PluginName: PartialEq<str> via the &PluginEntry path
+    .ok_or_else(|| ...)?;
+```
+
+**Drift.** `p.name: String` and `plugin: &PluginName`, so `*plugin: PluginName`. The expression `String == PluginName` requires `impl PartialEq<PluginName> for String` — which the plan's Task 1 doesn't define. The reverse comparison `*plugin == p.name` would require `impl PartialEq<String> for PluginName` — also not defined. Only `PartialEq<str>` and `PartialEq<&str>` are defined on the newtypes (matching the `AgentName` precedent).
+
+The plan's parenthetical comment ("PluginName: PartialEq<str> via the &PluginEntry path") is incorrect — `PartialEq<str>` doesn't help here because the LHS is `String`, not `str`/`PluginName`.
+
+**Amended.**
+
+```rust
+let entry = plugin_entries
+    .iter()
+    .find(|p| p.name == plugin.as_str())
+    .ok_or_else(|| ...)?;
+```
+
+`String == &str` works via the standard library's `PartialEq<&str> for String`. No newtype-specific impls needed.
+
+**Rationale.** Gate 1 — uncompilable code in a plan code block. The Phase 1 precedent (A-1, A-14, A-21) caught the same class of bug across multiple tasks; this is the Phase 1.5 equivalent. Verified by tracing: `plan.rs:Task 6 step 1` → newtype `PartialEq` impls in plan Task 1 → standard library trait coverage for `String`/`str`/`&str` interop.
+
+---
+
+## P1.5-2 — Gate 1: Task 6 step 1 `PluginError::NotFound` variant fields and name are wrong
+
+**Original (plan Task 6 step 1):**
+
+```rust
+.ok_or_else(|| Error::Plugin(PluginError::PluginNotFound {
+    plugin: plugin.as_str().to_string(),
+}))?;
+```
+
+**Drift.** Verified by reading `crates/kiro-market-core/src/error.rs:63-65`:
+
+```rust
+/// The requested plugin was not found inside its marketplace.
+#[error("plugin `{plugin}` not found in marketplace `{marketplace}`")]
+NotFound { plugin: String, marketplace: String },
+```
+
+Two issues:
+
+1. **Variant name is `NotFound`, not `PluginNotFound`.** The plan's name doesn't exist on `PluginError`.
+2. **Variant has TWO fields, not one** — `plugin` AND `marketplace`. The plan's code only fills the first.
+
+The current source at `service/browse.rs:756-761` (pre-migration) shows the right shape:
+
+```rust
+.ok_or_else(|| {
+    Error::Plugin(PluginError::NotFound {
+        plugin: plugin.to_owned(),
+        marketplace: marketplace.to_owned(),
+    })
+})?;
+```
+
+**Amended.**
+
+```rust
+.ok_or_else(|| {
+    Error::Plugin(PluginError::NotFound {
+        plugin: plugin.as_str().to_string(),
+        marketplace: marketplace.as_str().to_string(),
+    })
+})?;
+```
+
+(Combine with P1.5-1's fix to the `find` call.)
+
+**Rationale.** Gate 1 grounding — verified the actual `PluginError` definition rather than guessing the variant shape. The plan's Task 6 step 1 code was written from memory of "PluginNotFound" semantics rather than the exact source. Two-line fix; same execution path.
+
+---
+
+## P1.5-3 — Gate 5: Task 1 step 3 needs an explicit rationale for the `Ord`/`PartialOrd` derive
+
+**Original (plan Task 1 step 3 and Task 3 step 2):**
+
+The plan says:
+
+> Note: `MarketplaceName` and `PluginName` derive `Eq` and `Ord` is **not** derived. `BTreeMap` requires `Ord`. Add `Ord` and `PartialOrd` derives to both newtypes in `validation.rs`:
+>
+> ```rust
+> #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+> ```
+
+**Drift.** This is a NEW pattern for `kiro-market-core` — the existing newtypes (`RelativePath`, `AgentName`, `GitRef`) deliberately don't derive `Ord`. The plan adds the derive for a real reason (BTreeMap key requirement at `installed_plugins`'s aggregator), but doesn't document the rationale next to the derive line itself. Future readers (and reviewers) will see the divergence and wonder why.
+
+The Phase 1.5 design doc's **decision #5** documents the parallel "no `Default`" choice with a verbatim "matches existing precedent" note. The `Ord` derive deviation needs the same treatment — but in the OPPOSITE direction (we're adding a derive the others don't have).
+
+**Amended.** Replace Task 1 step 3's derive line with the documented variant:
+
+```rust
+// Ord/PartialOrd derived for use as BTreeMap keys in `installed_plugins`'s
+// aggregator (project.rs). Lexicographic ordering on the inner string is
+// well-defined and semantically equivalent to String's ordering — no
+// surprise for callers. Deviates from RelativePath/AgentName/GitRef
+// (which don't derive Ord) because none of those types are used as
+// map keys today.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct MarketplaceName(String);
+```
+
+(Same comment + derive on `PluginName`.)
+
+Add a Task 1 test that locks the contract (in addition to the existing `marketplace_name_ord_is_lexicographic_on_inner` test the plan already includes):
+
+```rust
+#[test]
+fn marketplace_name_ord_matches_inner_string_ord() {
+    let a = MarketplaceName::new("alpha").expect("valid");
+    let b = MarketplaceName::new("bravo").expect("valid");
+    assert_eq!(
+        a.cmp(&b),
+        a.as_str().cmp(b.as_str()),
+        "MarketplaceName::cmp must match inner String::cmp byte-for-byte"
+    );
+}
+```
+
+**Rationale.** Gate 5 type design — when introducing a derive that deviates from the existing newtype precedent, document the rationale at the derive site. The Phase 1 amendments precedent (A-25's wire-format-rule comment, the no-Default note in design.md) shows the project values "explain the choice next to the choice."
+
+---
+
+## P1.5-4 — Gate 1: Task 7 step 1 should cite Phase 1 I10's `From<ValidationError> for CommandError`
+
+**Original (plan Task 7 step 1):**
+
+```rust
+let marketplace = kiro_market_core::validation::MarketplaceName::new(marketplace)?;
+let plugin = kiro_market_core::validation::PluginName::new(plugin)?;
+```
+
+**Drift.** This relies on the `?` operator converting `ValidationError` → `CommandError`. The conversion exists at `crates/kiro-control-center/src-tauri/src/error.rs:113` (verified via LSP), but it was added by Phase 1 I10 as part of PR #94 — a reader who only sees the Phase 1.5 plan won't know whether the conversion exists. If they think it's missing, they may write a manual `.map_err(...)` or worse, propose adding the impl in this PR (creating a redundant edit).
+
+**Amended.** Add a one-line note to Task 7 step 1, just before the `MarketplaceName::new` snippet:
+
+> The `?` operator converts `ValidationError` → `CommandError` via the `From<ValidationError> for CommandError` impl in `error.rs:113`, added by PR #94's I10 work. No new conversion logic needed in this task.
+
+**Rationale.** Gate 1 grounding for the implementer's mental model — the plan should make load-bearing dependencies explicit. The same discipline as Phase 1's plan, which cited specific PR-83 work that the new code relied on.
+
+---
+
+## P1.5-5 — Gate 1: Task 3 step 7 conflates two compile-state notions
+
+**Original (plan Task 3 step 7):**
+
+> Many compilation errors expected during sub-step iteration. Work through them one by one. By the end of step 6, the kiro-market-core crate should build clean.
+>
+> ```bash
+> cargo test -p kiro-market-core 2>&1 | grep "test result:" | tail -5
+> ```
+>
+> Expected: all `kiro-market-core` tests pass (the migration is internal; behavior is preserved).
+>
+> **The `kiro-control-center` and `kiro-market` crates will NOT compile yet** — they call functions whose signatures just changed. That's expected; Tasks 5–7 fix them. Do not attempt to compile the full workspace until Task 7.
+
+**Drift.** The note is correct in intent but conflates two compile-state concepts:
+
+1. **Within `kiro-market-core` itself** — Task 3 changes ripple through ~50 sites in `project.rs`. The crate either compiles end-to-end (all sites updated) or it doesn't. There is no "intermediate compiles, final doesn't" — `cargo build -p kiro-market-core` is a single atomic check per task.
+
+2. **Across the workspace** — `kiro-control-center` and `kiro-market` call into the migrated APIs. After Task 3 they don't compile until Tasks 5–7 update their call sites. This is the genuine multi-task ripple.
+
+The plan's note is technically right but reads as if even kiro-market-core might be in a half-broken state during the task. It isn't — the implementer must batch all of Task 3's sub-steps into one coherent commit (or use `as_str()` shims at compatibility points if they want intermediate commits).
+
+**Amended.** Replace Task 3 step 7's note with:
+
+> **Compile boundaries:**
+>
+> - Within `kiro-market-core` itself, **all of Task 3's sub-steps must land coherently**. The crate either compiles or it doesn't — there's no half-state. If the implementer wants intermediate commits within Task 3, use `meta.marketplace.as_str()` shims at internal call sites that haven't been migrated yet, then strip the shims in a follow-up step.
+> - **Across the workspace**, `kiro-control-center` and `kiro-market` will NOT compile after Task 3 — their call sites still pass `&str` where `&MarketplaceName` is now required. That's expected; Tasks 4–7 fix the workspace ripple. Do not run `cargo build --workspace` until Task 7.
+
+**Rationale.** Gate 1 — clarity for the implementer's expectations. The Phase 1 PR #94 implementer reports cited "intermediate non-compiling state" several times; making the boundary explicit avoids the same confusion in Phase 1.5.
+
+---
+
+## Gates not flagged
+
+- **Gate 2 (Threat Model)** — pass. The plan migrates existing surface; no new untrusted byte sources. The newtype's `Deserialize` adds defensive validation at parse time, strengthening the existing trust model. PR #94's I9 walkers + the new newtype `Deserialize` gives belt-and-suspenders for tracking-file content.
+- **Gate 3 (Wire Format / FFI Shape)** — pass. `serde(transparent)` keeps wire format byte-identical. The plan's Task 1 step 1 includes round-trip and transparent-serialization tests that lock the contract. Existing JSON files round-trip through the migrated meta types without migration.
+- **Gate 4 (External Type Boundary)** — pass. No new `pub` enum variants introduced. `MarketplaceName::new` returns `ValidationError` (internal type with no external-error fields). `cargo xtask plan-lint --gate gate-4-external-error-boundary` is expected to pass during Task 8 step 4.
+- **Gate 5 (Type Design)** — mostly pass. Parse-don't-validate ✅; specta cfg-attr on validation newtypes ✅; classifier exhaustiveness N/A; classifier idempotent-payload rule N/A; enum-vs-boolean-pair N/A. The one finding (P1.5-3 above) is rationale documentation, not a substantive gap.
+
+## Summary of changes
+
+- **P1.5-1**: Task 6 step 1 comparison `p.name == *plugin` → `p.name == plugin.as_str()`. Compiles.
+- **P1.5-2**: Task 6 step 1 `PluginError::PluginNotFound { plugin }` → `PluginError::NotFound { plugin, marketplace }`. Matches actual variant shape.
+- **P1.5-3**: Add inline rationale comment on `Ord/PartialOrd` derive, plus a regression test asserting cmp matches inner String cmp.
+- **P1.5-4**: One-line note in Task 7 step 1 citing Phase 1 I10's `From<ValidationError> for CommandError`.
+- **P1.5-5**: Tighter wording in Task 3 step 7 separating crate-level vs workspace-level compile boundaries.
+
+No design-doc revisions required. The amendments are execution-time corrections; the architecture in `2026-04-30-phase-1-5-type-safety-design.md` stands as written.
+
+## References
+
+- `docs/plan-review-checklist.md` — the 5 gates this pass applied
+- `2026-04-29-plugin-first-install-plan-amendments.md` — Phase 1's amendments doc, format precedent (especially A-1 / A-14 / A-21 for compile-error class catches)
+- Source SHA at review time: `9ff4e7b` (post-PR-#94 `main`)

--- a/docs/plans/2026-04-30-phase-1-5-type-safety-plan.md
+++ b/docs/plans/2026-04-30-phase-1-5-type-safety-plan.md
@@ -1,0 +1,1472 @@
+# Phase 1.5 — Type-Safety Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `marketplace: &str` / `plugin: &str` with validated `MarketplaceName` / `PluginName` newtypes across the install / remove / aggregate API surface in `kiro-market-core`, and add the missing `marketplace` field to `InstallPluginResult` (A4) so the wire format is symmetric with `InstalledPluginInfo`.
+
+**Architecture:** Newtypes are defined in `validation.rs` next to the existing `RelativePath` / `AgentName` precedent — `serde(transparent)` for byte-identical JSON, `Deserialize` routed through the fallible `new` for parse-don't-validate at tracking-file load. They flow through `kiro-market-core` API signatures, tracking-file struct fields, and result types; Tauri command wrappers stay `String`-typed (constructing newtypes early in `_impl`) and the frontend stays `string`-typed. The migration is mechanical but rippling — argument-swap bugs become compile errors.
+
+**Tech Stack:** Rust edition 2024, `thiserror`, `serde` with `transparent`, `specta::Type` cfg-attr, `rstest` for tests, `cargo xtask plan-lint` for the project's structural gates.
+
+**Companion design doc:** `2026-04-30-phase-1-5-type-safety-design.md`
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/validation.rs` | Modify | Add `MarketplaceName`, `PluginName` (model after `AgentName`) |
+| `crates/kiro-market-core/src/service/test_support.rs` | Modify | Add `mp(&str) -> MarketplaceName` and `pn(&str) -> PluginName` helpers |
+| `crates/kiro-market-core/src/project.rs` | Modify | Migrate 4 tracking-file meta types, `InstalledPluginInfo`, `installed_plugins` aggregator, `KiroProject` removal/install API, free helpers |
+| `crates/kiro-market-core/src/steering/types.rs` | Modify | Migrate `SteeringInstallContext` and `SteeringError::PathOwnedByOtherPlugin.owner` |
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | Migrate `AgentInstallContext`, `InstallPluginResult` (incl. A4 `marketplace` field), `MarketplaceService` install API, the install free fns |
+| `crates/kiro-market-core/src/service/browse.rs` | Modify | Migrate `MarketplaceService::resolve_plugin_install_context*` |
+| `crates/kiro-market-core/tests/integration_native_install.rs` | Modify | Update test fixtures |
+| `crates/kiro-market/src/commands/install.rs` | Modify | CLI installs construct newtypes from clap-parsed strings |
+| `crates/kiro-control-center/src-tauri/src/commands/agents.rs` | Modify | Replace `validate_name(...)?` with `MarketplaceName::new(...)?` |
+| `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` | Modify | Same |
+| `crates/kiro-control-center/src-tauri/src/commands/steering.rs` | Modify | Same |
+| `crates/kiro-control-center/src-tauri/src/commands/browse.rs` | Modify | Same |
+| `crates/kiro-control-center/src-tauri/src/commands/installed.rs` | Modify | `remove_skill` constructs `PluginName` (via `validate_name` removal) — actually no, `remove_skill` takes a skill name not a plugin name; check whether anything in `installed.rs` needs migration |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | Auto-generated; emits `MarketplaceName` / `PluginName` TS aliases |
+
+---
+
+## Task 1: Define `MarketplaceName` and `PluginName` newtypes
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/validation.rs` — append after `AgentName`'s test module
+- Test: same file's `tests` module
+
+This task is self-contained: it adds two new types and their tests. Nothing in the rest of the workspace uses them yet, so the workspace stays compile-green throughout.
+
+- [ ] **Step 1: Write failing tests**
+
+Open `crates/kiro-market-core/src/validation.rs` and append to `mod tests`:
+
+```rust
+    // ──── MarketplaceName ────────────────────────────────────────────────
+
+    #[test]
+    fn marketplace_name_new_accepts_valid() {
+        let name = MarketplaceName::new("kiro-starter-kit").expect("valid");
+        assert_eq!(name.as_str(), "kiro-starter-kit");
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_empty() {
+        assert!(MarketplaceName::new("").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_traversal() {
+        assert!(MarketplaceName::new("../etc").is_err());
+        assert!(MarketplaceName::new("..").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_new_rejects_nul_byte() {
+        assert!(MarketplaceName::new("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn marketplace_name_partial_eq_against_str_and_ref_str() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        assert_eq!(name, *"mp");
+        assert_eq!(name, "mp");
+    }
+
+    #[test]
+    fn marketplace_name_accessors_round_trip() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        let s = name.clone().into_inner();
+        assert_eq!(s, "mp");
+        assert_eq!(name.as_str(), "mp");
+    }
+
+    #[derive(serde::Deserialize)]
+    struct MarketplaceNameWrapper {
+        name: MarketplaceName,
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_accepts_valid() {
+        let w: MarketplaceNameWrapper =
+            serde_json::from_str(r#"{"name":"kiro-starter-kit"}"#).expect("valid");
+        assert_eq!(w.name.as_str(), "kiro-starter-kit");
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_rejects_traversal() {
+        let result: Result<MarketplaceNameWrapper, _> =
+            serde_json::from_str(r#"{"name":"../etc"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_marketplace_name_rejects_empty() {
+        let result: Result<MarketplaceNameWrapper, _> =
+            serde_json::from_str(r#"{"name":""}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn serialize_marketplace_name_is_transparent_string() {
+        let name = MarketplaceName::new("mp").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        assert_eq!(json, r#""mp""#);
+    }
+
+    #[test]
+    fn marketplace_name_round_trips_through_serde_json() {
+        let name = MarketplaceName::new("kiro-starter-kit").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        let parsed: MarketplaceName = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, name);
+    }
+
+    // ──── PluginName ────────────────────────────────────────────────────
+
+    #[test]
+    fn plugin_name_new_accepts_valid() {
+        let name = PluginName::new("kiro-code-reviewer").expect("valid");
+        assert_eq!(name.as_str(), "kiro-code-reviewer");
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_empty() {
+        assert!(PluginName::new("").is_err());
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_traversal() {
+        assert!(PluginName::new("../etc").is_err());
+    }
+
+    #[test]
+    fn plugin_name_new_rejects_nul_byte() {
+        assert!(PluginName::new("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn plugin_name_partial_eq_against_str_and_ref_str() {
+        let name = PluginName::new("p").expect("valid");
+        assert_eq!(name, *"p");
+        assert_eq!(name, "p");
+    }
+
+    #[derive(serde::Deserialize)]
+    struct PluginNameWrapper {
+        name: PluginName,
+    }
+
+    #[test]
+    fn deserialize_plugin_name_rejects_traversal() {
+        let result: Result<PluginNameWrapper, _> =
+            serde_json::from_str(r#"{"name":"../etc"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn serialize_plugin_name_is_transparent_string() {
+        let name = PluginName::new("p").expect("valid");
+        let json = serde_json::to_string(&name).expect("serialize");
+        assert_eq!(json, r#""p""#);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/dwalleck/repos/kiro-marketplace-cli-phase-1-5
+cargo test -p kiro-market-core marketplace_name 2>&1 | tail -10
+```
+
+Expected: FAIL with `error[E0433]: cannot find type 'MarketplaceName' in this scope`.
+
+- [ ] **Step 3: Add the types**
+
+In `validation.rs`, after the `impl Deserialize<'de> for AgentName` block (around line 213) and before `WINDOWS_RESERVED_NAMES` (line 216), insert:
+
+```rust
+/// Validated marketplace name. Routes through [`validate_name`] at construction
+/// — non-empty, no NUL/control bytes, no path-traversal, no Windows-reserved
+/// names. The `serde(transparent)` representation keeps the JSON wire format
+/// byte-identical to a plain string; `Deserialize` is routed through `new` so
+/// `serde_json::from_slice` rejects malformed names at parse time.
+///
+/// Deliberately does NOT derive `Default` — `MarketplaceName::default()` would
+/// return `MarketplaceName(String::new())` which `validate_name` rejects.
+/// Matches the existing `RelativePath` / `AgentName` / `GitRef` precedent.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct MarketplaceName(String);
+
+impl MarketplaceName {
+    /// Construct after validation. Returns [`ValidationError`] on rejection.
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        validate_name(&value)?;
+        Ok(MarketplaceName(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for MarketplaceName {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for MarketplaceName {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for MarketplaceName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MarketplaceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl PartialEq<str> for MarketplaceName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for MarketplaceName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'de> Deserialize<'de> for MarketplaceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validated plugin name. Same shape as [`MarketplaceName`]; see that type's
+/// documentation for the construction and serde contract.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
+pub struct PluginName(String);
+
+impl PluginName {
+    pub fn new(value: impl Into<String>) -> Result<Self, ValidationError> {
+        let value = value.into();
+        validate_name(&value)?;
+        Ok(PluginName(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for PluginName {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for PluginName {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for PluginName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PluginName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl PartialEq<str> for PluginName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for PluginName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'de> Deserialize<'de> for PluginName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p kiro-market-core marketplace_name plugin_name 2>&1 | tail -15
+```
+
+Expected: ~16 tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/validation.rs
+git commit -m "feat(core): add MarketplaceName and PluginName newtypes (A1 step 1/8)
+
+Validated newtypes for marketplace and plugin name strings. Route through
+the existing validate_name (non-empty, no NUL/control bytes, no traversal,
+no Windows-reserved). serde(transparent) keeps wire format byte-identical
+to a plain string; Deserialize routed through new for parse-don't-validate
+at tracking-file load.
+
+Models after AgentName's shape (TryFrom impls, AsRef<str>, Display,
+PartialEq<str>, PartialEq<&str>, Deserialize). Deliberately does NOT
+derive Default — matches RelativePath/AgentName/GitRef precedent.
+
+No callers yet; subsequent commits in this PR migrate the kiro-market-core
+public API surface."
+```
+
+---
+
+## Task 2: Add `mp` and `pn` test helpers
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/test_support.rs`
+
+Test fixtures across the workspace pass `"mp"` / `"p"` literals to functions that will, after the migration, expect `&MarketplaceName` / `&PluginName`. Without a helper, every test site grows a `MarketplaceName::new("mp").expect("...")` boilerplate. Add focused helpers.
+
+- [ ] **Step 1: Add the helpers**
+
+Append to `crates/kiro-market-core/src/service/test_support.rs`:
+
+```rust
+/// Test helper: construct a [`MarketplaceName`] from a string literal,
+/// panicking on validation failure. The plan's test fixtures pass `"mp"`,
+/// `"plug-a"`, etc. — values controlled by the test author, not user
+/// input. `expect` is the right shape here because a fixture failure
+/// is a bug, not an error to handle.
+#[cfg(any(test, feature = "test-support"))]
+pub fn mp(s: &str) -> crate::validation::MarketplaceName {
+    crate::validation::MarketplaceName::new(s)
+        .unwrap_or_else(|e| panic!("test fixture: invalid marketplace name {s:?}: {e}"))
+}
+
+/// Test helper: construct a [`PluginName`] from a string literal. See
+/// [`mp`] for the contract.
+#[cfg(any(test, feature = "test-support"))]
+pub fn pn(s: &str) -> crate::validation::PluginName {
+    crate::validation::PluginName::new(s)
+        .unwrap_or_else(|e| panic!("test fixture: invalid plugin name {s:?}: {e}"))
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+```bash
+cargo build -p kiro-market-core --tests 2>&1 | tail -5
+```
+
+Expected: clean build (no usages yet, but compile must pass — `unwrap_or_else` with `panic!` is the test-fixture idiom; `expect` would also work but `unwrap_or_else` carries the original error message).
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/service/test_support.rs
+git commit -m "feat(test-support): add mp/pn helpers for MarketplaceName/PluginName fixtures (A1 step 2/8)
+
+Test fixtures across the workspace pass 'mp' / 'p' literals to functions
+that — after the A1 migration — expect &MarketplaceName / &PluginName.
+Centralising the construction in mp/pn keeps fixtures terse.
+
+The helpers use unwrap_or_else with panic! because a malformed test
+fixture is a bug, not an error to handle. Cfg-gated to test + the
+test-support feature so the Tauri crate's dev-dependencies activate
+the same helpers via feature override."
+```
+
+---
+
+## Task 3: Migrate `project.rs` — meta types, removal API, install paths, aggregator
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs` (the heavy lift — 4 meta types, 2 internal context structs, 5 removal methods, 6+ install methods/free fns, the `installed_plugins` aggregator + `InstalledPluginInfo`, and ~30 test fixtures)
+
+This task is the biggest single chunk because the changes ripple together — splitting them would require `.as_str()` shims in intermediate states. Single coherent commit.
+
+The migration shape: **every place that today reads / writes / accepts `marketplace` or `plugin` as `&str` / `String` becomes `&MarketplaceName` / `&PluginName` / `MarketplaceName` / `PluginName`**. Internal callers update to pass through; tracking-file deserializers automatically validate via the newtype's `Deserialize`.
+
+- [ ] **Step 1: Migrate the four tracking-file meta types**
+
+Change the field types. Search-and-replace in `project.rs`:
+
+```rust
+// InstalledSkillMeta (line 24-46) — change marketplace/plugin from String
+pub struct InstalledSkillMeta {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    // hash fields unchanged
+}
+
+// InstalledAgentMeta — same change
+// InstalledNativeCompanionsMeta — same change
+// InstalledSteeringMeta — same change
+```
+
+Add to imports at top of `project.rs`:
+
+```rust
+use crate::validation::{MarketplaceName, PluginName};
+```
+
+- [ ] **Step 2: Migrate `InstalledPluginInfo` and `installed_plugins` aggregator**
+
+```rust
+// InstalledPluginInfo at line 266
+pub struct InstalledPluginInfo {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub installed_version: Option<String>,
+    pub skill_count: u32,
+    // ... rest unchanged
+    pub installed_skills: Vec<String>,         // skill names — out of scope (see design)
+    pub installed_steering: Vec<std::path::PathBuf>,
+    pub installed_agents: Vec<String>,         // agent names — out of scope (see design)
+    pub earliest_install: String,
+    pub latest_install: String,
+}
+```
+
+Inside `installed_plugins` (`KiroProject` impl, around line 1013), the `BTreeMap<(String, String), Acc>` key becomes `BTreeMap<(MarketplaceName, PluginName), Acc>`:
+
+```rust
+let mut by_pair: BTreeMap<(MarketplaceName, PluginName), Acc> = BTreeMap::new();
+
+// In each loop body:
+let acc = by_pair
+    .entry((meta.marketplace.clone(), meta.plugin.clone()))
+    .or_default();
+```
+
+The terminal `.map(...)` block populates `InstalledPluginInfo.marketplace` and `.plugin` directly with the newtypes — no conversion needed:
+
+```rust
+.map(|((marketplace, plugin), mut acc)| {
+    acc.skills.sort();
+    acc.steering.sort();
+    acc.agents.sort();
+    let (latest_install_dt, installed_version) =
+        acc.latest.map_or_else(|| (now, None), |(t, v)| (t, v));
+    let earliest_install_dt = acc.earliest.unwrap_or(now);
+    InstalledPluginInfo {
+        marketplace,
+        plugin,
+        installed_version,
+        // ... unchanged
+    }
+})
+```
+
+Note: `MarketplaceName` and `PluginName` derive `Eq` and `Ord` is **not** derived. `BTreeMap` requires `Ord`. Add `Ord` and `PartialOrd` derives to both newtypes in `validation.rs`:
+
+```rust
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+```
+
+(Apply to both `MarketplaceName` and `PluginName`. Add the corresponding test in `validation.rs::tests`:)
+
+```rust
+#[test]
+fn marketplace_name_ord_is_lexicographic_on_inner() {
+    let a = MarketplaceName::new("alpha").expect("valid");
+    let b = MarketplaceName::new("bravo").expect("valid");
+    assert!(a < b);
+}
+```
+
+- [ ] **Step 3: Migrate `KiroProject` removal API signatures**
+
+```rust
+impl KiroProject {
+    pub fn remove_plugin(
+        &self,
+        marketplace: &MarketplaceName,
+        plugin: &PluginName,
+    ) -> crate::error::Result<RemovePluginResult> { ... }
+
+    pub fn remove_native_companions_for_plugin(
+        &self,
+        plugin: &PluginName,
+        marketplace: &MarketplaceName,
+    ) -> crate::error::Result<()> { ... }
+}
+```
+
+Inside `remove_plugin`, the filter clauses become:
+
+```rust
+let skills_to_remove: Vec<String> = skills
+    .skills
+    .iter()
+    .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
+    .map(|(name, _)| name.clone())
+    .collect();
+```
+
+(`MarketplaceName` derives `PartialEq`, so `meta.marketplace == *marketplace` is the comparison — same shape as before, just typed.)
+
+The `RemovePluginFailure { content_type, item: ..., error }` constructions inside `remove_plugin`'s match arms keep `String` for `content_type` and `item` (these are wire-format strings, not validated identifiers).
+
+The native_companions cleanup gets the marketplace-aware check (already in place from PR #94's A-16 work) — the comparison reads `meta.marketplace == *marketplace`.
+
+- [ ] **Step 4: Migrate `KiroProject` install paths**
+
+```rust
+impl KiroProject {
+    pub fn install_native_agent(
+        &self,
+        bundle: &crate::agent::NativeAgentBundle,
+        marketplace: &MarketplaceName,
+        plugin: &PluginName,
+        version: Option<&str>,
+        source_hash: &str,
+        mode: crate::service::InstallMode,
+    ) -> Result<InstalledNativeAgentOutcome, AgentError> { ... }
+
+    pub fn stage_native_companion_files(
+        &self,
+        plugin: &PluginName,
+        scan_root: &Path,
+        rel_paths: &[PathBuf],
+    ) -> crate::error::Result<(tempfile::TempDir, String)> { ... }
+}
+
+// Internal context structs at line 219, 556
+struct NativeCompanionsInput<'a> {
+    pub scan_root: &'a Path,
+    pub rel_paths: &'a [PathBuf],
+    pub marketplace: &'a MarketplaceName,
+    pub plugin: &'a PluginName,
+    pub version: Option<&'a str>,
+    pub source_hash: &'a str,
+    pub mode: crate::service::InstallMode,
+}
+
+struct CompanionInput<'a> {
+    pub marketplace: &'a MarketplaceName,
+    pub plugin: &'a PluginName,
+    pub version: Option<&'a str>,
+    pub agents_root: &'a Path,
+    pub prompt_rel: &'a Path,
+}
+```
+
+Free helper signatures (in the same file) update too — every place that today takes `plugin: &str` becomes `plugin: &PluginName`:
+
+```rust
+fn classify_native_collision(
+    installed: &InstalledAgents,
+    agent_name: &str,           // unchanged — this is the agent identifier, not marketplace/plugin
+    plugin: &PluginName,
+    source_hash: &str,
+    json_target: &Path,
+    mode: crate::service::InstallMode,
+) -> crate::error::Result<CollisionDecision<InstalledNativeAgentOutcome>> { ... }
+
+fn classify_steering_collision(
+    installed: &InstalledSteering,
+    rel_path: &Path,
+    plugin: &PluginName,
+    source_hash: &str,
+    dest: &Path,
+    mode: crate::service::InstallMode,
+) -> Result<CollisionDecision<SteeringIdempotentEcho>, crate::steering::SteeringError> { ... }
+
+fn synthesize_companion_entry(
+    installed: &mut InstalledAgents,
+    input: &CompanionInput<'_>,
+) -> crate::error::Result<()> { ... }
+
+fn strip_transferred_paths_from_other_plugins(
+    installed: &mut InstalledAgents,
+    plugin: &PluginName,
+    rel_paths: &[PathBuf],
+    agents_dir: &Path,
+) -> crate::error::Result<()> { ... }
+
+fn diff_prior_companion_files(
+    installed: &InstalledAgents,
+    plugin: &PluginName,
+    rel_paths: &[PathBuf],
+) -> Vec<PathBuf> { ... }
+
+fn remove_companion_files_best_effort(
+    rel_paths: &[PathBuf],
+    agents_dir: &Path,
+    plugin: &PluginName,
+)
+```
+
+- [ ] **Step 5: Update meta-construction sites**
+
+Every place that today does:
+
+```rust
+let meta = InstalledSkillMeta {
+    marketplace: ctx.marketplace.to_string(),
+    plugin: ctx.plugin.to_string(),
+    // ...
+};
+```
+
+becomes:
+
+```rust
+let meta = InstalledSkillMeta {
+    marketplace: ctx.marketplace.clone(),
+    plugin: ctx.plugin.clone(),
+    // ...
+};
+```
+
+(The context structs hold `&MarketplaceName` / `&PluginName` after Task 5; for now in Task 3, where `ctx.marketplace` is still `&str` from un-migrated context structs, you'll temporarily call `MarketplaceName::new(ctx.marketplace).expect("ctx already validated")` OR you can accept that this single task has a half-migrated state and the workspace doesn't cleanly compile until Tasks 4 + 5 land. **This task ends with the workspace IN A NON-COMPILING STATE if done in isolation** — see Step 7 note below.)
+
+- [ ] **Step 6: Update `project.rs::tests` test fixtures (~30 sites)**
+
+Every test that constructs an `InstalledSkillMeta` / `InstalledAgentMeta` / etc. with `marketplace: "mp".to_string()` becomes:
+
+```rust
+use crate::service::test_support::{mp, pn};
+
+let meta = InstalledSkillMeta {
+    marketplace: mp("mp"),
+    plugin: pn("plug-a"),
+    // ...
+};
+```
+
+Tests that call `project.remove_plugin("mp", "p")` become `project.remove_plugin(&mp("mp"), &pn("p"))`. Same for `remove_native_companions_for_plugin`.
+
+Tests that build JSON tracking files with `serde_json::json!(...)` strings — these test the deserialization path. Since `MarketplaceName::Deserialize` routes through `new`, the JSON strings just need to remain valid identifiers. The existing `"mp"` / `"plug-a"` test values are valid; nothing changes in the JSON construction itself.
+
+The one exception: tests that intentionally construct INVALID names to test rejection (e.g., `load_installed_rejects_path_traversal_in_skills_key`) — these continue to use raw strings in the JSON and assert that `load_installed` returns `Err`. The newtype's `Deserialize` rejection now happens at the load layer, possibly making the I9 walker's path-traversal check redundant for the meta fields (still relevant for HashMap keys). Verify the existing tests still pass; the assertion shape (`.is_err()`) is unchanged.
+
+- [ ] **Step 7: Build and test**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | tail -20
+```
+
+Many compilation errors expected during sub-step iteration. Work through them one by one. By the end of step 6, the kiro-market-core crate should build clean.
+
+```bash
+cargo test -p kiro-market-core 2>&1 | grep "test result:" | tail -5
+```
+
+Expected: all `kiro-market-core` tests pass (the migration is internal; behavior is preserved).
+
+**The `kiro-control-center` and `kiro-market` crates will NOT compile yet** — they call functions whose signatures just changed. That's expected; Tasks 5–7 fix them. Do not attempt to compile the full workspace until Task 7.
+
+- [ ] **Step 8: Lint and commit (kiro-market-core only)**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/project.rs crates/kiro-market-core/src/validation.rs
+git commit -m "refactor(core): migrate project.rs to MarketplaceName/PluginName (A1 step 3/8)
+
+Migrates project.rs's marketplace/plugin string surface to the validated
+newtypes:
+
+- 4 tracking-file meta types (InstalledSkillMeta, InstalledAgentMeta,
+  InstalledNativeCompanionsMeta, InstalledSteeringMeta) — parse-don't-validate
+  at serde load via the newtype Deserialize impls
+- InstalledPluginInfo + installed_plugins aggregator
+- KiroProject::remove_plugin and remove_native_companions_for_plugin
+  signatures (compiler now enforces argument order — closes the swap-arg
+  footgun the type-design reviewer flagged on PR #94)
+- KiroProject::install_native_agent + stage_native_companion_files
+- Internal NativeCompanionsInput / CompanionInput context structs
+- Free helpers (classify_native_collision, classify_steering_collision,
+  synthesize_companion_entry, strip_transferred_paths_from_other_plugins,
+  diff_prior_companion_files, remove_companion_files_best_effort)
+- ~30 test fixtures via mp() / pn() helpers
+
+Adds Ord+PartialOrd derives to MarketplaceName/PluginName so they can key
+the BTreeMap in installed_plugins.
+
+The kiro-control-center and kiro-market crates do NOT compile after this
+commit — Tasks 5-7 fix them. Subsequent commits in this PR will."
+```
+
+---
+
+## Task 4: Migrate `steering/types.rs`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/steering/types.rs`
+
+`SteeringInstallContext.marketplace`/`plugin` and `SteeringError::PathOwnedByOtherPlugin.owner` carry plugin-name strings.
+
+- [ ] **Step 1: Migrate `SteeringInstallContext`**
+
+```rust
+// Around line 20
+#[derive(Clone, Copy)]
+pub struct SteeringInstallContext<'a> {
+    pub mode: InstallMode,
+    pub marketplace: &'a crate::validation::MarketplaceName,
+    pub plugin: &'a crate::validation::PluginName,
+    pub version: Option<&'a str>,
+}
+```
+
+- [ ] **Step 2: Migrate `SteeringError::PathOwnedByOtherPlugin.owner`**
+
+```rust
+// Around line 55
+PathOwnedByOtherPlugin {
+    rel: PathBuf,
+    owner: crate::validation::PluginName,
+}
+```
+
+The `Display` impl for `SteeringError` currently formats `owner` via `{owner}`. After the migration, `PluginName: Display` delegates to the inner `String`, so the rendered message is byte-identical.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p kiro-market-core steering -- --nocapture 2>&1 | tail -10
+```
+
+Expected: all steering tests pass. The wire-format `serialize_steering_error` tests continue to lock the rendered string shape; `PluginName::Display` produces the same output as `String::Display` for valid names.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/steering/types.rs
+git commit -m "refactor(core): migrate SteeringInstallContext + SteeringError to PluginName (A1 step 4/8)
+
+SteeringInstallContext.marketplace/plugin become &MarketplaceName/&PluginName.
+SteeringError::PathOwnedByOtherPlugin.owner becomes PluginName. Display
+contract preserved (PluginName: Display delegates to inner String).
+
+The steering install path's wire format is unchanged — serialize_steering_error
+renders to the same string shape."
+```
+
+---
+
+## Task 5: Migrate `service/mod.rs` — install API + `InstallPluginResult` + A4
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs`
+
+This is the second-heaviest task. Migrates the `MarketplaceService` install API surface, `AgentInstallContext`, the install free fns, and lands A4 (`marketplace` field on `InstallPluginResult`).
+
+- [ ] **Step 1: Migrate `AgentInstallContext`**
+
+```rust
+// Around line 359
+pub struct AgentInstallContext<'a> {
+    pub mode: InstallMode,
+    pub accept_mcp: bool,
+    pub marketplace: &'a crate::validation::MarketplaceName,
+    pub plugin: &'a crate::validation::PluginName,
+    pub version: Option<&'a str>,
+}
+```
+
+- [ ] **Step 2: Migrate `InstallPluginResult` and add A4 `marketplace` field**
+
+```rust
+// Around line 419 — note: drop the Default derive (verified per design doc:
+// no consumer calls InstallPluginResult::default() and the newtypes don't
+// derive Default)
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct InstallPluginResult {
+    pub marketplace: crate::validation::MarketplaceName,    // NEW (A4)
+    pub plugin: crate::validation::PluginName,              // changed from String per A1
+    pub version: Option<String>,
+    pub skills: InstallSkillsResult,
+    pub steering: crate::steering::InstallSteeringResult,
+    pub agents: InstallAgentsResult,
+}
+```
+
+- [ ] **Step 3: Migrate `MarketplaceService::install_plugin` signature and body**
+
+```rust
+// Around line 1924
+pub fn install_plugin(
+    &self,
+    project: &crate::project::KiroProject,
+    marketplace: &crate::validation::MarketplaceName,
+    plugin: &crate::validation::PluginName,
+    mode: InstallMode,
+    accept_mcp: bool,
+) -> Result<InstallPluginResult, Error> {
+    let ctx = self.resolve_plugin_install_context(marketplace, plugin)?;
+
+    let skills = self.install_skills(
+        project,
+        &ctx.skill_dirs,
+        &InstallFilter::All,
+        mode,
+        marketplace,
+        plugin,
+        ctx.version.as_deref(),
+    );
+
+    let steering = Self::install_plugin_steering(
+        project,
+        &ctx.plugin_dir,
+        &ctx.steering_scan_paths,
+        crate::steering::SteeringInstallContext {
+            mode,
+            marketplace,
+            plugin,
+            version: ctx.version.as_deref(),
+        },
+    );
+
+    let agents = Self::install_plugin_agents(
+        project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext {
+            mode,
+            accept_mcp,
+            marketplace,
+            plugin,
+            version: ctx.version.as_deref(),
+        },
+    );
+
+    Ok(InstallPluginResult {
+        marketplace: marketplace.clone(),    // NEW (A4)
+        plugin: plugin.clone(),
+        version: ctx.version,
+        skills,
+        steering,
+        agents,
+    })
+}
+```
+
+- [ ] **Step 4: Migrate `MarketplaceService::install_skills` signature**
+
+```rust
+// Around line 1035
+pub fn install_skills(
+    &self,
+    project: &crate::project::KiroProject,
+    skill_dirs: &[PathBuf],
+    filter: &InstallFilter<'_>,
+    mode: InstallMode,
+    marketplace: &crate::validation::MarketplaceName,
+    plugin: &crate::validation::PluginName,
+    version: Option<&str>,
+) -> InstallSkillsResult { ... }
+```
+
+Internal callers update too. Inside the method body, anywhere that constructs an `InstalledSkillMeta`:
+
+```rust
+let meta = InstalledSkillMeta {
+    marketplace: marketplace.clone(),
+    plugin: plugin.clone(),
+    version: version.map(str::to_string),
+    installed_at: chrono::Utc::now(),
+    source_hash: Some(source_hash.clone()),
+    installed_hash: Some(installed_hash.clone()),
+};
+```
+
+- [ ] **Step 5: Migrate the install free fns**
+
+`install_plugin_steering` (around line 1349), `install_translated_agents_inner` (1420), `install_native_kiro_cli_agents_inner` (1549), `install_one_native_agent` (1607), `install_native_companions_for_plugin` (1699) — these are private/free and take the context structs that now hold newtypes. The signatures change only where they accept `&str` directly (none do — they all flow through `AgentInstallContext` / `SteeringInstallContext`). Verify by reading their bodies and patching any `meta.marketplace = ctx.marketplace.to_string()` to `meta.marketplace = ctx.marketplace.clone()`.
+
+- [ ] **Step 6: Update tests in `service/mod.rs::tests`**
+
+The tests in `mod tests` (line 2040+) construct contexts with `"mp"` / `"p"` literals. Use `mp("mp")` / `pn("p")` helpers:
+
+```rust
+use crate::service::test_support::{mp, pn};
+
+let result = svc
+    .install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+    .expect("install_plugin happy path");
+```
+
+The `InstallPluginResult` JSON-shape rstests (4774, 4808) must update to match the new shape:
+
+```rust
+#[test]
+fn install_plugin_result_json_shape_locks_default_subresults() {
+    let result = InstallPluginResult {
+        marketplace: mp("mp"),
+        plugin: pn("p"),
+        version: Some("1.0.0".into()),
+        skills: InstallSkillsResult::default(),
+        steering: crate::steering::InstallSteeringResult::default(),
+        agents: InstallAgentsResult::default(),
+    };
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(json["marketplace"], "mp");
+    assert_eq!(json["plugin"], "p");
+    assert_eq!(json["version"], "1.0.0");
+    assert!(json["skills"].is_object());
+    assert!(json["steering"].is_object());
+    assert!(json["agents"].is_object());
+}
+
+#[test]
+fn install_plugin_result_json_shape_with_populated_subresult() {
+    let result = InstallPluginResult {
+        marketplace: mp("mp"),
+        plugin: pn("p"),
+        version: Some("1.0.0".into()),
+        skills: InstallSkillsResult {
+            installed: vec!["alpha".into()],
+            ..InstallSkillsResult::default()
+        },
+        steering: crate::steering::InstallSteeringResult::default(),
+        agents: InstallAgentsResult::default(),
+    };
+    let json = serde_json::to_value(&result).expect("serialize");
+    let skills = json.pointer("/skills").expect("skills field exists");
+    assert!(skills.is_object());
+    assert_eq!(
+        skills
+            .pointer("/installed")
+            .and_then(|v| v.as_array())
+            .map(Vec::len),
+        Some(1),
+    );
+    // A4: marketplace field serializes as a plain string via serde(transparent)
+    assert_eq!(json["marketplace"], "mp");
+}
+```
+
+- [ ] **Step 7: Build kiro-market-core**
+
+```bash
+cargo build -p kiro-market-core --tests 2>&1 | tail -10
+cargo test -p kiro-market-core 2>&1 | grep "test result:" | tail -5
+```
+
+Expected: all kiro-market-core tests pass. (Tauri + CLI crates still don't compile; Tasks 6-7 fix them.)
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/service/mod.rs
+git commit -m "refactor(core): migrate service install API to newtypes; add A4 marketplace field (A1 step 5/8)
+
+- AgentInstallContext.marketplace/plugin now &MarketplaceName / &PluginName
+- InstallPluginResult.plugin: PluginName (was String); A4 adds .marketplace: MarketplaceName
+- InstallPluginResult drops the (unused) Default derive
+- MarketplaceService::install_plugin and install_skills signatures take
+  &MarketplaceName / &PluginName — argument order is now compiler-enforced
+- Free fns (install_plugin_steering, install_translated_agents_inner,
+  install_native_kiro_cli_agents_inner, install_one_native_agent,
+  install_native_companions_for_plugin) flow newtype contexts through
+- ~12 test fixtures via mp() / pn() helpers
+- The two install_plugin_result_json_shape_locks_* tests assert the A4
+  marketplace field serializes as a plain string via serde(transparent)"
+```
+
+---
+
+## Task 6: Migrate `service/browse.rs::resolve_plugin_install_context*`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/browse.rs`
+
+- [ ] **Step 1: Migrate the method signatures**
+
+```rust
+// Around line 719
+pub fn resolve_plugin_install_context(
+    &self,
+    marketplace: &crate::validation::MarketplaceName,
+    plugin: &crate::validation::PluginName,
+) -> Result<PluginInstallContext, Error> {
+    let mp_path = self.marketplace_path(marketplace.as_str());
+    let plugin_entries = self.list_plugin_entries(marketplace.as_str())?;
+    let entry = plugin_entries
+        .iter()
+        .find(|p| p.name == *plugin)        // PluginName: PartialEq<str> via the &PluginEntry path
+        .ok_or_else(|| Error::Plugin(PluginError::PluginNotFound {
+            plugin: plugin.as_str().to_string(),
+        }))?;
+    // ... rest of method body unchanged
+}
+```
+
+Note: `marketplace_path` and `list_plugin_entries` (both on `MarketplaceService`) take `&str` and stay that way — they're out of scope per the design's "non-install API stays String-typed" decision. Use `marketplace.as_str()` to bridge.
+
+`PluginEntry.name` is a `String` (out of scope for migration); the comparison `p.name == *plugin` works because `PluginName: PartialEq<str>` and the `*plugin` deref pattern.
+
+- [ ] **Step 2: Migrate the existing tests in `service/browse.rs::tests`**
+
+The `resolve_plugin_install_context_*` tests use string literals; switch to `mp("mp1")` / `pn("myplugin")`:
+
+```rust
+use crate::service::test_support::{mp, pn};
+
+let ctx = svc
+    .resolve_plugin_install_context(&mp("mp1"), &pn("myplugin"))
+    .expect("resolve");
+```
+
+About 6 test sites in `tests` need this update.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+cargo test -p kiro-market-core resolve_plugin_install_context 2>&1 | tail -10
+```
+
+Expected: all 9 resolve_plugin_install_context_* tests pass.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-market-core/src/service/browse.rs
+git commit -m "refactor(core): migrate resolve_plugin_install_context to newtypes (A1 step 6/8)
+
+resolve_plugin_install_context now takes &MarketplaceName / &PluginName.
+Internal calls to non-migrated MarketplaceService methods (marketplace_path,
+list_plugin_entries — both out of scope per Phase 1.5 design) bridge via
+marketplace.as_str()."
+```
+
+---
+
+## Task 7: Migrate Tauri `_impl`s — `commands/{agents,plugins,steering,browse,installed}.rs`
+
+**Files:**
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/agents.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/plugins.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/steering.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/browse.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/installed.rs`
+
+The Tauri command wrappers stay `String`-typed (FE callers pass strings; the design locks this). Inside each `_impl`, replace `validate_name(marketplace)?` with `MarketplaceName::new(marketplace)?` (and same for `plugin`). The resulting `MarketplaceName` flows to the (now-migrated) core API.
+
+- [ ] **Step 1: Update `commands/agents.rs::install_plugin_agents_impl`**
+
+```rust
+fn install_plugin_agents_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallAgentsResult, CommandError> {
+    let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = kiro_market_core::validation::MarketplaceName::new(marketplace)?;
+    let plugin = kiro_market_core::validation::PluginName::new(plugin)?;
+    let ctx = svc
+        .resolve_plugin_install_context(&marketplace, &plugin)
+        .map_err(CommandError::from)?;
+    let project = KiroProject::new(project_root);
+
+    Ok(MarketplaceService::install_plugin_agents(
+        &project,
+        &ctx.plugin_dir,
+        &ctx.agent_scan_paths,
+        ctx.format,
+        AgentInstallContext {
+            mode,
+            accept_mcp,
+            marketplace: &marketplace,
+            plugin: &plugin,
+            version: ctx.version.as_deref(),
+        },
+    ))
+}
+```
+
+The previous `validate_name(marketplace)?; validate_name(plugin)?;` lines from PR #94 (Phase 1 I10) are now redundant — the newtype's `new` performs the same validation. Delete those calls.
+
+- [ ] **Step 2: Update `commands/plugins.rs`** (3 commands: `install_plugin_impl`, `list_installed_plugins`, `remove_plugin`)
+
+```rust
+fn install_plugin_impl(
+    svc: &MarketplaceService,
+    marketplace: &str,
+    plugin: &str,
+    mode: InstallMode,
+    accept_mcp: bool,
+    project_path: &str,
+) -> Result<InstallPluginResult, CommandError> {
+    let project_root = validate_kiro_project_path(project_path)?;
+    let marketplace = kiro_market_core::validation::MarketplaceName::new(marketplace)?;
+    let plugin = kiro_market_core::validation::PluginName::new(plugin)?;
+    let project = KiroProject::new(project_root);
+    svc.install_plugin(&project, &marketplace, &plugin, mode, accept_mcp)
+        .map_err(CommandError::from)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn remove_plugin(
+    marketplace: String,
+    plugin: String,
+    project_path: String,
+) -> Result<RemovePluginResult, CommandError> {
+    let project_root = validate_kiro_project_path(&project_path)?;
+    let marketplace = kiro_market_core::validation::MarketplaceName::new(marketplace)?;
+    let plugin = kiro_market_core::validation::PluginName::new(plugin)?;
+    let project = KiroProject::new(project_root);
+    project
+        .remove_plugin(&marketplace, &plugin)
+        .map_err(CommandError::from)
+}
+```
+
+`list_installed_plugins` doesn't take marketplace/plugin args — no change needed beyond fixing any compile errors from `InstalledPluginsView.plugins[*].marketplace` now being `MarketplaceName` instead of `String` (probably nothing — the wrapper just returns the view).
+
+- [ ] **Step 3: Update `commands/steering.rs::install_plugin_steering_impl`**
+
+Same pattern: replace `validate_name(...)?` calls with `MarketplaceName::new(...)?` / `PluginName::new(...)?`, pass references to the migrated `MarketplaceService::install_plugin_steering`.
+
+- [ ] **Step 4: Update `commands/browse.rs::install_skills_impl`** and `list_plugins`
+
+`install_skills_impl` follows the same pattern. `list_plugins` only takes `marketplace: &str`; construct `MarketplaceName::new(marketplace)?` and pass through (note: `list_plugin_entries` itself stays `&str`-typed per the design's non-install scope, so the newtype is constructed for validation but `as_str()` is used for the actual call).
+
+- [ ] **Step 5: Update `commands/installed.rs::remove_skill`**
+
+`remove_skill` takes a skill name (not a plugin name) — no migration needed for the skill-name parameter. But `KiroProject::remove_skill` is in scope for the migration? **Check:** `KiroProject::remove_skill(name: &str)` is at `project.rs:797`. Looking at the design, only the plugin-cascade methods are listed. The skill-name parameter is not in scope.
+
+The Tauri `remove_skill` wrapper passes `name: String` to `KiroProject::remove_skill`; both stay `&str`-typed. No change in this task for `installed.rs::remove_skill`.
+
+- [ ] **Step 6: Update Tauri tests**
+
+All 5 command files have `#[cfg(test)] mod tests` blocks. The tests construct call args with `"mp".to_string()` literals; the wrapper signatures still take `String`, so the test inputs don't change. But tests that call core APIs directly (e.g., `install_plugin_impl(&svc, "mp", "p", ...)`) need to pass `&MarketplaceName` / `&PluginName`:
+
+```rust
+use kiro_market_core::service::test_support::{mp, pn};
+
+#[test]
+fn install_plugin_impl_orchestrates_all_three_paths() {
+    // ...
+    let project_root_str = make_kiro_project(dir.path());
+    let result = install_plugin_impl(
+        &svc,
+        "mp",
+        "p",
+        InstallMode::New,
+        false,
+        &project_root_str,
+    )
+    .expect("happy path");
+    // assertions: result.marketplace == "mp" (PluginName: PartialEq<&str>)
+    assert_eq!(result.marketplace, "mp");
+    assert_eq!(result.plugin, "p");
+}
+```
+
+The `install_plugin_impl_rejects_traversal_in_marketplace` and `..._rejects_nul_byte_in_plugin` tests (added in PR #94 I10) continue to work — the validation now happens via `MarketplaceName::new`'s ValidationError instead of a direct `validate_name` call, but the resulting `CommandError` shape is the same.
+
+- [ ] **Step 7: Verify the workspace finally compiles**
+
+```bash
+cargo build --workspace 2>&1 | tail -10
+```
+
+Expected: clean. The Tauri crate should now compile against the migrated core types.
+
+```bash
+cargo test --workspace 2>&1 | grep "test result:" | tail -10
+```
+
+Expected: all tests across all crates pass.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings
+cargo fmt --all
+git add crates/kiro-control-center/src-tauri/src/commands/agents.rs \
+        crates/kiro-control-center/src-tauri/src/commands/plugins.rs \
+        crates/kiro-control-center/src-tauri/src/commands/steering.rs \
+        crates/kiro-control-center/src-tauri/src/commands/browse.rs \
+        crates/kiro-control-center/src-tauri/src/commands/installed.rs
+git commit -m "refactor(tauri): construct MarketplaceName/PluginName at IPC boundary (A1 step 7/8)
+
+Replaces PR #94's I10 validate_name(...)? calls with the newtype
+constructor pattern. Same effective gate, but the resulting handle
+proves provenance for the rest of the function body.
+
+The Tauri command wrappers stay String-typed — FE callers pass strings;
+specta-aliased newtypes don't enforce nominal types in TS without branded
+patterns. The newtype is constructed in the _impl after
+validate_kiro_project_path."
+```
+
+---
+
+## Task 8: Migrate `kiro-market` CLI + integration tests + bindings + final sweep + open PR
+
+**Files:**
+- Modify: `crates/kiro-market/src/commands/install.rs`
+- Modify: `crates/kiro-market-core/tests/integration_native_install.rs`
+- Regenerate: `crates/kiro-control-center/src/lib/bindings.ts`
+
+- [ ] **Step 1: Update CLI install command**
+
+In `crates/kiro-market/src/commands/install.rs`, after clap parses the user's `plugin@marketplace` string, construct the newtypes:
+
+```rust
+use kiro_market_core::validation::{MarketplaceName, PluginName};
+
+// After parsing plugin_ref into (plugin_str, marketplace_str)...
+let marketplace = MarketplaceName::new(marketplace_str)
+    .with_context(|| format!("invalid marketplace name: {marketplace_str}"))?;
+let plugin = PluginName::new(plugin_str)
+    .with_context(|| format!("invalid plugin name: {plugin_str}"))?;
+
+// Then pass through:
+svc.install_plugin(&project, &marketplace, &plugin, mode, args.accept_mcp)
+```
+
+(Use `anyhow::Context` since the binary uses `anyhow` per CLAUDE.md.)
+
+The CLI's existing tests in `tests/cli_install.rs` (or wherever) — verify they still pass. The CLI accepts strings on the command line; validation now happens in the newtype constructor instead of separately. Error message shape may shift slightly; if tests assert exact error strings, update assertions.
+
+- [ ] **Step 2: Update `integration_native_install.rs`**
+
+Read the file:
+
+```bash
+grep -nE "marketplace:|plugin:|install_plugin" crates/kiro-market-core/tests/integration_native_install.rs | head -20
+```
+
+Update test fixtures to use `mp(...)` / `pn(...)` from `service::test_support`. The `test-support` feature must be enabled — verify via the existing `[dev-dependencies]` block in `kiro-market-core/Cargo.toml`.
+
+- [ ] **Step 3: Regenerate bindings.ts**
+
+```bash
+cargo test -p kiro-control-center --lib generate_types -- --ignored 2>&1 | tail -3
+```
+
+Expected: pass. Verify the new types appear:
+
+```bash
+grep -E "^export type (MarketplaceName|PluginName)\b" crates/kiro-control-center/src/lib/bindings.ts
+```
+
+Both should resolve to `string` (via `serde(transparent)` + specta).
+
+The frontend code (`BrowseTab.svelte`, `InstalledTab.svelte`) doesn't need changes — TS treats the aliases as `string` (the frontend's `pluginKey(p.marketplace, p.plugin)` calls work unchanged).
+
+- [ ] **Step 4: Apply the 5-gates plan-review checklist**
+
+Per `docs/plan-review-checklist.md`, apply each gate:
+
+```bash
+TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint 2>&1 | tail -10
+```
+
+Expected: all 6 sub-gates OK (gate-4-external-error-boundary, no-unwrap-in-production, no-panic-in-production, non-exhaustive-error-enum, no-frontend-deps-in-core, ffi-enum-serde-tag).
+
+Document any gate findings in `2026-04-30-phase-1-5-type-safety-plan-amendments.md` per the precedent.
+
+- [ ] **Step 5: Run all pre-commit gates**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --tests -- -D warnings
+cargo test --workspace 2>&1 | grep "test result:" | tail -10
+cd crates/kiro-control-center && npm run check 2>&1 | tail -3 && cd ../..
+```
+
+All green required.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add crates/kiro-market/src/commands/install.rs \
+        crates/kiro-market-core/tests/integration_native_install.rs \
+        crates/kiro-control-center/src/lib/bindings.ts
+git commit -m "refactor(cli+test): finish A1 migration; regenerate bindings (A1 step 8/8)
+
+- CLI install_plugin command constructs MarketplaceName/PluginName from
+  clap-parsed strings before calling core APIs (anyhow with_context on
+  validation failure)
+- Integration tests in kiro-market-core/tests/integration_native_install.rs
+  use mp() / pn() helpers
+- bindings.ts regenerated; MarketplaceName and PluginName emit as 'string'
+  type aliases via specta(transparent). Frontend code unchanged."
+git push -u origin feat/phase-1-5-types
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --title "feat: type-safety hardening — MarketplaceName/PluginName newtypes (Phase 1.5)" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1.5 of the plugin-first install architecture. Closes the swap-arg footgun in 7+ public APIs by introducing validated `MarketplaceName` / `PluginName` newtypes, and adds the missing `marketplace` field to `InstallPluginResult` for symmetry with `InstalledPluginInfo` (A4).
+
+Background: PR #94 (Phase 1) shipped with an 8-reviewer aggregated review where 3 reviewers convergent on the swap-arg risk. The CLAUDE.md \`validation.rs\` template (`RelativePath`, `AgentName`) was the natural pattern to apply.
+
+## What's in scope
+
+- **A1: `MarketplaceName` / `PluginName` newtypes.** Defined in `validation.rs` next to the existing `AgentName` precedent. `serde(transparent)` keeps wire format byte-identical; `Deserialize` routed through `new` (parse-don't-validate at tracking-file load).
+- **A4: `marketplace` field on `InstallPluginResult`.** One-line struct addition; populated by `install_plugin` orchestrator.
+
+Migration scope (per design):
+- 4 tracking-file meta types (`InstalledSkillMeta`, `InstalledAgentMeta`, `InstalledNativeCompanionsMeta`, `InstalledSteeringMeta`) — parse-validated at \`serde_json::from_slice\`
+- `InstalledPluginInfo` and the `installed_plugins` aggregator
+- `KiroProject` removal API: \`remove_plugin\`, \`remove_native_companions_for_plugin\`, plus internal install paths and free helpers
+- `MarketplaceService` install API: \`install_plugin\`, \`install_skills\`, \`install_plugin_steering\`, \`install_plugin_agents\`, \`resolve_plugin_install_context\`
+- `AgentInstallContext` + `SteeringInstallContext`
+- `SteeringError::PathOwnedByOtherPlugin.owner`
+- Tauri command \`_impl\`s: replaces I10 \`validate_name(...)?\` with \`MarketplaceName::new(...)?\`
+- CLI install command: constructs newtypes from clap-parsed strings
+
+## What's NOT in scope (deferred)
+
+- A2 \`RemovePluginResult\` shape symmetry (drop \`_count\`, return \`Vec<String>\`) — bundle with Phase 2 UI work
+- A3 \`InstallAgentsResult\` dual-track collapse — annotated as legacy-presenter scaffolding, low conviction
+- HashMap-key newtypes (\`SkillName\`, etc.) — keys stay \`String\`; PR #94's I9 walkers still validate
+- \`MarketplaceService\` non-install API (\`add\`, \`remove\`, \`update\`, \`list\`, \`marketplace_path\`, etc.) and \`MarketplaceAddResult.name\` — out of scope per Phase 1.5 design
+- Frontend nominal-type migration — \`bindings.ts\` emits aliases but BrowseTab/InstalledTab stay \`string\`-typed
+
+## Test plan
+
+- [x] \`cargo fmt --all --check\` clean
+- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
+- [x] \`cargo test --workspace\` all green (including ~16 new newtype tests)
+- [x] \`cargo xtask plan-lint\` all 6 sub-gates OK
+- [x] \`npm run check\` clean (frontend types via regenerated bindings.ts)
+- [x] Manual verification: \`InstallPluginResult\` JSON-shape rstests confirm \`marketplace\` and \`plugin\` serialize as plain strings (\`serde(transparent)\` contract holds)
+- [ ] Manual smoke against \`dwalleck/kiro-starter-kit\`: install kiro-code-reviewer, verify both A4 marketplace field flows through and the swap-arg compile errors prevented in core would also surface in any future caller
+
+## References
+
+- Design: \`docs/plans/2026-04-30-phase-1-5-type-safety-design.md\`
+- Plan: \`docs/plans/2026-04-30-phase-1-5-type-safety-plan.md\`
+- Predecessor: PR #94 (Phase 1, plugin-first install)
+- 8-reviewer aggregated review on PR #94 — Critical convergent finding: swap-arg footgun
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Design section | Covered by |
+|---|---|
+| New types (`MarketplaceName`, `PluginName`) | Task 1 |
+| Test helpers (`mp`, `pn`) | Task 2 |
+| Tracking-file meta type migration | Task 3 (steps 1, 6) |
+| `InstalledPluginInfo` + `installed_plugins` migration | Task 3 (step 2) |
+| `KiroProject` removal API migration | Task 3 (step 3) |
+| `KiroProject` install API + free helpers migration | Task 3 (step 4) |
+| `SteeringInstallContext` + `SteeringError` migration | Task 4 |
+| `AgentInstallContext` migration | Task 5 (step 1) |
+| `InstallPluginResult` migration + A4 `marketplace` field | Task 5 (step 2) |
+| `MarketplaceService` install API migration | Task 5 (steps 3-5) |
+| `resolve_plugin_install_context` migration | Task 6 |
+| Tauri `_impl` migration (5 files) | Task 7 |
+| CLI install command migration | Task 8 (step 1) |
+| Integration tests + bindings.ts regen | Task 8 (steps 2-3) |
+| 5-gates plan-review checklist | Task 8 (step 4) |
+| Final sweep + open PR | Task 8 (steps 5-7) |
+
+All design requirements have a task. The "open question" from the design doc (whether to derive `Default`) is resolved in Task 5 step 2 — drop `Default` from `InstallPluginResult`.
+
+### Placeholder scan
+
+- No "TBD" / "TODO" / "implement later" entries.
+- Every code block contains the actual code (signatures, body fragments, full structs where applicable).
+- Test code blocks include real `assert_eq!`s, not placeholder assertions.
+- Commands include exact paths and expected output.
+
+### Type consistency
+
+- `MarketplaceName` and `PluginName` use the same shape (verified via Task 1's spec).
+- `mp()` / `pn()` test helpers consistent across Tasks 3-8.
+- `InstallPluginResult.marketplace` (Task 5 step 2) is consistent with the design's struct definition.
+- `KiroProject::remove_plugin(&MarketplaceName, &PluginName)` argument order is preserved across Tasks 3 and 7 (the Tauri `_impl` calls match the core signature).
+- `SteeringInstallContext.marketplace: &MarketplaceName` (Task 4) matches the consumer in Task 5 step 3 (where `install_plugin` constructs it).
+
+### Open follow-ups (post-merge)
+
+- Apply the 5-gates plan-review checklist on this plan (per Task 8 step 4) and write `2026-04-30-phase-1-5-type-safety-plan-amendments.md` if any gate fires. The checklist explicitly says to do this BEFORE implementation; for Phase 1.5 the discipline is the same as Phase 1.
+
+---
+
+**Plan complete.** Suggested execution: subagent-driven, one task per subagent, two-stage review between tasks. Tasks 3 and 5 are the heavy lifts; the rest are straightforward.


### PR DESCRIPTION
## Summary

Phase 1.5 of the plugin-first install architecture. Closes the swap-arg footgun in 7+ public APIs by introducing validated `MarketplaceName` / `PluginName` newtypes, and adds the missing `marketplace` field to `InstallPluginResult` for symmetry with `InstalledPluginInfo` (A4).

Background: PR #94 (Phase 1) shipped with an 8-reviewer aggregated review where 3 reviewers convergent on the swap-arg risk. The CLAUDE.md `validation.rs` template (`RelativePath`, `AgentName`) was the natural pattern to apply.

## What's in scope

- **A1: `MarketplaceName` / `PluginName` newtypes.** Defined in `validation.rs` next to the existing `AgentName` precedent. `serde(transparent)` keeps wire format byte-identical; `Deserialize` routed through `new` (parse-don't-validate at tracking-file load).
- **A4: `marketplace` field on `InstallPluginResult`.** One-line struct addition; populated by `install_plugin` orchestrator. Wire-format ordering: `marketplace, plugin, version, skills, steering, agents`.

Migration scope (per design):
- 4 tracking-file meta types (`InstalledSkillMeta`, `InstalledAgentMeta`, `InstalledNativeCompanionsMeta`, `InstalledSteeringMeta`) — parse-validated at `serde_json::from_slice`
- `InstalledPluginInfo` and the `installed_plugins` aggregator
- `KiroProject` removal API: `remove_plugin`, `remove_native_companions_for_plugin`, plus internal install paths and free helpers
- `MarketplaceService` install API: `install_plugin`, `install_skills`, `install_plugin_steering`, `install_plugin_agents`, `resolve_plugin_install_context`
- `AgentInstallContext` + `SteeringInstallContext`
- `SteeringError::PathOwnedByOtherPlugin.owner`
- Tauri command `_impl`s: replaces I10 `validate_name(...)?` with `MarketplaceName::new(...)?` (per amendment P1.5-4, the existing `From<ValidationError> for CommandError` impl makes the `?` operator just work)
- CLI install command: constructs newtypes from clap-parsed strings via `anyhow::Context`

## What's NOT in scope (deferred)

- A2 `RemovePluginResult` shape symmetry (drop `_count`, return `Vec<String>`) — bundle with Phase 2 UI work
- A3 `InstallAgentsResult` dual-track collapse — annotated as legacy-presenter scaffolding, low conviction
- HashMap-key newtypes (`SkillName`, etc.) — keys stay `String`; PR #94's I9 walkers still validate
- `MarketplaceService` non-install API (`add`, `remove`, `update`, `list`, `marketplace_path`, `list_plugin_entries`) — out of scope per Phase 1.5 design (`marketplace.as_str()` bridges these from migrated callers)
- `AgentError::PathOwnedByOtherPlugin.owner` stays `String` (asymmetric with the migrated `SteeringError`) — see amendment P1.5-8 for rationale
- Frontend nominal-type migration — `bindings.ts` emits aliases but BrowseTab/InstalledTab stay `string`-typed

## Plan amendments captured during execution

8 amendments live in `docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md`:

- **P1.5-1, P1.5-2** (plan-review): Fixed the original Task 6 step 1's compile errors before implementation
- **P1.5-3** (plan-review): `Ord`/`PartialOrd` derive rationale documented at the derive site
- **P1.5-4** (plan-review): Cited PR #94's I10 `From<ValidationError> for CommandError` impl
- **P1.5-5** (plan-review): Clarified compile-state boundaries (intra-crate vs workspace)
- **P1.5-6, P1.5-7** (Task 3 implementation): `pub(crate) fn from_internal_unchecked` shim recipe + intra-crate ripple wider than plan estimated
- **P1.5-8** (Task 5 implementation): `from_internal_unchecked` definitions removed (dead_code + no allow); `AgentError::PathOwnedByOtherPlugin.owner` asymmetry decision documented

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` all green (including ~20 new newtype tests)
- [x] `cargo xtask plan-lint` all gates OK
- [x] `npm run check` clean (frontend types via regenerated bindings.ts)
- [x] Manual verification: `InstallPluginResult` JSON-shape rstests confirm `marketplace` and `plugin` serialize as plain strings (`serde(transparent)` contract holds)
- [ ] Manual smoke: install kiro-code-reviewer from a starter-kit marketplace, verify the A4 `marketplace` field flows through to `bindings.ts` correctly and the swap-arg compile errors prevented in core would also surface in any future caller

## References

- Design: `docs/plans/2026-04-30-phase-1-5-type-safety-design.md`
- Plan: `docs/plans/2026-04-30-phase-1-5-type-safety-plan.md`
- Amendments: `docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md`
- Predecessor: PR #94 (Phase 1, plugin-first install)
- 8-reviewer aggregated review on PR #94 — Critical convergent finding: swap-arg footgun

🤖 Generated with [Claude Code](https://claude.com/claude-code)