### PR TITLE
feat: update detection + RemovePluginResult reshape (Phase 2a backend)

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -1,6 +1,6 @@
 //! Plugin-level commands for the Tauri frontend.
 //!
-//! Three commands live here:
+//! Four commands live here:
 //!
 //! - [`install_plugin`] — orchestrator wrapper around
 //!   [`MarketplaceService::install_plugin`] (Task 1's core method). Carries
@@ -15,6 +15,10 @@
 //! - [`remove_plugin`] — cascade wrapper around
 //!   [`KiroProject::remove_plugin`] (Task 3). No `_impl` per A-19; same
 //!   project-only-read shape as `list_installed_plugins`.
+//! - [`detect_plugin_updates`] — update-detection wrapper around
+//!   [`MarketplaceService::detect_plugin_updates`] (Phase 2a). Splits
+//!   into [`detect_plugin_updates_impl`] per the service-consuming
+//!   convention so the body is testable without a Tauri runtime.
 
 use kiro_market_core::project::{InstalledPluginsView, KiroProject, RemovePluginResult};
 use kiro_market_core::service::{
@@ -139,7 +143,7 @@ pub async fn list_installed_plugins(
 
 /// Remove every skill, steering file, and agent for a given
 /// `(marketplace, plugin)` pair from the project, returning per-content
-/// removal counts.
+/// `removed: Vec<String>` lists plus per-content `failures` vecs.
 ///
 /// No `_impl` split (A-19): same rationale as
 /// [`list_installed_plugins`] above — `KiroProject`-only read/write,
@@ -162,12 +166,14 @@ pub async fn remove_plugin(
 
 #[cfg(test)]
 mod tests {
-    //! `_impl`-level tests for [`install_plugin_impl`] plus wrapper-level
-    //! tests for [`list_installed_plugins`] and [`remove_plugin`] (A-19:
-    //! the latter two have no `_impl`, so the wrapper IS the unit). The
-    //! `#[tauri::command]` attribute on `install_plugin` is a thin serde
-    //! shim and is not re-exercised here; see `commands/browse.rs::tests`
-    //! for the canonical pattern.
+    //! `_impl`-level tests for [`install_plugin_impl`] and
+    //! [`detect_plugin_updates_impl`] plus wrapper-level tests for
+    //! [`list_installed_plugins`] and [`remove_plugin`] (A-19: the
+    //! latter two have no `_impl`, so the wrapper IS the unit). The
+    //! `#[tauri::command]` attribute on `install_plugin` /
+    //! `detect_plugin_updates` is a thin serde shim and is not
+    //! re-exercised here; see `commands/browse.rs::tests` for the
+    //! canonical pattern.
 
     use std::fs;
 
@@ -541,15 +547,15 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// Removing a `(marketplace, plugin)` pair that was never installed
-    /// returns zeroed counts (not an error). The cascade's
-    /// "filter-then-remove" shape naturally produces zeros when no
-    /// tracking entries match.
+    /// returns empty per-content `removed` lists (not an error). The
+    /// cascade's "filter-then-remove" shape naturally produces empty
+    /// vecs when no tracking entries match.
     #[tokio::test]
     async fn remove_plugin_returns_zeros_for_nonexistent_pair() {
         let dir = tempfile::tempdir().expect("tempdir");
         let project_path = make_kiro_project(dir.path());
 
-        let counts = remove_plugin(
+        let result = remove_plugin(
             "mp-absent".to_string(),
             "plugin-absent".to_string(),
             project_path,
@@ -557,17 +563,18 @@ mod tests {
         .await
         .expect("remove on empty project must succeed");
 
-        assert!(counts.skills.removed.is_empty());
-        assert!(counts.steering.removed.is_empty());
-        assert!(counts.agents.removed.is_empty());
-        assert!(counts.skills.failures.is_empty());
-        assert!(counts.steering.failures.is_empty());
-        assert!(counts.agents.failures.is_empty());
+        assert!(result.skills.removed.is_empty());
+        assert!(result.steering.removed.is_empty());
+        assert!(result.agents.removed.is_empty());
+        assert!(result.skills.failures.is_empty());
+        assert!(result.steering.failures.is_empty());
+        assert!(result.agents.failures.is_empty());
     }
 
     /// After [`install_plugin_impl`] seeds all three content types,
-    /// `remove_plugin` must report counts matching what was installed
-    /// AND the tracking files must reflect the removal.
+    /// `remove_plugin` must report per-content removed lists matching
+    /// what was installed AND the tracking files must reflect the
+    /// removal.
     #[tokio::test]
     async fn remove_plugin_returns_expected_counts_after_install() {
         let (dir, svc) = temp_service();
@@ -589,7 +596,7 @@ mod tests {
         )
         .expect("seed via install_plugin_impl");
 
-        let counts = remove_plugin(
+        let result = remove_plugin(
             "mp1".to_string(),
             "myplugin".to_string(),
             project_path.clone(),
@@ -597,12 +604,12 @@ mod tests {
         .await
         .expect("cascade remove");
 
-        assert_eq!(counts.skills.removed, vec!["alpha"]);
-        assert_eq!(counts.steering.removed, vec!["guide.md"]);
-        assert_eq!(counts.agents.removed, vec!["reviewer"]);
-        assert!(counts.skills.failures.is_empty());
-        assert!(counts.steering.failures.is_empty());
-        assert!(counts.agents.failures.is_empty());
+        assert_eq!(result.skills.removed, vec!["alpha"]);
+        assert_eq!(result.steering.removed, vec!["guide.md"]);
+        assert_eq!(result.agents.removed, vec!["reviewer"]);
+        assert!(result.skills.failures.is_empty());
+        assert!(result.steering.failures.is_empty());
+        assert!(result.agents.failures.is_empty());
 
         let view_after = list_installed_plugins(project_path)
             .await

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -530,9 +530,12 @@ mod tests {
         .await
         .expect("remove on empty project must succeed");
 
-        assert_eq!(counts.skills_removed, 0);
-        assert_eq!(counts.steering_removed, 0);
-        assert_eq!(counts.agents_removed, 0);
+        assert!(counts.skills.removed.is_empty());
+        assert!(counts.steering.removed.is_empty());
+        assert!(counts.agents.removed.is_empty());
+        assert!(counts.skills.failures.is_empty());
+        assert!(counts.steering.failures.is_empty());
+        assert!(counts.agents.failures.is_empty());
     }
 
     /// After [`install_plugin_impl`] seeds all three content types,
@@ -567,9 +570,12 @@ mod tests {
         .await
         .expect("cascade remove");
 
-        assert_eq!(counts.skills_removed, 1);
-        assert_eq!(counts.steering_removed, 1);
-        assert_eq!(counts.agents_removed, 1);
+        assert_eq!(counts.skills.removed, vec!["alpha"]);
+        assert_eq!(counts.steering.removed, vec!["guide.md"]);
+        assert_eq!(counts.agents.removed, vec!["reviewer"]);
+        assert!(counts.skills.failures.is_empty());
+        assert!(counts.steering.failures.is_empty());
+        assert!(counts.agents.failures.is_empty());
 
         let view_after = list_installed_plugins(project_path)
             .await

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -17,7 +17,9 @@
 //!   project-only-read shape as `list_installed_plugins`.
 
 use kiro_market_core::project::{InstalledPluginsView, KiroProject, RemovePluginResult};
-use kiro_market_core::service::{InstallMode, InstallPluginResult, MarketplaceService};
+use kiro_market_core::service::{
+    DetectUpdatesResult, InstallMode, InstallPluginResult, MarketplaceService,
+};
 use kiro_market_core::validation::{MarketplaceName, PluginName};
 
 use crate::commands::{make_service, validate_kiro_project_path};
@@ -69,6 +71,25 @@ fn install_plugin_impl(
     let project = KiroProject::new(project_root);
     svc.install_plugin(&project, &marketplace, &plugin, mode, accept_mcp)
         .map_err(CommandError::from)
+}
+
+fn detect_plugin_updates_impl(
+    svc: &MarketplaceService,
+    project_path: &str,
+) -> Result<DetectUpdatesResult, CommandError> {
+    let project_root = validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(project_root);
+    svc.detect_plugin_updates(&project)
+        .map_err(CommandError::from)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn detect_plugin_updates(
+    project_path: String,
+) -> Result<DetectUpdatesResult, CommandError> {
+    let svc = make_service()?;
+    detect_plugin_updates_impl(&svc, &project_path)
 }
 
 /// List every installed plugin in the project, aggregated by
@@ -566,6 +587,28 @@ mod tests {
         let err = remove_plugin("mp1".to_string(), "myplugin".to_string(), String::new())
             .await
             .expect_err("empty project_path must error");
+        assert_eq!(err.error_type, ErrorType::Validation);
+    }
+
+    // -----------------------------------------------------------------------
+    // detect_plugin_updates_impl
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_plugin_updates_impl_happy_path() {
+        let (dir, svc) = temp_service();
+        let project_path = make_kiro_project(dir.path());
+        let result = detect_plugin_updates_impl(&svc, &project_path)
+            .expect("scan succeeds with empty project");
+        assert!(result.updates.is_empty());
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_impl_rejects_invalid_project_path() {
+        let (_dir, svc) = temp_service();
+        let result = detect_plugin_updates_impl(&svc, "/nonexistent/path/to/project");
+        let err = result.expect_err("invalid project path must be rejected");
         assert_eq!(err.error_type, ErrorType::Validation);
     }
 }

--- a/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/plugins.rs
@@ -83,6 +83,33 @@ fn detect_plugin_updates_impl(
         .map_err(CommandError::from)
 }
 
+/// Scan installed plugins for available updates by comparing each
+/// project tracking entry's recorded `version` and `source_hash`
+/// against the corresponding plugin in the marketplace cache. Reads
+/// from local cache only — callers that want fresh data run
+/// `update_marketplaces` first.
+///
+/// Returns a [`DetectUpdatesResult`] split into three vecs:
+/// - `updates`: plugins with an available update (typed
+///   `change_signal` distinguishes manifest version bump from
+///   content drift without version bump).
+/// - `failures`: plugins the scan couldn't check, with a typed
+///   `kind: PluginUpdateFailureKind` for FE branching (Rule 42).
+/// - `partial_load_warnings`: tracking files that failed to load
+///   (corrupt JSON etc.) — the other tracking files still
+///   contribute and the scan continues.
+///
+/// Splits into [`detect_plugin_updates_impl`] per the
+/// service-consuming-command convention so the body is testable
+/// without a Tauri runtime.
+///
+/// # Errors
+///
+/// Returns `CommandError::Validation` on an invalid `project_path`.
+/// Per-plugin scan failures land in
+/// [`DetectUpdatesResult::failures`] (a typed entry, not an
+/// `Err(CommandError)`) so a single bad plugin doesn't abort the
+/// whole scan.
 #[tauri::command]
 #[specta::specta]
 pub async fn detect_plugin_updates(

--- a/crates/kiro-control-center/src-tauri/src/lib.rs
+++ b/crates/kiro-control-center/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ fn create_builder() -> Builder<tauri::Wry> {
         commands::plugins::install_plugin,
         commands::plugins::list_installed_plugins,
         commands::plugins::remove_plugin,
+        commands::plugins::detect_plugin_updates,
     ])
 }
 

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -151,13 +151,42 @@ export const commands = {
 	/**
 	 *  Remove every skill, steering file, and agent for a given
 	 *  `(marketplace, plugin)` pair from the project, returning per-content
-	 *  removal counts.
+	 *  `removed: Vec<String>` lists plus per-content `failures` vecs.
 	 * 
 	 *  No `_impl` split (A-19): same rationale as
 	 *  [`list_installed_plugins`] above — `KiroProject`-only read/write,
 	 *  no service.
 	 */
 	removePlugin: (marketplace: string, plugin: string, projectPath: string) => typedError<RemovePluginResult, CommandError>(__TAURI_INVOKE("remove_plugin", { marketplace, plugin, projectPath })),
+	/**
+	 *  Scan installed plugins for available updates by comparing each
+	 *  project tracking entry's recorded `version` and `source_hash`
+	 *  against the corresponding plugin in the marketplace cache. Reads
+	 *  from local cache only — callers that want fresh data run
+	 *  `update_marketplaces` first.
+	 * 
+	 *  Returns a [`DetectUpdatesResult`] split into three vecs:
+	 *  - `updates`: plugins with an available update (typed
+	 *    `change_signal` distinguishes manifest version bump from
+	 *    content drift without version bump).
+	 *  - `failures`: plugins the scan couldn't check, with a typed
+	 *    `kind: PluginUpdateFailureKind` for FE branching (Rule 42).
+	 *  - `partial_load_warnings`: tracking files that failed to load
+	 *    (corrupt JSON etc.) — the other tracking files still
+	 *    contribute and the scan continues.
+	 * 
+	 *  Splits into [`detect_plugin_updates_impl`] per the
+	 *  service-consuming-command convention so the body is testable
+	 *  without a Tauri runtime.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `CommandError::Validation` on an invalid `project_path`.
+	 *  Per-plugin scan failures land in
+	 *  [`DetectUpdatesResult::failures`] (a typed entry, not an
+	 *  `Err(CommandError)`) so a single bad plugin doesn't abort the
+	 *  whole scan.
+	 */
 	detectPluginUpdates: (projectPath: string) => typedError<DetectUpdatesResult, CommandError>(__TAURI_INVOKE("detect_plugin_updates", { projectPath })),
 };
 
@@ -960,28 +989,94 @@ export type PluginSkillsResult = {
 };
 
 /**
- *  A plugin the update scan couldn't check. `reason` is the rendered
- *  error chain via [`crate::error::error_full_chain`] per CLAUDE.md FFI
- *  rule (any wire-format `reason`/`error: String` field uses
- *  `error_full_chain(&err)`, not `err.to_string()`).
+ *  A plugin the update scan couldn't check.
+ * 
+ *  `kind` is the stable programmatic discriminant frontends should
+ *  `match` on (per CLAUDE.md Rule 42: match error types, not error
+ *  strings). `reason` is the rendered error chain via
+ *  [`crate::error::error_full_chain`] per the FFI rule — suitable for
+ *  log lines or fallback UI rendering, but never for branching logic.
  */
 export type PluginUpdateFailure = {
 	marketplace: MarketplaceName,
 	plugin: PluginName,
+	kind: PluginUpdateFailureKind,
 	reason: string,
 };
 
 /**
- *  A single plugin with an update available. `installed_version` is
- *  `None` for legacy installs whose tracking file lacked the version
- *  field; `available_version` is `None` when the marketplace plugin
- *  manifest itself lacks a version. The `change_signal` discriminates
- *  between manifest-version change and content-drift-without-version-bump.
+ *  Why an update-detection scan couldn't check a plugin. Tagged enum
+ *  for FFI per the `ffi-enum-serde-tag` plan-lint gate (PR #91):
+ *  `#[serde(tag = "kind", rename_all = "snake_case")]` produces
+ *  `{ "kind": "manifest_unreadable" }` in JSON, which `tauri-specta`
+ *  emits as a discriminated TS union.
+ * 
+ *  Closes original-review I4: `PluginUpdateFailure` was opaque
+ *  (substring matching `reason` to differentiate failure types
+ *  violated CLAUDE.md Rule 42). The classifier
+ *  [`PluginUpdateFailureKind::from_error`] is exhaustive per the
+ *  CLAUDE.md classifier rule — a new error variant either matches
+ *  here explicitly or routes through `Other` after a written-down
+ *  rationale.
+ */
+export type PluginUpdateFailureKind = 
+/**
+ *  Marketplace cache directory missing or plugin removed from
+ *  the marketplace's manifest.
+ */
+{ kind: "marketplace_unavailable" } | 
+/**
+ *  `plugin.json` missing in the marketplace cache (typically the
+ *  plugin was deleted from upstream and the cache hasn't been
+ *  refreshed). Also covers symlink-refused per the C5 defense.
+ */
+{ kind: "manifest_unreadable" } | 
+/**
+ *  `plugin.json` exists but failed to parse (malformed JSON,
+ *  missing required fields, etc.).
+ */
+{ kind: "manifest_invalid" } | 
+/**
+ *  Hash recomputation against an installed file failed (file
+ *  missing in the cache, permission denied, etc.).
+ */
+{ kind: "hash_failed" } | 
+/**
+ *  Catch-all for unanticipated failure shapes. Surfacing this
+ *  rather than panicking lets the FE render a generic "scan
+ *  failed" badge while the typed variants drive specific
+ *  remediation. Each new error class deliberately routed here
+ *  should also be considered for promotion to a typed variant.
+ */
+{ kind: "other" };
+
+/**
+ *  A single plugin with an update available.
+ * 
+ *  The `change_signal` discriminates between manifest-version change
+ *  and content-drift-without-version-bump.
  */
 export type PluginUpdateInfo = {
 	marketplace: MarketplaceName,
 	plugin: PluginName,
+	/**
+	 *  `None` means the project's tracking file lacked a `version`
+	 *  field at install time (a legacy install pre-Stage-1, before
+	 *  the version field was added to the tracking schema). Cases
+	 *  where the tracking file itself failed to load are surfaced via
+	 *  [`DetectUpdatesResult::partial_load_warnings`], NOT via
+	 *  `Some(None)` here.
+	 */
 	installed_version: string | null,
+	/**
+	 *  `None` means the marketplace plugin manifest exists but lacks
+	 *  a `version` field. After NC1's `ManifestVersion` 3-state
+	 *  split, cases where the manifest is missing or unreadable
+	 *  (symlinked, `NotFound`) surface as a [`PluginUpdateFailure`] —
+	 *  they no longer collapse into `Some(None)` here. So
+	 *  `available_version: None` is now an unambiguous "marketplace
+	 *  says no version" signal.
+	 */
 	available_version: string | null,
 	change_signal: UpdateChangeSignal,
 };
@@ -1410,12 +1505,12 @@ export type UnmappedReason =
 export type UpdateChangeSignal = 
 /**
  *  Manifest version string differs (with or without content hash diff).
- *  FE renders "Update v1.0 → v1.1".
+ *  Designed for FE rendering as "Update v1.0 → v1.1".
  */
 { kind: "version_bumped" } | 
 /**
  *  Manifest version unchanged but at least one source-hash diff
- *  detected. FE renders "Content updated since install".
+ *  detected. Designed for FE rendering as "Content updated since install".
  */
 { kind: "content_changed" };
 

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -195,10 +195,17 @@ export type CommandError = {
  *  from cache, manifest malformed, hash computation failure). Plugins
  *  with no update available are absent from both vecs (the implicit
  *  "everything's fine" set).
+ * 
+ *  `partial_load_warnings` carries tracking-file load failures that
+ *  happened before `installed_plugins()` returned — e.g. a corrupt
+ *  `installed-skills.json` means the corresponding skills are missing
+ *  from `plugins` and the warning is surfaced here so the caller can
+ *  render a "partial state" banner.
  */
 export type DetectUpdatesResult = {
 	updates?: PluginUpdateInfo[],
 	failures?: PluginUpdateFailure[],
+	partial_load_warnings?: TrackingLoadWarning[],
 };
 
 // A discovered Kiro project found during directory scanning.
@@ -1006,9 +1013,10 @@ export type RelativePath = string;
  *  Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
  *  the install-side [`crate::service::InstallAgentsResult`] shape.
  *  `removed` is a flat vec of translated agent names + native agent
- *  names + native companion file paths (rendered) — matches the
- *  install-side asymmetry where native companions are agent-side
- *  artifacts.
+ *  names. Native companion file paths are NOT itemized (P2a-3
+ *  decision α) — the `native_companions` cascade step succeeds with
+ *  no per-file entries. If the FE later wants per-companion
+ *  granularity, that's an additive field change.
  */
 export type RemoveAgentsResult = {
 	removed?: string[],

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -1070,7 +1070,7 @@ export type PluginUpdateInfo = {
 	installed_version: string | null,
 	/**
 	 *  `None` means the marketplace plugin manifest exists but lacks
-	 *  a `version` field. After NC1's `ManifestVersion` 3-state
+	 *  a `version` field. After NC1's `ManifestState` 3-state
 	 *  split, cases where the manifest is missing or unreadable
 	 *  (symlinked, `NotFound`) surface as a [`PluginUpdateFailure`] —
 	 *  they no longer collapse into `Some(None)` here. So

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -17,6 +17,17 @@ export const commands = {
 	 *  per-skill failures vanished into `warn!` logs, leaving the frontend to
 	 *  wonder why the count shrank; surfacing them structurally lets the UI
 	 *  show "N skills failed to load" with a drill-down.
+	 * 
+	 *  The IPC-boundary [`MarketplaceName::new`] / [`PluginName::new`]
+	 *  constructors plus [`validate_kiro_project_path`] gate the wrapper
+	 *  before any service or filesystem access. Without these guards a
+	 *  frontend-supplied `marketplace = "../etc/passwd"` would reach
+	 *  [`MarketplaceService::marketplace_path`] (`cache::marketplace_path`)
+	 *  via a bare path join and force an FS read at
+	 *  `<registries_dir>/../etc/passwd` — the read-side analogue of the
+	 *  install-side hardening from PR #94's I10. Validation runs *before*
+	 *  [`make_service`] so rejection paths never touch `$HOME` / the cache
+	 *  directory.
 	 */
 	listAvailableSkills: (marketplace: string, plugin: string, projectPath: string) => typedError<PluginSkillsResult, CommandError>(__TAURI_INVOKE("list_available_skills", { marketplace, plugin, projectPath })),
 	/**
@@ -27,6 +38,11 @@ export const commands = {
 	 *  plugin filter is active. The returned [`BulkSkillsResult::skipped`]
 	 *  carries plugin-level errors (missing directory, malformed manifest,
 	 *  remote source) so the frontend can surface a partial-listing warning.
+	 * 
+	 *  The IPC-boundary [`MarketplaceName::new`] plus
+	 *  [`validate_kiro_project_path`] gate the wrapper before any service or
+	 *  filesystem access — same defense-in-depth contract as
+	 *  [`list_available_skills`].
 	 */
 	listAllSkillsForMarketplace: (marketplace: string, projectPath: string) => typedError<BulkSkillsResult, CommandError>(__TAURI_INVOKE("list_all_skills_for_marketplace", { marketplace, projectPath })),
 	/**
@@ -142,6 +158,7 @@ export const commands = {
 	 *  no service.
 	 */
 	removePlugin: (marketplace: string, plugin: string, projectPath: string) => typedError<RemovePluginResult, CommandError>(__TAURI_INVOKE("remove_plugin", { marketplace, plugin, projectPath })),
+	detectPluginUpdates: (projectPath: string) => typedError<DetectUpdatesResult, CommandError>(__TAURI_INVOKE("detect_plugin_updates", { projectPath })),
 };
 
 /* Types */
@@ -169,6 +186,19 @@ export type BulkSkillsResult = {
 export type CommandError = {
 	message: string,
 	error_type: ErrorType,
+};
+
+/**
+ *  Result of [`MarketplaceService::detect_plugin_updates`] — a scan over
+ *  installed plugins. `updates` lists plugins with available updates;
+ *  `failures` lists plugins the scan couldn't check (marketplace gone
+ *  from cache, manifest malformed, hash computation failure). Plugins
+ *  with no update available are absent from both vecs (the implicit
+ *  "everything's fine" set).
+ */
+export type DetectUpdatesResult = {
+	updates?: PluginUpdateInfo[],
+	failures?: PluginUpdateFailure[],
 };
 
 // A discovered Kiro project found during directory scanning.
@@ -922,6 +952,33 @@ export type PluginSkillsResult = {
 	skipped_skills: SkippedSkill[],
 };
 
+/**
+ *  A plugin the update scan couldn't check. `reason` is the rendered
+ *  error chain via [`crate::error::error_full_chain`] per CLAUDE.md FFI
+ *  rule (any wire-format `reason`/`error: String` field uses
+ *  `error_full_chain(&err)`, not `err.to_string()`).
+ */
+export type PluginUpdateFailure = {
+	marketplace: MarketplaceName,
+	plugin: PluginName,
+	reason: string,
+};
+
+/**
+ *  A single plugin with an update available. `installed_version` is
+ *  `None` for legacy installs whose tracking file lacked the version
+ *  field; `available_version` is `None` when the marketplace plugin
+ *  manifest itself lacks a version. The `change_signal` discriminates
+ *  between manifest-version change and content-drift-without-version-bump.
+ */
+export type PluginUpdateInfo = {
+	marketplace: MarketplaceName,
+	plugin: PluginName,
+	installed_version: string | null,
+	available_version: string | null,
+	change_signal: UpdateChangeSignal,
+};
+
 // Summary information about a Kiro project directory.
 export type ProjectInfo = {
 	path: string,
@@ -946,64 +1003,72 @@ export type ProjectInfo = {
 export type RelativePath = string;
 
 /**
- *  One per-step failure recorded by [`KiroProject::remove_plugin`] when
- *  a per-content removal fails mid-cascade. The cascade keeps going on
- *  remaining content types; the caller surfaces these to the user as a
- *  partial-failure summary.
+ *  Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+ *  the install-side [`crate::service::InstallAgentsResult`] shape.
+ *  `removed` is a flat vec of translated agent names + native agent
+ *  names + native companion file paths (rendered) — matches the
+ *  install-side asymmetry where native companions are agent-side
+ *  artifacts.
  */
-export type RemovePluginFailure = {
+export type RemoveAgentsResult = {
+	removed?: string[],
+	failures?: RemoveItemFailure[],
+};
+
+/**
+ *  One failure during a per-content-type removal step. The discriminator
+ *  (which content type) is the parent type — no `content_type: String`
+ *  field needed (it's expressed structurally via the parent's field
+ *  name in [`RemovePluginResult`]).
+ */
+export type RemoveItemFailure = {
 	/**
-	 *  Which content type errored: `"skill"` / `"steering"` / `"agent"`
-	 *  / `"native_companions"`.
-	 */
-	content_type: string,
-	/**
-	 *  The item identifier — skill or agent name, or steering rel-path
-	 *  rendered via `Path::display()`. Empty string for the
-	 *  `"native_companions"` row, which is plugin-scoped rather than
-	 *  per-item.
+	 *  The skill/agent name or steering rel-path rendered via
+	 *  [`std::path::Path::display`].
 	 */
 	item: string,
 	/**
 	 *  Rendered error chain via [`crate::error::error_full_chain`] —
-	 *  wire format per CLAUDE.md "in any wire-format `reason`/`error:
-	 *  String` field that crosses the FFI, use `error_full_chain(&err)`".
+	 *  wire format per CLAUDE.md FFI rule.
 	 */
 	error: string,
 };
 
 /**
- *  Aggregated counts returned by
- *  [`KiroProject::remove_plugin`] — one tally per content type so the
- *  caller (CLI / Tauri) can render a one-line "removed N skills,
- *  M steering files, K agents" summary without re-reading the tracking
- *  files.
+ *  Result of [`KiroProject::remove_plugin`] — per-content-type
+ *  sub-results, symmetric with [`crate::service::InstallPluginResult`].
+ *  Native companions fold into [`RemoveAgentsResult`] (matches the
+ *  install-side asymmetry where native companions are agent-side
+ *  artifacts).
  * 
- *  Counts are post-cascade across every per-content removal that
- *  completed successfully. A per-step error during the cascade does
- *  **not** abort the work — the cascade keeps going on the remaining
- *  content types and records the failure in `failed`. Only "failed
- *  to even read the initial tracking files" is surfaced as the
- *  cascade's outer `Err` (I5). Orphan-tracking recoveries (A-12) still
- *  count as "removed" because the per-content remove drops the
- *  tracking row and treats the missing on-disk entry as success.
+ *  No `marketplace` / `plugin` echo fields — caller already passed
+ *  those args to `remove_plugin`. (Different from
+ *  [`crate::service::InstallPluginResult`] which gained `marketplace`
+ *  in Phase 1.5 A4 because that type lives in lists where
+ *  self-identification is needed.)
  */
 export type RemovePluginResult = {
-	skills_removed: number,
-	steering_removed: number,
-	agents_removed: number,
-	/**
-	 *  Per-step errors encountered during the cascade. The cascade
-	 *  keeps making progress on remaining content types when one
-	 *  step fails — same policy as `InstallPluginResult`'s sub-result
-	 *  `failed` vecs (A-15). Empty on a clean cascade.
-	 * 
-	 *  `serde(default)` is kept for legacy-JSON tolerance.
-	 *  `skip_serializing_if` is intentionally absent — `tauri-specta`
-	 *  2.0.0-rc.24 unified mode rejects it (A-25). Empty Vec serializes
-	 *  as `[]` rather than being omitted.
-	 */
-	failed?: RemovePluginFailure[],
+	skills: RemoveSkillsResult,
+	steering: RemoveSteeringResult,
+	agents: RemoveAgentsResult,
+};
+
+/**
+ *  Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+ *  the install-side [`InstallSkillsResult`] shape.
+ */
+export type RemoveSkillsResult = {
+	removed?: string[],
+	failures?: RemoveItemFailure[],
+};
+
+/**
+ *  Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+ *  the install-side `InstallSteeringResult` shape.
+ */
+export type RemoveSteeringResult = {
+	removed?: string[],
+	failures?: RemoveItemFailure[],
 };
 
 // Top-level category for a Kiro CLI setting.
@@ -1327,6 +1392,24 @@ export type UnmappedReason =
  *  concept with no reliable Kiro mapping.
  */
 "BareCopilotName";
+
+/**
+ *  Why an update is being surfaced. Tagged enum for FFI per the
+ *  `ffi-enum-serde-tag` plan-lint gate (PR #91): `#[serde(tag = "kind",
+ *  rename_all = "snake_case")]` produces `{ "kind": "version_bumped" }`
+ *  in JSON, which `tauri-specta` emits as a discriminated TS union.
+ */
+export type UpdateChangeSignal = 
+/**
+ *  Manifest version string differs (with or without content hash diff).
+ *  FE renders "Update v1.0 → v1.1".
+ */
+{ kind: "version_bumped" } | 
+/**
+ *  Manifest version unchanged but at least one source-hash diff
+ *  detected. FE renders "Content updated since install".
+ */
+{ kind: "content_changed" };
 
 // Result of updating one or more marketplaces.
 export type UpdateResult = {

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -138,6 +138,29 @@ pub enum PluginError {
         source: io::Error,
     },
 
+    /// Marketplace-cache `plugin.json` could not be read. Distinct from
+    /// [`Self::ManifestReadFailed`] (project-side / install-time) so a
+    /// future classifier can render "your project is broken" vs "the
+    /// local marketplace cache is broken — run `kiro-market update`"
+    /// without substring-matching paths. Carries the underlying
+    /// [`io::Error`] via `#[source]`.
+    #[error("could not read marketplace cache manifest at {path}")]
+    CacheManifestReadFailed {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    /// Marketplace-cache `plugin.json` exists but failed to parse.
+    /// Distinct from [`Self::InvalidManifest`] (project-side /
+    /// install-time) for the same reason as
+    /// [`Self::CacheManifestReadFailed`]. `reason` carries the rendered
+    /// `serde_json` error chain — the type does NOT leak through this
+    /// public API per CLAUDE.md gate-4 (`#[non_exhaustive]` enum +
+    /// `reason: String`).
+    #[error("invalid marketplace cache manifest at {path}: {reason}")]
+    CacheManifestInvalid { path: PathBuf, reason: String },
+
     /// A caller asked for a local filesystem path to a plugin whose source
     /// is remote (GitHub / Git URL / Git subdir). Resolving it would
     /// require a clone, which the caller explicitly did not request.
@@ -233,7 +256,9 @@ impl PluginError {
             | Self::NotADirectory { .. }
             | Self::SymlinkRefused { .. }
             | Self::DirectoryUnreadable { .. }
-            | Self::ManifestReadFailed { .. } => None,
+            | Self::ManifestReadFailed { .. }
+            | Self::CacheManifestReadFailed { .. }
+            | Self::CacheManifestInvalid { .. } => None,
         }
     }
 }
@@ -692,6 +717,20 @@ mod tests {
         },
         "plugin `acme` uses a remote source and is not available locally"
     )]
+    #[case::plugin_cache_manifest_read_failed(
+        PluginError::CacheManifestReadFailed {
+            path: PathBuf::from("/tmp/cache/p/plugin.json"),
+            source: io::Error::from(io::ErrorKind::NotFound),
+        },
+        "could not read marketplace cache manifest at /tmp/cache/p/plugin.json"
+    )]
+    #[case::plugin_cache_manifest_invalid(
+        PluginError::CacheManifestInvalid {
+            path: PathBuf::from("/tmp/cache/p/plugin.json"),
+            reason: "missing field `name`".into(),
+        },
+        "invalid marketplace cache manifest at /tmp/cache/p/plugin.json: missing field `name`"
+    )]
     fn plugin_error_display(#[case] err: PluginError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);
     }
@@ -796,6 +835,14 @@ mod tests {
     #[case::no_skills(PluginError::NoSkills {
         name: "empty".into(),
         path: PathBuf::from("/tmp/plugins/empty"),
+    })]
+    #[case::cache_manifest_read_failed(PluginError::CacheManifestReadFailed {
+        path: PathBuf::from("/tmp/cache/p/plugin.json"),
+        source: io::Error::from(io::ErrorKind::NotFound),
+    })]
+    #[case::cache_manifest_invalid(PluginError::CacheManifestInvalid {
+        path: PathBuf::from("/tmp/cache/p/plugin.json"),
+        reason: "expected `,` got `}`".into(),
     })]
     fn remediation_hint_returns_none_for_variants_without_actionable_step(
         #[case] err: PluginError,

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -414,7 +414,7 @@ pub struct RemoveSteeringResult {
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct RemoveAgentsResult {
     #[serde(default)]
-    pub removed: Vec<String>, // agent names + native companion paths, flat
+    pub removed: Vec<String>,
     #[serde(default)]
     pub failures: Vec<RemoveItemFailure>,
 }
@@ -6061,8 +6061,8 @@ mod tests {
         // whose unlink fails (directory at destination). The cascade
         // must:
         //   - count the skill as removed
-        //   - record the steering failure in `result.failed` (NOT
-        //     short-circuit)
+        //   - record the steering failure in `result.steering.failures`
+        //     (NOT short-circuit)
         //   - still return Ok(result)
         use chrono::Utc;
         let (_dir, project) = temp_project();

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -16,7 +16,7 @@ use crate::agent::tools::MappedTool;
 use crate::agent::{AgentDefinition, AgentDialect};
 use crate::error::{AgentError, SkillError};
 use crate::validation;
-use crate::validation::{MarketplaceName, PluginName};
+use crate::validation::{MarketplaceName, PluginName, RelativePath};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -75,8 +75,25 @@ pub struct InstalledAgentMeta {
     /// Relative path under the plugin's `agents/` directory of the
     /// source file that was installed. `None` for legacy entries
     /// installed before this field was added.
+    ///
+    /// Wrapped in [`RelativePath`] so `serde_json::from_slice` rejects
+    /// path-traversal attempts (`"../../etc/passwd"`) at tracking-file
+    /// load time per CLAUDE.md's "Parse, don't validate" rule. The
+    /// `RelativePath::Deserialize` impl routes through `RelativePath::new`,
+    /// which forbids `..`, absolute paths, NUL bytes, and embedded
+    /// backslashes — closing NC2 from PR #96 review (the original
+    /// `Option<PathBuf>` type let a tampered tracking file's
+    /// `source_path` escape the install boundary at hash recompute time
+    /// in [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]).
+    ///
+    /// Cross-file invariant: install-time filename conventions in
+    /// [`crate::service::MarketplaceService::install_translated_agents_inner`]
+    /// must stay in sync with the dialect-classifier fallback in
+    /// `scan_plugin_for_content_drift`. If the install side starts
+    /// emitting paths that disagree with the fallback (e.g. Copilot's
+    /// `.agent.md` vs `.md`), drift detection misreports legacy entries.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_path: Option<PathBuf>,
+    pub source_path: Option<RelativePath>,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
     /// install time. `None` for entries written before Stage 1 of the
@@ -3776,6 +3793,70 @@ mod tests {
             }
             other => panic!("expected Error::Io(InvalidData), got {other:?}"),
         }
+    }
+
+    /// NC2 (PR #96 re-review): a tampered `installed-agents.json`
+    /// whose per-agent `source_path` contains a traversal entry would,
+    /// without the `RelativePath` newtype on `InstalledAgentMeta`,
+    /// reach `hash_artifact(agents_dir, &[rel])` at update-detection
+    /// time and read arbitrary host files. The newtype's `Deserialize`
+    /// impl routes through `RelativePath::new` which rejects `..`,
+    /// absolute paths, NUL, and embedded backslashes — failing at
+    /// `serde_json::from_slice` time, before any path joins happen.
+    #[test]
+    fn load_installed_agents_rejects_path_traversal_in_source_path() {
+        let (_dir, project) = temp_project();
+        let tracking_path = project.root.join(".kiro/installed-agents.json");
+        fs::create_dir_all(tracking_path.parent().unwrap()).unwrap();
+        let tampered = serde_json::json!({
+            "agents": {
+                "victim": {
+                    "marketplace": "m",
+                    "plugin": "p",
+                    "version": null,
+                    "installed_at": chrono::Utc::now(),
+                    "dialect": "claude",
+                    "source_path": "../../etc/passwd",
+                }
+            }
+        });
+        fs::write(&tracking_path, tampered.to_string()).unwrap();
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("traversal in source_path must be refused at load time");
+        // serde_json deserialize errors land in Error::Json
+        // (mapped via #[error(transparent)] on Error::Json).
+        match err {
+            crate::error::Error::Json(_) => {}
+            other => panic!("expected Error::Json (RelativePath rejection), got {other:?}"),
+        }
+    }
+
+    /// NC2 + parse-don't-validate sanity: a well-formed `source_path`
+    /// (forward-slash relative path under `agents/`) must round-trip
+    /// through serde and end up as `Some(RelativePath)`.
+    #[test]
+    fn installed_agent_meta_round_trips_valid_source_path() {
+        use crate::validation::RelativePath;
+        let meta = InstalledAgentMeta {
+            marketplace: mp("m"),
+            plugin: pn("p"),
+            version: None,
+            installed_at: Utc::now(),
+            dialect: AgentDialect::Claude,
+            source_path: Some(RelativePath::new("subdir/agent.md").expect("valid rel path")),
+            source_hash: None,
+            installed_hash: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(
+            json.contains("\"source_path\":\"subdir/agent.md\""),
+            "wire format must remain a flat string, got: {json}"
+        );
+        let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
+        let rp = back.source_path.expect("source_path should be Some");
+        assert_eq!(rp.as_str(), "subdir/agent.md");
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -411,58 +411,23 @@ pub struct RemoveItemFailure {
     pub error: String,
 }
 
-/// Aggregated counts returned by
-/// [`KiroProject::remove_plugin`] — one tally per content type so the
-/// caller (CLI / Tauri) can render a one-line "removed N skills,
-/// M steering files, K agents" summary without re-reading the tracking
-/// files.
+/// Result of [`KiroProject::remove_plugin`] — per-content-type
+/// sub-results, symmetric with [`crate::service::InstallPluginResult`].
+/// Native companions fold into [`RemoveAgentsResult`] (matches the
+/// install-side asymmetry where native companions are agent-side
+/// artifacts).
 ///
-/// Counts are post-cascade across every per-content removal that
-/// completed successfully. A per-step error during the cascade does
-/// **not** abort the work — the cascade keeps going on the remaining
-/// content types and records the failure in `failed`. Only "failed
-/// to even read the initial tracking files" is surfaced as the
-/// cascade's outer `Err` (I5). Orphan-tracking recoveries (A-12) still
-/// count as "removed" because the per-content remove drops the
-/// tracking row and treats the missing on-disk entry as success.
-#[derive(Debug, Clone, Default, Serialize)]
+/// No `marketplace` / `plugin` echo fields — caller already passed
+/// those args to `remove_plugin`. (Different from
+/// [`crate::service::InstallPluginResult`] which gained `marketplace`
+/// in Phase 1.5 A4 because that type lives in lists where
+/// self-identification is needed.)
+#[derive(Clone, Debug, Default, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct RemovePluginResult {
-    pub skills_removed: u32,
-    pub steering_removed: u32,
-    pub agents_removed: u32,
-    /// Per-step errors encountered during the cascade. The cascade
-    /// keeps making progress on remaining content types when one
-    /// step fails — same policy as `InstallPluginResult`'s sub-result
-    /// `failed` vecs (A-15). Empty on a clean cascade.
-    ///
-    /// `serde(default)` is kept for legacy-JSON tolerance.
-    /// `skip_serializing_if` is intentionally absent — `tauri-specta`
-    /// 2.0.0-rc.24 unified mode rejects it (A-25). Empty Vec serializes
-    /// as `[]` rather than being omitted.
-    #[serde(default)]
-    pub failed: Vec<RemovePluginFailure>,
-}
-
-/// One per-step failure recorded by [`KiroProject::remove_plugin`] when
-/// a per-content removal fails mid-cascade. The cascade keeps going on
-/// remaining content types; the caller surfaces these to the user as a
-/// partial-failure summary.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-pub struct RemovePluginFailure {
-    /// Which content type errored: `"skill"` / `"steering"` / `"agent"`
-    /// / `"native_companions"`.
-    pub content_type: String,
-    /// The item identifier — skill or agent name, or steering rel-path
-    /// rendered via `Path::display()`. Empty string for the
-    /// `"native_companions"` row, which is plugin-scoped rather than
-    /// per-item.
-    pub item: String,
-    /// Rendered error chain via [`crate::error::error_full_chain`] —
-    /// wire format per CLAUDE.md "in any wire-format `reason`/`error:
-    /// String` field that crosses the FFI, use `error_full_chain(&err)`".
-    pub error: String,
+    pub skills: RemoveSkillsResult,
+    pub steering: RemoveSteeringResult,
+    pub agents: RemoveAgentsResult,
 }
 
 /// Per-`(marketplace, plugin)` accumulator used by
@@ -1485,9 +1450,7 @@ impl KiroProject {
     ) -> crate::error::Result<RemovePluginResult> {
         let mut result = RemovePluginResult::default();
 
-        // Skills. The A-16 marketplace check is preserved by the newtype
-        // `PartialEq` impl (see also the `native_companions` cleanup at
-        // the bottom of this method).
+        // Skills cascade
         let skills = self.load_installed()?;
         let skills_to_remove: Vec<String> = skills
             .skills
@@ -1498,23 +1461,17 @@ impl KiroProject {
         for name in &skills_to_remove {
             match self.remove_skill(name) {
                 Ok(()) => {
-                    result.skills_removed = result.skills_removed.saturating_add(1);
+                    result.skills.removed.push(name.clone());
                 }
                 Err(e) => {
-                    // I5: collect, don't abort. I3 closed the orphan-
-                    // tracking gap so `SkillError::NotInstalled` from
-                    // here is now "no tracking entry" — which the
-                    // cascade's `filter` already excluded. So this
-                    // arm is for genuine fs / serialisation failures.
                     warn!(
                         skill = %name,
                         plugin = plugin.as_str(),
                         marketplace = marketplace.as_str(),
                         error = %e,
-                        "remove_plugin: skill removal failed; recording in `failed`"
+                        "remove_plugin: skill removal failed; recording in failures"
                     );
-                    result.failed.push(RemovePluginFailure {
-                        content_type: "skill".to_string(),
+                    result.skills.failures.push(RemoveItemFailure {
                         item: name.clone(),
                         error: crate::error::error_full_chain(&e),
                     });
@@ -1522,7 +1479,7 @@ impl KiroProject {
             }
         }
 
-        // Steering files.
+        // Steering cascade
         let steering = self.load_installed_steering()?;
         let steering_to_remove: Vec<PathBuf> = steering
             .files
@@ -1533,7 +1490,7 @@ impl KiroProject {
         for rel in &steering_to_remove {
             match self.remove_steering_file(rel) {
                 Ok(()) => {
-                    result.steering_removed = result.steering_removed.saturating_add(1);
+                    result.steering.removed.push(rel.display().to_string());
                 }
                 Err(e) => {
                     warn!(
@@ -1541,10 +1498,9 @@ impl KiroProject {
                         plugin = plugin.as_str(),
                         marketplace = marketplace.as_str(),
                         error = %e,
-                        "remove_plugin: steering removal failed; recording in `failed`"
+                        "remove_plugin: steering removal failed; recording in failures"
                     );
-                    result.failed.push(RemovePluginFailure {
-                        content_type: "steering".to_string(),
+                    result.steering.failures.push(RemoveItemFailure {
                         item: rel.display().to_string(),
                         error: crate::error::error_full_chain(&e),
                     });
@@ -1552,7 +1508,7 @@ impl KiroProject {
             }
         }
 
-        // Agents.
+        // Agents cascade
         let agents = self.load_installed_agents()?;
         let agents_to_remove: Vec<String> = agents
             .agents
@@ -1563,7 +1519,7 @@ impl KiroProject {
         for name in &agents_to_remove {
             match self.remove_agent(name) {
                 Ok(()) => {
-                    result.agents_removed = result.agents_removed.saturating_add(1);
+                    result.agents.removed.push(name.clone());
                 }
                 Err(e) => {
                     warn!(
@@ -1571,10 +1527,9 @@ impl KiroProject {
                         plugin = plugin.as_str(),
                         marketplace = marketplace.as_str(),
                         error = %e,
-                        "remove_plugin: agent removal failed; recording in `failed`"
+                        "remove_plugin: agent removal failed; recording in failures"
                     );
-                    result.failed.push(RemovePluginFailure {
-                        content_type: "agent".to_string(),
+                    result.agents.failures.push(RemoveItemFailure {
                         item: name.clone(),
                         error: crate::error::error_full_chain(&e),
                     });
@@ -1582,20 +1537,16 @@ impl KiroProject {
             }
         }
 
-        // native_companions cleanup (A-3 + A-16). Idempotent — the
-        // helper returns Ok even if the entry doesn't exist or
-        // belongs to a different marketplace. Per I5 a failure here
-        // also lands in `result.failed` rather than aborting.
+        // Native companions cleanup (A-3 + A-16). Idempotent.
         if let Err(e) = self.remove_native_companions_for_plugin(plugin, marketplace) {
             warn!(
                 plugin = plugin.as_str(),
                 marketplace = marketplace.as_str(),
                 error = %e,
-                "remove_plugin: native_companions cleanup failed; recording in `failed`"
+                "remove_plugin: native_companions cleanup failed; recording in failures"
             );
-            result.failed.push(RemovePluginFailure {
-                content_type: "native_companions".to_string(),
-                item: String::new(),
+            result.agents.failures.push(RemoveItemFailure {
+                item: format!("native_companions:{}", plugin.as_str()),
                 error: crate::error::error_full_chain(&e),
             });
         }
@@ -5871,9 +5822,12 @@ mod tests {
         let result = project
             .remove_plugin(&mp("mp"), &pn("p"))
             .expect("remove_plugin");
-        assert_eq!(result.skills_removed, 1);
-        assert_eq!(result.steering_removed, 1);
-        assert_eq!(result.agents_removed, 0);
+        assert_eq!(result.skills.removed, vec!["alpha"]);
+        assert_eq!(result.steering.removed, vec!["guide.md"]);
+        assert!(result.agents.removed.is_empty());
+        assert!(result.skills.failures.is_empty());
+        assert!(result.steering.failures.is_empty());
+        assert!(result.agents.failures.is_empty());
 
         let post = project
             .installed_plugins()
@@ -5926,7 +5880,12 @@ mod tests {
         let result = project
             .remove_plugin(&mp("mp-a"), &pn("p"))
             .expect("remove mp-a/p");
-        assert_eq!(result.steering_removed, 1, "only mp-a/p's entry");
+        assert_eq!(result.steering.removed, vec!["a.md"], "only mp-a/p's entry");
+        assert!(result.skills.removed.is_empty());
+        assert!(result.agents.removed.is_empty());
+        assert!(result.skills.failures.is_empty());
+        assert!(result.steering.failures.is_empty());
+        assert!(result.agents.failures.is_empty());
 
         let tracking = project.load_installed_steering().expect("load");
         assert!(
@@ -5974,14 +5933,19 @@ mod tests {
             .remove_plugin(&mp("mp"), &pn("p"))
             .expect("orphan recovery: must NOT abort");
         assert_eq!(
-            result.skills_removed, 1,
+            result.skills.removed,
+            vec!["orphan"],
             "orphan tracking entry counts as removed (A-12)"
         );
         assert!(
-            result.failed.is_empty(),
+            result.skills.failures.is_empty(),
             "I3: orphan recovery is no longer a `failed` entry; remove_skill \
              drops the tracking row and treats missing on-disk dir as success"
         );
+        assert!(result.steering.removed.is_empty());
+        assert!(result.agents.removed.is_empty());
+        assert!(result.steering.failures.is_empty());
+        assert!(result.agents.failures.is_empty());
         // I3: remove_skill now drops the tracking row on the orphan
         // path, so installed_plugins() must NOT surface this plugin
         // anymore. Closes A-24.
@@ -6062,31 +6026,64 @@ mod tests {
             .expect("I5: cascade returns Ok even with per-step failures");
 
         assert_eq!(
-            result.skills_removed, 1,
+            result.skills.removed,
+            vec!["removable"],
             "I5: skill removal succeeded and counted"
         );
-        assert_eq!(
-            result.steering_removed, 0,
-            "I5: steering removal failed — count must NOT increment"
+        assert!(
+            result.steering.removed.is_empty(),
+            "I5: steering removal failed — must NOT appear in removed"
         );
         assert_eq!(
-            result.failed.len(),
+            result.steering.failures.len(),
             1,
-            "I5: exactly one failed entry expected, got {:?}",
-            result.failed
+            "I5: exactly one steering failure expected, got {:?}",
+            result.steering.failures
         );
         assert_eq!(
-            result.failed[0].content_type, "steering",
-            "I5: content_type must identify which sub-step errored"
-        );
-        assert_eq!(
-            result.failed[0].item, "guide.md",
+            result.steering.failures[0].item, "guide.md",
             "I5: item must identify which entry errored"
         );
         assert!(
-            !result.failed[0].error.is_empty(),
+            !result.steering.failures[0].error.is_empty(),
             "I5: error string must be populated via error_full_chain"
         );
+        assert!(result.skills.failures.is_empty());
+        assert!(result.agents.removed.is_empty());
+        assert!(result.agents.failures.is_empty());
+    }
+
+    #[test]
+    fn remove_plugin_result_json_shape_locks_default_empty() {
+        let result = RemovePluginResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert!(json["skills"].is_object());
+        assert!(json["steering"].is_object());
+        assert!(json["agents"].is_object());
+        assert_eq!(json["skills"]["removed"], serde_json::json!([]));
+        assert_eq!(json["skills"]["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_plugin_result_json_shape_with_populated_removed_and_failures() {
+        let result = RemovePluginResult {
+            skills: RemoveSkillsResult {
+                removed: vec!["alpha".into()],
+                failures: vec![],
+            },
+            steering: RemoveSteeringResult {
+                removed: vec![],
+                failures: vec![RemoveItemFailure {
+                    item: "broken.md".into(),
+                    error: "io: permission denied".into(),
+                }],
+            },
+            agents: RemoveAgentsResult::default(),
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["skills"]["removed"][0], "alpha");
+        assert_eq!(json["steering"]["failures"][0]["item"], "broken.md");
+        assert_eq!(json["agents"]["removed"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -72,6 +72,11 @@ pub struct InstalledAgentMeta {
     /// Which source dialect the agent was parsed from. Persisted via the
     /// enum's serde rename so the wire format stays `"claude"` / `"copilot"`.
     pub dialect: AgentDialect,
+    /// Relative path under the plugin's `agents/` directory of the
+    /// source file that was installed. `None` for legacy entries
+    /// installed before this field was added.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<PathBuf>,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
     /// install time. `None` for entries written before Stage 1 of the
@@ -384,9 +389,10 @@ pub struct RemoveSteeringResult {
 /// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
 /// the install-side [`crate::service::InstallAgentsResult`] shape.
 /// `removed` is a flat vec of translated agent names + native agent
-/// names + native companion file paths (rendered) — matches the
-/// install-side asymmetry where native companions are agent-side
-/// artifacts.
+/// names. Native companion file paths are NOT itemized (P2a-3
+/// decision α) — the `native_companions` cascade step succeeds with
+/// no per-file entries. If the FE later wants per-companion
+/// granularity, that's an additive field change.
 #[derive(Clone, Debug, Default, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct RemoveAgentsResult {
@@ -1412,7 +1418,7 @@ impl KiroProject {
     /// Cascade-remove every tracked entry from `(marketplace, plugin)`
     /// across all three `installed-*.json` tracking files. Unlinks
     /// the on-disk files, updates the tracking JSON files atomically,
-    /// and returns aggregated counts.
+    /// and returns per-content-type sub-results.
     ///
     /// **Orphan-tracking recovery (A-12 + I3).** If a tracking entry
     /// references a path that no longer exists on disk (state
@@ -1423,26 +1429,28 @@ impl KiroProject {
     /// resurrects the plugin in `installed_plugins()`.
     ///
     /// **Per-step failures (I5).** A per-content removal that fails
-    /// mid-cascade does NOT abort. The failure is recorded in
-    /// `result.failed`; the cascade keeps going on the remaining
-    /// content types so partial progress isn't lost. Same policy as
-    /// `InstallPluginResult`'s sub-result `failed` vecs (A-15).
+    /// mid-cascade does NOT abort. The failure is recorded in the
+    /// appropriate sub-result's `failures` vec (e.g.
+    /// `result.skills.failures`); the cascade keeps going on the
+    /// remaining content types so partial progress isn't lost. Same
+    /// policy as `InstallPluginResult`'s sub-result `failed` vecs
+    /// (A-15).
     ///
     /// **`native_companions` cleanup (A-3 + A-16).** After per-agent
     /// removals, the plugin-level `native_companions` entry is
     /// dropped if its `marketplace` field matches `marketplace` (the
     /// map is keyed by plugin name alone, so the marketplace check
     /// disambiguates same-named plugins across marketplaces). A
-    /// failure here also lands in `result.failed` rather than
+    /// failure here lands in `result.agents.failures` rather than
     /// short-circuiting the cascade.
     ///
     /// # Errors
     ///
     /// Reserved for "failed to even read the initial tracking files"
     /// (the three `load_installed*()` calls). Per-step errors during
-    /// the loop go into `result.failed`. Tracking-file loads can fail
-    /// with I/O errors, JSON parse errors, or path-traversal
-    /// validation errors (A-4).
+    /// the loop go into the sub-results' `failures` vecs.
+    /// Tracking-file loads can fail with I/O errors, JSON parse
+    /// errors, or path-traversal validation errors (A-4).
     pub fn remove_plugin(
         &self,
         marketplace: &MarketplaceName,
@@ -2583,6 +2591,7 @@ impl KiroProject {
                         version: version.map(String::from),
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
+                        source_path: None,
                         source_hash: Some(source_hash.to_string()),
                         installed_hash: Some(installed_hash.clone()),
                     },
@@ -3467,6 +3476,7 @@ mod tests {
             version: Some("1.2.3".into()),
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
+            source_path: None,
             source_hash: None,
             installed_hash: None,
         };
@@ -3489,6 +3499,7 @@ mod tests {
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
+            source_path: None,
             source_hash: None,
             installed_hash: None,
         };
@@ -4570,6 +4581,7 @@ mod tests {
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
+            source_path: None,
             source_hash: None,
             installed_hash: None,
         }
@@ -6155,9 +6167,20 @@ mod tests {
         )
         .expect("agents tracking");
 
-        project
+        let result = project
             .remove_plugin(&mp("mp"), &pn("p"))
             .expect("remove_plugin");
+
+        // P2a-3 sub-decision α: agents.removed does NOT itemize companion
+        // files; the step succeeds with an empty removed vec.
+        assert!(
+            result.agents.removed.is_empty(),
+            "native_companions success yields no per-file entries in agents.removed"
+        );
+        assert!(
+            result.agents.failures.is_empty(),
+            "native_companions cleanup must not fail for matching marketplace"
+        );
 
         let tracking = project.load_installed_agents().expect("load");
         assert!(

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -359,6 +359,58 @@ pub struct TrackingLoadWarning {
     pub error: String,
 }
 
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side [`InstallSkillsResult`] shape.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSkillsResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // skill names
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side `InstallSteeringResult` shape.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSteeringResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // rendered via Path::display()
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side [`crate::service::InstallAgentsResult`] shape.
+/// `removed` is a flat vec of translated agent names + native agent
+/// names + native companion file paths (rendered) — matches the
+/// install-side asymmetry where native companions are agent-side
+/// artifacts.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveAgentsResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // agent names + native companion paths, flat
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// One failure during a per-content-type removal step. The discriminator
+/// (which content type) is the parent type — no `content_type: String`
+/// field needed (it's expressed structurally via the parent's field
+/// name in [`RemovePluginResult`]).
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveItemFailure {
+    /// The skill/agent name or steering rel-path rendered via
+    /// [`std::path::Path::display`].
+    pub item: String,
+    /// Rendered error chain via [`crate::error::error_full_chain`] —
+    /// wire format per CLAUDE.md FFI rule.
+    pub error: String,
+}
+
 /// Aggregated counts returned by
 /// [`KiroProject::remove_plugin`] — one tally per content type so the
 /// caller (CLI / Tauri) can render a one-line "removed N skills,
@@ -3762,6 +3814,110 @@ mod tests {
             }
             other => panic!("expected Error::Io(InvalidData), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn remove_skills_result_json_shape_default_empty() {
+        let result = RemoveSkillsResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_skills_result_json_shape_with_populated_removed() {
+        let result = RemoveSkillsResult {
+            removed: vec!["alpha".into(), "beta".into()],
+            failures: vec![],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!(["alpha", "beta"]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_skills_result_json_shape_with_populated_failure() {
+        let result = RemoveSkillsResult {
+            removed: vec![],
+            failures: vec![RemoveItemFailure {
+                item: "broken".into(),
+                error: "io: permission denied".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["failures"][0]["item"], "broken");
+        assert_eq!(json["failures"][0]["error"], "io: permission denied");
+    }
+
+    // Symmetric tests for RemoveSteeringResult
+    #[test]
+    fn remove_steering_result_json_shape_default_empty() {
+        let result = RemoveSteeringResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_steering_result_json_shape_with_populated_removed() {
+        let result = RemoveSteeringResult {
+            removed: vec!["guide.md".into()],
+            failures: vec![],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!(["guide.md"]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_steering_result_json_shape_with_populated_failure() {
+        let result = RemoveSteeringResult {
+            removed: vec![],
+            failures: vec![RemoveItemFailure {
+                item: "broken.md".into(),
+                error: "io: permission denied".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["failures"][0]["item"], "broken.md");
+        assert_eq!(json["failures"][0]["error"], "io: permission denied");
+    }
+
+    // Symmetric tests for RemoveAgentsResult
+    #[test]
+    fn remove_agents_result_json_shape_default_empty() {
+        let result = RemoveAgentsResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_agents_result_json_shape_with_populated_removed() {
+        let result = RemoveAgentsResult {
+            removed: vec!["reviewer".into(), "companions/prompt.md".into()],
+            failures: vec![],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(
+            json["removed"],
+            serde_json::json!(["reviewer", "companions/prompt.md"])
+        );
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_agents_result_json_shape_with_populated_failure() {
+        let result = RemoveAgentsResult {
+            removed: vec![],
+            failures: vec![RemoveItemFailure {
+                item: "broken-agent".into(),
+                error: "io: permission denied".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["failures"][0]["item"], "broken-agent");
+        assert_eq!(json["failures"][0]["error"], "io: permission denied");
     }
 
     #[test]

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -184,7 +184,17 @@ impl SkippedReason {
             // `NotFound` and `ManifestNotFound` stay here because they
             // represent "caller asked for the wrong thing" — a user-input
             // bug, not a damaged plugin to fold into `skipped`.
-            PluginError::NotFound { .. } | PluginError::ManifestNotFound { .. } => None,
+            //
+            // The cache-side variants (CacheManifestReadFailed /
+            // CacheManifestInvalid) belong to the update-detection
+            // path (`detect_plugin_updates`), not the bulk-listing
+            // path that produces `SkippedPlugin`. They route through
+            // PluginUpdateFailureKind instead, so they correctly
+            // return None here.
+            PluginError::NotFound { .. }
+            | PluginError::ManifestNotFound { .. }
+            | PluginError::CacheManifestReadFailed { .. }
+            | PluginError::CacheManifestInvalid { .. } => None,
         }
     }
 }

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1107,7 +1107,13 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Err
         }
     }
 
-    let bytes = match fs::read(&manifest_path) {
+    // Resource cap: bound the read at MAX_PLUGIN_MANIFEST_BYTES so a
+    // malicious marketplace shipping a multi-GB plugin.json cannot OOM
+    // the process before serde sees a byte. Mirrors the cap applied to
+    // service::mod::load_plugin_manifest_version in the Phase 2a
+    // detection path. Pre-existing crate-wide gap flagged by
+    // marketplace-security-reviewer in PR #96 review.
+    let bytes = match super::read_capped(&manifest_path, super::MAX_PLUGIN_MANIFEST_BYTES) {
         Ok(b) => b,
         Err(e) => {
             warn!(
@@ -1554,6 +1560,38 @@ mod tests {
         assert!(
             result.is_none(),
             "symlinked plugin.json must be treated as absent, got: {result:?}"
+        );
+    }
+
+    /// Resource cap regression: a `plugin.json` larger than
+    /// `MAX_PLUGIN_MANIFEST_BYTES` (1 MiB) must be rejected before
+    /// serde sees the bytes. Mitigates the OOM vector flagged by
+    /// marketplace-security-reviewer in PR #96 review (a malicious
+    /// marketplace could otherwise ship a multi-GB manifest and OOM
+    /// the host). The cap fires at `super::read_capped`, which
+    /// returns `io::ErrorKind::InvalidData` — surfaced here as
+    /// [`PluginError::ManifestReadFailed`].
+    #[test]
+    fn load_plugin_manifest_rejects_oversized_file() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plugin_dir = tmp.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        let manifest_path = plugin_dir.join("plugin.json");
+        // Write 2 MiB of valid JSON-ish bytes — well over the 1 MiB cap.
+        // The cap fires before parse, so the content shape doesn't
+        // matter. We open with sync_data() to make sure the file is
+        // committed before the read.
+        let mut f = fs::File::create(&manifest_path).expect("create manifest");
+        f.write_all(&vec![b'A'; 2 * 1024 * 1024])
+            .expect("write 2 MiB");
+        f.sync_all().expect("sync");
+
+        let err = load_plugin_manifest(&plugin_dir)
+            .expect_err("oversized plugin.json must be refused at the cap");
+        assert!(
+            matches!(err, Error::Plugin(PluginError::ManifestReadFailed { .. })),
+            "expected ManifestReadFailed for cap-exceeded, got: {err:?}"
         );
     }
 

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -946,7 +946,7 @@ fn discover_skills_for_plugin(
 /// or its `agents` list is empty. Mirrors the "empty list means no
 /// custom paths, not no agents" fallback policy used by
 /// [`discover_skills_for_plugin`].
-fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
+pub(super) fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
     if let Some(m) = manifest.filter(|m| !m.agents.is_empty()) {
         m.agents.clone()
     } else {
@@ -961,7 +961,7 @@ fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String>
 /// back to [`crate::DEFAULT_STEERING_PATHS`] when the manifest is absent
 /// or its `steering` list is empty. Mirrors
 /// [`agent_scan_paths_for_plugin`].
-fn steering_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
+pub(super) fn steering_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
     if let Some(m) = manifest.filter(|m| !m.steering.is_empty()) {
         m.steering.clone()
     } else {

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1110,9 +1110,9 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Err
     // Resource cap: bound the read at MAX_PLUGIN_MANIFEST_BYTES so a
     // malicious marketplace shipping a multi-GB plugin.json cannot OOM
     // the process before serde sees a byte. Mirrors the cap applied to
-    // service::mod::load_plugin_manifest_version in the Phase 2a
-    // detection path. Pre-existing crate-wide gap flagged by
-    // marketplace-security-reviewer in PR #96 review.
+    // service::mod::load_plugin_manifest in the Phase 2a detection path.
+    // Pre-existing crate-wide gap flagged by marketplace-security-reviewer
+    // in PR #96 review.
     let bytes = match super::read_capped(&manifest_path, super::MAX_PLUGIN_MANIFEST_BYTES) {
         Ok(b) => b,
         Err(e) => {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2309,12 +2309,13 @@ impl MarketplaceService {
         let marketplace_path = self.marketplace_path(marketplace_name);
         let plugin_dir = self.resolve_local_plugin_dir(entry, &marketplace_path)?;
 
-        // NC1 (PR #96 re-review): when `load_plugin_manifest`
-        // collapsed `Ok(None)` for "manifest legitimately lacks
-        // version" and "manifest unreadable", the latter case combined
-        // with `installed_version: Some(_)` below to emit a phantom
-        // `PluginUpdateInfo { available_version: None, change_signal:
-        // VersionBumped }`. After the `ManifestState` 3-state split,
+        // NC1 (PR #96 re-review): pre-rename, `load_plugin_manifest_version`
+        // returned `Ok(None)` for both "manifest legitimately lacks
+        // version" and "manifest unreadable", and the latter case
+        // combined with `installed_version: Some(_)` below to emit a
+        // phantom `PluginUpdateInfo { available_version: None,
+        // change_signal: VersionBumped }`. After the `ManifestState`
+        // 3-state split (and rename to `load_plugin_manifest`),
         // unreadable surfaces as a per-plugin failure that lands in
         // `DetectUpdatesResult::failures` — never as "update available
         // to nothing".
@@ -2507,14 +2508,23 @@ impl MarketplaceService {
         let mut content_drift = false;
         let mut legacy_fallback = false;
 
-        // Skills — keyed under `skills/<name>/` per the install path's
-        // `discover_skill_dirs` recipe. Skills do not currently support
-        // a custom scan-path declaration on the manifest (the
-        // `manifest.skills: Vec<String>` field exists but the install
-        // path treats it identically across declared roots), so the
-        // hardcoded `plugin_dir.join("skills")` here is the same shape
-        // install uses today. Out of scope for the steering/agents
-        // scan-path fix.
+        // Skills — keyed under `skills/<name>/`. KNOWN BUG:
+        // `discover_skills_for_plugin` (browse.rs) honors
+        // `manifest.skills` and a plugin declaring `skills: ["./packs/"]`
+        // installs skill dirs under `<plugin_dir>/packs/<name>/`, but
+        // this loop hardcodes `plugin_dir.join("skills")` and will
+        // false-positive drift on every scan for such plugins — the
+        // same class of bug the steering/agents loops below fixed.
+        //
+        // Closing it requires either (a) probing each declared skill
+        // scan path for a directory named `<name>` (analogous to
+        // `hash_artifact_in_scan_paths` but against `hash_dir_tree`),
+        // or (b) extending `InstalledSkillMeta` with a `source_path`
+        // field so detection knows which scan root to consult without
+        // probing. Option (b) matches the `InstalledAgentMeta`
+        // precedent. Either fix is broader than the steering/agents
+        // scan-path closure shipped in this commit; tracked as a
+        // follow-up rather than expanding scope here.
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
@@ -5829,7 +5839,11 @@ mod tests {
     /// the scan can produce projects to a known
     /// [`PluginUpdateFailureKind`]. If the classifier ever silently
     /// returns `Other` for a variant that should have a typed
-    /// kind, this test surfaces the regression.
+    /// kind, this test surfaces the regression. The compiler enforces
+    /// *exhaustiveness* over `PluginError` (via `classify_plugin_error`),
+    /// but not *correct mapping* — a future swap of `CacheManifestInvalid`
+    /// from `ManifestInvalid` to `Other` would compile clean and silently
+    /// change wire-format kinds. This table locks the routing.
     #[test]
     fn plugin_update_failure_kind_from_error_classifies_known_variants() {
         use crate::error::{MarketplaceError, PluginError};
@@ -5845,6 +5859,35 @@ mod tests {
             (
                 Error::Plugin(PluginError::ManifestNotFound {
                     path: PathBuf::from("/x"),
+                }),
+                PluginUpdateFailureKind::ManifestUnreadable,
+            ),
+            // Cache-side variants — added in PR #96 and the canonical
+            // detection path. Pre-fix these routed through the
+            // `Error::Plugin(_)` wildcard into `Other`; post-fix they
+            // carry typed kinds. Locking the routing so a future
+            // refactor can't silently drop them back to `Other`.
+            (
+                Error::Plugin(PluginError::CacheManifestReadFailed {
+                    path: PathBuf::from("/x"),
+                    source: std::io::Error::new(std::io::ErrorKind::NotFound, "x"),
+                }),
+                PluginUpdateFailureKind::ManifestUnreadable,
+            ),
+            (
+                Error::Plugin(PluginError::CacheManifestInvalid {
+                    path: PathBuf::from("/x"),
+                    reason: "bad".into(),
+                }),
+                PluginUpdateFailureKind::ManifestInvalid,
+            ),
+            // Project-side counterparts that share the install-time
+            // error vocabulary; they may surface transitively via
+            // `resolve_local_plugin_dir`.
+            (
+                Error::Plugin(PluginError::ManifestReadFailed {
+                    path: PathBuf::from("/x"),
+                    source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "x"),
                 }),
                 PluginUpdateFailureKind::ManifestUnreadable,
             ),
@@ -6657,6 +6700,147 @@ mod tests {
             result.failures.is_empty(),
             "expected no failures (pre-fix would return a hash NotFound \
              error because detection looked under hardcoded `./steering/`); \
+             got: {:?}",
+            result.failures
+        );
+    }
+
+    /// PR #96 review I1: sibling of the steering test above for the
+    /// **native-companions** loop, which got the symmetric scan-path
+    /// fix. A plugin declaring `agents: ["./companions/"]` stores
+    /// companion files under `<plugin_dir>/companions/`, but pre-fix
+    /// detection hardcoded `<plugin_dir>/agents/` and would emit a
+    /// hash `NotFound` failure on every scan.
+    ///
+    /// The native-companions cascade has a separate, pre-existing
+    /// install-time hash bug (documented on
+    /// `detect_plugin_updates_copilot_agent_legacy_fallback` above —
+    /// install hashes against the destination, detection re-hashes
+    /// against the source, so the two never match through the install
+    /// path). To isolate the scan-path fix, we synthesize the tracking
+    /// entry by hand: compute the source-side hash directly via
+    /// `crate::hash::hash_artifact` and write it into
+    /// `installed-agents.json`. With the scan-path fix, detection
+    /// finds the companion under the declared `./companions/` root,
+    /// recomputes the matching hash, and reports no drift. Without
+    /// the scan-path fix, detection would look under `./agents/`
+    /// (which doesn't exist in this fixture), `hash_artifact` would
+    /// return `NotFound`, and the plugin would surface as a failure.
+    #[test]
+    fn detect_plugin_updates_native_companions_with_custom_scan_path_no_false_drift() {
+        use crate::project::{
+            InstalledAgentMeta, InstalledAgents, InstalledNativeCompanionsMeta, KiroProject,
+        };
+        use crate::service::test_support::{
+            relative_path_entry, seed_marketplace_with_registry, temp_service,
+        };
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+
+        // Companion source under a NON-default agent scan path. If
+        // detection used the hardcoded `./agents/` default,
+        // `hash_artifact_in_scan_paths` would return its synthesised
+        // NotFound and the plugin would surface as a HashFailed
+        // failure.
+        let companions_root = plugin_dir.join("companions");
+        let prompts_dir = companions_root.join("prompts");
+        fs::create_dir_all(&prompts_dir).expect("create prompts dir");
+        fs::write(prompts_dir.join("reviewer.md"), b"prompt body\n")
+            .expect("write companion source");
+
+        // Manifest declares the custom scan path. The Phase 2a fix
+        // makes `scan_plugin_for_content_drift`'s native-companions
+        // loop consult `agent_scan_paths_for_plugin(manifest)` instead
+        // of `plugin_dir.join("agents")`.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0","agents":["./companions/"]}"#,
+        )
+        .expect("write plugin.json");
+
+        // Compute the source hash directly using the install-side
+        // recipe so we can construct a tracking entry whose
+        // `source_hash` matches what the (post-fix) detection scan
+        // will recompute against the same scan root. `meta.files` is
+        // relative to the scan root, mirroring
+        // `install_native_companions_for_plugin`'s persistence shape.
+        let companion_rel = PathBuf::from("prompts/reviewer.md");
+        let source_hash =
+            crate::hash::hash_artifact(&companions_root, std::slice::from_ref(&companion_rel))
+                .expect("hash source companion");
+
+        let project_tmp = tempfile::tempdir().expect("project tempdir");
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        let kiro_dir = project_tmp.path().join(".kiro");
+        fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        // `installed_plugins()` aggregates from `agents.agents`,
+        // `skills.skills`, and `steering.files` — but NOT from
+        // `agents.native_companions`. Without an entry in one of those
+        // three maps the plugin would not surface in the scan loop and
+        // the test would pass vacuously. Mirror the pattern used by
+        // `detect_plugin_updates_copilot_agent_legacy_fallback`: a
+        // single legacy translated-agent entry (`source_hash: None`)
+        // registers the plugin and triggers only the harmless
+        // `legacy_fallback = true` branch, leaving the
+        // native-companions cascade as the only thing the assertion
+        // depends on.
+        let mut agents_map = HashMap::new();
+        agents_map.insert(
+            "registrar".to_string(),
+            InstalledAgentMeta {
+                marketplace: mp("mp"),
+                plugin: pn("p"),
+                version: Some("1.0".to_owned()),
+                installed_at: chrono::Utc::now(),
+                dialect: crate::agent::AgentDialect::Native,
+                source_path: None,
+                source_hash: None,
+                installed_hash: None,
+            },
+        );
+
+        let mut companions = HashMap::new();
+        companions.insert(
+            "p".to_string(),
+            InstalledNativeCompanionsMeta {
+                marketplace: mp("mp"),
+                plugin: pn("p"),
+                version: Some("1.0".to_owned()),
+                installed_at: chrono::Utc::now(),
+                files: vec![companion_rel.clone()],
+                source_hash: source_hash.clone(),
+                // installed_hash isn't consulted by the drift scan;
+                // any value works for this test.
+                installed_hash: source_hash,
+            },
+        );
+        let installed = InstalledAgents {
+            agents: agents_map,
+            native_companions: companions,
+        };
+        fs::write(
+            kiro_dir.join("installed-agents.json"),
+            serde_json::to_vec_pretty(&installed).expect("serialize tracking"),
+        )
+        .expect("write installed-agents.json");
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "expected no updates for an unchanged native-companions bundle \
+             under a custom agent scan path; got: {:?}",
+            result.updates
+        );
+        assert!(
+            result.failures.is_empty(),
+            "expected no failures (pre-fix would return a hash NotFound \
+             error because detection looked under hardcoded `./agents/`); \
              got: {:?}",
             result.failures
         );

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2585,6 +2585,7 @@ impl MarketplaceService {
 /// `Unreadable { reason }` is "do not compare versions — surface a
 /// per-plugin failure instead". Module-private — the public surface
 /// remains [`PluginUpdateInfo`] / [`PluginUpdateFailure`].
+#[derive(Debug)]
 enum ManifestVersion {
     /// Manifest read; carries the (possibly absent) `version` field.
     Found(Option<String>),
@@ -6457,6 +6458,33 @@ mod tests {
             result.failures
         );
         assert_eq!(result.failures[0].plugin.as_str(), "p");
+    }
+
+    /// Commit 9 / Phase 2a sibling of
+    /// `service::browse::tests::load_plugin_manifest_rejects_oversized_file`:
+    /// the detection-side `load_plugin_manifest_version` shares the
+    /// same `read_capped` defense; verify it fires here too.
+    #[test]
+    fn load_plugin_manifest_version_rejects_oversized_file() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plugin_dir = tmp.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        let manifest_path = plugin_dir.join("plugin.json");
+        let mut f = fs::File::create(&manifest_path).expect("create manifest");
+        f.write_all(&vec![b'A'; 2 * 1024 * 1024])
+            .expect("write 2 MiB");
+        f.sync_all().expect("sync");
+
+        let err = MarketplaceService::load_plugin_manifest_version(&plugin_dir)
+            .expect_err("oversized plugin.json must be refused at the cap");
+        assert!(
+            matches!(
+                err,
+                Error::Plugin(PluginError::CacheManifestReadFailed { .. })
+            ),
+            "expected CacheManifestReadFailed for cap-exceeded, got: {err:?}"
+        );
     }
 
     /// I-N2 (PR #96 re-review): mirrors `service::browse::tests::

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2503,7 +2503,43 @@ impl MarketplaceService {
                             meta.dialect,
                             meta.source_path.as_ref(),
                         );
-                        let computed = crate::hash::hash_artifact(&base, &[filename])?;
+                        let computed = match crate::hash::hash_artifact(
+                            &base,
+                            std::slice::from_ref(&filename),
+                        ) {
+                            Ok(h) => h,
+                            Err(crate::hash::HashError::ReadFailed { path, source })
+                                if source.kind() == std::io::ErrorKind::NotFound
+                                    && meta.source_path.is_none() =>
+                            {
+                                // I-N7 (PR #96 re-review): the dialect
+                                // fallback resolved a path that doesn't
+                                // exist in the cache — typical cause is
+                                // a pre-C7 install (no source_path
+                                // tracked) where the install-time
+                                // filename convention disagrees with
+                                // detection's dialect-fallback (e.g. a
+                                // Copilot agent installed under a
+                                // non-`{name}.agent.md` filename).
+                                // Surface an actionable message instead
+                                // of "file not found".
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::NotFound,
+                                    format!(
+                                        "agent `{name}` was installed before \
+                                         `source_path` tracking landed (legacy \
+                                         entry); the dialect-fallback path `{}` is \
+                                         not present in the marketplace cache. \
+                                         Reinstall the plugin to populate \
+                                         `source_path` so update detection can \
+                                         locate the source file unambiguously.",
+                                        path.display(),
+                                    ),
+                                )
+                                .into());
+                            }
+                            Err(e) => return Err(e.into()),
+                        };
                         if computed != *stored {
                             content_drift = true;
                             return Ok((content_drift, legacy_fallback));

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -496,16 +496,94 @@ pub struct PluginUpdateInfo {
     pub change_signal: UpdateChangeSignal,
 }
 
-/// A plugin the update scan couldn't check. `reason` is the rendered
-/// error chain via [`crate::error::error_full_chain`] per CLAUDE.md FFI
-/// rule (any wire-format `reason`/`error: String` field uses
-/// `error_full_chain(&err)`, not `err.to_string()`).
+/// A plugin the update scan couldn't check.
+///
+/// `kind` is the stable programmatic discriminant frontends should
+/// `match` on (per CLAUDE.md Rule 42: match error types, not error
+/// strings). `reason` is the rendered error chain via
+/// [`crate::error::error_full_chain`] per the FFI rule — suitable for
+/// log lines or fallback UI rendering, but never for branching logic.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct PluginUpdateFailure {
     pub marketplace: crate::validation::MarketplaceName,
     pub plugin: crate::validation::PluginName,
+    pub kind: PluginUpdateFailureKind,
     pub reason: String,
+}
+
+/// Why an update-detection scan couldn't check a plugin. Tagged enum
+/// for FFI per the `ffi-enum-serde-tag` plan-lint gate (PR #91):
+/// `#[serde(tag = "kind", rename_all = "snake_case")]` produces
+/// `{ "kind": "manifest_unreadable" }` in JSON, which `tauri-specta`
+/// emits as a discriminated TS union.
+///
+/// Closes original-review I4: `PluginUpdateFailure` was opaque
+/// (substring matching `reason` to differentiate failure types
+/// violated CLAUDE.md Rule 42). The classifier
+/// [`PluginUpdateFailureKind::from_error`] is exhaustive per the
+/// CLAUDE.md classifier rule — a new error variant either matches
+/// here explicitly or routes through `Other` after a written-down
+/// rationale.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginUpdateFailureKind {
+    /// Marketplace cache directory missing or plugin removed from
+    /// the marketplace's manifest.
+    MarketplaceUnavailable,
+    /// `plugin.json` missing in the marketplace cache (typically the
+    /// plugin was deleted from upstream and the cache hasn't been
+    /// refreshed). Also covers symlink-refused per the C5 defense.
+    ManifestUnreadable,
+    /// `plugin.json` exists but failed to parse (malformed JSON,
+    /// missing required fields, etc.).
+    ManifestInvalid,
+    /// Hash recomputation against an installed file failed (file
+    /// missing in the cache, permission denied, etc.).
+    HashFailed,
+    /// Catch-all for unanticipated failure shapes. Surfacing this
+    /// rather than panicking lets the FE render a generic "scan
+    /// failed" badge while the typed variants drive specific
+    /// remediation. Each new error class deliberately routed here
+    /// should also be considered for promotion to a typed variant.
+    Other,
+}
+
+impl PluginUpdateFailureKind {
+    /// Project an [`Error`] into the right
+    /// [`PluginUpdateFailureKind`] variant. Exhaustive per the
+    /// CLAUDE.md classifier rule — every entry-point error class
+    /// `check_plugin_for_update` can produce is enumerated; the
+    /// final `Other` arm is reserved for genuinely unanticipated
+    /// errors and is intentional rather than a `_` catch-all.
+    #[must_use]
+    pub fn from_error(err: &Error) -> Self {
+        match err {
+            Error::Plugin(PluginError::NotFound { .. }) => Self::MarketplaceUnavailable,
+            Error::Plugin(
+                PluginError::ManifestNotFound { .. } | PluginError::ManifestReadFailed { .. },
+            ) => Self::ManifestUnreadable,
+            Error::Plugin(PluginError::InvalidManifest { .. }) => Self::ManifestInvalid,
+            Error::Hash(_) => Self::HashFailed,
+            Error::Marketplace(crate::error::MarketplaceError::NotFound { .. }) => {
+                Self::MarketplaceUnavailable
+            }
+            // All other Plugin variants and all other top-level
+            // Error categories route to Other. Written down so a new
+            // variant lands here intentionally rather than silently.
+            Error::Plugin(_)
+            | Error::Marketplace(_)
+            | Error::Skill(_)
+            | Error::Agent(_)
+            | Error::Steering(_)
+            | Error::Git(_)
+            | Error::Validation(_)
+            | Error::Io(_)
+            | Error::Json(_) => Self::Other,
+        }
+    }
 }
 
 /// Why an update is being surfaced. Tagged enum for FFI per the
@@ -2129,6 +2207,7 @@ impl MarketplaceService {
                 Err(err) => failures.push(PluginUpdateFailure {
                     marketplace: plugin_info.marketplace.clone(),
                     plugin: plugin_info.plugin.clone(),
+                    kind: PluginUpdateFailureKind::from_error(&err),
                     reason: error_full_chain(&err),
                 }),
             }
@@ -5442,6 +5521,7 @@ mod tests {
             failures: vec![PluginUpdateFailure {
                 marketplace: mp("mp2"),
                 plugin: pn("p2"),
+                kind: PluginUpdateFailureKind::ManifestUnreadable,
                 reason: "marketplace not in cache".into(),
             }],
             partial_load_warnings: vec![crate::project::TrackingLoadWarning {
@@ -5460,6 +5540,7 @@ mod tests {
         );
         assert_eq!(json["failures"][0]["marketplace"], "mp2");
         assert_eq!(json["failures"][0]["plugin"], "p2");
+        assert_eq!(json["failures"][0]["kind"]["kind"], "manifest_unreadable");
         assert_eq!(json["failures"][0]["reason"], "marketplace not in cache");
         assert_eq!(
             json["partial_load_warnings"][0]["tracking_file"],
@@ -5494,6 +5575,75 @@ mod tests {
         };
         let json = serde_json::to_value(&info).expect("serialize");
         assert_eq!(json["change_signal"]["kind"], "content_changed");
+    }
+
+    /// JSON-shape lock for every [`PluginUpdateFailureKind`] variant
+    /// — pins the wire-format discriminator strings so a future
+    /// rename or `serde(rename)` typo lights up tests, not the
+    /// frontend's `match` arms. The frontend must branch on `kind`
+    /// (Rule 42), so each tag string is part of the FFI contract.
+    #[rstest::rstest]
+    #[case(
+        PluginUpdateFailureKind::MarketplaceUnavailable,
+        "marketplace_unavailable"
+    )]
+    #[case(PluginUpdateFailureKind::ManifestUnreadable, "manifest_unreadable")]
+    #[case(PluginUpdateFailureKind::ManifestInvalid, "manifest_invalid")]
+    #[case(PluginUpdateFailureKind::HashFailed, "hash_failed")]
+    #[case(PluginUpdateFailureKind::Other, "other")]
+    fn plugin_update_failure_kind_json_shape(
+        #[case] kind: PluginUpdateFailureKind,
+        #[case] expected_tag: &str,
+    ) {
+        let json = serde_json::to_value(&kind).expect("serialize");
+        assert_eq!(
+            json["kind"], expected_tag,
+            "wire-format discriminator must stay stable for FE branching"
+        );
+    }
+
+    /// Classifier-exhaustiveness witness: every entry-point error
+    /// the scan can produce projects to a known
+    /// [`PluginUpdateFailureKind`]. If the classifier ever silently
+    /// returns `Other` for a variant that should have a typed
+    /// kind, this test surfaces the regression.
+    #[test]
+    fn plugin_update_failure_kind_from_error_classifies_known_variants() {
+        use crate::error::{MarketplaceError, PluginError};
+        use std::path::PathBuf;
+        let cases: &[(Error, PluginUpdateFailureKind)] = &[
+            (
+                Error::Plugin(PluginError::NotFound {
+                    plugin: "p".into(),
+                    marketplace: "m".into(),
+                }),
+                PluginUpdateFailureKind::MarketplaceUnavailable,
+            ),
+            (
+                Error::Plugin(PluginError::ManifestNotFound {
+                    path: PathBuf::from("/x"),
+                }),
+                PluginUpdateFailureKind::ManifestUnreadable,
+            ),
+            (
+                Error::Plugin(PluginError::InvalidManifest {
+                    path: PathBuf::from("/x"),
+                    reason: "bad".into(),
+                }),
+                PluginUpdateFailureKind::ManifestInvalid,
+            ),
+            (
+                Error::Marketplace(MarketplaceError::NotFound { name: "m".into() }),
+                PluginUpdateFailureKind::MarketplaceUnavailable,
+            ),
+        ];
+        for (err, expected) in cases {
+            let got = PluginUpdateFailureKind::from_error(err);
+            assert!(
+                std::mem::discriminant(&got) == std::mem::discriminant(expected),
+                "from_error({err:?}) -> {got:?}, expected {expected:?}"
+            );
+        }
     }
 
     // -------------------------------------------------------------------

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2508,7 +2508,7 @@ impl MarketplaceService {
         let mut content_drift = false;
         let mut legacy_fallback = false;
 
-        // Skills — keyed under `skills/<name>/`. KNOWN BUG:
+        // Skills — keyed under `skills/<name>/`. KNOWN BUG (issue #97):
         // `discover_skills_for_plugin` (browse.rs) honors
         // `manifest.skills` and a plugin declaring `skills: ["./packs/"]`
         // installs skill dirs under `<plugin_dir>/packs/<name>/`, but
@@ -2522,9 +2522,10 @@ impl MarketplaceService {
         // or (b) extending `InstalledSkillMeta` with a `source_path`
         // field so detection knows which scan root to consult without
         // probing. Option (b) matches the `InstalledAgentMeta`
-        // precedent. Either fix is broader than the steering/agents
-        // scan-path closure shipped in this commit; tracked as a
-        // follow-up rather than expanding scope here.
+        // precedent. Tracked at
+        // https://github.com/dwalleck/kiro-control-center/issues/97
+        // — out of scope for the steering/agents scan-path closure
+        // shipped in PR #96.
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -562,10 +562,20 @@ impl PluginUpdateFailureKind {
     pub fn from_error(err: &Error) -> Self {
         match err {
             Error::Plugin(PluginError::NotFound { .. }) => Self::MarketplaceUnavailable,
+            // Cache-side variants are the canonical detection path
+            // (Phase 2a). Project-side variants
+            // (`ManifestReadFailed` / `InvalidManifest`) map here too
+            // because `check_plugin_for_update` may surface them
+            // transitively via `resolve_local_plugin_dir` which
+            // shares the install-time error vocabulary.
             Error::Plugin(
-                PluginError::ManifestNotFound { .. } | PluginError::ManifestReadFailed { .. },
+                PluginError::ManifestNotFound { .. }
+                | PluginError::ManifestReadFailed { .. }
+                | PluginError::CacheManifestReadFailed { .. },
             ) => Self::ManifestUnreadable,
-            Error::Plugin(PluginError::InvalidManifest { .. }) => Self::ManifestInvalid,
+            Error::Plugin(
+                PluginError::InvalidManifest { .. } | PluginError::CacheManifestInvalid { .. },
+            ) => Self::ManifestInvalid,
             Error::Hash(_) => Self::HashFailed,
             Error::Marketplace(crate::error::MarketplaceError::NotFound { .. }) => {
                 Self::MarketplaceUnavailable
@@ -2252,11 +2262,14 @@ impl MarketplaceService {
             ManifestVersion::Found(v) => v,
             ManifestVersion::Unreadable { reason } => {
                 let manifest_path = plugin_dir.join("plugin.json");
-                // ManifestNotFound's Display embeds the path; we wrap
-                // the symlink/missing distinction into the carried
-                // io::Error so error_full_chain renders both pieces in
-                // the wire-format `PluginUpdateFailure.reason`.
-                return Err(PluginError::ManifestReadFailed {
+                // CacheManifestReadFailed's Display embeds the path;
+                // we wrap the symlink/missing distinction into the
+                // carried io::Error so error_full_chain renders both
+                // pieces in the wire-format `PluginUpdateFailure.reason`.
+                // The cache-side variant routes through
+                // PluginUpdateFailureKind::ManifestUnreadable in the
+                // outer detect_plugin_updates loop (see Commit 5).
+                return Err(PluginError::CacheManifestReadFailed {
                     path: manifest_path,
                     source: std::io::Error::new(std::io::ErrorKind::NotFound, reason),
                 }
@@ -2350,7 +2363,7 @@ impl MarketplaceService {
                 });
             }
             Err(e) => {
-                return Err(PluginError::ManifestReadFailed {
+                return Err(PluginError::CacheManifestReadFailed {
                     path: manifest_path,
                     source: e,
                 }
@@ -2361,7 +2374,7 @@ impl MarketplaceService {
         let bytes = match read_capped(&manifest_path, MAX_PLUGIN_MANIFEST_BYTES) {
             Ok(b) => b,
             Err(e) => {
-                return Err(PluginError::ManifestReadFailed {
+                return Err(PluginError::CacheManifestReadFailed {
                     path: manifest_path,
                     source: e,
                 }
@@ -2371,7 +2384,7 @@ impl MarketplaceService {
 
         match crate::plugin::PluginManifest::from_json(&bytes) {
             Ok(manifest) => Ok(ManifestVersion::Found(manifest.version)),
-            Err(e) => Err(PluginError::InvalidManifest {
+            Err(e) => Err(PluginError::CacheManifestInvalid {
                 path: manifest_path,
                 reason: error_full_chain(&e),
             }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -452,6 +452,12 @@ pub struct InstallPluginResult {
 /// from cache, manifest malformed, hash computation failure). Plugins
 /// with no update available are absent from both vecs (the implicit
 /// "everything's fine" set).
+///
+/// `partial_load_warnings` carries tracking-file load failures that
+/// happened before `installed_plugins()` returned — e.g. a corrupt
+/// `installed-skills.json` means the corresponding skills are missing
+/// from `plugins` and the warning is surfaced here so the caller can
+/// render a "partial state" banner.
 #[derive(Clone, Debug, Default, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct DetectUpdatesResult {
@@ -459,6 +465,8 @@ pub struct DetectUpdatesResult {
     pub updates: Vec<PluginUpdateInfo>,
     #[serde(default)]
     pub failures: Vec<PluginUpdateFailure>,
+    #[serde(default)]
+    pub partial_load_warnings: Vec<crate::project::TrackingLoadWarning>,
 }
 
 /// A single plugin with an update available. `installed_version` is
@@ -1580,6 +1588,10 @@ impl MarketplaceService {
                 version: ctx.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
+                source_path: path
+                    .strip_prefix(plugin_dir)
+                    .ok()
+                    .map(std::path::Path::to_path_buf),
                 source_hash: None,
                 installed_hash: None,
             };
@@ -2112,7 +2124,11 @@ impl MarketplaceService {
                 }),
             }
         }
-        Ok(DetectUpdatesResult { updates, failures })
+        Ok(DetectUpdatesResult {
+            updates,
+            failures,
+            partial_load_warnings: view.partial_load_warnings,
+        })
     }
 
     fn check_plugin_for_update(
@@ -2133,12 +2149,7 @@ impl MarketplaceService {
             })?;
 
         let marketplace_path = self.marketplace_path(marketplace_name);
-        let plugin_dir = self.resolve_plugin_dir(
-            entry,
-            &marketplace_path,
-            marketplace_name,
-            GitProtocol::Https,
-        )?;
+        let plugin_dir = self.resolve_local_plugin_dir(entry, &marketplace_path)?;
 
         let available_version = Self::load_plugin_manifest_version(&plugin_dir)?;
 
@@ -2179,6 +2190,29 @@ impl MarketplaceService {
     /// Load `plugin.json` from `plugin_dir` and return its `version` field.
     fn load_plugin_manifest_version(plugin_dir: &Path) -> Result<Option<String>, Error> {
         let manifest_path = plugin_dir.join("plugin.json");
+
+        // Symlink defense: refuse to follow symlinks (C5 security fix).
+        match fs::symlink_metadata(&manifest_path) {
+            Ok(m) if m.file_type().is_symlink() => {
+                warn!(
+                    path = %manifest_path.display(),
+                    "plugin.json is a symlink, refusing to follow; treating as missing"
+                );
+                return Ok(None);
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(PluginError::ManifestReadFailed {
+                    path: manifest_path,
+                    source: e,
+                }
+                .into());
+            }
+        }
+
         match fs::read(&manifest_path) {
             Ok(bytes) => match crate::plugin::PluginManifest::from_json(&bytes) {
                 Ok(manifest) => Ok(manifest.version),
@@ -2188,7 +2222,6 @@ impl MarketplaceService {
                 }
                 .into()),
             },
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(PluginError::ManifestReadFailed {
                 path: manifest_path,
                 source: e,
@@ -2252,12 +2285,20 @@ impl MarketplaceService {
                 match &meta.source_hash {
                     Some(stored) => {
                         let agents_dir = plugin_dir.join("agents");
-                        let rel_path = match meta.dialect {
-                            crate::agent::AgentDialect::Native => {
-                                PathBuf::from(format!("{name}.json"))
-                            }
-                            _ => PathBuf::from(format!("{name}.md")),
-                        };
+                        let rel_path =
+                            meta.source_path
+                                .clone()
+                                .unwrap_or_else(|| match meta.dialect {
+                                    crate::agent::AgentDialect::Native => {
+                                        PathBuf::from(format!("{name}.json"))
+                                    }
+                                    crate::agent::AgentDialect::Claude => {
+                                        PathBuf::from(format!("{name}.md"))
+                                    }
+                                    crate::agent::AgentDialect::Copilot => {
+                                        PathBuf::from(format!("{name}.agent.md"))
+                                    }
+                                });
                         let computed = crate::hash::hash_artifact(&agents_dir, &[rel_path])?;
                         if computed != *stored {
                             content_drift = true;
@@ -5156,6 +5197,7 @@ mod tests {
         let json = serde_json::to_value(&result).expect("serialize");
         assert_eq!(json["updates"], serde_json::json!([]));
         assert_eq!(json["failures"], serde_json::json!([]));
+        assert_eq!(json["partial_load_warnings"], serde_json::json!([]));
     }
 
     #[test]
@@ -5174,6 +5216,10 @@ mod tests {
                 plugin: pn("p2"),
                 reason: "marketplace not in cache".into(),
             }],
+            partial_load_warnings: vec![crate::project::TrackingLoadWarning {
+                tracking_file: "installed-skills.json".into(),
+                error: "simulated".into(),
+            }],
         };
         let json = serde_json::to_value(&result).expect("serialize");
         assert_eq!(json["updates"][0]["marketplace"], "mp1");
@@ -5187,6 +5233,11 @@ mod tests {
         assert_eq!(json["failures"][0]["marketplace"], "mp2");
         assert_eq!(json["failures"][0]["plugin"], "p2");
         assert_eq!(json["failures"][0]["reason"], "marketplace not in cache");
+        assert_eq!(
+            json["partial_load_warnings"][0]["tracking_file"],
+            "installed-skills.json"
+        );
+        assert_eq!(json["partial_load_warnings"][0]["error"], "simulated");
     }
 
     #[test]
@@ -5373,6 +5424,66 @@ mod tests {
         assert_eq!(result.failures.len(), 1);
         assert_eq!(result.failures[0].plugin.as_str(), "p");
         assert_eq!(result.failures[0].marketplace.as_str(), "mp");
+    }
+
+    #[test]
+    fn detect_plugin_updates_structured_source_returns_failure() {
+        use crate::marketplace::{PluginEntry, PluginSource, StructuredSource};
+        use crate::project::KiroProject;
+        use crate::service::test_support::{mp, pn, seed_marketplace_with_registry, temp_service};
+
+        let (dir, svc) = temp_service();
+
+        // Seed marketplace with a structured-source plugin.
+        let entries = vec![PluginEntry {
+            name: "structured-p".into(),
+            description: None,
+            source: PluginSource::Structured(StructuredSource::GitHub {
+                repo: "foo/bar".into(),
+                git_ref: Some("main".into()),
+                sha: None,
+            }),
+        }];
+        let _mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+
+        // Manually create a project with a tracking entry for this plugin.
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        let tracking = crate::project::InstalledSkills {
+            skills: [(
+                "dummy-skill".into(),
+                crate::project::InstalledSkillMeta {
+                    marketplace: mp("mp"),
+                    plugin: pn("structured-p"),
+                    version: Some("1.0".into()),
+                    installed_at: chrono::Utc::now(),
+                    source_hash: None,
+                    installed_hash: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
+        std::fs::create_dir_all(tracking_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &tracking_path,
+            serde_json::to_vec_pretty(&tracking).unwrap(),
+        )
+        .unwrap();
+
+        // Detection must NOT clone; it should return a per-plugin failure.
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(result.updates.is_empty());
+        assert_eq!(result.failures.len(), 1);
+        assert_eq!(result.failures[0].plugin.as_str(), "structured-p");
+        assert_eq!(result.failures[0].marketplace.as_str(), "mp");
+        assert!(
+            result.failures[0].reason.contains("remote source"),
+            "expected remote-source failure, got: {}",
+            result.failures[0].reason
+        );
     }
 
     #[test]
@@ -5619,6 +5730,186 @@ mod tests {
         assert!(matches!(
             result.updates[0].change_signal,
             UpdateChangeSignal::ContentChanged
+        ));
+        assert!(result.failures.is_empty());
+    }
+
+    /// P2a-1 finding: malformed plugin.json must surface as a per-plugin
+    /// failure, not as a toplevel Err.
+    #[test]
+    fn detect_plugin_updates_malformed_plugin_json_surfaces_as_failure() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        // Write a VALID manifest for install, then corrupt it after.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Now corrupt the manifest so the detection scan hits InvalidManifest.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":1.0}"#, // 1.0 is a number, not a string — malformed
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "malformed manifest must not produce an update entry"
+        );
+        assert_eq!(
+            result.failures.len(),
+            1,
+            "malformed manifest must produce exactly one failure, got: {:?}",
+            result.failures
+        );
+        assert_eq!(result.failures[0].plugin.as_str(), "p");
+        assert!(
+            result.failures[0].reason.contains("manifest"),
+            "failure reason must mention the manifest, got: {}",
+            result.failures[0].reason
+        );
+    }
+
+    /// P2a-1 finding: an unreadable plugin.json (directory instead of file)
+    /// must surface as a per-plugin failure via `ManifestReadFailed`.
+    #[test]
+    fn detect_plugin_updates_unreadable_plugin_json_surfaces_as_failure() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Replace plugin.json with a directory so fs::read fails
+        fs::remove_file(plugin_dir.join("plugin.json")).unwrap();
+        fs::create_dir(plugin_dir.join("plugin.json")).unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "unreadable manifest must not produce an update entry"
+        );
+        assert_eq!(
+            result.failures.len(),
+            1,
+            "unreadable manifest must produce exactly one failure, got: {:?}",
+            result.failures
+        );
+        assert_eq!(result.failures[0].plugin.as_str(), "p");
+        assert!(
+            result.failures[0].reason.contains("manifest"),
+            "failure reason must mention the manifest, got: {}",
+            result.failures[0].reason
+        );
+    }
+
+    /// P2a-4 finding: agents have the same `Option<String>` `source_hash` shape
+    /// as skills and must follow the same legacy fallback path. Uses a
+    /// native-format agent to avoid the translated-agent companion-files
+    /// path-reconstruction complexity (C7).
+    #[test]
+    fn detect_plugin_updates_agent_legacy_fallback_source_hash_none() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        let agents_dir = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("reviewer.json"),
+            br#"{"name":"reviewer","description":"Reviews"}"#,
+        )
+        .unwrap();
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0","format":"kiro-cli"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Verify the agent was actually installed before mutating.
+        let tracking_pre = project.load_installed_agents().unwrap();
+        assert!(
+            tracking_pre.agents.contains_key("reviewer"),
+            "agent must be installed before test mutation"
+        );
+
+        // Set agent source_hash: None in tracking file
+        let mut tracking = project.load_installed_agents().unwrap();
+        for meta in tracking.agents.values_mut() {
+            meta.source_hash = None;
+        }
+        let tracking_path = project_tmp.path().join(".kiro/installed-agents.json");
+        fs::write(
+            &tracking_path,
+            serde_json::to_vec_pretty(&tracking).unwrap(),
+        )
+        .unwrap();
+
+        // Bump version
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.1","format":"kiro-cli"}"#,
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(
+            result.updates.len(),
+            1,
+            "agent with source_hash: None and version bump must surface as update, got: {result:?}"
+        );
+        assert_eq!(result.updates[0].plugin.as_str(), "p");
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
         ));
         assert!(result.failures.is_empty());
     }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -469,17 +469,29 @@ pub struct DetectUpdatesResult {
     pub partial_load_warnings: Vec<crate::project::TrackingLoadWarning>,
 }
 
-/// A single plugin with an update available. `installed_version` is
-/// `None` for legacy installs whose tracking file lacked the version
-/// field; `available_version` is `None` when the marketplace plugin
-/// manifest itself lacks a version. The `change_signal` discriminates
-/// between manifest-version change and content-drift-without-version-bump.
+/// A single plugin with an update available.
+///
+/// The `change_signal` discriminates between manifest-version change
+/// and content-drift-without-version-bump.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct PluginUpdateInfo {
     pub marketplace: crate::validation::MarketplaceName,
     pub plugin: crate::validation::PluginName,
+    /// `None` means the project's tracking file lacked a `version`
+    /// field at install time (a legacy install pre-Stage-1, before
+    /// the version field was added to the tracking schema). Cases
+    /// where the tracking file itself failed to load are surfaced via
+    /// [`DetectUpdatesResult::partial_load_warnings`], NOT via
+    /// `Some(None)` here.
     pub installed_version: Option<String>,
+    /// `None` means the marketplace plugin manifest exists but lacks
+    /// a `version` field. After NC1's `ManifestVersion` 3-state
+    /// split, cases where the manifest is missing or unreadable
+    /// (symlinked, `NotFound`) surface as a [`PluginUpdateFailure`] —
+    /// they no longer collapse into `Some(None)` here. So
+    /// `available_version: None` is now an unambiguous "marketplace
+    /// says no version" signal.
     pub available_version: Option<String>,
     pub change_signal: UpdateChangeSignal,
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2065,6 +2065,224 @@ impl MarketplaceService {
             agents,
         })
     }
+
+    /// Scan installed plugins, comparing each tracking-file `version` and
+    /// `source_hash` against the corresponding marketplace plugin manifest +
+    /// source files in the local cache. Reads from local cache only;
+    /// callers run `update_marketplaces` first if they want fresh data.
+    ///
+    /// "Update available" = at least one source-hash differs from the
+    /// tracking entry's `source_hash`, OR the marketplace plugin manifest's
+    /// `version` is not byte-equal to the most-recently-installed version
+    /// across the three tracking files. Strict string inequality on
+    /// versions, no semver — downgrades pushed by marketplace owners are
+    /// surfaced.
+    ///
+    /// Per-plugin failures (marketplace gone from cache, plugin removed
+    /// from manifest, manifest malformed, hash recomputation failed) land
+    /// in `failures`, not in `Result::Err`. Plugins with no update available
+    /// are absent from both vecs.
+    ///
+    /// Legacy fallback: if any tracked file's `source_hash` is `None`
+    /// (pre-Stage-1 install), drop back to version-only comparison for that
+    /// plugin. Same versions in legacy mode -> no entry in updates (content
+    /// drift undetectable until next install).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only if `project.installed_plugins()` fails to load
+    /// the aggregate view (e.g. a tracking file is unreadable at the
+    /// `installed_plugins()` layer). Per-plugin scan failures are collected
+    /// in `DetectUpdatesResult::failures`, not in `Result::Err`.
+    pub fn detect_plugin_updates(
+        &self,
+        project: &crate::project::KiroProject,
+    ) -> Result<DetectUpdatesResult, Error> {
+        let view = project.installed_plugins()?;
+        let mut updates = Vec::new();
+        let mut failures = Vec::new();
+        for plugin_info in view.plugins {
+            match self.check_plugin_for_update(project, &plugin_info) {
+                Ok(Some(update)) => updates.push(update),
+                Ok(None) => {}
+                Err(err) => failures.push(PluginUpdateFailure {
+                    marketplace: plugin_info.marketplace.clone(),
+                    plugin: plugin_info.plugin.clone(),
+                    reason: error_full_chain(&err),
+                }),
+            }
+        }
+        Ok(DetectUpdatesResult { updates, failures })
+    }
+
+    fn check_plugin_for_update(
+        &self,
+        project: &crate::project::KiroProject,
+        plugin_info: &crate::project::InstalledPluginInfo,
+    ) -> Result<Option<PluginUpdateInfo>, Error> {
+        let marketplace_name = plugin_info.marketplace.as_str();
+        let plugin_name = plugin_info.plugin.as_str();
+
+        let entries = self.list_plugin_entries(marketplace_name)?;
+        let entry = entries
+            .iter()
+            .find(|e| e.name == plugin_name)
+            .ok_or_else(|| PluginError::NotFound {
+                plugin: plugin_name.to_owned(),
+                marketplace: marketplace_name.to_owned(),
+            })?;
+
+        let marketplace_path = self.marketplace_path(marketplace_name);
+        let plugin_dir = self.resolve_plugin_dir(
+            entry,
+            &marketplace_path,
+            marketplace_name,
+            GitProtocol::Https,
+        )?;
+
+        let available_version = Self::load_plugin_manifest_version(&plugin_dir)?;
+
+        let (content_drift, legacy_fallback) =
+            Self::scan_plugin_for_content_drift(project, plugin_info, &plugin_dir)?;
+
+        let installed_version = plugin_info.installed_version.clone();
+        let version_differs = installed_version != available_version;
+
+        if version_differs {
+            return Ok(Some(PluginUpdateInfo {
+                marketplace: plugin_info.marketplace.clone(),
+                plugin: plugin_info.plugin.clone(),
+                installed_version,
+                available_version,
+                change_signal: UpdateChangeSignal::VersionBumped,
+            }));
+        }
+
+        if content_drift {
+            return Ok(Some(PluginUpdateInfo {
+                marketplace: plugin_info.marketplace.clone(),
+                plugin: plugin_info.plugin.clone(),
+                installed_version,
+                available_version,
+                change_signal: UpdateChangeSignal::ContentChanged,
+            }));
+        }
+
+        if legacy_fallback {
+            // Drift undetectable — same versions means no entry.
+            return Ok(None);
+        }
+
+        Ok(None)
+    }
+
+    /// Load `plugin.json` from `plugin_dir` and return its `version` field.
+    fn load_plugin_manifest_version(plugin_dir: &Path) -> Result<Option<String>, Error> {
+        let manifest_path = plugin_dir.join("plugin.json");
+        match fs::read(&manifest_path) {
+            Ok(bytes) => match crate::plugin::PluginManifest::from_json(&bytes) {
+                Ok(manifest) => Ok(manifest.version),
+                Err(e) => Err(PluginError::InvalidManifest {
+                    path: manifest_path,
+                    reason: error_full_chain(&e),
+                }
+                .into()),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(PluginError::ManifestReadFailed {
+                path: manifest_path,
+                source: e,
+            }
+            .into()),
+        }
+    }
+
+    /// Scan all tracking entries for `(marketplace, plugin)` and compare
+    /// their stored `source_hash` against freshly-computed hashes from
+    /// `plugin_dir`.
+    ///
+    /// `content_drift = false && legacy_fallback = true` means "no drift
+    /// detected among hashable entries; some entries had no `source_hash`
+    /// so a clean miss is possible." Callers should treat `legacy_fallback`
+    /// as "drift undetectable" rather than "drift absent."
+    fn scan_plugin_for_content_drift(
+        project: &crate::project::KiroProject,
+        plugin_info: &crate::project::InstalledPluginInfo,
+        plugin_dir: &Path,
+    ) -> Result<(bool, bool), Error> {
+        let mut content_drift = false;
+        let mut legacy_fallback = false;
+
+        // Skills
+        let installed_skills = project.load_installed()?;
+        for (name, meta) in &installed_skills.skills {
+            if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+                match &meta.source_hash {
+                    Some(stored) => {
+                        let skill_dir = plugin_dir.join("skills").join(name);
+                        let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+                        if computed != *stored {
+                            content_drift = true;
+                            return Ok((content_drift, legacy_fallback));
+                        }
+                    }
+                    None => legacy_fallback = true,
+                }
+            }
+        }
+
+        // Steering
+        let installed_steering = project.load_installed_steering()?;
+        for (rel_path, meta) in &installed_steering.files {
+            if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+                let steering_dir = plugin_dir.join("steering");
+                let computed =
+                    crate::hash::hash_artifact(&steering_dir, std::slice::from_ref(rel_path))?;
+                if computed != meta.source_hash {
+                    content_drift = true;
+                    return Ok((content_drift, legacy_fallback));
+                }
+            }
+        }
+
+        // Agents
+        let installed_agents = project.load_installed_agents()?;
+        for (name, meta) in &installed_agents.agents {
+            if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+                match &meta.source_hash {
+                    Some(stored) => {
+                        let agents_dir = plugin_dir.join("agents");
+                        let rel_path = match meta.dialect {
+                            crate::agent::AgentDialect::Native => {
+                                PathBuf::from(format!("{name}.json"))
+                            }
+                            _ => PathBuf::from(format!("{name}.md")),
+                        };
+                        let computed = crate::hash::hash_artifact(&agents_dir, &[rel_path])?;
+                        if computed != *stored {
+                            content_drift = true;
+                            return Ok((content_drift, legacy_fallback));
+                        }
+                    }
+                    None => legacy_fallback = true,
+                }
+            }
+        }
+
+        // Native companions
+        for meta in installed_agents.native_companions.values() {
+            if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+                let agents_dir = plugin_dir.join("agents");
+                let computed = crate::hash::hash_artifact(&agents_dir, &meta.files)?;
+                if computed != meta.source_hash {
+                    content_drift = true;
+                    return Ok((content_drift, legacy_fallback));
+                }
+            }
+        }
+
+        Ok((content_drift, legacy_fallback))
+    }
 }
 
 /// Decide whether a skill name passes the install filter.
@@ -4997,5 +5215,411 @@ mod tests {
         };
         let json = serde_json::to_value(&info).expect("serialize");
         assert_eq!(json["change_signal"]["kind"], "content_changed");
+    }
+
+    // -------------------------------------------------------------------
+    // detect_plugin_updates behavioral tests
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn detect_plugin_updates_happy_path_no_updates() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "expected no updates: {:?}",
+            result.updates
+        );
+        assert!(
+            result.failures.is_empty(),
+            "expected no failures: {:?}",
+            result.failures
+        );
+    }
+
+    #[test]
+    fn detect_plugin_updates_version_bump() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Bump manifest version
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.1"}"#,
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(result.updates.len(), 1);
+        assert_eq!(result.updates[0].plugin.as_str(), "p");
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
+        ));
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_content_drift_without_version_bump() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Mutate a skill file in the cache
+        let skill_dir = plugin_dir.join("skills/alpha");
+        fs::write(skill_dir.join("SKILL.md"), "mutated content").unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(result.updates.len(), 1);
+        assert_eq!(result.updates[0].plugin.as_str(), "p");
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::ContentChanged
+        ));
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_per_plugin_failure_surfacing() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Remove marketplace from cache
+        fs::remove_dir_all(&mp_path).unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(result.updates.is_empty());
+        assert_eq!(result.failures.len(), 1);
+        assert_eq!(result.failures[0].plugin.as_str(), "p");
+        assert_eq!(result.failures[0].marketplace.as_str(), "mp");
+    }
+
+    #[test]
+    fn detect_plugin_updates_legacy_fallback_source_hash_none() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Set source_hash: None in tracking file
+        let mut tracking = project.load_installed().unwrap();
+        for meta in tracking.skills.values_mut() {
+            meta.source_hash = None;
+        }
+        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
+        fs::write(
+            &tracking_path,
+            serde_json::to_vec_pretty(&tracking).unwrap(),
+        )
+        .unwrap();
+
+        // Bump version
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.1"}"#,
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(result.updates.len(), 1);
+        assert_eq!(result.updates[0].plugin.as_str(), "p");
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
+        ));
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Set source_hash: None in tracking file
+        let mut tracking = project.load_installed().unwrap();
+        for meta in tracking.skills.values_mut() {
+            meta.source_hash = None;
+        }
+        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
+        fs::write(
+            &tracking_path,
+            serde_json::to_vec_pretty(&tracking).unwrap(),
+        )
+        .unwrap();
+
+        // Same version, no mutation
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(result.updates.is_empty());
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_mixed_scenario() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+
+        // Marketplace mp with 3 plugins
+        let primary_entries = vec![
+            relative_path_entry("no_update", "plugins/no_update"),
+            relative_path_entry("version_bumped", "plugins/version_bumped"),
+            relative_path_entry("content_drift", "plugins/content_drift"),
+        ];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &primary_entries);
+        for name in ["no_update", "version_bumped", "content_drift"] {
+            // Use plugin-specific skill names so they don't collide across plugins.
+            let skill_name = format!("{name}_skill");
+            make_plugin_with_skills(&mp_path, name, &[&skill_name]);
+            let pdir = mp_path.join(format!("plugins/{name}"));
+            fs::write(
+                pdir.join("plugin.json"),
+                format!(r#"{{"name":"{name}","version":"1.0"}}"#),
+            )
+            .unwrap();
+        }
+
+        // Marketplace mp2 with 1 plugin
+        let secondary_entries = vec![relative_path_entry("missing", "plugins/missing")];
+        let mp2_path = seed_marketplace_with_registry(dir.path(), &svc, "mp2", &secondary_entries);
+        make_plugin_with_skills(&mp2_path, "missing", &["missing_skill"]);
+        fs::write(
+            mp2_path.join("plugins/missing/plugin.json"),
+            br#"{"name":"missing","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        for name in ["no_update", "version_bumped", "content_drift"] {
+            svc.install_plugin(&project, &mp("mp"), &pn(name), InstallMode::New, false)
+                .unwrap_or_else(|_| panic!("install {name}"));
+        }
+        svc.install_plugin(
+            &project,
+            &mp("mp2"),
+            &pn("missing"),
+            InstallMode::New,
+            false,
+        )
+        .expect("install missing");
+
+        // version_bumped: bump version
+        fs::write(
+            mp_path.join("plugins/version_bumped/plugin.json"),
+            br#"{"name":"version_bumped","version":"1.1"}"#,
+        )
+        .unwrap();
+
+        // content_drift: mutate skill file
+        fs::write(
+            mp_path.join("plugins/content_drift/skills/content_drift_skill/SKILL.md"),
+            "mutated content",
+        )
+        .unwrap();
+
+        // missing: remove mp2 marketplace directory and registry
+        fs::remove_dir_all(&mp2_path).unwrap();
+        let reg_path = dir.path().join("registries/mp2.json");
+        if reg_path.exists() {
+            fs::remove_file(&reg_path).unwrap();
+        }
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(
+            result.updates.len(),
+            2,
+            "expected 2 updates: {:?}",
+            result.updates
+        );
+        assert_eq!(
+            result.failures.len(),
+            1,
+            "expected 1 failure: {:?}",
+            result.failures
+        );
+
+        let update_names: Vec<&str> = result.updates.iter().map(|u| u.plugin.as_str()).collect();
+        assert!(update_names.contains(&"version_bumped"));
+        assert!(update_names.contains(&"content_drift"));
+
+        assert_eq!(result.failures[0].plugin.as_str(), "missing");
+        assert_eq!(result.failures[0].marketplace.as_str(), "mp2");
+    }
+
+    #[test]
+    fn detect_plugin_updates_per_plugin_granularity() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["s1", "s2", "s3"]);
+
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let steering_dir = plugin_dir.join("steering");
+        fs::create_dir_all(&steering_dir).unwrap();
+        fs::write(steering_dir.join("guide1.md"), "guide1").unwrap();
+        fs::write(steering_dir.join("guide2.md"), "guide2").unwrap();
+
+        let agents_dir = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("a.md"), "---\nname: a\n---\n").unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Mutate exactly one steering file
+        fs::write(steering_dir.join("guide1.md"), "mutated guide1").unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(
+            result.updates.len(),
+            1,
+            "expected 1 update: {:?}",
+            result.updates
+        );
+        assert_eq!(result.updates[0].plugin.as_str(), "p");
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::ContentChanged
+        ));
+        assert!(result.failures.is_empty());
     }
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -486,7 +486,7 @@ pub struct PluginUpdateInfo {
     /// `Some(None)` here.
     pub installed_version: Option<String>,
     /// `None` means the marketplace plugin manifest exists but lacks
-    /// a `version` field. After NC1's `ManifestVersion` 3-state
+    /// a `version` field. After NC1's `ManifestState` 3-state
     /// split, cases where the manifest is missing or unreadable
     /// (symlinked, `NotFound`) surface as a [`PluginUpdateFailure`] —
     /// they no longer collapse into `Some(None)` here. So
@@ -554,37 +554,25 @@ pub enum PluginUpdateFailureKind {
 impl PluginUpdateFailureKind {
     /// Project an [`Error`] into the right
     /// [`PluginUpdateFailureKind`] variant. Exhaustive per the
-    /// CLAUDE.md classifier rule — every entry-point error class
-    /// `check_plugin_for_update` can produce is enumerated; the
-    /// final `Other` arm is reserved for genuinely unanticipated
-    /// errors and is intentional rather than a `_` catch-all.
+    /// CLAUDE.md classifier rule — `Error::Plugin` delegates to
+    /// [`classify_plugin_error`] which enumerates every
+    /// [`PluginError`] variant explicitly; remaining top-level
+    /// categories are listed by name. Adding a new
+    /// [`PluginError`] variant produces a compile error in
+    /// `classify_plugin_error`, which is the forcing function the
+    /// rule requires.
     #[must_use]
     pub fn from_error(err: &Error) -> Self {
         match err {
-            Error::Plugin(PluginError::NotFound { .. }) => Self::MarketplaceUnavailable,
-            // Cache-side variants are the canonical detection path
-            // (Phase 2a). Project-side variants
-            // (`ManifestReadFailed` / `InvalidManifest`) map here too
-            // because `check_plugin_for_update` may surface them
-            // transitively via `resolve_local_plugin_dir` which
-            // shares the install-time error vocabulary.
-            Error::Plugin(
-                PluginError::ManifestNotFound { .. }
-                | PluginError::ManifestReadFailed { .. }
-                | PluginError::CacheManifestReadFailed { .. },
-            ) => Self::ManifestUnreadable,
-            Error::Plugin(
-                PluginError::InvalidManifest { .. } | PluginError::CacheManifestInvalid { .. },
-            ) => Self::ManifestInvalid,
+            Error::Plugin(pe) => classify_plugin_error(pe),
             Error::Hash(_) => Self::HashFailed,
             Error::Marketplace(crate::error::MarketplaceError::NotFound { .. }) => {
                 Self::MarketplaceUnavailable
             }
-            // All other Plugin variants and all other top-level
-            // Error categories route to Other. Written down so a new
-            // variant lands here intentionally rather than silently.
-            Error::Plugin(_)
-            | Error::Marketplace(_)
+            // Remaining top-level Error categories route to Other.
+            // Written down so a new top-level variant lands here
+            // intentionally rather than silently.
+            Error::Marketplace(_)
             | Error::Skill(_)
             | Error::Agent(_)
             | Error::Steering(_)
@@ -593,6 +581,49 @@ impl PluginUpdateFailureKind {
             | Error::Io(_)
             | Error::Json(_) => Self::Other,
         }
+    }
+}
+
+/// Classify a [`PluginError`] for [`PluginUpdateFailureKind::from_error`].
+///
+/// Every variant is matched explicitly so a newly-added
+/// [`PluginError`] forces a compile-time decision here. `PluginError`
+/// is `#[non_exhaustive]`, but that attribute only requires a wildcard
+/// in *external* crates — within `kiro-market-core` an exhaustive match
+/// still triggers a non-exhaustive-pattern error when a variant lands
+/// without a corresponding arm. Mirrors
+/// [`crate::service::browse::SkippedReason::from_plugin_error`]'s
+/// structure, which the CLAUDE.md classifier-rule docs cite as the
+/// canonical example.
+fn classify_plugin_error(err: &PluginError) -> PluginUpdateFailureKind {
+    match err {
+        PluginError::NotFound { .. } => PluginUpdateFailureKind::MarketplaceUnavailable,
+        // Cache-side variants are the canonical detection path
+        // (Phase 2a). Project-side variants (`ManifestNotFound`,
+        // `ManifestReadFailed`) map here too because
+        // `check_plugin_for_update` may surface them transitively via
+        // `resolve_local_plugin_dir`, which shares the install-time
+        // error vocabulary.
+        PluginError::ManifestNotFound { .. }
+        | PluginError::ManifestReadFailed { .. }
+        | PluginError::CacheManifestReadFailed { .. } => {
+            PluginUpdateFailureKind::ManifestUnreadable
+        }
+        PluginError::InvalidManifest { .. } | PluginError::CacheManifestInvalid { .. } => {
+            PluginUpdateFailureKind::ManifestInvalid
+        }
+        // The remaining variants all surface during install /
+        // discovery, not detection — they should not reach
+        // `from_error` in practice. Routing them through `Other`
+        // keeps the wire format honest if one ever does, while the
+        // exhaustive match guarantees a new `PluginError` variant
+        // forces a fresh classification decision.
+        PluginError::NoSkills { .. }
+        | PluginError::DirectoryMissing { .. }
+        | PluginError::NotADirectory { .. }
+        | PluginError::SymlinkRefused { .. }
+        | PluginError::DirectoryUnreadable { .. }
+        | PluginError::RemoteSourceNotLocal { .. } => PluginUpdateFailureKind::Other,
     }
 }
 
@@ -2278,18 +2309,18 @@ impl MarketplaceService {
         let marketplace_path = self.marketplace_path(marketplace_name);
         let plugin_dir = self.resolve_local_plugin_dir(entry, &marketplace_path)?;
 
-        // NC1 (PR #96 re-review): when `load_plugin_manifest_version`
+        // NC1 (PR #96 re-review): when `load_plugin_manifest`
         // collapsed `Ok(None)` for "manifest legitimately lacks
         // version" and "manifest unreadable", the latter case combined
         // with `installed_version: Some(_)` below to emit a phantom
         // `PluginUpdateInfo { available_version: None, change_signal:
-        // VersionBumped }`. After the `ManifestVersion` 3-state split,
+        // VersionBumped }`. After the `ManifestState` 3-state split,
         // unreadable surfaces as a per-plugin failure that lands in
         // `DetectUpdatesResult::failures` — never as "update available
         // to nothing".
-        let available_version = match Self::load_plugin_manifest_version(&plugin_dir)? {
-            ManifestVersion::Found(v) => v,
-            ManifestVersion::Unreadable { reason } => {
+        let manifest = match Self::load_plugin_manifest(&plugin_dir)? {
+            ManifestState::Found(m) => m,
+            ManifestState::Unreadable { reason } => {
                 let manifest_path = plugin_dir.join("plugin.json");
                 // CacheManifestReadFailed's Display embeds the path;
                 // we wrap the symlink/missing distinction into the
@@ -2305,10 +2336,19 @@ impl MarketplaceService {
                 .into());
             }
         };
+        let available_version = manifest.version.clone();
 
+        // Pass the manifest into the drift scan so steering and
+        // native-companion hashing probe the same scan paths the
+        // install used. Pre-fix, `scan_plugin_for_content_drift`
+        // hardcoded `plugin_dir/steering` and `plugin_dir/agents`,
+        // which produced false-positive drift on every scan for
+        // plugins declaring custom `steering: [...]` /
+        // `agents: [...]` paths.
         let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
             plugin_info,
             &plugin_dir,
+            Some(&manifest),
             installed_skills,
             installed_steering,
             installed_agents,
@@ -2353,18 +2393,22 @@ impl MarketplaceService {
         Ok(None)
     }
 
-    /// Load `plugin.json` from `plugin_dir` and report the manifest's
-    /// `version` field — distinguishing between three semantically
-    /// distinct outcomes per NC1 (PR #96 re-review):
+    /// Load `plugin.json` from `plugin_dir` and return the full parsed
+    /// [`crate::plugin::PluginManifest`] — three semantically distinct
+    /// outcomes per NC1 (PR #96 re-review):
     ///
-    /// - [`ManifestVersion::Found(Some(v))`] — manifest read; `version`
-    ///   field present.
-    /// - [`ManifestVersion::Found(None)`] — manifest read; `version`
-    ///   field legitimately absent.
-    /// - [`ManifestVersion::Unreadable`] — manifest could not be read for
+    /// - [`ManifestState::Found`] — manifest read and parsed. Caller
+    ///   reads `.version` for the version comparison AND `.agents` /
+    ///   `.steering` for the scan-path probing in
+    ///   [`Self::scan_plugin_for_content_drift`] (per the
+    ///   manifest-respects-scan-paths fix from the PR #96 re-review;
+    ///   pre-fix, drift detection compared against the hardcoded
+    ///   `./steering/` and `./agents/` defaults regardless of what the
+    ///   manifest declared).
+    /// - [`ManifestState::Unreadable`] — manifest could not be read for
     ///   a non-fatal reason (symlink-refused or `NotFound`). The
     ///   caller must surface this as a per-plugin failure rather than
-    ///   collapse it with the `Found(None)` arm — otherwise the
+    ///   collapse it with `Found(_).version.is_none()` — otherwise the
     ///   version-comparison logic produces a phantom
     ///   `PluginUpdateInfo { available_version: None, change_signal:
     ///   VersionBumped }` whenever an installed plugin happens to carry
@@ -2382,7 +2426,7 @@ impl MarketplaceService {
     /// reads are bounded at [`MAX_PLUGIN_MANIFEST_BYTES`] so a malicious
     /// marketplace shipping a multi-GB `plugin.json` cannot OOM the
     /// process before serde sees a byte.
-    fn load_plugin_manifest_version(plugin_dir: &Path) -> Result<ManifestVersion, Error> {
+    fn load_plugin_manifest(plugin_dir: &Path) -> Result<ManifestState, Error> {
         let manifest_path = plugin_dir.join("plugin.json");
 
         // Symlink defense: refuse to follow symlinks (C5 security fix).
@@ -2392,13 +2436,13 @@ impl MarketplaceService {
                     path = %manifest_path.display(),
                     "plugin.json is a symlink, refusing to follow; treating as unreadable"
                 );
-                return Ok(ManifestVersion::Unreadable {
+                return Ok(ManifestState::Unreadable {
                     reason: "plugin.json is a symlink — refused".to_owned(),
                 });
             }
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(ManifestVersion::Unreadable {
+                return Ok(ManifestState::Unreadable {
                     reason: "plugin.json missing in marketplace cache".to_owned(),
                 });
             }
@@ -2423,7 +2467,7 @@ impl MarketplaceService {
         };
 
         match crate::plugin::PluginManifest::from_json(&bytes) {
-            Ok(manifest) => Ok(ManifestVersion::Found(manifest.version)),
+            Ok(manifest) => Ok(ManifestState::Found(manifest)),
             Err(e) => Err(PluginError::CacheManifestInvalid {
                 path: manifest_path,
                 reason: error_full_chain(&e),
@@ -2436,6 +2480,18 @@ impl MarketplaceService {
     /// their stored `source_hash` against freshly-computed hashes from
     /// `plugin_dir`.
     ///
+    /// `manifest` is the plugin's parsed `plugin.json`, used to derive
+    /// the configured `agents` / `steering` scan paths so detection
+    /// hashes against the same roots install used. Pre-fix the
+    /// steering and native-companion loops hardcoded `plugin_dir/
+    /// steering` and `plugin_dir/agents`, producing false-positive
+    /// drift on every scan for plugins declaring custom paths
+    /// (PR #96 review #6). The manifest is `Option<&...>` so callers
+    /// that lack a parsed manifest fall back to
+    /// [`crate::DEFAULT_STEERING_PATHS`] / [`crate::DEFAULT_AGENT_PATHS`]
+    /// via the same helpers `MarketplaceService::install_plugin`
+    /// uses.
+    ///
     /// `content_drift = false && legacy_fallback = true` means "no drift
     /// detected among hashable entries; some entries had no `source_hash`
     /// so a clean miss is possible." Callers should treat `legacy_fallback`
@@ -2443,6 +2499,7 @@ impl MarketplaceService {
     fn scan_plugin_for_content_drift(
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
+        manifest: Option<&crate::plugin::PluginManifest>,
         installed_skills: &crate::project::InstalledSkills,
         installed_steering: &crate::project::InstalledSteering,
         installed_agents: &crate::project::InstalledAgents,
@@ -2450,7 +2507,14 @@ impl MarketplaceService {
         let mut content_drift = false;
         let mut legacy_fallback = false;
 
-        // Skills
+        // Skills — keyed under `skills/<name>/` per the install path's
+        // `discover_skill_dirs` recipe. Skills do not currently support
+        // a custom scan-path declaration on the manifest (the
+        // `manifest.skills: Vec<String>` field exists but the install
+        // path treats it identically across declared roots), so the
+        // hardcoded `plugin_dir.join("skills")` here is the same shape
+        // install uses today. Out of scope for the steering/agents
+        // scan-path fix.
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
@@ -2467,12 +2531,21 @@ impl MarketplaceService {
             }
         }
 
-        // Steering
+        // Steering — probe each configured scan path. Install hashes
+        // via `hash_artifact(&f.scan_root, &[rel])` per
+        // `install_plugin_steering`, so detection MUST iterate the
+        // declared scan paths and use the first one where the file
+        // exists. A single hardcoded `plugin_dir/steering` would
+        // false-positive every plugin declaring `steering: ["./guides/"]`
+        // — see PR #96 review comment #6.
+        let steering_paths = crate::service::browse::steering_scan_paths_for_plugin(manifest);
         for (rel_path, meta) in &installed_steering.files {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                let steering_dir = plugin_dir.join("steering");
-                let computed =
-                    crate::hash::hash_artifact(&steering_dir, std::slice::from_ref(rel_path))?;
+                let computed = hash_artifact_in_scan_paths(
+                    plugin_dir,
+                    &steering_paths,
+                    std::slice::from_ref(rel_path),
+                )?;
                 if computed != meta.source_hash {
                     content_drift = true;
                     return Ok((content_drift, legacy_fallback));
@@ -2556,11 +2629,17 @@ impl MarketplaceService {
             }
         }
 
-        // Native companions
+        // Native companions — same probe-each-scan-path treatment as
+        // steering. Install hashes via `hash_artifact(&scan_root,
+        // &rel_paths)` per `install_native_companions_for_plugin`,
+        // and the install path requires every companion in the bundle
+        // to share a single scan root (`MultipleScanRootsNotSupported`
+        // errors otherwise) — so `meta.files` resolves under whichever
+        // configured agent scan path actually contains the bundle.
+        let agent_paths = crate::service::browse::agent_scan_paths_for_plugin(manifest);
         for meta in installed_agents.native_companions.values() {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                let agents_dir = plugin_dir.join("agents");
-                let computed = crate::hash::hash_artifact(&agents_dir, &meta.files)?;
+                let computed = hash_artifact_in_scan_paths(plugin_dir, &agent_paths, &meta.files)?;
                 if computed != meta.source_hash {
                     content_drift = true;
                     return Ok((content_drift, legacy_fallback));
@@ -2572,7 +2651,58 @@ impl MarketplaceService {
     }
 }
 
-/// 3-state outcome of [`MarketplaceService::load_plugin_manifest_version`].
+/// Try to hash `rel_paths` against each `scan_path` joined to
+/// `plugin_dir`, returning the first successful hash. Probes the
+/// configured scan paths in order and recovers from
+/// `ErrorKind::NotFound` so a plugin whose files moved between
+/// configured scan roots (or whose manifest lists multiple roots) is
+/// detected at whichever root actually contains the bundle.
+/// Non-`NotFound` hash errors propagate immediately so genuine
+/// permission / I/O issues are not masked.
+///
+/// If every scan path returned `NotFound`, the last `NotFound` error
+/// is propagated so the caller (`scan_plugin_for_content_drift`)
+/// surfaces it as a per-plugin failure with a path the user can
+/// investigate. `scan_paths` is empty in practice only if the helpers
+/// in [`crate::service::browse`] regress — both fall back to
+/// non-empty defaults — so the empty-vec branch synthesises a generic
+/// `NotFound` rather than panicking.
+fn hash_artifact_in_scan_paths(
+    plugin_dir: &Path,
+    scan_paths: &[String],
+    rel_paths: &[PathBuf],
+) -> Result<String, Error> {
+    let mut last_not_found: Option<Error> = None;
+    for sp in scan_paths {
+        // `discover_steering_files_in_dirs` and the agent-discovery
+        // siblings strip the leading `./` before joining; mirror that
+        // here so the resolved path matches install-time exactly
+        // regardless of whether the manifest writes `"steering/"` or
+        // `"./steering/"`.
+        let scan_root = plugin_dir.join(sp.trim_start_matches("./"));
+        match crate::hash::hash_artifact(&scan_root, rel_paths) {
+            Ok(h) => return Ok(h),
+            Err(crate::hash::HashError::ReadFailed { path, source })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                last_not_found = Some(crate::hash::HashError::ReadFailed { path, source }.into());
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Err(last_not_found.unwrap_or_else(|| {
+        crate::hash::HashError::ReadFailed {
+            path: plugin_dir.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no scan paths configured for plugin",
+            ),
+        }
+        .into()
+    }))
+}
+
+/// 3-state outcome of [`MarketplaceService::load_plugin_manifest`].
 ///
 /// Distinguishing "manifest exists, version field absent" from "manifest
 /// could not be read" closes NC1 (PR #96 re-review): collapsing both
@@ -2581,18 +2711,22 @@ impl MarketplaceService {
 /// to carry a `version` and the cache's `plugin.json` is symlinked or
 /// missing.
 ///
-/// `Found(Some(v))` and `Found(None)` are both "scan succeeded";
-/// `Unreadable { reason }` is "do not compare versions — surface a
-/// per-plugin failure instead". Module-private — the public surface
-/// remains [`PluginUpdateInfo`] / [`PluginUpdateFailure`].
+/// `Found(_)` carries the full [`crate::plugin::PluginManifest`] so
+/// callers can inspect the `version` field AND the `agents` /
+/// `steering` scan-path declarations — the latter feeds
+/// [`MarketplaceService::scan_plugin_for_content_drift`] so detection
+/// hashes against the same scan roots install used. `Unreadable {
+/// reason }` is "do not compare versions — surface a per-plugin
+/// failure instead". Module-private — the public surface remains
+/// [`PluginUpdateInfo`] / [`PluginUpdateFailure`].
 #[derive(Debug)]
-enum ManifestVersion {
-    /// Manifest read; carries the (possibly absent) `version` field.
-    Found(Option<String>),
+enum ManifestState {
+    /// Manifest read and parsed; carries the full manifest.
+    Found(crate::plugin::PluginManifest),
     /// Manifest could not be read for a non-fatal reason
     /// (symlink-refused or `NotFound` on the cache copy). Caller must
     /// treat this as a per-plugin failure rather than collapse it with
-    /// `Found(None)` — see NC1 above.
+    /// `Found(_).version.is_none()` — see NC1 above.
     Unreadable {
         /// Human-readable reason; embedded into the wire-format
         /// `PluginUpdateFailure.reason` via `error_full_chain`. Kept
@@ -6382,15 +6516,15 @@ mod tests {
     }
 
     /// NC1 (PR #96 re-review): the C5 symlink defense returned
-    /// `Ok(None)` from `load_plugin_manifest_version` when the
-    /// `plugin.json` symlink was refused. That `None` then collapsed
+    /// `Ok(None)` from `load_plugin_manifest_version` (pre-rename) when
+    /// the `plugin.json` symlink was refused. That `None` then collapsed
     /// with `installed_version: Some("1.0")` in the version-comparison
     /// path to emit a phantom `PluginUpdateInfo { available_version:
     /// None, change_signal: VersionBumped }` — telling the user "an
     /// update is available to nothing" whenever an installed plugin's
     /// cache `plugin.json` had been swapped for a symlink.
     ///
-    /// Post-fix: the 3-state `ManifestVersion` enum routes
+    /// Post-fix: the 3-state `ManifestState` enum routes
     /// "unreadable" through the per-plugin failure arm. This test
     /// pins the no-phantom-update contract by deleting the cache
     /// `plugin.json` after install and asserting the scan produces
@@ -6435,10 +6569,10 @@ mod tests {
         );
 
         // Now make the cache plugin.json unreadable: delete it.
-        // Pre-NC1 fix: load_plugin_manifest_version returns Ok(None),
-        // version_differs becomes true (Some("1.0") != None), and the
-        // result has a phantom `VersionBumped` update with
-        // available_version: None.
+        // Pre-NC1 fix: load_plugin_manifest_version (pre-rename)
+        // returned Ok(None), version_differs became true
+        // (Some("1.0") != None), and the result had a phantom
+        // `VersionBumped` update with available_version: None.
         fs::remove_file(plugin_dir.join("plugin.json")).unwrap();
 
         let result = svc.detect_plugin_updates(&project).expect("detect");
@@ -6460,12 +6594,80 @@ mod tests {
         assert_eq!(result.failures[0].plugin.as_str(), "p");
     }
 
+    /// PR #96 review #6: a plugin whose `plugin.json` declares a
+    /// custom `steering: ["./guides/"]` scan path would false-positive
+    /// drift on every detection scan — install hashed against
+    /// `<plugin_dir>/guides/`, but pre-fix `scan_plugin_for_content_drift`
+    /// hardcoded `<plugin_dir>/steering/` regardless of the manifest.
+    /// This test installs such a plugin without modifying the source
+    /// and asserts the scan reports zero updates and zero failures.
+    /// A regression here means hashing fell back to the hardcoded
+    /// default again.
+    #[test]
+    fn detect_plugin_updates_steering_with_custom_scan_path_no_false_drift() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            relative_path_entry, seed_marketplace_with_registry, temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+        fs::create_dir_all(plugin_dir.join("guides")).expect("create guides dir");
+        // Steering source under a NON-default path. If detection used
+        // the hardcoded `./steering/` default, hash_artifact would
+        // return NotFound and the plugin would surface as a failure.
+        fs::write(plugin_dir.join("guides/playbook.md"), b"how to ship\n")
+            .expect("write steering source");
+        // Manifest declares the custom scan path. The Phase 2a fix
+        // makes `scan_plugin_for_content_drift` consult this field.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0","steering":["./guides/"]}"#,
+        )
+        .expect("write plugin.json");
+
+        let project_tmp = tempfile::tempdir().expect("project tempdir");
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Sanity: install actually placed the steering file under
+        // `.kiro/steering/` so the tracking entry exists for the scan
+        // to compare against. Without this precondition the test would
+        // pass vacuously.
+        assert!(
+            project_tmp
+                .path()
+                .join(".kiro/steering/playbook.md")
+                .exists(),
+            "precondition: steering file must be installed"
+        );
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "expected no updates for an unchanged source under a custom \
+             steering scan path; got: {:?}",
+            result.updates
+        );
+        assert!(
+            result.failures.is_empty(),
+            "expected no failures (pre-fix would return a hash NotFound \
+             error because detection looked under hardcoded `./steering/`); \
+             got: {:?}",
+            result.failures
+        );
+    }
+
     /// Commit 9 / Phase 2a sibling of
     /// `service::browse::tests::load_plugin_manifest_rejects_oversized_file`:
-    /// the detection-side `load_plugin_manifest_version` shares the
+    /// the detection-side `load_plugin_manifest` shares the
     /// same `read_capped` defense; verify it fires here too.
     #[test]
-    fn load_plugin_manifest_version_rejects_oversized_file() {
+    fn load_plugin_manifest_rejects_oversized_file() {
         use std::io::Write;
         let tmp = tempfile::tempdir().expect("tempdir");
         let plugin_dir = tmp.path().join("plugin");
@@ -6476,7 +6678,7 @@ mod tests {
             .expect("write 2 MiB");
         f.sync_all().expect("sync");
 
-        let err = MarketplaceService::load_plugin_manifest_version(&plugin_dir)
+        let err = MarketplaceService::load_plugin_manifest(&plugin_dir)
             .expect_err("oversized plugin.json must be refused at the cap");
         assert!(
             matches!(
@@ -6496,13 +6698,13 @@ mod tests {
     /// target bytes via `error_full_chain` into the wire-format
     /// `PluginUpdateFailure.reason`.
     ///
-    /// Asserts the function returns `ManifestVersion::Unreadable { ... }`,
-    /// NOT `ManifestVersion::Found(_)`. `PluginManifest` requires `name`
+    /// Asserts the function returns `ManifestState::Unreadable { ... }`,
+    /// NOT `ManifestState::Found(_)`. `PluginManifest` requires `name`
     /// (else parse fails); the symlink target is a complete valid
     /// manifest so absence/presence is unambiguous.
     #[cfg(unix)]
     #[test]
-    fn load_plugin_manifest_version_refuses_symlink() {
+    fn load_plugin_manifest_refuses_symlink() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let plugin_dir = tmp.path().join("plugin");
         fs::create_dir_all(&plugin_dir).expect("create plugin dir");
@@ -6521,19 +6723,20 @@ mod tests {
         std::os::unix::fs::symlink(&sensitive, plugin_dir.join("plugin.json"))
             .expect("create symlink");
 
-        let result = MarketplaceService::load_plugin_manifest_version(&plugin_dir)
-            .expect("symlink must yield ManifestVersion::Unreadable, not Err");
+        let result = MarketplaceService::load_plugin_manifest(&plugin_dir)
+            .expect("symlink must yield ManifestState::Unreadable, not Err");
         match result {
-            ManifestVersion::Unreadable { reason } => {
+            ManifestState::Unreadable { reason } => {
                 assert!(
                     reason.contains("symlink"),
                     "reason must mention symlink, got: {reason}"
                 );
             }
-            ManifestVersion::Found(v) => {
+            ManifestState::Found(m) => {
                 panic!(
-                    "symlinked plugin.json must NOT be parsed; got Found({v:?}) — \
-                     symlink defense regressed"
+                    "symlinked plugin.json must NOT be parsed; got Found(name={:?}, version={:?}) — \
+                     symlink defense regressed",
+                    m.name, m.version
                 );
             }
         }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2342,7 +2342,6 @@ impl MarketplaceService {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
                     Some(stored) => {
-                        let agents_dir = plugin_dir.join("agents");
                         // Two notes on this fallback (C6 area):
                         // (a) the dialect-default branch only fires for
                         //     tracking entries written before the
@@ -2353,21 +2352,21 @@ impl MarketplaceService {
                         //     must mirror the install-time naming
                         //     convention or a content-hash diff will be
                         //     misreported as drift.
-                        let rel_path: PathBuf = match &meta.source_path {
-                            Some(rp) => PathBuf::from(rp.as_str()),
-                            None => match meta.dialect {
-                                crate::agent::AgentDialect::Native => {
-                                    PathBuf::from(format!("{name}.json"))
-                                }
-                                crate::agent::AgentDialect::Claude => {
-                                    PathBuf::from(format!("{name}.md"))
-                                }
-                                crate::agent::AgentDialect::Copilot => {
-                                    PathBuf::from(format!("{name}.agent.md"))
-                                }
-                            },
-                        };
-                        let computed = crate::hash::hash_artifact(&agents_dir, &[rel_path])?;
+                        //
+                        // Hash invariant: install-side
+                        // `hash_translated_source` hashes via
+                        // `hash_artifact(parent_dir, &[filename])` so
+                        // the digest's path-component is the bare
+                        // filename. Detection MUST match that recipe,
+                        // i.e. base = parent dir, rel = filename — not
+                        // base = agents_dir + rel = "agents/foo.md".
+                        let (base, filename) = agent_hash_inputs(
+                            plugin_dir,
+                            name,
+                            meta.dialect,
+                            meta.source_path.as_ref(),
+                        );
+                        let computed = crate::hash::hash_artifact(&base, &[filename])?;
                         if computed != *stored {
                             content_drift = true;
                             return Ok((content_drift, legacy_fallback));
@@ -2448,6 +2447,45 @@ fn read_capped(path: &Path, cap: u64) -> std::io::Result<Vec<u8>> {
         ));
     }
     Ok(buf)
+}
+
+/// Compute the `(base_dir, filename)` pair that recreates the
+/// install-side hash recipe used by
+/// [`crate::project::KiroProject::hash_translated_source`] for a
+/// tracked agent. Used by
+/// [`MarketplaceService::scan_plugin_for_content_drift`] so detection
+/// hashes match the bytes the install side fed into BLAKE3 — the
+/// install hashes via `hash_artifact(parent, &[filename])` so detection
+/// MUST also pass `(parent, filename)` rather than `(agents_dir,
+/// "subdir/file.md")`, since the digest includes the rel-path bytes.
+///
+/// `source_path` (when `Some`) is relative to `plugin_dir`. We split
+/// it back into `(plugin_dir + rel.parent(), rel.file_name())` to
+/// match the install recipe. The dialect-fallback branch produces a
+/// bare filename relative to `plugin_dir/agents`, mirroring the
+/// pre-C7 install behavior.
+fn agent_hash_inputs(
+    plugin_dir: &Path,
+    name: &str,
+    dialect: crate::agent::AgentDialect,
+    source_path: Option<&crate::validation::RelativePath>,
+) -> (PathBuf, PathBuf) {
+    if let Some(rp) = source_path {
+        let full = plugin_dir.join(rp.as_str());
+        let parent = full
+            .parent()
+            .map_or_else(|| plugin_dir.to_path_buf(), Path::to_path_buf);
+        let fname = full
+            .file_name()
+            .map_or_else(|| PathBuf::from(rp.as_str()), PathBuf::from);
+        return (parent, fname);
+    }
+    let fname = match dialect {
+        crate::agent::AgentDialect::Native => PathBuf::from(format!("{name}.json")),
+        crate::agent::AgentDialect::Claude => PathBuf::from(format!("{name}.md")),
+        crate::agent::AgentDialect::Copilot => PathBuf::from(format!("{name}.agent.md")),
+    };
+    (plugin_dir.join("agents"), fname)
 }
 
 /// Build the tracking-file `source_path` for a translated agent install
@@ -6169,5 +6207,277 @@ mod tests {
             result.failures
         );
         assert_eq!(result.failures[0].plugin.as_str(), "p");
+    }
+
+    /// I-N2 (PR #96 re-review): mirrors `service::browse::tests::
+    /// load_plugin_manifest_refuses_symlinked_manifest` for the Phase 2a
+    /// detection-side function. Without this test, a future refactor
+    /// could replace the `symlink_metadata` check with `Path::exists()`
+    /// (which follows symlinks) and silently re-open the C5 leak vector
+    /// — the cache `plugin.json`'s parse error embeds the symlinked
+    /// target bytes via `error_full_chain` into the wire-format
+    /// `PluginUpdateFailure.reason`.
+    ///
+    /// Asserts the function returns `ManifestVersion::Unreadable { ... }`,
+    /// NOT `ManifestVersion::Found(_)`. `PluginManifest` requires `name`
+    /// (else parse fails); the symlink target is a complete valid
+    /// manifest so absence/presence is unambiguous.
+    #[cfg(unix)]
+    #[test]
+    fn load_plugin_manifest_version_refuses_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plugin_dir = tmp.path().join("plugin");
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+
+        // A target with valid PluginManifest content so we can tell
+        // "absent" from "parsed but wrong". PluginManifest requires
+        // the `name` field — the previous agent's broken fixture
+        // omitted it.
+        let sensitive = tmp.path().join("secrets.json");
+        fs::write(
+            &sensitive,
+            br#"{"name":"leaked","version":"1.0","skills":[]}"#,
+        )
+        .expect("write target");
+
+        std::os::unix::fs::symlink(&sensitive, plugin_dir.join("plugin.json"))
+            .expect("create symlink");
+
+        let result = MarketplaceService::load_plugin_manifest_version(&plugin_dir)
+            .expect("symlink must yield ManifestVersion::Unreadable, not Err");
+        match result {
+            ManifestVersion::Unreadable { reason } => {
+                assert!(
+                    reason.contains("symlink"),
+                    "reason must mention symlink, got: {reason}"
+                );
+            }
+            ManifestVersion::Found(v) => {
+                panic!(
+                    "symlinked plugin.json must NOT be parsed; got Found({v:?}) — \
+                     symlink defense regressed"
+                );
+            }
+        }
+    }
+
+    /// I-N3 (PR #96 re-review) — DEFERRED VARIANT: directly testing
+    /// the Copilot dialect through the translated install path
+    /// surfaces a separate pre-existing bug in
+    /// [`scan_plugin_for_content_drift`]'s `native_companions` arm
+    /// (companion `source_hash` is computed against the destination
+    /// `project/.kiro/agents/` at install time, but detection
+    /// re-hashes against the marketplace cache `plugin_dir/agents/`,
+    /// so the paths never resolve and a `PluginUpdateFailure` is
+    /// always emitted). That bug is unrelated to NC1/NC2/C7 and is
+    /// out of scope for this remediation cycle — it requires routing
+    /// the destination dir through `scan_plugin_for_content_drift`,
+    /// which is a Phase 2b structural change.
+    ///
+    /// Until the upstream `native_companions` detection bug is fixed,
+    /// the Copilot legacy-fallback path is exercised in a unit test
+    /// that bypasses the install path. Below: build the tracking
+    /// state by hand so we can isolate the dialect-classifier branch
+    /// without dragging in the broken `native_companions` cascade.
+    #[test]
+    fn detect_plugin_updates_copilot_agent_legacy_fallback() {
+        use crate::project::{InstalledAgentMeta, InstalledAgents, KiroProject};
+        use crate::service::test_support::{
+            relative_path_entry, seed_marketplace_with_registry, temp_service,
+        };
+        use std::collections::HashMap;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+        let agents_dir = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        // Filename stem matches the frontmatter name so the dialect
+        // fallback `{name}.agent.md` resolves.
+        let agent_body = b"---\nname: reviewer\ndescription: Reviews\n---\n\nBody.\n";
+        fs::write(agents_dir.join("reviewer.agent.md"), agent_body).unwrap();
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        // Build a hand-crafted installed-agents.json that mirrors a
+        // pre-C7 install (no source_path, no source_hash) so we
+        // exercise the dialect-fallback branch in isolation. Skip
+        // synthesizing native_companions to sidestep the unrelated
+        // pre-existing bug noted in the rustdoc above.
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        let kiro_dir = project_tmp.path().join(".kiro");
+        fs::create_dir_all(&kiro_dir).unwrap();
+        let mut agents_map = HashMap::new();
+        agents_map.insert(
+            "reviewer".to_string(),
+            InstalledAgentMeta {
+                marketplace: mp("mp"),
+                plugin: pn("p"),
+                version: Some("1.0".to_owned()),
+                installed_at: chrono::Utc::now(),
+                dialect: crate::agent::AgentDialect::Copilot,
+                source_path: None,
+                // Legacy entry: no source_hash → triggers
+                // `legacy_fallback = true` in scan; version-comparison
+                // path then drives the result.
+                source_hash: None,
+                installed_hash: None,
+            },
+        );
+        let installed = InstalledAgents {
+            agents: agents_map,
+            native_companions: HashMap::new(),
+        };
+        fs::write(
+            kiro_dir.join("installed-agents.json"),
+            serde_json::to_vec_pretty(&installed).unwrap(),
+        )
+        .unwrap();
+
+        // Bump version so we get a deterministic update entry.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.1"}"#,
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.failures.is_empty(),
+            "Copilot legacy-fallback path must succeed, got failures: {:?}",
+            result.failures
+        );
+        assert_eq!(
+            result.updates.len(),
+            1,
+            "Copilot agent legacy fallback + version bump must surface as exactly \
+             one update, got: {result:?}"
+        );
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
+        ));
+    }
+
+    /// I-N3 sibling: a Copilot agent with `source_path: Some(rel)`
+    /// (post-C7 install shape) — detection finds the file via the
+    /// populated path, NOT the dialect fallback. Bypasses the
+    /// translated install path for the same reason as the legacy
+    /// test above.
+    #[test]
+    fn detect_plugin_updates_copilot_agent_with_source_path() {
+        use crate::project::{InstalledAgentMeta, InstalledAgents, KiroProject};
+        use crate::service::test_support::{
+            relative_path_entry, seed_marketplace_with_registry, temp_service,
+        };
+        use crate::validation::RelativePath;
+        use std::collections::HashMap;
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+        let agents_dir = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        let agent_body = b"---\nname: reviewer\ndescription: Reviews\n---\n\nBody.\n";
+        fs::write(agents_dir.join("reviewer.agent.md"), agent_body).unwrap();
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        // Compute the expected hash the same way install_translated_agents_inner's
+        // hash_translated_source helper does: hash_artifact(parent, &[filename]).
+        let expected_hash =
+            crate::hash::hash_artifact(&agents_dir, &[PathBuf::from("reviewer.agent.md")])
+                .expect("hash");
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        let kiro_dir = project_tmp.path().join(".kiro");
+        fs::create_dir_all(&kiro_dir).unwrap();
+        let mut agents_map = HashMap::new();
+        agents_map.insert(
+            "reviewer".to_string(),
+            InstalledAgentMeta {
+                marketplace: mp("mp"),
+                plugin: pn("p"),
+                version: Some("1.0".to_owned()),
+                installed_at: chrono::Utc::now(),
+                dialect: crate::agent::AgentDialect::Copilot,
+                source_path: Some(
+                    RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
+                ),
+                source_hash: Some(expected_hash),
+                installed_hash: None,
+            },
+        );
+        let installed = InstalledAgents {
+            agents: agents_map,
+            native_companions: HashMap::new(),
+        };
+        fs::write(
+            kiro_dir.join("installed-agents.json"),
+            serde_json::to_vec_pretty(&installed).unwrap(),
+        )
+        .unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.failures.is_empty(),
+            "Copilot source_path detection must succeed, got failures: {:?}",
+            result.failures
+        );
+        assert!(
+            result.updates.is_empty(),
+            "no mutation; updates must be empty, got: {:?}",
+            result.updates
+        );
+    }
+
+    /// I-N6 (PR #96 re-review): C4 plumbing test. Default-empty + JSON-
+    /// shape locks didn't verify the `partial_load_warnings` field is
+    /// actually populated from `view.partial_load_warnings` — only
+    /// that the field exists on the wire. This test corrupts
+    /// `installed-skills.json` directly and asserts the warning bubbles
+    /// through `installed_plugins() -> detect_plugin_updates ->
+    /// DetectUpdatesResult::partial_load_warnings`.
+    #[test]
+    fn detect_plugin_updates_forwards_partial_load_warnings() {
+        use crate::project::KiroProject;
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let kiro_dir = project_tmp.path().join(".kiro");
+        fs::create_dir_all(&kiro_dir).expect("kiro dir");
+        // Invalid JSON in installed-skills.json — installed_plugins()
+        // must surface this in partial_load_warnings rather than
+        // aborting.
+        fs::write(
+            kiro_dir.join("installed-skills.json"),
+            b"{ this is not json",
+        )
+        .expect("write corrupt tracking");
+
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        let (_dir, svc) = crate::service::test_support::temp_service();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert_eq!(
+            result.partial_load_warnings.len(),
+            1,
+            "corrupt installed-skills.json must surface as exactly one \
+             partial_load_warnings entry, got: {:?}",
+            result.partial_load_warnings
+        );
+        assert_eq!(
+            result.partial_load_warnings[0].tracking_file, "installed-skills.json",
+            "warning must name the corrupt tracking file"
+        );
     }
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2208,10 +2208,37 @@ impl MarketplaceService {
         project: &crate::project::KiroProject,
     ) -> Result<DetectUpdatesResult, Error> {
         let view = project.installed_plugins()?;
+        // Hoist the three tracking-file loads above the per-plugin
+        // loop (originally-deferred IMPORTANT in PR #96 review). Pre-fix:
+        // `scan_plugin_for_content_drift` called
+        // load_installed{,_steering,_agents}() once per plugin, so a
+        // project with N installed plugins did 3N reads + JSON
+        // deserializations where 3 are sufficient. Side-benefit:
+        // tracking-file load failures no longer get misattributed to
+        // whichever plugin happens to be first in the iteration
+        // order — they're folded into `partial_load_warnings` (the
+        // view already did that walk; here we follow the same
+        // defaulting pattern so a corrupt tracking file doesn't
+        // double-surface as both a warning AND a top-level Err).
+        let installed_skills = project
+            .load_installed()
+            .unwrap_or_else(|_| crate::project::InstalledSkills::default());
+        let installed_steering = project
+            .load_installed_steering()
+            .unwrap_or_else(|_| crate::project::InstalledSteering::default());
+        let installed_agents = project
+            .load_installed_agents()
+            .unwrap_or_else(|_| crate::project::InstalledAgents::default());
+
         let mut updates = Vec::new();
         let mut failures = Vec::new();
         for plugin_info in view.plugins {
-            match self.check_plugin_for_update(project, &plugin_info) {
+            match self.check_plugin_for_update(
+                &plugin_info,
+                &installed_skills,
+                &installed_steering,
+                &installed_agents,
+            ) {
                 Ok(Some(update)) => updates.push(update),
                 Ok(None) => {}
                 Err(err) => failures.push(PluginUpdateFailure {
@@ -2231,8 +2258,10 @@ impl MarketplaceService {
 
     fn check_plugin_for_update(
         &self,
-        project: &crate::project::KiroProject,
         plugin_info: &crate::project::InstalledPluginInfo,
+        installed_skills: &crate::project::InstalledSkills,
+        installed_steering: &crate::project::InstalledSteering,
+        installed_agents: &crate::project::InstalledAgents,
     ) -> Result<Option<PluginUpdateInfo>, Error> {
         let marketplace_name = plugin_info.marketplace.as_str();
         let plugin_name = plugin_info.plugin.as_str();
@@ -2277,8 +2306,13 @@ impl MarketplaceService {
             }
         };
 
-        let (content_drift, legacy_fallback) =
-            Self::scan_plugin_for_content_drift(project, plugin_info, &plugin_dir)?;
+        let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
+            plugin_info,
+            &plugin_dir,
+            installed_skills,
+            installed_steering,
+            installed_agents,
+        )?;
 
         let installed_version = plugin_info.installed_version.clone();
         let version_differs = installed_version != available_version;
@@ -2401,15 +2435,16 @@ impl MarketplaceService {
     /// so a clean miss is possible." Callers should treat `legacy_fallback`
     /// as "drift undetectable" rather than "drift absent."
     fn scan_plugin_for_content_drift(
-        project: &crate::project::KiroProject,
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
+        installed_skills: &crate::project::InstalledSkills,
+        installed_steering: &crate::project::InstalledSteering,
+        installed_agents: &crate::project::InstalledAgents,
     ) -> Result<(bool, bool), Error> {
         let mut content_drift = false;
         let mut legacy_fallback = false;
 
         // Skills
-        let installed_skills = project.load_installed()?;
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
@@ -2427,7 +2462,6 @@ impl MarketplaceService {
         }
 
         // Steering
-        let installed_steering = project.load_installed_steering()?;
         for (rel_path, meta) in &installed_steering.files {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 let steering_dir = plugin_dir.join("steering");
@@ -2441,7 +2475,6 @@ impl MarketplaceService {
         }
 
         // Agents
-        let installed_agents = project.load_installed_agents()?;
         for (name, meta) in &installed_agents.agents {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -605,10 +605,10 @@ impl PluginUpdateFailureKind {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum UpdateChangeSignal {
     /// Manifest version string differs (with or without content hash diff).
-    /// FE renders "Update v1.0 → v1.1".
+    /// Designed for FE rendering as "Update v1.0 → v1.1".
     VersionBumped,
     /// Manifest version unchanged but at least one source-hash diff
-    /// detected. FE renders "Content updated since install".
+    /// detected. Designed for FE rendering as "Content updated since install".
     ContentChanged,
 }
 
@@ -2338,14 +2338,20 @@ impl MarketplaceService {
         }
 
         if legacy_fallback {
-            // Drift undetectable — same versions means no entry.
-            return Ok(None);
+            // Drift undetectable for legacy entries (no source_hash) —
+            // same versions means no entry. Logging at debug so the
+            // legacy-fallback case is observable in traces without
+            // surfacing in normal operation.
+            tracing::debug!(
+                marketplace = %plugin_info.marketplace,
+                plugin = %plugin_info.plugin,
+                "scan saw a legacy (pre-Stage-1) tracking entry with no \
+                 source_hash; falling back to version-only comparison and \
+                 returning no update entry"
+            );
         }
-
         Ok(None)
     }
-
-    // (See `ManifestVersion` enum and `read_capped` helper at module scope below.)
 
     /// Load `plugin.json` from `plugin_dir` and report the manifest's
     /// `version` field — distinguishing between three semantically

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1588,10 +1588,7 @@ impl MarketplaceService {
                 version: ctx.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
-                source_path: path
-                    .strip_prefix(plugin_dir)
-                    .ok()
-                    .map(std::path::Path::to_path_buf),
+                source_path: relative_source_path_for_tracking(&path, plugin_dir),
                 source_hash: None,
                 installed_hash: None,
             };
@@ -2151,7 +2148,30 @@ impl MarketplaceService {
         let marketplace_path = self.marketplace_path(marketplace_name);
         let plugin_dir = self.resolve_local_plugin_dir(entry, &marketplace_path)?;
 
-        let available_version = Self::load_plugin_manifest_version(&plugin_dir)?;
+        // NC1 (PR #96 re-review): when `load_plugin_manifest_version`
+        // collapsed `Ok(None)` for "manifest legitimately lacks
+        // version" and "manifest unreadable", the latter case combined
+        // with `installed_version: Some(_)` below to emit a phantom
+        // `PluginUpdateInfo { available_version: None, change_signal:
+        // VersionBumped }`. After the `ManifestVersion` 3-state split,
+        // unreadable surfaces as a per-plugin failure that lands in
+        // `DetectUpdatesResult::failures` — never as "update available
+        // to nothing".
+        let available_version = match Self::load_plugin_manifest_version(&plugin_dir)? {
+            ManifestVersion::Found(v) => v,
+            ManifestVersion::Unreadable { reason } => {
+                let manifest_path = plugin_dir.join("plugin.json");
+                // ManifestNotFound's Display embeds the path; we wrap
+                // the symlink/missing distinction into the carried
+                // io::Error so error_full_chain renders both pieces in
+                // the wire-format `PluginUpdateFailure.reason`.
+                return Err(PluginError::ManifestReadFailed {
+                    path: manifest_path,
+                    source: std::io::Error::new(std::io::ErrorKind::NotFound, reason),
+                }
+                .into());
+            }
+        };
 
         let (content_drift, legacy_fallback) =
             Self::scan_plugin_for_content_drift(project, plugin_info, &plugin_dir)?;
@@ -2187,8 +2207,38 @@ impl MarketplaceService {
         Ok(None)
     }
 
-    /// Load `plugin.json` from `plugin_dir` and return its `version` field.
-    fn load_plugin_manifest_version(plugin_dir: &Path) -> Result<Option<String>, Error> {
+    // (See `ManifestVersion` enum and `read_capped` helper at module scope below.)
+
+    /// Load `plugin.json` from `plugin_dir` and report the manifest's
+    /// `version` field — distinguishing between three semantically
+    /// distinct outcomes per NC1 (PR #96 re-review):
+    ///
+    /// - [`ManifestVersion::Found(Some(v))`] — manifest read; `version`
+    ///   field present.
+    /// - [`ManifestVersion::Found(None)`] — manifest read; `version`
+    ///   field legitimately absent.
+    /// - [`ManifestVersion::Unreadable`] — manifest could not be read for
+    ///   a non-fatal reason (symlink-refused or `NotFound`). The
+    ///   caller must surface this as a per-plugin failure rather than
+    ///   collapse it with the `Found(None)` arm — otherwise the
+    ///   version-comparison logic produces a phantom
+    ///   `PluginUpdateInfo { available_version: None, change_signal:
+    ///   VersionBumped }` whenever an installed plugin happens to carry
+    ///   a `version` string.
+    ///
+    /// The symlink defense embedded here exists because the
+    /// `InvalidManifest` error path's `reason` field includes the
+    /// rendered serde error, which on a symlinked manifest would
+    /// surface bytes from the symlink target (a host file outside the
+    /// untrusted cloned-marketplace tree). Refusing to follow symlinks
+    /// at stat time keeps that exfiltration channel closed. Mirrors
+    /// `service::browse::load_plugin_manifest`'s defense.
+    ///
+    /// Resource cap (Commit 9 / pre-existing security observation):
+    /// reads are bounded at [`MAX_PLUGIN_MANIFEST_BYTES`] so a malicious
+    /// marketplace shipping a multi-GB `plugin.json` cannot OOM the
+    /// process before serde sees a byte.
+    fn load_plugin_manifest_version(plugin_dir: &Path) -> Result<ManifestVersion, Error> {
         let manifest_path = plugin_dir.join("plugin.json");
 
         // Symlink defense: refuse to follow symlinks (C5 security fix).
@@ -2196,13 +2246,17 @@ impl MarketplaceService {
             Ok(m) if m.file_type().is_symlink() => {
                 warn!(
                     path = %manifest_path.display(),
-                    "plugin.json is a symlink, refusing to follow; treating as missing"
+                    "plugin.json is a symlink, refusing to follow; treating as unreadable"
                 );
-                return Ok(None);
+                return Ok(ManifestVersion::Unreadable {
+                    reason: "plugin.json is a symlink — refused".to_owned(),
+                });
             }
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(None);
+                return Ok(ManifestVersion::Unreadable {
+                    reason: "plugin.json missing in marketplace cache".to_owned(),
+                });
             }
             Err(e) => {
                 return Err(PluginError::ManifestReadFailed {
@@ -2213,18 +2267,22 @@ impl MarketplaceService {
             }
         }
 
-        match fs::read(&manifest_path) {
-            Ok(bytes) => match crate::plugin::PluginManifest::from_json(&bytes) {
-                Ok(manifest) => Ok(manifest.version),
-                Err(e) => Err(PluginError::InvalidManifest {
+        let bytes = match read_capped(&manifest_path, MAX_PLUGIN_MANIFEST_BYTES) {
+            Ok(b) => b,
+            Err(e) => {
+                return Err(PluginError::ManifestReadFailed {
                     path: manifest_path,
-                    reason: error_full_chain(&e),
+                    source: e,
                 }
-                .into()),
-            },
-            Err(e) => Err(PluginError::ManifestReadFailed {
+                .into());
+            }
+        };
+
+        match crate::plugin::PluginManifest::from_json(&bytes) {
+            Ok(manifest) => Ok(ManifestVersion::Found(manifest.version)),
+            Err(e) => Err(PluginError::InvalidManifest {
                 path: manifest_path,
-                source: e,
+                reason: error_full_chain(&e),
             }
             .into()),
         }
@@ -2285,20 +2343,30 @@ impl MarketplaceService {
                 match &meta.source_hash {
                     Some(stored) => {
                         let agents_dir = plugin_dir.join("agents");
-                        let rel_path =
-                            meta.source_path
-                                .clone()
-                                .unwrap_or_else(|| match meta.dialect {
-                                    crate::agent::AgentDialect::Native => {
-                                        PathBuf::from(format!("{name}.json"))
-                                    }
-                                    crate::agent::AgentDialect::Claude => {
-                                        PathBuf::from(format!("{name}.md"))
-                                    }
-                                    crate::agent::AgentDialect::Copilot => {
-                                        PathBuf::from(format!("{name}.agent.md"))
-                                    }
-                                });
+                        // Two notes on this fallback (C6 area):
+                        // (a) the dialect-default branch only fires for
+                        //     tracking entries written before the
+                        //     `source_path` field existed (legacy
+                        //     installs); post-NC2 entries always carry a
+                        //     validated `RelativePath`.
+                        // (b) Copilot's `.agent.md` (vs `.md`) extension
+                        //     must mirror the install-time naming
+                        //     convention or a content-hash diff will be
+                        //     misreported as drift.
+                        let rel_path: PathBuf = match &meta.source_path {
+                            Some(rp) => PathBuf::from(rp.as_str()),
+                            None => match meta.dialect {
+                                crate::agent::AgentDialect::Native => {
+                                    PathBuf::from(format!("{name}.json"))
+                                }
+                                crate::agent::AgentDialect::Claude => {
+                                    PathBuf::from(format!("{name}.md"))
+                                }
+                                crate::agent::AgentDialect::Copilot => {
+                                    PathBuf::from(format!("{name}.agent.md"))
+                                }
+                            },
+                        };
                         let computed = crate::hash::hash_artifact(&agents_dir, &[rel_path])?;
                         if computed != *stored {
                             content_drift = true;
@@ -2323,6 +2391,116 @@ impl MarketplaceService {
         }
 
         Ok((content_drift, legacy_fallback))
+    }
+}
+
+/// 3-state outcome of [`MarketplaceService::load_plugin_manifest_version`].
+///
+/// Distinguishing "manifest exists, version field absent" from "manifest
+/// could not be read" closes NC1 (PR #96 re-review): collapsing both
+/// into `Option<String>::None` causes `check_plugin_for_update` to emit
+/// a phantom `VersionBumped` entry whenever an installed plugin happens
+/// to carry a `version` and the cache's `plugin.json` is symlinked or
+/// missing.
+///
+/// `Found(Some(v))` and `Found(None)` are both "scan succeeded";
+/// `Unreadable { reason }` is "do not compare versions — surface a
+/// per-plugin failure instead". Module-private — the public surface
+/// remains [`PluginUpdateInfo`] / [`PluginUpdateFailure`].
+enum ManifestVersion {
+    /// Manifest read; carries the (possibly absent) `version` field.
+    Found(Option<String>),
+    /// Manifest could not be read for a non-fatal reason
+    /// (symlink-refused or `NotFound` on the cache copy). Caller must
+    /// treat this as a per-plugin failure rather than collapse it with
+    /// `Found(None)` — see NC1 above.
+    Unreadable {
+        /// Human-readable reason; embedded into the wire-format
+        /// `PluginUpdateFailure.reason` via `error_full_chain`. Kept
+        /// out of the typed public API so callers cannot substring-match.
+        reason: String,
+    },
+}
+
+/// Maximum bytes a `plugin.json` is allowed to occupy before
+/// [`read_capped`] returns an error. 1 MiB is well above any plausible
+/// manifest (the largest in this workspace's fixtures is < 4 KiB) and
+/// well below process-OOM territory. Mitigates the resource-exhaustion
+/// vector flagged by marketplace-security-reviewer in PR #96 re-review:
+/// a malicious marketplace could otherwise ship a multi-GB
+/// `plugin.json` and OOM the host before serde sees a byte.
+const MAX_PLUGIN_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+/// Read a file with a hard byte cap. Returns
+/// [`std::io::ErrorKind::InvalidData`] if the file exceeds `cap` bytes
+/// (so callers can distinguish from genuine I/O failure). The cap is
+/// enforced via `Read::take`, so the process never allocates more than
+/// `cap` bytes for the buffer.
+fn read_capped(path: &Path, cap: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+    let file = fs::File::open(path)?;
+    let mut buf = Vec::with_capacity(usize::try_from(cap.min(64 * 1024)).unwrap_or(64 * 1024));
+    let read = (&file).take(cap + 1).read_to_end(&mut buf)?;
+    if u64::try_from(read).unwrap_or(u64::MAX) > cap {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("file at {} exceeds the {cap}-byte cap", path.display()),
+        ));
+    }
+    Ok(buf)
+}
+
+/// Build the tracking-file `source_path` for a translated agent install
+/// as a [`crate::validation::RelativePath`] so the on-disk JSON
+/// survives the post-load validation pass (NC2).
+///
+/// Today [`crate::agent::discover::discover_agents_in_dirs`] always
+/// yields paths under `plugin_dir`, but a silent `.ok()` would mask any
+/// future invariant break (Rule 35) — explicit `warn!` plus the
+/// dialect-fallback in
+/// [`MarketplaceService::scan_plugin_for_content_drift`] keep detection
+/// working even if `source_path` lands as `None`.
+///
+/// The forward-slash conversion is required because
+/// `RelativePath::new` rejects backslashes for cross-platform
+/// portability of the wire format.
+fn relative_source_path_for_tracking(
+    path: &Path,
+    plugin_dir: &Path,
+) -> Option<crate::validation::RelativePath> {
+    let rel = match path.strip_prefix(plugin_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                plugin_dir = %plugin_dir.display(),
+                error = %e,
+                "agent path is not under plugin_dir; source_path will fall back \
+                 to dialect default during update detection"
+            );
+            return None;
+        }
+    };
+    let rel_str = rel
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+    match crate::validation::RelativePath::new(rel_str) {
+        Ok(rp) => Some(rp),
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                plugin_dir = %plugin_dir.display(),
+                error = %e,
+                "agent path could not be expressed as RelativePath; source_path \
+                 will fall back to dialect default during update detection"
+            );
+            None
+        }
     }
 }
 
@@ -5912,5 +6090,84 @@ mod tests {
             UpdateChangeSignal::VersionBumped
         ));
         assert!(result.failures.is_empty());
+    }
+
+    /// NC1 (PR #96 re-review): the C5 symlink defense returned
+    /// `Ok(None)` from `load_plugin_manifest_version` when the
+    /// `plugin.json` symlink was refused. That `None` then collapsed
+    /// with `installed_version: Some("1.0")` in the version-comparison
+    /// path to emit a phantom `PluginUpdateInfo { available_version:
+    /// None, change_signal: VersionBumped }` — telling the user "an
+    /// update is available to nothing" whenever an installed plugin's
+    /// cache `plugin.json` had been swapped for a symlink.
+    ///
+    /// Post-fix: the 3-state `ManifestVersion` enum routes
+    /// "unreadable" through the per-plugin failure arm. This test
+    /// pins the no-phantom-update contract by deleting the cache
+    /// `plugin.json` after install and asserting the scan produces
+    /// zero updates and exactly one failure (not an update with
+    /// `available_version: None`).
+    #[test]
+    fn detect_plugin_updates_unreadable_manifest_does_not_phantom_version_bump() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
+            temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
+        let plugin_dir = mp_path.join("plugins/p");
+        // Install with a manifest carrying version "1.0" so the
+        // tracking file records `installed_version: Some("1.0")` —
+        // the precondition for the phantom-version-bump regression.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0"}"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Tracking should now carry version="1.0".
+        let tracking = project.load_installed().expect("load tracking");
+        assert_eq!(
+            tracking
+                .skills
+                .get("alpha")
+                .and_then(|m| m.version.as_deref()),
+            Some("1.0"),
+            "precondition: tracking carries installed_version Some(\"1.0\")"
+        );
+
+        // Now make the cache plugin.json unreadable: delete it.
+        // Pre-NC1 fix: load_plugin_manifest_version returns Ok(None),
+        // version_differs becomes true (Some("1.0") != None), and the
+        // result has a phantom `VersionBumped` update with
+        // available_version: None.
+        fs::remove_file(plugin_dir.join("plugin.json")).unwrap();
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+
+        // Post-fix: zero updates, one failure.
+        assert!(
+            result.updates.is_empty(),
+            "unreadable cache plugin.json must NOT phantom-bump to a \
+             VersionBumped update with available_version: None; got: {:?}",
+            result.updates
+        );
+        assert_eq!(
+            result.failures.len(),
+            1,
+            "unreadable cache manifest must surface as exactly one \
+             per-plugin failure, got: {:?}",
+            result.failures
+        );
+        assert_eq!(result.failures[0].plugin.as_str(), "p");
     }
 }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -446,6 +446,64 @@ pub struct InstallPluginResult {
     pub agents: InstallAgentsResult,
 }
 
+/// Result of [`MarketplaceService::detect_plugin_updates`] — a scan over
+/// installed plugins. `updates` lists plugins with available updates;
+/// `failures` lists plugins the scan couldn't check (marketplace gone
+/// from cache, manifest malformed, hash computation failure). Plugins
+/// with no update available are absent from both vecs (the implicit
+/// "everything's fine" set).
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct DetectUpdatesResult {
+    #[serde(default)]
+    pub updates: Vec<PluginUpdateInfo>,
+    #[serde(default)]
+    pub failures: Vec<PluginUpdateFailure>,
+}
+
+/// A single plugin with an update available. `installed_version` is
+/// `None` for legacy installs whose tracking file lacked the version
+/// field; `available_version` is `None` when the marketplace plugin
+/// manifest itself lacks a version. The `change_signal` discriminates
+/// between manifest-version change and content-drift-without-version-bump.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateInfo {
+    pub marketplace: crate::validation::MarketplaceName,
+    pub plugin: crate::validation::PluginName,
+    pub installed_version: Option<String>,
+    pub available_version: Option<String>,
+    pub change_signal: UpdateChangeSignal,
+}
+
+/// A plugin the update scan couldn't check. `reason` is the rendered
+/// error chain via [`crate::error::error_full_chain`] per CLAUDE.md FFI
+/// rule (any wire-format `reason`/`error: String` field uses
+/// `error_full_chain(&err)`, not `err.to_string()`).
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateFailure {
+    pub marketplace: crate::validation::MarketplaceName,
+    pub plugin: crate::validation::PluginName,
+    pub reason: String,
+}
+
+/// Why an update is being surfaced. Tagged enum for FFI per the
+/// `ffi-enum-serde-tag` plan-lint gate (PR #91): `#[serde(tag = "kind",
+/// rename_all = "snake_case")]` produces `{ "kind": "version_bumped" }`
+/// in JSON, which `tauri-specta` emits as a discriminated TS union.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpdateChangeSignal {
+    /// Manifest version string differs (with or without content hash diff).
+    /// FE renders "Update v1.0 → v1.1".
+    VersionBumped,
+    /// Manifest version unchanged but at least one source-hash diff
+    /// detected. FE renders "Content updated since install".
+    ContentChanged,
+}
+
 /// An agent that failed to install, with the typed error.
 ///
 /// `name` is `Some` once parsing has identified the agent; pre-parse
@@ -4872,5 +4930,72 @@ mod tests {
         // surfaces in this test, not just the default-shape lock.
         assert_eq!(json["marketplace"], "mp");
         assert_eq!(json["plugin"], "p");
+    }
+
+    #[test]
+    fn detect_updates_result_json_shape_default_empty() {
+        let result = DetectUpdatesResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["updates"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn detect_updates_result_json_shape_with_one_update_and_one_failure() {
+        use crate::service::test_support::{mp, pn};
+        let result = DetectUpdatesResult {
+            updates: vec![PluginUpdateInfo {
+                marketplace: mp("mp1"),
+                plugin: pn("p1"),
+                installed_version: Some("1.0".into()),
+                available_version: Some("1.1".into()),
+                change_signal: UpdateChangeSignal::VersionBumped,
+            }],
+            failures: vec![PluginUpdateFailure {
+                marketplace: mp("mp2"),
+                plugin: pn("p2"),
+                reason: "marketplace not in cache".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["updates"][0]["marketplace"], "mp1");
+        assert_eq!(json["updates"][0]["plugin"], "p1");
+        assert_eq!(json["updates"][0]["installed_version"], "1.0");
+        assert_eq!(json["updates"][0]["available_version"], "1.1");
+        assert_eq!(
+            json["updates"][0]["change_signal"]["kind"],
+            "version_bumped"
+        );
+        assert_eq!(json["failures"][0]["marketplace"], "mp2");
+        assert_eq!(json["failures"][0]["plugin"], "p2");
+        assert_eq!(json["failures"][0]["reason"], "marketplace not in cache");
+    }
+
+    #[test]
+    fn plugin_update_info_json_shape_version_bumped() {
+        use crate::service::test_support::{mp, pn};
+        let info = PluginUpdateInfo {
+            marketplace: mp("mp"),
+            plugin: pn("p"),
+            installed_version: Some("1.0".into()),
+            available_version: Some("1.1".into()),
+            change_signal: UpdateChangeSignal::VersionBumped,
+        };
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert_eq!(json["change_signal"]["kind"], "version_bumped");
+    }
+
+    #[test]
+    fn plugin_update_info_json_shape_content_changed() {
+        use crate::service::test_support::{mp, pn};
+        let info = PluginUpdateInfo {
+            marketplace: mp("mp"),
+            plugin: pn("p"),
+            installed_version: Some("1.0".into()),
+            available_version: Some("1.0".into()),
+            change_signal: UpdateChangeSignal::ContentChanged,
+        };
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert_eq!(json["change_signal"]["kind"], "content_changed");
     }
 }

--- a/docs/plans/2026-04-29-plugin-first-install-design.md
+++ b/docs/plans/2026-04-29-plugin-first-install-design.md
@@ -1,6 +1,6 @@
 # Plugin-First Install — Design
 
-> **Status:** design draft. Phase 1 plan in `2026-04-29-plugin-first-install-plan.md`. Phase 2 plan deferred until Phase 1 ships.
+> **Status:** Phase 1 shipped (PR #94, main merge `9ff4e7b`). Phase 1.5 type-safety hardening shipped (PR #95, main merge `a9f7b97`) — `MarketplaceName` / `PluginName` newtypes + A4 marketplace field on `InstallPluginResult`. Phase 2 plan deferred; sketch refreshed 2026-04-30 to reflect newtypes and bundle A2 (`RemovePluginResult` shape symmetry).
 
 ## Problem
 
@@ -184,6 +184,8 @@ The banner-collision concern (code-reviewer finding from PR 92's review) is addr
 
 ## Phase 2 architecture (sketch)
 
+> **Post-Phase-1.5 type-refresh (2026-04-30):** The signatures below were updated after PR #95 merged the `MarketplaceName` / `PluginName` newtypes. `PluginUpdateInfo`'s name fields use the newtypes (parse-don't-validate at deserialization, compile-enforced argument order across the install/update API surface). The update action uses `InstallMode::Force`, not the pre-1.5 `force: bool` shape. **A2** (`RemovePluginResult` shape symmetry — drop `_count: u32`, return `Vec<String>` per content type) was deferred from Phase 1.5 for bundling here, since the wire-format change needs frontend updates landing alongside.
+
 ### Update detection
 
 ```rust
@@ -208,18 +210,34 @@ impl MarketplaceService {
 }
 
 pub struct PluginUpdateInfo {
-    pub marketplace: String,
-    pub plugin: String,
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
     pub installed_version: Option<String>,
     pub available_version: Option<String>,
 }
 ```
 
-Tauri command `detect_plugin_updates(project_path)` returns the same shape.
+Tauri command `detect_plugin_updates(project_path)` returns the same shape. Per Phase 1.5's lesson (PR #95 I1), the wrapper does not need to construct newtypes from FE input — `detect_plugin_updates` reads from already-validated tracking files, and `PluginUpdateInfo`'s newtype-typed fields enforce parse-don't-validate at the deserialization boundary.
 
 ### Update action
 
-No new Tauri command. The update action is `install_plugin(..., force=true)`. The frontend renders an "Update" button in place of "Install" when `detect_plugin_updates` shows the plugin needs one.
+No new Tauri command. The update action is `install_plugin(project, &marketplace, &plugin, InstallMode::Force, accept_mcp)` — the existing `MarketplaceService::install_plugin` signature (post-Phase-1.5) already takes the newtypes and `InstallMode::Force`. The frontend renders an "Update" button in place of "Install" when `detect_plugin_updates` shows the plugin needs one.
+
+### A2 — `RemovePluginResult` shape symmetry (bundled here per Phase 1.5 design)
+
+Phase 1's `RemovePluginResult { skills_removed: u32, steering_removed: u32, agents_removed: u32 }` is asymmetric with `InstallPluginResult` (which carries `Vec`-typed sub-results, not just counts). Phase 1.5 deferred this reshape so the wire-format change could land alongside the InstalledTab UI work that consumes it.
+
+```rust
+pub struct RemovePluginResult {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub skills_removed: Vec<String>,        // skill names
+    pub steering_removed: Vec<PathBuf>,     // relative paths under .kiro/steering/
+    pub agents_removed: Vec<String>,        // agent names
+}
+```
+
+The frontend's "Removed N items" toast becomes "Removed: alpha, beta, gamma" — actionable detail without a follow-up navigation. Counts are recoverable via `.len()` on each Vec.
 
 ### Phase 2 alternatives (rejected for v1, documented for future)
 

--- a/docs/plans/2026-04-29-plugin-first-install-design.md
+++ b/docs/plans/2026-04-29-plugin-first-install-design.md
@@ -227,6 +227,15 @@ No new Tauri command. The update action is `install_plugin(project, &marketplace
 
 Phase 1's `RemovePluginResult { skills_removed: u32, steering_removed: u32, agents_removed: u32 }` is asymmetric with `InstallPluginResult` (which carries `Vec`-typed sub-results, not just counts). Phase 1.5 deferred this reshape so the wire-format change could land alongside the InstalledTab UI work that consumes it.
 
+> **Superseded by Phase 2a.** The sketch below was the design-time
+> shape; the implementation that landed in PR #96 uses nested
+> per-content-type sub-results (`skills`, `steering`, `agents` each
+> carrying `removed` + `failures`) and drops the `marketplace` /
+> `plugin` echo fields (caller already passed them to `remove_plugin`).
+> See `docs/plans/2026-04-30-phase-2a-update-detection-design.md` for
+> the canonical shape and `crates/kiro-market-core/src/project.rs`'s
+> `RemovePluginResult` for the implementation.
+
 ```rust
 pub struct RemovePluginResult {
     pub marketplace: MarketplaceName,

--- a/docs/plans/2026-04-30-phase-2a-update-detection-design.md
+++ b/docs/plans/2026-04-30-phase-2a-update-detection-design.md
@@ -1,0 +1,309 @@
+# Phase 2a — Update Detection (Backend) — Design
+
+> **Status:** design draft. Implementation plan to be written next via the `superpowers:writing-plans` skill once this design is approved. Phase 2a ships as a backend-only PR; Phase 2b (UI) follows as a separate PR consuming these types.
+
+## Problem
+
+PR #95 (Phase 1.5 type-safety hardening) closed the `MarketplaceName` / `PluginName` swap-arg footgun and shipped the A4 marketplace field on `InstallPluginResult`. Two gaps remain on the path to a complete plugin lifecycle:
+
+1. **No way to detect that a plugin has updates.** A user installs `kiro-code-reviewer` v1.0 on Monday. The marketplace owner pushes v1.1 on Wednesday. The user has no signal — the Installed tab shows v1.0 forever, and the user only finds out by re-installing manually. The Phase 1 design (`2026-04-29-plugin-first-install-design.md`, lines 27-31, 185-233) sketched this work as Phase 2 and deferred the implementation plan until Phase 1 shipped.
+2. **`RemovePluginResult` returns opaque counts.** After `kiro-market remove plugin@marketplace`, the toast says "Removed 3 skills, 1 steering file, 2 agents" — the user knows the magnitude but not which items. The Phase 1.5 design (decision A2, line 197) explicitly deferred the reshape to bundle here in Phase 2 because the wire-format change needs frontend consumption landing alongside.
+
+Phase 2a covers the **backend** for both. Phase 2b will land the UI surfaces (Update indicator on plugin cards, Update button wiring, refreshed Remove toast) as a separate PR.
+
+## Approach
+
+**Detection signal: hybrid hash + version.** Compare each installed file's `source_hash` (recorded by Stage-1 content-hash work) against the marketplace cache file's current hash. If any differ, an update is available. The version-string comparison provides the human-readable label (`UpdateChangeSignal::VersionBumped` for `v1.0 → v1.1`, `UpdateChangeSignal::ContentChanged` when content drifted without a version bump). The hybrid catches author hygiene gaps — markdown-heavy plugins (most of them) often see content edits without manifest version increments.
+
+**Per-plugin failure surfacing.** A scan covers many `(marketplace, plugin)` pairs. Some can fail independently (marketplace not in local cache, plugin removed from manifest, manifest malformed). The scan returns a `DetectUpdatesResult { updates, failures }` — plugins with no update available are absent from both vecs (the implicit "everything's fine" set). Matches the A-12 cascade pattern (`remove_plugin`) and the `installed_plugins.partial_load_warnings` pattern from Phase 1.
+
+**`RemovePluginResult` reshape.** Restructure into per-content-type sub-results (`RemoveSkillsResult`, `RemoveSteeringResult`, `RemoveAgentsResult`), each with `removed: Vec<String>` and `failures: Vec<RemoveItemFailure>`. Symmetric with `InstallPluginResult`'s sub-result structure (`InstallSkillsResult`, etc.). Native companions fold into `RemoveAgentsResult` (matching install-side asymmetry).
+
+**Action: existing `install_plugin` with `InstallMode::Force`.** No new Tauri command for the update *action*. Phase 1.5 already shipped the right signature (`install_plugin(project, &MarketplaceName, &PluginName, InstallMode::Force, accept_mcp)`); the FE just calls it when the user clicks "Update".
+
+## User-locked decisions
+
+These came out of the `2026-04-30` brainstorming conversation. Documented here so they don't drift during implementation:
+
+1. **Scope: pure update flow.** Phase 2a is strictly update detection + A2 reshape. No bundled tech-debt cleanups (e.g., `From<CoreError>` exhaustiveness, cross-marketplace idempotency edge, HashMap-key newtypes). Rationale: tight PR scope is the explicit constraint; bundled work inflates review surface and dilutes focus. The deferred items remain captured for future phases.
+
+2. **Implementation split: 2a backend + 2b UI.** Backend ships first as its own PR (no FE consumer yet); UI follows as a second PR. Mirrors the steering precedent (PR 83 backend + PR 92 UI) which kept reviews focused. Phase 1.5 already proved that `bindings.ts` regeneration without a FE consumer is fine.
+
+3. **Failure handling: per-plugin failure surfacing.** Scan results are `DetectUpdatesResult { updates, failures }` — a separate failures vec, not Option-typed fields on the success type. Matches the A-12 cascade pattern. Toplevel `Result::Err` is reserved for "couldn't read tracking files at all"; per-marketplace / per-plugin failures land in `failures`. UI consumption is two `.find()` calls per card.
+
+4. **A2 reshape: per-content-type sub-results.** `RemovePluginResult { skills, steering, agents }` symmetric with `InstallPluginResult`. Shared `RemoveItemFailure` type across the three sub-results — discriminator is the parent type, no `content_type: String` field. Native companions fold into `RemoveAgentsResult.removed` flat. **No `marketplace` / `plugin` echo fields** — caller already knows what they asked to remove. (Different from Phase 1.5 A4, which added `marketplace` to `InstallPluginResult` because that type lives in lists where self-identification matters.)
+
+5. **Detection signal: hybrid hash + version.** Hash drives the "update available?" decision; version provides the human-readable label. `UpdateChangeSignal` is a tagged enum (`#[serde(tag = "kind", rename_all = "snake_case")]`) per the `ffi-enum-serde-tag` plan-lint gate. **Legacy fallback:** plugins installed before Stage-1 hash tracking (`source_hash: None` on tracking entries) fall back to version-only comparison; classified as `VersionBumped` if versions differ, otherwise no entry (content drift undetectable until next install).
+
+## Phase 2a architecture
+
+### Update detection
+
+```rust
+// crates/kiro-market-core/src/service/mod.rs
+
+impl MarketplaceService {
+    /// Scan installed plugins, comparing each tracking-file `version` and
+    /// `source_hash` against the corresponding marketplace plugin manifest +
+    /// source files in the local cache.
+    ///
+    /// "Update available" = either (a) at least one source hash differs from
+    /// the corresponding `source_hash` in the tracking file, or (b) the
+    /// marketplace plugin manifest's `version` is not byte-equal to the
+    /// highest installed version across the three tracking files. Strict
+    /// string inequality on versions, no semver — downgrades pushed by
+    /// marketplace owners are surfaced.
+    ///
+    /// Reads from the local marketplace cache. Callers who want fresh data
+    /// run `update_marketplaces` first (existing pattern).
+    ///
+    /// Per-plugin failures (marketplace gone from cache, plugin removed
+    /// from manifest, manifest malformed) land in `failures`, not in
+    /// `Result::Err`. Plugins with no update available are absent from
+    /// both vecs.
+    pub fn detect_plugin_updates(
+        &self,
+        project: &KiroProject,
+    ) -> Result<DetectUpdatesResult, Error>;
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct DetectUpdatesResult {
+    #[serde(default)]
+    pub updates: Vec<PluginUpdateInfo>,
+    #[serde(default)]
+    pub failures: Vec<PluginUpdateFailure>,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateInfo {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub installed_version: Option<String>,    // None when tracking files have no version
+    pub available_version: Option<String>,    // None when manifest also lacks version
+    pub change_signal: UpdateChangeSignal,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateFailure {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub reason: String,    // error_full_chain at the boundary (per CLAUDE.md FFI rule)
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpdateChangeSignal {
+    /// Manifest version string differs (with or without content hash diff).
+    /// FE renders "Update v1.0 → v1.1".
+    VersionBumped,
+    /// Manifest version unchanged but at least one source-hash diff detected.
+    /// FE renders "Content updated since install".
+    ContentChanged,
+}
+```
+
+**Detection logic** (per installed plugin, called from inside `detect_plugin_updates`):
+
+1. Walk every installed-file entry across the 4 tracking files (skills, steering, agents, native_companions) for this `(marketplace, plugin)`.
+2. For each entry with a non-None `source_hash`, recompute the hash of the corresponding marketplace-cache content and compare. **The hash function MUST match what the install path used** — `hash::hash_dir_tree` for skills (skills are directories per `project.rs:910,930`), `hash::hash_artifact` for steering and agents (single-file or rel-paths-list per `service/mod.rs:1669,1741`). Re-applying the install-path hash function ensures byte-equal comparisons; using a different hash function would produce false positives.
+3. If any recomputed hash differs OR if the marketplace plugin manifest's `version` differs from the version of the most recently installed file across the three tracking files (matches `installed_plugins`'s `latest_install`-keyed selection at `project.rs::installed_plugins`) → there's an update; classify by version-string comparison (`VersionBumped` if versions differ, `ContentChanged` if versions match but hashes differ).
+4. **Legacy fallback:** if `source_hash` is None for any tracked file (legacy install pre-Stage-1), fall back to version-string comparison only. If versions differ → `VersionBumped`. If versions match → no entry (content drift undetectable for legacy installs).
+5. Per-plugin scan errors (cache file not found, hash computation failure, marketplace gone) get an entry in `failures` with `error_full_chain(&err)` as `reason`.
+
+**Tauri command:** `detect_plugin_updates(project_path: String) -> Result<DetectUpdatesResult, CommandError>`. Service-consuming command — uses the `_impl(svc, project_path)` pattern per CLAUDE.md. Validates `project_path` via `validate_kiro_project_path`. No `MarketplaceName::new` / `PluginName::new` construction at the IPC boundary because the wrapper takes no name args (it scans the whole project). The returned `DetectUpdatesResult`'s newtype-typed fields enforce parse-don't-validate at the deserialization boundary.
+
+**Result-only surface:** no toplevel `Result::Err` for "couldn't reach marketplace X" — that's a per-plugin failure in `failures`. The toplevel `Err` is reserved for "couldn't read tracking files at all" (project layout broken) — same shape as `installed_plugins` already has.
+
+### A2 — `RemovePluginResult` reshape (per-content-type sub-results)
+
+```rust
+// crates/kiro-market-core/src/project.rs
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemovePluginResult {
+    pub skills: RemoveSkillsResult,
+    pub steering: RemoveSteeringResult,
+    pub agents: RemoveAgentsResult,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSkillsResult {
+    #[serde(default)]
+    pub removed: Vec<String>,                   // skill names
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSteeringResult {
+    #[serde(default)]
+    pub removed: Vec<String>,                   // rendered via Path::display() (matches existing failures.item shape)
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveAgentsResult {
+    #[serde(default)]
+    pub removed: Vec<String>,                   // translated agent names + native agent names + native companion paths, flat
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveItemFailure {
+    pub item: String,                           // skill/agent name or steering rel-path rendered
+    pub error: String,                          // error_full_chain at the boundary
+}
+```
+
+**Three deliberate decisions:**
+
+1. **Shared `RemoveItemFailure` type** across the three sub-results rather than per-content-type failure types. The discriminator is the *parent type* (you know what content type failed because you read it from `result.skills.failures`). The existing `RemovePluginFailure.content_type: String` discriminator goes away because it's now expressed through the parent.
+2. **Native companions fold into `RemoveAgentsResult.removed`** as a flat vec of mixed names and paths. Matches install-side asymmetry where native companions are agent-side artifacts. If FE later wants native-vs-translated breakdown, that's an additive field change.
+3. **No `marketplace` / `plugin` echo fields** on `RemovePluginResult` — caller already knows what they asked to remove (different from Phase 1.5 A4 which added `marketplace` to `InstallPluginResult` because that type lives in lists where self-identification is needed).
+
+**Cascade behavior unchanged.** The cascade still keeps making progress on remaining content types when one step fails (per A-15). Per-content-type failures land in the parent's `failures` vec; the cascade returns `RemovePluginResult` populated as far as it got. Native_companions failures land in `agents.failures` as part of the agent cascade step.
+
+**`#[serde(default)]` on each vec field** for legacy-JSON tolerance, no `skip_serializing_if` (per A-25, tauri-specta unified-mode rejects it).
+
+## Wire format / FFI
+
+**New types crossing FFI:** `DetectUpdatesResult`, `PluginUpdateInfo`, `PluginUpdateFailure`, `UpdateChangeSignal`, restructured `RemovePluginResult`, `RemoveSkillsResult`, `RemoveSteeringResult`, `RemoveAgentsResult`, `RemoveItemFailure`. All use `#[cfg_attr(feature = "specta", derive(specta::Type))]`. All vec fields use `#[serde(default)]` no `skip_serializing_if` per A-25. The `UpdateChangeSignal` enum complies with `ffi-enum-serde-tag` (PR #91 plan-lint gate) via `#[serde(tag = "kind", rename_all = "snake_case")]`.
+
+**Wire-format JSON-shape locks** (rstest cases) — one each for:
+- `DetectUpdatesResult` default empty
+- `DetectUpdatesResult` populated with one update + one failure
+- `PluginUpdateInfo` with `change_signal: VersionBumped`
+- `PluginUpdateInfo` with `change_signal: ContentChanged`
+- Restructured `RemovePluginResult` default empty
+- Restructured `RemovePluginResult` populated with removed + failure entries
+
+Mirror PR #94's `install_plugin_result_json_shape_locks_default_subresults` pattern.
+
+**Backward compat for `RemovePluginResult`:** A2 is a *breaking* wire-format change. The previous shape (`skills_removed: u32, steering_removed: u32, agents_removed: u32, failures: Vec<RemovePluginFailure>`) ships in PR #94 and #95 main today. **No compat shim** — the single-PR-per-phase pattern means consumers update at the same time as the producer. The Tauri command `remove_plugin` returns the new shape; bindings.ts regen propagates it; Phase 2b UI is the only consumer.
+
+## Module map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | Add `detect_plugin_updates`, `DetectUpdatesResult`, `PluginUpdateInfo`, `PluginUpdateFailure`, `UpdateChangeSignal` |
+| `crates/kiro-market-core/src/project.rs` | Modify | Reshape `RemovePluginResult`; add `RemoveSkillsResult` / `RemoveSteeringResult` / `RemoveAgentsResult` / `RemoveItemFailure`; update `KiroProject::remove_plugin` to populate the new sub-result types; remove the `RemovePluginFailure` type |
+| `crates/kiro-market-core/src/cache.rs` | Modify (small, optional) | If detection-scan code lives outside the existing `hash::hash_dir_tree` / `hash::hash_artifact` call sites, add a helper that resolves a `(marketplace, plugin, content-type, rel_path)` tuple to the right cache path + hash function; otherwise reuse the existing hash module directly from `service/mod.rs::detect_plugin_updates`. |
+| `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` | Modify | Add `detect_plugin_updates` Tauri command (`_impl(svc, project_path)` shape per CLAUDE.md service-consuming pattern); `remove_plugin` wrapper unchanged but returns the new shape |
+| `crates/kiro-control-center/src-tauri/src/lib.rs` | Modify | Register `detect_plugin_updates` in `collect_commands!` |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | Auto-generated; emits new types + restructured `RemovePluginResult` |
+| `crates/kiro-market-core/tests/integration_*.rs` | Modify | Update `RemovePluginResult`-asserting integration tests to the new shape |
+
+**Frontend changes are zero in 2a** — `bindings.ts` regeneration will surface the type changes to TS, but no Svelte component consumes them yet (that's 2b). The intermediate state is the same shape Phase 1.5 already proved is fine.
+
+## Testing strategy
+
+### `detect_plugin_updates` (new)
+
+- **Happy path no updates** — fixture marketplace with plugin v1.0 (matching content hashes), project with installed v1.0 → `DetectUpdatesResult { updates: [], failures: [] }`
+- **Version bump detection** — fixture marketplace with plugin v1.1, project with installed v1.0 → `updates: [{ change_signal: VersionBumped, available_version: Some("1.1"), installed_version: Some("1.0") }]`
+- **Content drift detection (no version bump)** — fixture marketplace where a skill file's content is mutated but `version` unchanged → `updates: [{ change_signal: ContentChanged }]`
+- **Per-plugin failure surfacing** — fixture project with installed plugin from a marketplace not in cache → `updates: [], failures: [{ reason: "..." }]` (verify reason chains via `error_full_chain`)
+- **Legacy fallback (source_hash: None)** — fixture project with `source_hash: None` on tracking entries (pre-Stage-1 install); marketplace at v1.1, installed at v1.0 → `updates: [{ change_signal: VersionBumped }]`; same versions → `updates: []` (content drift undetectable)
+- **Mixed scenario** — project with 4 installed plugins: one no-update, one version-bumped, one content-drift, one whose marketplace is missing → asserts each plugin lands in the right vec with the right `change_signal`
+- **Multiple content types in one plugin** — plugin with 3 skills + 2 steering + 1 agent; only one steering file has content drift → `updates: [{ change_signal: ContentChanged }]` (per-plugin granularity, not per-file)
+
+### A2 reshape (existing tests modified)
+
+- Existing `KiroProject::remove_plugin` rstests (PR #94's A-12 cascade tests at `project.rs:5567+`) update assertions from `result.skills_removed: u32` etc. to `result.skills.removed: Vec<String>`; verify named items appear
+- Per-content-type failure landing — fixture where steering removal fails mid-cascade; assert failure lands in `result.steering.failures`, not `result.skills.failures`
+- Native companions cascade-step failure → lands in `result.agents.failures`
+- Empty-cascade case (no installed entries for plugin) → `RemovePluginResult { skills: default, steering: default, agents: default }`
+
+### JSON-shape locks (new rstests in `service/mod.rs::tests` + `project.rs::tests`)
+
+- `detect_updates_result_json_shape_locks_default_empty`
+- `detect_updates_result_json_shape_with_one_update_and_one_failure`
+- `plugin_update_info_json_shape_version_bumped`
+- `plugin_update_info_json_shape_content_changed`
+- `remove_plugin_result_json_shape_locks_default_empty`
+- `remove_plugin_result_json_shape_with_populated_subresult` (skills.removed populated, steering.failures populated)
+
+### Tauri command tests (`commands/plugins.rs::tests`)
+
+- `detect_plugin_updates_impl_happy_path` — uses `temp_service` fixture; verifies the wrapper threads `MarketplaceService::detect_plugin_updates` correctly
+- `detect_plugin_updates_impl_rejects_invalid_project_path` — `validate_kiro_project_path` rejection surfaces as `ErrorType::Validation`
+
+### Plan-lint
+
+`cargo xtask plan-lint` continues to enforce: gate-4-external-error-boundary (no external error leaks), no-unwrap-in-production, ffi-enum-serde-tag (covers the new `UpdateChangeSignal`).
+
+## Out of scope
+
+Documented here so they don't drift into the plan:
+
+- **Phase 2b UI work** — Update indicator on plugin cards, Update button wiring, refreshed Remove toast. Separate PR; consumes the types defined here.
+- **Hash memoization in marketplace cache** — perf optimization (compute source hashes once per `kiro-market update`, store in cache index, detection becomes metadata-only reads). Realistic projects probably take <100ms for a fresh-hash scan; can ship later if needed.
+- **Per-content-type update granularity** — rejected for v1 per Phase 1 design's "Phase 2 alternatives" section; plugins are coherent bundles.
+- **Auto-update / background polling** — rejected for v1 per Phase 1 design; security-sensitive (a malicious marketplace could push a hostile MCP server).
+- **HashMap-key newtypes** (`SkillName`, `AgentName` for the keys) — deferred to a later phase. The I9 walkers + Phase 1.5 newtype `Deserialize` already give belt-and-suspenders.
+- **`From<CoreError>` exhaustiveness fix** — PR #95 silent-failure-hunter S3 finding; pre-existing CLAUDE.md classifier rule violation. Sibling task.
+- **Cross-marketplace same-plugin idempotency edge** (`project.rs:2937-2956`) — PR #95 marketplace-security-reviewer suggestion; pre-existing behavior. May matter for Phase 2b UI work but doesn't block 2a backend.
+- **CSP `csp: null` hardening, TOCTOU lock-spanning, vitest setup** — different category (security/test infra); separate phases.
+- **`RemovePluginResult` backward-compat shim** — A2 is a breaking wire-format change shipped together with its consumer; no shim.
+
+## 5-Gates self-review
+
+### Gate 1 — Grounding
+
+**Real incident driving this work?** Yes, two:
+1. PR #95's review process flagged that `detect_plugin_updates` would inherit the swap-arg footgun if Phase 1.5 hadn't closed it first — Phase 2a is the natural follow-on.
+2. The "are people actually good about incrementing plugin versions?" concern surfaced during the 2026-04-30 brainstorm — drove the hybrid hash detection (decision #5). Markdown-heavy plugins (most of them) are exactly where authors under-bump, and version-only detection would silently miss those updates.
+
+### Gate 2 — Threat Model
+
+**Untrusted inputs:**
+
+- **Tracking-file content** (`InstalledSkillMeta.marketplace`, `source_hash`, etc.) — already parse-validated at `serde_json::from_slice` via Phase 1.5's newtype `Deserialize` impls. No new untrusted parse points.
+- **Marketplace plugin manifest fields** (`version`, file lists) — already validated by existing core parsers (`PluginManifest`, `RelativePath`); Phase 2a doesn't introduce new untrusted parse points.
+- **Marketplace cache source files** — `fs::read` + xxhash. The cache is populated by `kiro-market update` from authenticated git operations; the contents are trusted at hash-time. The hash itself is xxhash (fast, non-cryptographic) — appropriate for change detection, not authentication.
+- **`project_path` from Tauri FFI** — `validate_kiro_project_path` from PR 83 still applies; new `detect_plugin_updates` wrapper calls it.
+
+### Gate 3 — Wire Format / FFI
+
+**`UpdateChangeSignal` enum** uses `#[serde(tag = "kind", rename_all = "snake_case")]` — complies with `ffi-enum-serde-tag` plan-lint gate (PR #91). All new types use `#[cfg_attr(feature = "specta", derive(specta::Type))]`. All vec fields use `#[serde(default)]` no `skip_serializing_if` (A-25).
+
+**JSON-shape rstests** (listed in Testing Strategy) lock the contract for new types. `DetectUpdatesResult` and the restructured `RemovePluginResult` default-empty + populated cases both pinned.
+
+**Breaking change:** `RemovePluginResult`'s reshape is wire-format-breaking. No compat shim — single-PR-per-phase pattern means the consumer (Phase 2b UI) updates at the same time as the producer (this PR's `bindings.ts` regen). Phase 2b PR depends on this PR.
+
+### Gate 4 — External Type Boundary
+
+**No new external errors introduced** in `kiro-market-core`'s public API. The cache-read helper in `cache.rs` may surface `io::Error` on read failures — wrap in a typed variant per CLAUDE.md "map external errors at adapter boundary" recipe (`#[non_exhaustive]` enum + `reason: String` + `error_full_chain`). `cargo xtask plan-lint --gate gate-4-external-error-boundary` will catch any leak. The new `PluginUpdateFailure.reason: String` field is the wire-format projection of any per-plugin error chain.
+
+### Gate 5 — Type Design
+
+- **`UpdateChangeSignal` as enum** rather than two booleans (`version_bumped: bool, content_changed: bool`) — single source of truth, exhaustive matching enforced, FE switch statement is total.
+- **`DetectUpdatesResult { updates, failures }` shape** distinguishes "data" from "failures" at the type level — the FE knows what kind of thing it's looking at without inspecting an `Option<error>` field.
+- **Newtype-typed name fields** throughout (`MarketplaceName`, `PluginName`) — Phase 1.5's invariant carries through.
+- **`Option<String>` for versions** distinguishes "no version field in manifest" from "matches" — sentinel-free.
+- **Per-content-type sub-results** for `RemovePluginResult` — each sub-result is a self-contained unit (removed + failures), and the parent type discriminator removes the need for a stringly-typed `content_type: String` field.
+- **No new validation newtypes introduced.** Existing newtypes (`MarketplaceName`, `PluginName`, `RelativePath`, `AgentName`) cover the parse-don't-validate boundaries.
+
+## References
+
+- `2026-04-29-plugin-first-install-design.md` — Phase 1 + Phase 2 sketch (post-1.5 refresh applied 2026-04-30)
+- `2026-04-30-phase-1-5-type-safety-design.md` — Phase 1.5 design; A4 `marketplace` field, A2 deferral note (line 197 in design)
+- `2026-04-30-phase-1-5-type-safety-plan-amendments.md` — 8 amendments (P1.5-1 through P1.5-8); especially A-25 (`skip_serializing_if` rejection on FFI types)
+- `2026-04-29-plugin-first-install-plan-amendments.md` — Phase 1's amendments, especially A-12 (cascade orphan recovery), A-15 (cascade keeps making progress on partial failures), A-16 (marketplace-aware native_companions cleanup), A-25 (skip_serializing_if rule)
+- `2026-04-23-stage1-content-hash-primitive-plan.md` — Stage 1 content-hash work that populated `source_hash` on tracking-file meta types (load-bearing for the hybrid detection signal)
+- PR #94 — Phase 1 (plugin-first install)
+- PR #95 — Phase 1.5 (type-safety hardening); convergent reviewer findings on swap-arg footgun closed
+- `docs/plan-review-checklist.md` — 5-gates self-review used above
+- CLAUDE.md — `validation.rs` newtype template, FFI rules (`error_full_chain`, no `skip_serializing_if` per A-25), `_impl(svc, ...)` Tauri command pattern, "map external errors at adapter boundary" recipe

--- a/docs/plans/2026-05-01-phase-2a-update-detection-plan-amendments.md
+++ b/docs/plans/2026-05-01-phase-2a-update-detection-plan-amendments.md
@@ -1,0 +1,295 @@
+# Phase 2a — Plan Amendments
+
+> **Status:** plan-review pass per `docs/plan-review-checklist.md`.
+> Fixes drift between `2026-05-01-phase-2a-update-detection-plan.md` and the
+> actual SHA at `40a6fc6` (post-PR-#95 main + Phase 2a design + plan).
+> Format follows the precedent set by `2026-04-30-phase-1-5-type-safety-plan-amendments.md`.
+
+5-gates pass via LSP-first + code-reviewer-style discipline (per A-8 + the
+"two complementary passes" rule in CLAUDE.md). Pass found **3 CRITICAL**,
+**3 IMPORTANT**, and **1 OBSERVATION**. The CRITICAL findings are
+compile-blockers / wrong-shape errors of exactly the class P1.5-1 and
+P1.5-2 caught — API-shape assumptions baked into the plan against an
+out-of-date mental model.
+
+Each amendment cites the gate that fired, names the original plan
+text, gives the amended text, and explains the rationale. Apply
+during execution; **P2a-1 requires a one-question design decision**
+before Task 2 begins (call it out below).
+
+---
+
+## P2a-1 — Gate 5: `PluginEntry` has no `version` field; `available_version` resolution as written won't compile
+
+**Original (Task 2, Step 2 — `check_plugin_for_update`):**
+
+```rust
+let plugin_entries = self.list_plugin_entries(plugin_info.marketplace.as_str())?;
+let plugin_entry = plugin_entries
+    .iter()
+    .find(|p| p.name == plugin_info.plugin.as_str())
+    .ok_or_else(|| { Error::Plugin(crate::error::PluginError::NotFound { ... }) })?;
+
+let available_version = plugin_entry.version.clone();
+```
+
+**Drift.** `PluginEntry` is defined in `crates/kiro-market-core/src/marketplace.rs:32-36` with exactly three fields: `name: String`, `description: Option<String>`, `source: PluginSource`. There is **no `version` field**. The version field that the design references lives on `PluginManifest` (`crates/kiro-market-core/src/plugin.rs:17` — `pub version: Option<String>`) — i.e. it's in the per-plugin `plugin.json`, not in the marketplace's `marketplace.json` plugin list. `list_plugin_entries` returns `Vec<PluginEntry>` (verified at `service/mod.rs:1012-1042`). Calling `.version` on a `PluginEntry` won't compile.
+
+The design's "Detection logic" step 3 also refers to "the marketplace plugin manifest's `version`" — meaning `PluginManifest.version`, not `PluginEntry.version`. The plan slid from "`PluginManifest.version`" to "`plugin_entry.version`" without noticing they're different types.
+
+**Required design decision before Task 2 begins:**
+
+(A) **Cache-load `plugin.json` per plugin during detection.** Resolve `PluginEntry.source` to a cache directory, `fs::read(plugin_dir.join("plugin.json"))`, parse via `PluginManifest::from_json`, read `manifest.version`. One extra file read per installed plugin during the scan. Matches the existing install path's resolution (which already loads `plugin.json` to discover the install contents).
+
+(B) **Extend `PluginEntry` to include `version: Option<String>` populated at marketplace-load time.** Marketplace catalog parser (`try_read_manifest`) gains a "load each plugin's manifest upfront" step. Changes the marketplace catalog parse semantics; touches more code than (A); affects every consumer of `PluginEntry` (specta type emission included).
+
+**Recommended: (A).** Keeps `PluginEntry` (the wire-format type for the marketplace catalog list) unchanged. Version is only needed for detection, not for the catalog browse UI. Matches existing install-path resolution pattern.
+
+**Amended.** Replace Task 2's `check_plugin_for_update` `available_version` block:
+
+```rust
+// Resolve the plugin's cache directory by joining marketplace_path + the
+// PluginSource. Both PluginSource::RelativePath and PluginSource::Structured
+// resolve to a per-plugin subdir under <marketplace_root>; reuse the
+// existing resolution helper (search install code for the pattern — likely
+// in MarketplaceService::resolve_plugin_install_context).
+let cache_dir = self.marketplace_path(plugin_info.marketplace.as_str());
+let plugin_dir = match &plugin_entry.source {
+    crate::marketplace::PluginSource::RelativePath(rel) => cache_dir.join(rel.as_str()),
+    crate::marketplace::PluginSource::Structured(_) => {
+        // Verify the existing resolution helper covers Structured sources;
+        // most likely resolve_plugin_install_context has the canonical logic.
+        // Reuse, don't reimplement.
+        todo!("reuse resolve_plugin_install_context's PluginSource resolution");
+    }
+};
+
+let manifest_bytes = std::fs::read(plugin_dir.join("plugin.json"))
+    .map_err(|e| /* wrap into a typed PluginError::ManifestReadFailed-style variant */)?;
+let manifest = crate::plugin::PluginManifest::from_json(&manifest_bytes)
+    .map_err(|e| /* wrap — serde_json::Error must NOT leak per CLAUDE.md gate-4 */)?;
+let available_version = manifest.version;
+```
+
+The plan must also (i) pick or define the right error variants for "plugin.json missing in cache" and "plugin.json malformed in cache" (both are per-plugin failures that should land in `PluginUpdateFailure.reason` via `error_full_chain`); CLAUDE.md's "map external errors at adapter boundary" recipe applies — `serde_json::Error` does NOT cross the public API; wrap it in a `#[non_exhaustive]` variant with `reason: String + error_full_chain(&err)`. (ii) Update Task 2's required-research LSP queries to include `workspaceSymbol query=resolve_plugin_install_context` so the implementer reuses the existing `PluginSource` resolution.
+
+**Rationale.** Gate 5 (Type Design) and Gate 1 (Grounding). This is a compile-blocking error and the central data-flow assumption of Task 2; the LSP-first pass on `marketplace.rs` would have caught it. Without this fix the implementer wastes hours discovering the gap and then has to redesign the cache lookup mid-task. Also surfaces a Gate 4 concern (a new `serde_json::Error` translation point in `service/mod.rs`).
+
+---
+
+## P2a-2 — Gate 5: existing field is `failed: Vec<...>`, not `failures: Vec<...>`; rename inconsistency throughout the plan
+
+**Original (Task 5 + Task 6, repeatedly):**
+
+> Plan: `failures: Vec<RemovePluginFailure>` (file-structure summary, Step 1 commit message, Step 2 prose, "If `RemovePluginFailure` is referenced anywhere…")
+> Plan Task 6 search: `grep -rn "skills_removed\|steering_removed\|agents_removed\|RemovePluginFailure" crates/kiro-control-center/`
+
+**Drift.** The actual field on the *current* `RemovePluginResult` is `failed: Vec<RemovePluginFailure>` (`project.rs:392`), not `failures`. Existing rstests assert on `result.failed`. The Task 6 grep also misses references to the old field (`failed`).
+
+The plan's *new* `RemoveSkillsResult` / `RemoveSteeringResult` / `RemoveAgentsResult` use a field named `failures` (Task 4, Step 1). Mixing the new naming convention with the old `failed` is fine in isolation, but the plan never explicitly calls out the rename — implementer reading "failures" everywhere may try to grep for `result.failed` references and miss the new-vs-old distinction.
+
+**Amended.** Add to Task 5 Step 1:
+
+> **Field-name change:** the existing `RemovePluginResult.failed: Vec<RemovePluginFailure>` becomes `result.<content_type>.failures: Vec<RemoveItemFailure>` per sub-result. The new types use `failures` (matching Task 4's additive types). Migrate callers explicitly; do not silently keep `failed` for backward compat — the type is breaking-changing anyway.
+
+In Task 6 Step 1, expand the search:
+
+```bash
+grep -rn "skills_removed\|steering_removed\|agents_removed\|RemovePluginFailure\|\.failed\b" crates/kiro-control-center/
+```
+
+Filter results — `result.failed` also appears on `InstallSkillsResult` / `InstallSteeringResult` / `InstallAgentsResult`; only `RemovePluginResult.failed` references need updating. Use surrounding context to disambiguate.
+
+**Rationale.** Gate 5 (type-shape contract). One sentence of plan prose prevents 30 minutes of confusion when the implementer sees `result.failures` in the migration sketch and `result.failed` in the existing code.
+
+---
+
+## P2a-3 — Gate 5: `KiroProject::remove_plugin` migration sketch references non-existent helpers (`load_installed_skills_or_default`, `remove_skill_internal`)
+
+**Original (Task 5, Step 3 migration sketch):**
+
+```rust
+let mut skills = self.load_installed_skills_or_default()?;
+// ...
+match self.remove_skill_internal(&mut skills, &skill_name) { ... }
+self.save_installed_skills(&skills)?;
+```
+
+**Drift.** Looking at the actual `remove_plugin` body (`project.rs:1429-1552`):
+- The skill loader is `self.load_installed()` (returns `InstalledSkills`), not `self.load_installed_skills_or_default()`. There is no `_or_default` suffix; the loader already returns default on missing-file (`project.rs:795-806`).
+- The cascade calls `self.remove_skill(name)` (line 1447), not `self.remove_skill_internal(&mut skills, &skill_name)`. There is no `remove_skill_internal` helper that takes `&mut InstalledSkills`. The current impl re-loads inside `remove_skill`.
+- There is no `save_installed_skills(&skills)` call after the loop — the skill removal helper writes its own tracking on each call.
+- `load_installed_steering` / `load_installed_agents` exist (lines 1009, 959), but again the cascade body relies on the inner `remove_*` helpers to handle their own writes.
+
+The plan's migration sketch invents an in-memory-mutate-then-batch-save pattern that doesn't match the current code, and references two API names (`load_installed_skills_or_default`, `remove_skill_internal`) that don't exist. The implementer following this sketch produces non-compiling code AND changes the I/O semantics (one save per cascade vs. many in current code).
+
+**Amended.** Rewrite Task 5 Step 3's migration sketch to match the existing skeleton — keep the per-iteration `remove_skill(name)` / `remove_steering_file(rel)` / `remove_agent(name)` calls and only change where successes/failures land. Concretely:
+
+```rust
+let skills = self.load_installed()?;
+let skills_to_remove: Vec<String> = skills.skills.iter()
+    .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
+    .map(|(name, _)| name.clone()).collect();
+for name in &skills_to_remove {
+    match self.remove_skill(name) {
+        Ok(()) => result.skills.removed.push(name.clone()),
+        Err(e) => {
+            warn!(skill = %name, plugin = %plugin, marketplace = %marketplace, error = %e, "remove_plugin: skill removal failed");
+            result.skills.failures.push(RemoveItemFailure {
+                item: name.clone(),
+                error: crate::error::error_full_chain(&e),
+            });
+        }
+    }
+}
+
+// Steering: load_installed_steering(), filter, for-loop calls self.remove_steering_file(rel).
+// Agents: load_installed_agents(), filter, for-loop calls self.remove_agent(name).
+// Native companions: trailing if-let on self.remove_native_companions_for_plugin(plugin, marketplace).
+//   On Err -> push to result.agents.failures with item: format!("native_companions:{plugin}")
+//   (the step is plugin-scoped, not per-companion-file).
+```
+
+**Native-companions removed-list ambiguity (design clarification needed):** The plan says `result.agents.removed` includes "native companion paths". But `remove_native_companions_for_plugin` returns `()` — it does NOT currently expose the list of removed companion paths. Pick one:
+
+- **(α)** Limit `agents.removed` to "translated agent names + native agent names". Native_companions success = "the cascade step ran without error" but yields no per-file entries. Document this in Task 5 step 3.
+- **(β)** Refactor `remove_native_companions_for_plugin` to return `Vec<PathBuf>` (the unlinked paths). Adds scope to Task 5.
+
+**Recommended: (α)** for Phase 2a tight scope. Document as a Phase 2b follow-up if the UI wants per-companion granularity. Update Task 5 Step 3's `removed: Vec<String>` doc-comment for `RemoveAgentsResult` to reflect this.
+
+**Rationale.** Gate 5 + Gate 1. The migration sketch is the highest-risk part of Task 5; a wrong sketch is exactly the kind of plan defect that costs an implementer cycles. The "removed companion paths" question is a real design ambiguity that the implementer cannot resolve without going back to the user.
+
+---
+
+## P2a-4 — Gate 5 (IMPORTANT): `source_hash` is `Option<String>` only on skills/agents; steering & native_companions store it as plain `String` — legacy fallback applies asymmetrically
+
+**Original:** plan + design repeatedly reference "if `source_hash` is None for any tracked file (legacy install pre-Stage-1), fall back to version-string comparison only".
+
+**Drift.** The four tracking-meta types differ:
+- `InstalledSkillMeta.source_hash: Option<String>` (`project.rs:45`)
+- `InstalledAgentMeta.source_hash: Option<String>` (`project.rs:80`)
+- `InstalledSteeringMeta.source_hash: String` (`project.rs:151`) — NOT optional
+- `InstalledNativeCompanionsMeta.source_hash: String` (`project.rs:117`) — NOT optional
+
+The legacy-fallback flag therefore only ever flips inside the skills + agents arms of the walk; steering and native_companions always have a hash to compare. The plan's framing implies symmetric handling.
+
+**Amended.** Add to Task 2 Step 2 implementer notes:
+
+> **Per-content-type source_hash shape:** `InstalledSkillMeta.source_hash` and `InstalledAgentMeta.source_hash` are `Option<String>` (legacy entries pre-Stage-1 carry `None`). `InstalledSteeringMeta.source_hash` and `InstalledNativeCompanionsMeta.source_hash` are plain `String` (these tracking files were introduced after Stage 1 — no legacy entries exist). The legacy-fallback flag therefore only ever flips inside the skills + agents arms of the walk; steering and native_companions always have a hash to compare.
+
+Also update the design's Detection-logic step 4 to mirror this.
+
+**Rationale.** Gate 5. Half a finding because the implementer would notice on first compile (`Option<String>` vs `String` mismatch is loud), but the plan's framing implies symmetric handling, and an implementer might add unnecessary `Some(_)` wrapping or `if let Some(_) = ` ceremony for steering/native_companions.
+
+---
+
+## P2a-5 — Gate 5 (IMPORTANT): `change_signal` decision-table semantics need a doc-comment to clarify "false" means "no observed drift" not "no drift exists"
+
+**Original (Task 2, Step 2):**
+
+```rust
+let change_signal = match (content_drift, version_differs, legacy_fallback) {
+    (_, true, _) => Some(UpdateChangeSignal::VersionBumped),
+    (true, false, _) => Some(UpdateChangeSignal::ContentChanged),
+    (false, false, true) => None,
+    (false, false, false) => None,
+};
+```
+
+**Drift.** When `legacy_fallback = true`, content_drift is *unknown*, not *false*. The plan models it as `(content_drift: false, legacy_fallback: true)` because legacy entries skip the hash check. That's defensible, but a future reader of the code sees `content_drift = false` for a legacy-fallback plugin and thinks the hash check ran clean.
+
+**Amended.** Add a doc-comment on `scan_plugin_for_content_drift`:
+
+> Returns `(content_drift, legacy_fallback)` where `content_drift = false && legacy_fallback = true` means "no drift detected among hashable entries; some entries had no source_hash so a clean miss is possible." Callers should treat legacy_fallback as "drift undetectable" rather than "drift absent."
+
+Optional secondary: rename `content_drift` to `observed_content_drift` in the helper signature and decision-table. Not load-bearing.
+
+**Rationale.** Gate 5. The semantic reading is correct end-to-end, but the implementer-note prose is ambiguous. One line of doc-comment closes a future-maintainer-style finding.
+
+---
+
+## P2a-6 — Gate 3 (IMPORTANT): Task 6 underestimates Tauri test breakage; 6 assertions across 2 test functions, not 1
+
+**Original (Task 5 Step 6 + Task 6 Step 1):**
+
+> Task 5 step 6: "The Tauri crate will NOT compile after this commit — `commands/plugins.rs::remove_plugin` may still reference fields that no longer exist (e.g., `result.skills_removed`)."
+> Task 6 step 1: "Expected: matches in `commands/plugins.rs::tests` (or similar) referencing the old field names. Update each."
+
+**Drift.** `commands/plugins.rs` lines 512-514, 549-551 contain six concrete assertions on `counts.skills_removed` / `.steering_removed` / `.agents_removed`. The Tauri command's `remove_plugin` wrapper itself doesn't read these fields (it just passes the result through), so the wrapper compiles fine. But `commands/plugins.rs::tests` is part of the same crate, so the **whole crate's test compilation fails** after Task 5. Two test functions need updates — `remove_plugin_returns_zeros_for_nonexistent_pair` (line 500), `remove_plugin_returns_expected_counts_after_install` (line 521) — six total assertions across both. The Task 6 sketch only shows one before/after pair.
+
+**Amended.** Update Task 6 step 1 with explicit file-path + line-number guidance:
+
+```bash
+# Expected hits (verified in worktree at HEAD 40a6fc6):
+# - crates/kiro-control-center/src-tauri/src/commands/plugins.rs:512-514, 549-551
+#   (two test functions:
+#    - remove_plugin_returns_zeros_for_nonexistent_pair (line 500)
+#    - remove_plugin_returns_expected_counts_after_install (line 521))
+# - crates/kiro-control-center/src/lib/bindings.ts:954, 992-994, 1006
+#   (TypeScript declarations — regenerated automatically in Task 7)
+grep -rn "skills_removed\|steering_removed\|agents_removed\|RemovePluginFailure" crates/kiro-control-center/
+```
+
+In Task 6 step 2, change "update assertions" to "update **all six assertions across both test functions**", with a sketch showing the second test (`remove_plugin_returns_expected_counts_after_install`) in addition to the first.
+
+Also add a note to Task 5 step 6: "Run `cargo test -p kiro-control-center --no-run` between Task 5 and Task 6 to confirm the expected breakage shape (compile errors at the 6 assertion sites, not at the wrapper)."
+
+**Rationale.** Gate 3 + action linkage. Without this, an implementer running the Task 6 grep, finding the hits, and updating only the first test will hit a confusing test failure in the second one.
+
+---
+
+## P2a-7 — OBSERVATION: Tauri command registration snippet in Task 3 doesn't match the existing import style; `skip_serializing_if` note worth adding to Task 2
+
+**Original (Task 3, Step 3):**
+
+```rust
+let builder = tauri_specta::Builder::<tauri::Wry>::new()
+    .commands(tauri_specta::collect_commands![
+```
+
+**Drift.** The actual `lib.rs:11-40` uses `use tauri_specta::{collect_commands, Builder};` and the `Builder::<tauri::Wry>::new().commands(collect_commands![...])` shape (no `tauri_specta::` qualifier on the macro). The plan's snippet is functionally correct but doesn't match the existing import style.
+
+A-25 from Phase 1's amendments warned about `tauri-specta` 2.0.0-rc.24 unified-mode rejecting `skip_serializing_if`. The plan correctly omits `skip_serializing_if` from new types. But the existing `InstalledSkillMeta.source_hash` carries `#[serde(default, skip_serializing_if = "Option::is_none")]` (`project.rs:44`) — that's safe because the meta types are NOT specta-derived; this is not in tension with A-25.
+
+**Amended.** Update Task 3 Step 3 snippet to match the actual import style:
+
+```rust
+// In lib.rs, find the existing `Builder::<tauri::Wry>::new().commands(collect_commands![...])`
+// invocation. Append `commands::plugins::detect_plugin_updates,` after the existing
+// `commands::plugins::remove_plugin,` line (currently line 40).
+```
+
+Add a one-line note in Task 2 Step 2 implementer notes:
+
+> The `source_hash` field on the meta types uses `#[serde(default, skip_serializing_if = "Option::is_none")]`. This is safe because the meta types are NOT specta-derived; A-25's restriction applies only to `specta::Type` structs.
+
+**Rationale.** Observation only — implementer would catch the import style on file-read. Captured for completeness.
+
+---
+
+## Gates not flagged
+
+- **Gate 2 (Threat Model)** — pass. The new detection scan reads from local cache; no new untrusted byte sources. `validate_kiro_project_path` covers the IPC path-arg gate.
+- **Gate 4 (External Type Boundary)** — partial pass with an action item from P2a-1. The new `serde_json::Error` translation point introduced by loading `plugin.json` per plugin must follow CLAUDE.md's "`#[non_exhaustive]` enum + `reason: String` + `error_full_chain`" recipe. `cargo xtask plan-lint --gate gate-4-external-error-boundary` will catch any leak; flagging proactively here so the implementer chooses the variant up front rather than retrofitting.
+
+## Summary of changes
+
+- **P2a-1 (CRITICAL)**: `PluginEntry.version` doesn't exist; resolve via cache-load `plugin.json` → `PluginManifest.version`. **Requires user design decision (A) vs (B); recommend (A).**
+- **P2a-2 (CRITICAL)**: existing field is `failed: Vec<RemovePluginFailure>`, not `failures`; explicit rename note.
+- **P2a-3 (CRITICAL)**: migration sketch references non-existent helpers (`load_installed_skills_or_default`, `remove_skill_internal`); rewrite to match `self.load_installed()` + per-iteration `self.remove_skill(name)`. **Sub-decision (α) vs (β) for native_companions removed-list scope; recommend (α).**
+- **P2a-4 (IMPORTANT)**: `source_hash` is asymmetric — `Option<String>` on skills/agents only, plain `String` on steering/native_companions; document the asymmetry.
+- **P2a-5 (IMPORTANT)**: doc-comment on `scan_plugin_for_content_drift` clarifying `content_drift = false` semantics under legacy fallback.
+- **P2a-6 (IMPORTANT)**: 6 assertions across 2 Tauri test functions, not 1; explicit file:line guidance.
+- **P2a-7 (OBSERVATION)**: Tauri command registration snippet style + `skip_serializing_if` note for meta types.
+
+**Two design decisions to lock before Task 1:** P2a-1's (A) vs (B), P2a-3's (α) vs (β). Both have recommended defaults.
+
+No design-doc revisions required at the architecture level. The amendments are execution-time corrections; the design at `2026-04-30-phase-2a-update-detection-design.md` stands as written modulo the typed field-shape details captured here.
+
+## References
+
+- `docs/plan-review-checklist.md` — the 5 gates this pass applied
+- `docs/plans/2026-04-30-phase-1-5-type-safety-plan-amendments.md` — Phase 1.5 amendments format precedent (especially P1.5-1 / P1.5-2 for compile-error class catches)
+- `docs/plans/2026-04-29-plugin-first-install-plan-amendments.md` — Phase 1's amendments, especially A-8 (LSP-first discipline rule), A-15 (cascade keep-going policy), A-16 (marketplace-aware cleanup), A-25 (skip_serializing_if rule)
+- Source SHA at review time: `40a6fc6` (post-PR-#95 main + Phase 2a design + plan)
+- Worktree: `/home/dwalleck/repos/kiro-marketplace-cli-phase-2a` on branch `feat/phase-2a-update-detection`

--- a/docs/plans/2026-05-01-phase-2a-update-detection-plan.md
+++ b/docs/plans/2026-05-01-phase-2a-update-detection-plan.md
@@ -1,0 +1,1393 @@
+# Phase 2a — Update Detection (Backend) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `MarketplaceService::detect_plugin_updates` (hybrid hash + version detection over installed plugins) plus a Tauri command, and reshape `RemovePluginResult` from opaque counts into per-content-type sub-results (A2 — bundled here per Phase 1.5 design's deferral). Backend-only; Phase 2b (UI) ships separately.
+
+**Architecture:** Detection walks every installed-file entry across the 4 tracking files (skills, steering, agents, native_companions), recomputes the marketplace cache hash using the same hash function the install path used (`hash::hash_dir_tree` for skill directories, `hash::hash_artifact` for steering/agent files), and compares against the tracking file's stored `source_hash`. If any hash differs OR the manifest version is non-equal to the most-recently-installed version, the plugin gets an entry in `DetectUpdatesResult.updates` with a `change_signal` discriminating version-bump vs content-drift. Per-plugin failures (cache-miss, hash failure) land in `DetectUpdatesResult.failures`. The reshape replaces `RemovePluginResult { skills_removed: u32, ... }` with a 3-sub-result struct symmetric to `InstallPluginResult`, dropping the `RemovePluginFailure.content_type: String` discriminator in favor of the parent type.
+
+**Tech Stack:** Rust edition 2024, `thiserror`, `serde` with `transparent`/tagged enums, `specta::Type` cfg-attr, `rstest` for tests, `cargo xtask plan-lint` for the project's structural gates. Reuses `hash::hash_dir_tree` / `hash::hash_artifact` from existing Stage-1 content-hash work (no new hash module).
+
+**Companion design doc:** `2026-04-30-phase-2a-update-detection-design.md`
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-market-core/src/service/mod.rs` | Modify | Add `detect_plugin_updates`, `DetectUpdatesResult`, `PluginUpdateInfo`, `PluginUpdateFailure`, `UpdateChangeSignal` + their JSON-shape locks + behavioral tests |
+| `crates/kiro-market-core/src/project.rs` | Modify | Reshape `RemovePluginResult` to `{ skills, steering, agents }`; add `RemoveSkillsResult`, `RemoveSteeringResult`, `RemoveAgentsResult`, `RemoveItemFailure`; remove obsolete `RemovePluginFailure` type; migrate `KiroProject::remove_plugin` body to populate the new sub-result types; update existing rstests asserting on the old shape |
+| `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` | Modify | Add `detect_plugin_updates` Tauri command with `_impl(svc, project_path)` shape; existing `remove_plugin` wrapper unchanged but returns the new shape (tests update) |
+| `crates/kiro-control-center/src-tauri/src/lib.rs` | Modify | Register `detect_plugin_updates` in `tauri_specta::collect_commands!` |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Regenerate | Auto-generated; emits new types + restructured `RemovePluginResult` |
+
+**Frontend changes are zero in 2a.** `bindings.ts` regen surfaces type changes to TS, but no Svelte component consumes them yet. The intermediate state is the same shape Phase 1.5 already proved is fine.
+
+---
+
+## Task 1: Define detection types in `service/mod.rs`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` (add types + JSON-shape lock tests)
+
+This task is purely additive — adds the four new types and locks their wire format. Nothing in the rest of the workspace uses them yet.
+
+- [ ] **Step 1: Add the type definitions**
+
+In `crates/kiro-market-core/src/service/mod.rs`, near the existing `InstallPluginResult` (around line 440), add:
+
+```rust
+/// Result of [`MarketplaceService::detect_plugin_updates`] — a scan over
+/// installed plugins. `updates` lists plugins with available updates;
+/// `failures` lists plugins the scan couldn't check (marketplace gone
+/// from cache, manifest malformed, hash computation failure). Plugins
+/// with no update available are absent from both vecs (the implicit
+/// "everything's fine" set).
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct DetectUpdatesResult {
+    #[serde(default)]
+    pub updates: Vec<PluginUpdateInfo>,
+    #[serde(default)]
+    pub failures: Vec<PluginUpdateFailure>,
+}
+
+/// A single plugin with an update available. `installed_version` is
+/// `None` for legacy installs whose tracking file lacked the version
+/// field; `available_version` is `None` when the marketplace plugin
+/// manifest itself lacks a version. The `change_signal` discriminates
+/// between manifest-version change and content-drift-without-version-bump.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateInfo {
+    pub marketplace: crate::validation::MarketplaceName,
+    pub plugin: crate::validation::PluginName,
+    pub installed_version: Option<String>,
+    pub available_version: Option<String>,
+    pub change_signal: UpdateChangeSignal,
+}
+
+/// A plugin the update scan couldn't check. `reason` is the rendered
+/// error chain via [`crate::error::error_full_chain`] per CLAUDE.md FFI
+/// rule (any wire-format `reason`/`error: String` field uses
+/// `error_full_chain(&err)`, not `err.to_string()`).
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct PluginUpdateFailure {
+    pub marketplace: crate::validation::MarketplaceName,
+    pub plugin: crate::validation::PluginName,
+    pub reason: String,
+}
+
+/// Why an update is being surfaced. Tagged enum for FFI per the
+/// `ffi-enum-serde-tag` plan-lint gate (PR #91): `#[serde(tag = "kind",
+/// rename_all = "snake_case")]` produces `{ "kind": "version_bumped" }`
+/// in JSON, which `tauri-specta` emits as a discriminated TS union.
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpdateChangeSignal {
+    /// Manifest version string differs (with or without content hash diff).
+    /// FE renders "Update v1.0 → v1.1".
+    VersionBumped,
+    /// Manifest version unchanged but at least one source-hash diff
+    /// detected. FE renders "Content updated since install".
+    ContentChanged,
+}
+```
+
+- [ ] **Step 2: Add JSON-shape lock tests**
+
+In the existing `mod tests` block of `service/mod.rs`, near the `install_plugin_result_json_shape_*` tests, add:
+
+```rust
+    #[test]
+    fn detect_updates_result_json_shape_default_empty() {
+        let result = DetectUpdatesResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["updates"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn detect_updates_result_json_shape_with_one_update_and_one_failure() {
+        use crate::service::test_support::{mp, pn};
+        let result = DetectUpdatesResult {
+            updates: vec![PluginUpdateInfo {
+                marketplace: mp("mp1"),
+                plugin: pn("p1"),
+                installed_version: Some("1.0".into()),
+                available_version: Some("1.1".into()),
+                change_signal: UpdateChangeSignal::VersionBumped,
+            }],
+            failures: vec![PluginUpdateFailure {
+                marketplace: mp("mp2"),
+                plugin: pn("p2"),
+                reason: "marketplace not in cache".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["updates"][0]["marketplace"], "mp1");
+        assert_eq!(json["updates"][0]["plugin"], "p1");
+        assert_eq!(json["updates"][0]["installed_version"], "1.0");
+        assert_eq!(json["updates"][0]["available_version"], "1.1");
+        assert_eq!(json["updates"][0]["change_signal"]["kind"], "version_bumped");
+        assert_eq!(json["failures"][0]["marketplace"], "mp2");
+        assert_eq!(json["failures"][0]["plugin"], "p2");
+        assert_eq!(json["failures"][0]["reason"], "marketplace not in cache");
+    }
+
+    #[test]
+    fn plugin_update_info_json_shape_version_bumped() {
+        use crate::service::test_support::{mp, pn};
+        let info = PluginUpdateInfo {
+            marketplace: mp("mp"),
+            plugin: pn("p"),
+            installed_version: Some("1.0".into()),
+            available_version: Some("1.1".into()),
+            change_signal: UpdateChangeSignal::VersionBumped,
+        };
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert_eq!(json["change_signal"]["kind"], "version_bumped");
+    }
+
+    #[test]
+    fn plugin_update_info_json_shape_content_changed() {
+        use crate::service::test_support::{mp, pn};
+        let info = PluginUpdateInfo {
+            marketplace: mp("mp"),
+            plugin: pn("p"),
+            installed_version: Some("1.0".into()),
+            available_version: Some("1.0".into()),
+            change_signal: UpdateChangeSignal::ContentChanged,
+        };
+        let json = serde_json::to_value(&info).expect("serialize");
+        assert_eq!(json["change_signal"]["kind"], "content_changed");
+    }
+```
+
+- [ ] **Step 3: Run tests + lint**
+
+```bash
+cargo test -p kiro-market-core --lib detect_updates_result_json_shape plugin_update_info_json_shape 2>&1 | tail -10
+cargo clippy -p kiro-market-core --tests -- -D warnings 2>&1 | tail -5
+cargo fmt --all
+```
+
+Expected: 4 tests pass; clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): add update-detection types (Phase 2a step 1/7)
+
+Adds DetectUpdatesResult, PluginUpdateInfo, PluginUpdateFailure, and
+UpdateChangeSignal in service/mod.rs. UpdateChangeSignal uses
+#[serde(tag = "kind", rename_all = "snake_case")] per the
+ffi-enum-serde-tag plan-lint gate (PR #91). All vec fields use
+#[serde(default)] no skip_serializing_if (per A-25, tauri-specta
+unified-mode rejects it).
+
+JSON-shape lock tests pin the wire format for both UpdateChangeSignal
+variants and the default-empty + populated cases of DetectUpdatesResult.
+
+No callers yet; Task 2 implements MarketplaceService::detect_plugin_updates.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement `MarketplaceService::detect_plugin_updates`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` (add the method + private helper + behavioral tests)
+
+This is the meaty task. Implements the hybrid hash + version detection logic with per-plugin failure surfacing and legacy-install fallback.
+
+### Required research (LSP-first per A-8)
+
+Before writing, run:
+
+```
+LSP operation=documentSymbol filePath=crates/kiro-market-core/src/project.rs
+LSP operation=workspaceSymbol query=hash_dir_tree
+LSP operation=workspaceSymbol query=hash_artifact
+LSP operation=workspaceSymbol query=marketplace_path
+LSP operation=workspaceSymbol query=PluginManifest
+```
+
+Note from the symbol map:
+- Exact signature of `KiroProject::installed_plugins() -> Result<InstalledPluginsView>` (returns `Vec<InstalledPluginInfo>` + `partial_load_warnings`)
+- Exact signature of `crate::hash::hash_dir_tree(dir: &Path)` (returns `Result<String>`) and `hash::hash_artifact(scan_root: &Path, rel_paths: &[PathBuf])` (returns `Result<String>`)
+- Exact signature of `MarketplaceService::marketplace_path(name: &str) -> PathBuf` (still `&str`-typed per Phase 1.5 design)
+- The `PluginManifest` shape — specifically the `version: Option<String>` field and how to load it from a marketplace cache entry
+
+`partial_load_warnings` from `installed_plugins()` is NOT surfaced into `DetectUpdatesResult` — those are tracking-file-load failures already surfaced by the existing `installed_plugins` Tauri command. Detection only checks plugins that loaded successfully.
+
+### Implementation steps
+
+- [ ] **Step 1: Write failing behavioral tests**
+
+In `service/mod.rs::tests`, add the following tests (each test sets up a fixture marketplace + Kiro project, then asserts the detection result):
+
+```rust
+    use crate::service::test_support::{mp, pn};
+
+    #[test]
+    fn detect_plugin_updates_happy_path_no_updates() {
+        // Fixture: marketplace with plugin v1.0, project with installed v1.0
+        // (matching content hashes).
+        let (svc, _temp) = temp_service_with_seeded_marketplace(/* see helper */);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_root = make_kiro_project(dir.path());
+        let project = crate::project::KiroProject::new(project_root);
+        // ... install plugin at v1.0 ...
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert!(result.updates.is_empty(), "no updates expected: {:?}", result);
+        assert!(result.failures.is_empty(), "no failures expected: {:?}", result);
+    }
+
+    #[test]
+    fn detect_plugin_updates_version_bump() {
+        // Fixture: marketplace with plugin v1.0, install, then bump marketplace
+        // manifest to v1.1 (same content). Expect: VersionBumped.
+        // ...
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert_eq!(result.updates.len(), 1);
+        assert_eq!(result.updates[0].plugin, "p");
+        assert_eq!(result.updates[0].installed_version, Some("1.0".into()));
+        assert_eq!(result.updates[0].available_version, Some("1.1".into()));
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
+        ));
+    }
+
+    #[test]
+    fn detect_plugin_updates_content_drift_without_version_bump() {
+        // Fixture: marketplace with plugin v1.0, install, then mutate a skill
+        // file content in the marketplace cache (but keep version: 1.0).
+        // Expect: ContentChanged.
+        // ...
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert_eq!(result.updates.len(), 1);
+        assert_eq!(result.updates[0].installed_version, Some("1.0".into()));
+        assert_eq!(result.updates[0].available_version, Some("1.0".into()));
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::ContentChanged
+        ));
+    }
+
+    #[test]
+    fn detect_plugin_updates_per_plugin_failure_surfacing() {
+        // Fixture: install plugin from marketplace mp1, then remove the
+        // marketplace from the cache (or rename the dir). Expect: empty
+        // updates, one failure with reason mentioning the marketplace.
+        // ...
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert!(result.updates.is_empty());
+        assert_eq!(result.failures.len(), 1);
+        assert_eq!(result.failures[0].marketplace, "mp1");
+        assert!(!result.failures[0].reason.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_legacy_fallback_source_hash_none() {
+        // Fixture: install plugin v1.0, then directly mutate the tracking
+        // file to set source_hash: None (simulating pre-Stage-1 install).
+        // Bump marketplace to v1.1. Expect: VersionBumped.
+        // ...
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert_eq!(result.updates.len(), 1);
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::VersionBumped
+        ));
+    }
+
+    #[test]
+    fn detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update() {
+        // Fixture: install v1.0, set source_hash: None, leave marketplace at
+        // v1.0. Content drift undetectable -> no entry in updates.
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert!(result.updates.is_empty(),
+            "legacy install with matching version should show no update (drift undetectable)");
+    }
+
+    #[test]
+    fn detect_plugin_updates_mixed_scenario() {
+        // Fixture: 4 installed plugins:
+        //   p1: no update (matching version + content)
+        //   p2: version bumped (v1.0 -> v1.1)
+        //   p3: content drift (v1.0, but skill file mutated)
+        //   p4: marketplace removed from cache (failure)
+        // Expect: 2 updates (p2 + p3), 1 failure (p4), p1 absent from both.
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert_eq!(result.updates.len(), 2);
+        assert_eq!(result.failures.len(), 1);
+        let updated_plugins: Vec<&str> = result.updates.iter().map(|u| u.plugin.as_str()).collect();
+        assert!(updated_plugins.contains(&"p2"));
+        assert!(updated_plugins.contains(&"p3"));
+        assert_eq!(result.failures[0].plugin, "p4");
+    }
+
+    #[test]
+    fn detect_plugin_updates_per_plugin_granularity() {
+        // Fixture: plugin with 3 skills + 2 steering + 1 agent installed.
+        // Mutate ONE steering file in the marketplace cache. Expect: ONE
+        // entry in updates (per-plugin granularity, not per-file).
+        let result = svc.detect_plugin_updates(&project).expect("scan");
+        assert_eq!(result.updates.len(), 1);
+        assert!(matches!(
+            result.updates[0].change_signal,
+            UpdateChangeSignal::ContentChanged
+        ));
+    }
+```
+
+Run them and confirm they FAIL:
+
+```bash
+cargo test -p kiro-market-core --lib detect_plugin_updates 2>&1 | tail -15
+```
+
+Expected: all 8 tests fail with "no method `detect_plugin_updates` for `MarketplaceService`".
+
+- [ ] **Step 2: Add the method + private helper**
+
+In `service/mod.rs`, add to the `impl MarketplaceService` block:
+
+```rust
+    /// Scan installed plugins, comparing each tracking-file `version` and
+    /// `source_hash` against the corresponding marketplace plugin manifest +
+    /// source files in the local cache. Reads from local cache only;
+    /// callers run `update_marketplaces` first if they want fresh data.
+    ///
+    /// "Update available" = at least one source-hash differs from the
+    /// tracking entry's `source_hash`, OR the marketplace plugin manifest's
+    /// `version` is not byte-equal to the most-recently-installed version
+    /// across the three tracking files. Strict string inequality on
+    /// versions, no semver — downgrades pushed by marketplace owners are
+    /// surfaced.
+    ///
+    /// Per-plugin failures (marketplace gone from cache, plugin removed
+    /// from manifest, manifest malformed, hash recomputation failed) land
+    /// in `failures`, not in `Result::Err`. Plugins with no update available
+    /// are absent from both vecs.
+    ///
+    /// Legacy fallback: if any tracked file's `source_hash` is `None`
+    /// (pre-Stage-1 install), drop back to version-only comparison for that
+    /// plugin. Same versions in legacy mode -> no entry in updates (content
+    /// drift undetectable until next install).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only when the toplevel `installed_plugins()` read
+    /// fails (project layout broken). Per-plugin errors land in `failures`.
+    pub fn detect_plugin_updates(
+        &self,
+        project: &crate::project::KiroProject,
+    ) -> Result<DetectUpdatesResult, Error> {
+        let view = project.installed_plugins()?;
+
+        let mut updates = Vec::new();
+        let mut failures = Vec::new();
+
+        for plugin_info in view.plugins {
+            match self.check_plugin_for_update(&plugin_info) {
+                Ok(Some(update)) => updates.push(update),
+                Ok(None) => {} // plugin is up-to-date
+                Err(err) => failures.push(PluginUpdateFailure {
+                    marketplace: plugin_info.marketplace.clone(),
+                    plugin: plugin_info.plugin.clone(),
+                    reason: crate::error::error_full_chain(&err),
+                }),
+            }
+        }
+
+        Ok(DetectUpdatesResult { updates, failures })
+    }
+
+    /// Check a single installed plugin against its marketplace cache entry.
+    /// Returns `Ok(Some(_))` if an update is available, `Ok(None)` if up-to-date.
+    /// Returns `Err` for the per-plugin failure cases (marketplace gone, etc.)
+    /// — the caller maps these to `PluginUpdateFailure`.
+    fn check_plugin_for_update(
+        &self,
+        plugin_info: &crate::project::InstalledPluginInfo,
+    ) -> Result<Option<PluginUpdateInfo>, Error> {
+        // Step 1: Resolve the marketplace + plugin in the cache.
+        let plugin_entries = self.list_plugin_entries(plugin_info.marketplace.as_str())?;
+        let plugin_entry = plugin_entries
+            .iter()
+            .find(|p| p.name == plugin_info.plugin.as_str())
+            .ok_or_else(|| {
+                Error::Plugin(crate::error::PluginError::NotFound {
+                    plugin: plugin_info.plugin.as_str().to_string(),
+                    marketplace: plugin_info.marketplace.as_str().to_string(),
+                })
+            })?;
+
+        let available_version = plugin_entry.version.clone();
+
+        // Step 2: Walk every installed-file entry for this plugin and
+        // recompute the marketplace cache hash. First mismatch wins (no
+        // need to hash remaining files for the same plugin once we know
+        // there's drift).
+        //
+        // Implementer note: the meta types live on InstalledPluginInfo in
+        // a partially-aggregated shape. To get the per-file source_hash
+        // values, you need to re-load the tracking files (or extend
+        // InstalledPluginInfo with the source_hash field). Recommend the
+        // re-load approach to keep InstalledPluginInfo's wire format
+        // stable.
+        //
+        // For each content type (skills, steering, agents, native_companions):
+        //   - Filter the tracking file's entries to the matching plugin
+        //   - For each entry with source_hash: Some(stored):
+        //       - Compute the cache hash via the appropriate hash function
+        //         (hash_dir_tree for skill directories, hash_artifact for
+        //         steering and agent files)
+        //       - If stored != cache, set content_drift = true and break
+        //   - For each entry with source_hash: None, set legacy_fallback = true
+        //
+        // After the walk:
+        //   - If content_drift: return Some(VersionBumped or ContentChanged
+        //     based on version comparison)
+        //   - Else if version differs: return Some(VersionBumped)
+        //   - Else if legacy_fallback and version matches: return None
+        //     (drift undetectable)
+        //   - Else: return None (up-to-date)
+
+        let installed_version = plugin_info.installed_version.clone();
+        let (content_drift, legacy_fallback) =
+            self.scan_plugin_for_content_drift(plugin_info)?;
+
+        let version_differs = installed_version != available_version;
+
+        let change_signal = match (content_drift, version_differs, legacy_fallback) {
+            (_, true, _) => Some(UpdateChangeSignal::VersionBumped),
+            (true, false, _) => Some(UpdateChangeSignal::ContentChanged),
+            (false, false, true) => None, // legacy fallback, versions match -> drift undetectable
+            (false, false, false) => None, // up-to-date
+        };
+
+        Ok(change_signal.map(|signal| PluginUpdateInfo {
+            marketplace: plugin_info.marketplace.clone(),
+            plugin: plugin_info.plugin.clone(),
+            installed_version,
+            available_version,
+            change_signal: signal,
+        }))
+    }
+
+    /// Returns `(content_drift_detected, legacy_fallback_seen)`. Walks
+    /// the 4 tracking files for entries matching this plugin. First
+    /// content-drift detection short-circuits subsequent file hashes
+    /// (within the same plugin); legacy_fallback is sticky for the scan.
+    fn scan_plugin_for_content_drift(
+        &self,
+        plugin_info: &crate::project::InstalledPluginInfo,
+    ) -> Result<(bool, bool), Error> {
+        // Implementer: this requires re-loading the tracking files to access
+        // the per-entry source_hash values. See KiroProject::load_installed_*
+        // helpers (private; may need pub(crate) exposure).
+        //
+        // Iterate skills, steering, agents, native_companions — for entries
+        // with marketplace == plugin_info.marketplace AND plugin == plugin_info.plugin:
+        //   - source_hash: Some(stored) -> recompute cache hash, compare
+        //   - source_hash: None -> set legacy_fallback = true, skip hash check
+        // Short-circuit on first hash mismatch.
+        //
+        // Cache path resolution:
+        //   - Skills: <marketplace_path>/skills/<skill_name>/  (dir, hash_dir_tree)
+        //   - Steering: <marketplace_path>/steering/<rel_path>  (file, hash_artifact)
+        //   - Agents (translated): <marketplace_path>/agents/<rel_path>  (hash_artifact)
+        //   - Agents (native): <marketplace_path>/agents/<rel_path>  (hash_artifact)
+        //   - Native companions: <marketplace_path>/<companion_paths>  (hash_artifact)
+        //
+        // Use self.marketplace_path(plugin_info.marketplace.as_str()) for the base.
+
+        todo!("scan_plugin_for_content_drift: see implementer notes above")
+    }
+```
+
+**Implementer note for `scan_plugin_for_content_drift`:** the function above leaves the actual file-walking logic as `todo!()` because the exact tracking-file accessors depend on what's `pub(crate)` vs `pub` in `project.rs`. During implementation:
+
+1. Use `LSP documentSymbol` on `crates/kiro-market-core/src/project.rs` to find the `load_installed_skills` / `load_installed_steering` / `load_installed_agents` / `load_installed_native_companions` accessors. They're likely `pub(crate)` already (the existing `installed_plugins` aggregator uses them).
+2. If any are private, expose them as `pub(crate)` — these are internal helpers, not new public API.
+3. Walk the entries; filter by `meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin`.
+4. For each matching entry, branch on `meta.source_hash.as_deref()`:
+   - `Some(stored)`: recompute cache hash via the appropriate hash function; compare; short-circuit on mismatch.
+   - `None`: set `legacy_fallback = true`; continue.
+5. Return `(content_drift, legacy_fallback)`.
+
+The `todo!()` ensures the function won't ship without a real implementation — the tests will fail at the panic site, surfacing the gap.
+
+- [ ] **Step 3: Add the test helper for fixtures**
+
+The behavioral tests in Step 1 need a few fixture-builder helpers. Add to `service/test_support.rs` (or a new `mod test_helpers` inside `service/mod.rs::tests` if you prefer to keep them test-only):
+
+```rust
+/// Test helper: seed a marketplace with one plugin containing one skill,
+/// then mutate the skill's content (or version) to simulate an update.
+/// Returns the marketplace name + plugin name as newtypes.
+#[cfg(any(test, feature = "test-support"))]
+pub fn seed_marketplace_with_one_plugin(
+    cache_root: &Path,
+    marketplace: &str,
+    plugin: &str,
+    version: &str,
+) -> (MarketplaceName, PluginName) {
+    // ... write a marketplace.json + plugin.json + skill SKILL.md ...
+}
+
+/// Test helper: mutate the marketplace cache to bump a plugin's version
+/// without changing any file content.
+#[cfg(any(test, feature = "test-support"))]
+pub fn bump_plugin_version_in_cache(
+    cache_root: &Path,
+    marketplace: &MarketplaceName,
+    plugin: &PluginName,
+    new_version: &str,
+);
+
+/// Test helper: mutate the marketplace cache by appending a byte to one
+/// of the plugin's skill files. Leaves the manifest version unchanged.
+#[cfg(any(test, feature = "test-support"))]
+pub fn mutate_plugin_skill_content(
+    cache_root: &Path,
+    marketplace: &MarketplaceName,
+    plugin: &PluginName,
+    skill_name: &str,
+);
+
+/// Test helper: directly rewrite a tracking file to set source_hash: None
+/// on one entry (simulates pre-Stage-1 install).
+#[cfg(any(test, feature = "test-support"))]
+pub fn null_source_hash_for_skill(
+    project_root: &Path,
+    marketplace: &MarketplaceName,
+    plugin: &PluginName,
+    skill_name: &str,
+);
+```
+
+- [ ] **Step 4: Run tests + iterate**
+
+```bash
+cargo test -p kiro-market-core --lib detect_plugin_updates 2>&1 | tail -20
+```
+
+Expected: tests pass once `scan_plugin_for_content_drift` is implemented. Iterate until all 8 pass.
+
+```bash
+cargo test -p kiro-market-core --lib 2>&1 | grep "test result:" | tail -3
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/kiro-market-core/src/service/mod.rs crates/kiro-market-core/src/service/test_support.rs
+git commit -m "$(cat <<'EOF'
+feat(core): implement detect_plugin_updates with hybrid hash + version (Phase 2a step 2/7)
+
+MarketplaceService::detect_plugin_updates walks every installed-file
+entry across the 4 tracking files (skills, steering, agents,
+native_companions), recomputes the marketplace cache hash using the
+same hash function the install path used (hash_dir_tree for skill
+directories, hash_artifact for steering and agent files), and
+compares against the tracking file's stored source_hash.
+
+Update-available logic:
+- Any source-hash mismatch OR manifest version != installed version
+  -> Some(PluginUpdateInfo)
+- VersionBumped vs ContentChanged classified by version-string compare
+- Legacy fallback: source_hash: None on any tracked file -> version-only
+  comparison; same versions -> no entry (drift undetectable)
+
+Per-plugin failures (marketplace gone, hash failure, plugin removed
+from manifest) land in DetectUpdatesResult.failures via error_full_chain
+projection — match the A-12 cascade pattern from remove_plugin.
+
+Toplevel Result::Err reserved for "couldn't read tracking files at all"
+(installed_plugins() failed). Per-plugin checks are total: a single bad
+plugin doesn't knock out scan visibility for the rest.
+
+8 behavioral rstests cover happy path, version bump, content drift,
+per-plugin failure surfacing, legacy fallback (both with and without
+version diff), mixed scenario, and per-plugin granularity (one mutated
+file -> one update entry, not many).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add the `detect_plugin_updates` Tauri command
+
+**Files:**
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/plugins.rs`
+- Modify: `crates/kiro-control-center/src-tauri/src/lib.rs` (register)
+
+- [ ] **Step 1: Write failing tests**
+
+In `crates/kiro-control-center/src-tauri/src/commands/plugins.rs::tests`, add:
+
+```rust
+    #[test]
+    fn detect_plugin_updates_impl_happy_path() {
+        let (svc, _temp) = temp_service();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_path = make_kiro_project(dir.path());
+        let result = detect_plugin_updates_impl(&svc, &project_path)
+            .expect("scan succeeds with empty project");
+        assert!(result.updates.is_empty());
+        assert!(result.failures.is_empty());
+    }
+
+    #[test]
+    fn detect_plugin_updates_impl_rejects_invalid_project_path() {
+        let (svc, _temp) = temp_service();
+        let result = detect_plugin_updates_impl(&svc, "/nonexistent/path/to/project");
+        let err = result.expect_err("invalid project path must be rejected");
+        assert_eq!(err.kind, ErrorType::Validation);
+    }
+```
+
+Run them:
+
+```bash
+cargo test -p kiro-control-center --lib detect_plugin_updates_impl 2>&1 | tail -10
+```
+
+Expected: FAIL with "cannot find function `detect_plugin_updates_impl`".
+
+- [ ] **Step 2: Implement the wrapper + `_impl`**
+
+In `crates/kiro-control-center/src-tauri/src/commands/plugins.rs`, add (near the existing `install_plugin_impl`):
+
+```rust
+fn detect_plugin_updates_impl(
+    svc: &MarketplaceService,
+    project_path: &str,
+) -> Result<DetectUpdatesResult, CommandError> {
+    let project_root = validate_kiro_project_path(project_path)?;
+    let project = KiroProject::new(project_root);
+    svc.detect_plugin_updates(&project)
+        .map_err(CommandError::from)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn detect_plugin_updates(
+    project_path: String,
+) -> Result<DetectUpdatesResult, CommandError> {
+    let svc = make_service()?;
+    detect_plugin_updates_impl(&svc, &project_path)
+}
+```
+
+Update the imports at the top of the file:
+
+```rust
+use kiro_market_core::service::{
+    DetectUpdatesResult,                           // NEW
+    InstallMode, InstallPluginResult, MarketplaceService,
+};
+```
+
+(Adjust to match the actual import order in the file — the existing import block is alphabetical-ish.)
+
+- [ ] **Step 3: Register in `lib.rs`**
+
+In `crates/kiro-control-center/src-tauri/src/lib.rs`, find the `tauri_specta::collect_commands!` invocation and add `detect_plugin_updates` to the list. Example shape:
+
+```rust
+let builder = tauri_specta::Builder::<tauri::Wry>::new()
+    .commands(tauri_specta::collect_commands![
+        // ... existing commands ...
+        commands::plugins::install_plugin,
+        commands::plugins::list_installed_plugins,
+        commands::plugins::remove_plugin,
+        commands::plugins::detect_plugin_updates,         // NEW
+        // ... rest of existing commands ...
+    ])
+    // ...
+```
+
+(Verify exact `collect_commands!` invocation by reading the file — Phase 1.5 didn't change registration order, so the existing pattern is the template.)
+
+- [ ] **Step 4: Run tests + verify build**
+
+```bash
+cargo test -p kiro-control-center --lib detect_plugin_updates_impl 2>&1 | tail -5
+cargo build -p kiro-control-center 2>&1 | tail -5
+cargo clippy -p kiro-control-center --tests -- -D warnings
+cargo fmt --all
+```
+
+Expected: 2 tests pass, Tauri crate builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/kiro-control-center/src-tauri/src/commands/plugins.rs \
+        crates/kiro-control-center/src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(tauri): add detect_plugin_updates Tauri command (Phase 2a step 3/7)
+
+Wraps MarketplaceService::detect_plugin_updates with the standard
+_impl(svc, project_path) shape per CLAUDE.md (service-consuming
+command). Validates project_path via validate_kiro_project_path
+(existing PR #83 pattern).
+
+No MarketplaceName::new / PluginName::new construction at the IPC
+boundary — the wrapper takes no name args (it scans the whole project).
+The returned DetectUpdatesResult's newtype-typed fields enforce
+parse-don't-validate at the deserialization boundary.
+
+Registered in tauri_specta::collect_commands! in lib.rs. Tests cover
+happy path (empty project) and validate_kiro_project_path rejection.
+
+bindings.ts regen happens in Task 7.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add new `RemovePluginResult` sub-result types (additive prep)
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs` (add types + JSON-shape locks)
+
+This task is purely additive — adds the four new sub-result types but does NOT yet replace the existing `RemovePluginResult`. That's Task 5. This split lets Task 4 be a small, easy-to-review commit and Task 5 the focused migration.
+
+- [ ] **Step 1: Add the new types**
+
+In `crates/kiro-market-core/src/project.rs`, near the existing `RemovePluginResult` (search for `pub struct RemovePluginResult`), add (BEFORE `RemovePluginResult` so the new types are in scope):
+
+```rust
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side [`InstallSkillsResult`] shape.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSkillsResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // skill names
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side `InstallSteeringResult` shape.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveSteeringResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // rendered via Path::display()
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// Per-content-type sub-result for [`RemovePluginResult`]. Mirrors
+/// the install-side [`crate::service::InstallAgentsResult`] shape.
+/// `removed` is a flat vec of translated agent names + native agent
+/// names + native companion file paths (rendered) — matches the
+/// install-side asymmetry where native companions are agent-side
+/// artifacts.
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveAgentsResult {
+    #[serde(default)]
+    pub removed: Vec<String>, // agent names + native companion paths, flat
+    #[serde(default)]
+    pub failures: Vec<RemoveItemFailure>,
+}
+
+/// One failure during a per-content-type removal step. The discriminator
+/// (which content type) is the parent type — no `content_type: String`
+/// field needed (it's expressed structurally via the parent's field
+/// name in [`RemovePluginResult`]).
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemoveItemFailure {
+    /// The skill/agent name or steering rel-path rendered via
+    /// [`std::path::Path::display`].
+    pub item: String,
+    /// Rendered error chain via [`crate::error::error_full_chain`] —
+    /// wire format per CLAUDE.md FFI rule.
+    pub error: String,
+}
+```
+
+- [ ] **Step 2: Add JSON-shape lock tests**
+
+In the existing `mod tests` block of `project.rs`, add:
+
+```rust
+    #[test]
+    fn remove_skills_result_json_shape_default_empty() {
+        let result = RemoveSkillsResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!([]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_skills_result_json_shape_with_populated_removed() {
+        let result = RemoveSkillsResult {
+            removed: vec!["alpha".into(), "beta".into()],
+            failures: vec![],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["removed"], serde_json::json!(["alpha", "beta"]));
+        assert_eq!(json["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_skills_result_json_shape_with_populated_failure() {
+        let result = RemoveSkillsResult {
+            removed: vec![],
+            failures: vec![RemoveItemFailure {
+                item: "broken".into(),
+                error: "io: permission denied".into(),
+            }],
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["failures"][0]["item"], "broken");
+        assert_eq!(json["failures"][0]["error"], "io: permission denied");
+    }
+```
+
+(Symmetric tests for `RemoveSteeringResult` and `RemoveAgentsResult` — same shape, different type names. Three tests per sub-result; 9 tests total.)
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cargo build -p kiro-market-core --tests 2>&1 | tail -5
+cargo test -p kiro-market-core --lib remove_skills_result remove_steering_result remove_agents_result 2>&1 | tail -10
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+```
+
+Expected: clean build; 9 JSON-shape tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kiro-market-core/src/project.rs
+git commit -m "$(cat <<'EOF'
+feat(core): add RemovePluginResult sub-result types (Phase 2a step 4/7)
+
+Additive prep for A2 (RemovePluginResult reshape). Adds:
+- RemoveSkillsResult { removed: Vec<String>, failures: Vec<RemoveItemFailure> }
+- RemoveSteeringResult { same shape }
+- RemoveAgentsResult { same shape — flat vec for translated + native + companions }
+- RemoveItemFailure { item, error } — shared across all three sub-results
+  because the discriminator is the parent type
+
+The existing RemovePluginResult { skills_removed: u32, ... } is
+unchanged in this commit — Task 5 restructures it to use the new
+sub-results. Splitting the additive types from the cascade migration
+keeps each commit small and reviewable.
+
+JSON-shape lock tests cover default-empty + populated-removed +
+populated-failure for each sub-result (9 tests total).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Restructure `RemovePluginResult` + migrate `KiroProject::remove_plugin`
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs` (heavy lift — restructure `RemovePluginResult`, migrate cascade body, remove obsolete `RemovePluginFailure`, update existing rstests)
+
+This is the heavy task for A2. Breaking wire-format change.
+
+- [ ] **Step 1: Restructure `RemovePluginResult`**
+
+Replace the existing `RemovePluginResult` definition with:
+
+```rust
+/// Result of [`KiroProject::remove_plugin`] — per-content-type
+/// sub-results, symmetric with [`crate::service::InstallPluginResult`].
+/// Native companions fold into [`RemoveAgentsResult`] (matches the
+/// install-side asymmetry where native companions are agent-side
+/// artifacts).
+///
+/// No `marketplace` / `plugin` echo fields — caller already passed
+/// those args to `remove_plugin`. (Different from
+/// [`crate::service::InstallPluginResult`] which gained `marketplace`
+/// in Phase 1.5 A4 because that type lives in lists where
+/// self-identification is needed.)
+#[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RemovePluginResult {
+    pub skills: RemoveSkillsResult,
+    pub steering: RemoveSteeringResult,
+    pub agents: RemoveAgentsResult,
+}
+```
+
+Delete the old definition entirely (the `skills_removed: u32` / `steering_removed: u32` / `agents_removed: u32` fields and the `failures: Vec<RemovePluginFailure>` field).
+
+- [ ] **Step 2: Remove the obsolete `RemovePluginFailure` type**
+
+Delete the entire `pub struct RemovePluginFailure { ... }` definition (search for `pub struct RemovePluginFailure`). The new `RemoveItemFailure` (added in Task 4) supersedes it; the parent type expresses the discriminator structurally.
+
+If `RemovePluginFailure` is referenced anywhere else in the workspace (search via `LSP workspaceSymbol query=RemovePluginFailure`), update those references — they should all be inside `KiroProject::remove_plugin`'s body which gets migrated in Step 3.
+
+- [ ] **Step 3: Migrate `KiroProject::remove_plugin`'s body**
+
+Find `pub fn remove_plugin(...)`. The current body increments per-content-type counters (`skills_removed: u32 += 1`) and pushes failures into a single flat `Vec<RemovePluginFailure>`. After migration, it pushes successes into `result.skills.removed` / `result.steering.removed` / `result.agents.removed` and failures into `result.skills.failures` / `result.steering.failures` / `result.agents.failures`.
+
+Sketch of the migration shape (the existing cascade structure stays — only the result-type accesses change):
+
+```rust
+pub fn remove_plugin(
+    &self,
+    marketplace: &crate::validation::MarketplaceName,
+    plugin: &crate::validation::PluginName,
+) -> crate::error::Result<RemovePluginResult> {
+    let mut result = RemovePluginResult::default();
+
+    // === Skills cascade ===
+    let mut skills = self.load_installed_skills_or_default()?;
+    let skills_to_remove: Vec<String> = skills
+        .skills
+        .iter()
+        .filter(|(_, meta)| meta.marketplace == *marketplace && meta.plugin == *plugin)
+        .map(|(name, _)| name.clone())
+        .collect();
+    for skill_name in skills_to_remove {
+        match self.remove_skill_internal(&mut skills, &skill_name) {
+            Ok(()) => result.skills.removed.push(skill_name),
+            Err(err) => {
+                tracing::warn!(skill = %skill_name, plugin = %plugin, marketplace = %marketplace, error = %err, "remove_plugin: skill removal failed");
+                result.skills.failures.push(RemoveItemFailure {
+                    item: skill_name,
+                    error: crate::error::error_full_chain(&err),
+                });
+            }
+        }
+    }
+    self.save_installed_skills(&skills)?;
+
+    // === Steering cascade === (symmetric)
+    // ...
+
+    // === Agents cascade === (symmetric, including native companions folded in)
+    // ...
+
+    Ok(result)
+}
+```
+
+**Native_companions cascade step:** the existing implementation calls `remove_native_companions_for_plugin` as a separate step. Per A2's design, native_companion failures land in `result.agents.failures` (same parent as agents). The successful-removal items (companion file paths rendered) go into `result.agents.removed` alongside translated and native agent names — flat vec.
+
+The structural ordering of cascade steps (skills → steering → agents → native_companions) and the per-step error policy (keep going on failures, don't abort) are preserved — only the destination of successes/failures changes.
+
+- [ ] **Step 4: Update existing `KiroProject::remove_plugin` rstests**
+
+In `project.rs::tests`, find the existing rstests on `remove_plugin` (search for `fn remove_plugin_` and `fn remove_native_companions_`). They currently assert on the old shape (`result.skills_removed: u32`, `result.failures: Vec<RemovePluginFailure>` with `content_type: "skill"`). Update assertions to the new shape:
+
+Before (example):
+```rust
+let result = project.remove_plugin(&mp("mp"), &pn("p")).expect("ok");
+assert_eq!(result.skills_removed, 1);
+assert_eq!(result.steering_removed, 0);
+assert_eq!(result.agents_removed, 0);
+assert!(result.failures.is_empty());
+```
+
+After:
+```rust
+let result = project.remove_plugin(&mp("mp"), &pn("p")).expect("ok");
+assert_eq!(result.skills.removed, vec!["my-skill".to_string()]);
+assert!(result.steering.removed.is_empty());
+assert!(result.agents.removed.is_empty());
+assert!(result.skills.failures.is_empty());
+assert!(result.steering.failures.is_empty());
+assert!(result.agents.failures.is_empty());
+```
+
+Tests that exercised per-step failure landing (e.g., `remove_plugin_drops_native_companions_entry_for_matching_marketplace`, `remove_plugin_continues_after_skill_failure`) need their failure assertions updated:
+
+Before:
+```rust
+assert_eq!(result.failures.len(), 1);
+assert_eq!(result.failures[0].content_type, "skill");
+assert_eq!(result.failures[0].item, "broken-skill");
+```
+
+After:
+```rust
+assert_eq!(result.skills.failures.len(), 1);
+assert_eq!(result.skills.failures[0].item, "broken-skill");
+```
+
+(Same shape for steering / agents — failure lands in the right sub-result by virtue of which cascade step generated it.)
+
+The A-16 cross-marketplace tests (`remove_plugin_only_removes_matching_marketplace_plugin_pair`, `remove_native_companions_for_plugin_only_removes_matching_marketplace`) keep their existing logic — only the `removed` field assertions update.
+
+- [ ] **Step 5: Add new JSON-shape lock for restructured `RemovePluginResult`**
+
+```rust
+    #[test]
+    fn remove_plugin_result_json_shape_locks_default_empty() {
+        let result = RemovePluginResult::default();
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert!(json["skills"].is_object());
+        assert!(json["steering"].is_object());
+        assert!(json["agents"].is_object());
+        assert_eq!(json["skills"]["removed"], serde_json::json!([]));
+        assert_eq!(json["skills"]["failures"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn remove_plugin_result_json_shape_with_populated_removed_and_failures() {
+        let result = RemovePluginResult {
+            skills: RemoveSkillsResult {
+                removed: vec!["alpha".into()],
+                failures: vec![],
+            },
+            steering: RemoveSteeringResult {
+                removed: vec![],
+                failures: vec![RemoveItemFailure {
+                    item: "broken.md".into(),
+                    error: "io: permission denied".into(),
+                }],
+            },
+            agents: RemoveAgentsResult::default(),
+        };
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(json["skills"]["removed"][0], "alpha");
+        assert_eq!(json["steering"]["failures"][0]["item"], "broken.md");
+        assert_eq!(json["agents"]["removed"], serde_json::json!([]));
+    }
+```
+
+- [ ] **Step 6: Build and run tests**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | tail -10
+cargo test -p kiro-market-core --lib remove_plugin 2>&1 | tail -20
+cargo test -p kiro-market-core --lib 2>&1 | grep "test result:" | tail -3
+cargo clippy -p kiro-market-core --tests -- -D warnings
+cargo fmt --all
+```
+
+Expected: clean build; all `remove_plugin_*` rstests pass under the new assertion shape; full kiro-market-core suite green.
+
+The Tauri crate will NOT compile after this commit — `commands/plugins.rs::remove_plugin` may still reference fields that no longer exist (e.g., `result.skills_removed`). Task 6 fixes the Tauri crate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/kiro-market-core/src/project.rs
+git commit -m "$(cat <<'EOF'
+refactor(core): A2 — restructure RemovePluginResult into sub-results (Phase 2a step 5/7)
+
+RemovePluginResult { skills_removed: u32, steering_removed: u32,
+agents_removed: u32, failures: Vec<RemovePluginFailure> } becomes
+RemovePluginResult { skills: RemoveSkillsResult, steering:
+RemoveSteeringResult, agents: RemoveAgentsResult } — symmetric with
+InstallPluginResult.
+
+Each sub-result carries `removed: Vec<String>` (item names; for
+steering, paths rendered via Path::display(); for agents, flat vec
+including translated agent names, native agent names, and native
+companion paths) and `failures: Vec<RemoveItemFailure>`. The shared
+RemoveItemFailure type replaces RemovePluginFailure — the
+content_type: String discriminator goes away because the parent type
+expresses it structurally.
+
+KiroProject::remove_plugin's body migration:
+- Per-content-type cascade structure unchanged (skills -> steering ->
+  agents -> native_companions, keep going on per-step failures)
+- Successes append to result.<content_type>.removed
+- Failures append to result.<content_type>.failures via error_full_chain
+- Native_companions failures land in result.agents.failures (same
+  parent as agents, matching install-side asymmetry)
+
+A-16 marketplace-aware cleanup preserved at all 4 cascade filters
+(meta.marketplace == *marketplace && meta.plugin == *plugin).
+
+Existing rstests on remove_plugin migrated to the new assertion shape
+(result.skills.removed instead of result.skills_removed, etc.). New
+JSON-shape lock test pins the restructured wire format.
+
+The Tauri crate doesn't compile after this commit — Task 6 fixes
+commands/plugins.rs.
+
+Breaking wire-format change. No compat shim — single-PR-per-phase
+pattern means the consumer (Phase 2b UI) updates at the same time as
+the producer (this PR's bindings.ts regen).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Update `commands/plugins.rs::remove_plugin` to the new shape
+
+**Files:**
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/plugins.rs` (Tauri wrapper unchanged but tests update; verify no leftover references to old shape)
+
+The Tauri `remove_plugin` wrapper signature is unchanged (it still takes `String` args and returns `Result<RemovePluginResult, CommandError>`). The wire-format change ripples through specta's bindings.ts regeneration (Task 7); the Tauri crate's Rust code only needs updates where tests assert on the old shape.
+
+- [ ] **Step 1: Find references to old `RemovePluginResult` shape**
+
+```bash
+cd /home/dwalleck/repos/kiro-marketplace-cli
+grep -rn "skills_removed\|steering_removed\|agents_removed\|RemovePluginFailure" crates/kiro-control-center/
+```
+
+Expected: matches in `commands/plugins.rs::tests` (or similar) referencing the old field names. Update each.
+
+- [ ] **Step 2: Update existing `remove_plugin` tests**
+
+In `commands/plugins.rs::tests` (search for `fn remove_plugin_`), update assertions:
+
+Before:
+```rust
+assert_eq!(result.skills_removed, 2);
+```
+
+After:
+```rust
+assert_eq!(result.skills.removed.len(), 2);
+// or stronger: assert_eq!(result.skills.removed, vec!["alpha", "beta"]);
+```
+
+If any test asserted on `RemovePluginFailure.content_type`, update to read from the appropriate sub-result's `failures` vec.
+
+- [ ] **Step 3: Verify the workspace compiles**
+
+```bash
+cargo build --workspace 2>&1 | tail -10
+cargo test -p kiro-control-center --lib remove_plugin 2>&1 | tail -10
+cargo clippy --workspace --tests -- -D warnings
+cargo fmt --all
+```
+
+Expected: clean workspace build; Tauri remove_plugin tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kiro-control-center/src-tauri/src/commands/plugins.rs
+git commit -m "$(cat <<'EOF'
+refactor(tauri): consume new RemovePluginResult sub-result shape (Phase 2a step 6/7)
+
+Tauri remove_plugin wrapper signature is unchanged — it still takes
+String args and returns Result<RemovePluginResult, CommandError>. The
+wire-format change ripples through specta's bindings.ts regen (Task 7).
+
+Test assertions migrated:
+- result.skills_removed: u32 -> result.skills.removed: Vec<String>
+- result.failures[i].content_type discriminator -> appropriate
+  sub-result's failures vec
+
+A2 reshape's frontend ripple lands in Phase 2b (the UI PR consuming
+the new bindings.ts).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Regenerate `bindings.ts`, run all pre-commit gates, open PR
+
+**Files:**
+- Regenerate: `crates/kiro-control-center/src/lib/bindings.ts`
+
+- [ ] **Step 1: Regenerate `bindings.ts`**
+
+```bash
+cd /home/dwalleck/repos/kiro-marketplace-cli  # or the worktree
+cargo test -p kiro-control-center --lib generate_types -- --ignored 2>&1 | tail -5
+```
+
+Expected: pass. Verify the new types appear:
+
+```bash
+grep -E "^export type (DetectUpdatesResult|PluginUpdateInfo|PluginUpdateFailure|UpdateChangeSignal|RemoveSkillsResult|RemoveSteeringResult|RemoveAgentsResult|RemoveItemFailure)\b" crates/kiro-control-center/src/lib/bindings.ts
+```
+
+All 8 should appear. Verify shapes:
+- `DetectUpdatesResult` — `{ updates: PluginUpdateInfo[], failures: PluginUpdateFailure[] }`
+- `UpdateChangeSignal` — discriminated union: `{ kind: "version_bumped" } | { kind: "content_changed" }`
+- `RemovePluginResult` — `{ skills: RemoveSkillsResult, steering: RemoveSteeringResult, agents: RemoveAgentsResult }`
+
+The frontend code (`BrowseTab.svelte`, `InstalledTab.svelte`) doesn't need changes in Phase 2a — TS treats the type changes as a wire-format diff that no Svelte component currently consumes (the existing FE doesn't show update indicators or read individual removed item names). Phase 2b consumes them.
+
+- [ ] **Step 2: Run all pre-commit gates**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --tests -- -D warnings
+cargo test --workspace 2>&1 | grep "test result:" | tail -10
+cd crates/kiro-control-center && npm run check 2>&1 | tail -5 && cd ../..
+TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint 2>&1 | tail -10
+```
+
+All MUST pass. If `npm run check` reports new errors related to the migrated bindings, investigate — most likely the FE has a typed reference to `result.skills_removed` somewhere that needs updating to `result.skills.removed.length`. The expected zero-FE-change state holds only if the FE doesn't currently consume `RemovePluginResult` count fields. If it does, either:
+- Update the FE call site as part of this PR (cleanest)
+- Capture as a Phase 2b finding in the amendments doc and ship a stub
+
+If `cargo xtask plan-lint` reports any findings, document them in `2026-05-01-phase-2a-update-detection-plan-amendments.md` (creating it if needed) per the precedent set by Phase 1 + 1.5.
+
+- [ ] **Step 3: Commit `bindings.ts`**
+
+```bash
+git add crates/kiro-control-center/src/lib/bindings.ts
+git commit -m "$(cat <<'EOF'
+chore(bindings): regenerate TS bindings for Phase 2a (step 7/7)
+
+Emits the new detection types (DetectUpdatesResult, PluginUpdateInfo,
+PluginUpdateFailure, UpdateChangeSignal as discriminated union) and
+the restructured RemovePluginResult { skills, steering, agents }
+shape. Frontend code unchanged in Phase 2a — Phase 2b consumes these
+types.
+
+All pre-commit gates pass:
+- cargo fmt --all --check: clean
+- cargo clippy --workspace --tests -- -D warnings: clean
+- cargo test --workspace: all green
+- npm run check (frontend): clean
+- cargo xtask plan-lint (all gates): OK
+
+Phase 2a complete. The detection backend and A2 reshape ship as a
+backend-only PR; Phase 2b adds the Update indicator UI on plugin
+cards and the refreshed Remove toast consuming these types.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/phase-2a-update-detection
+```
+
+(If you're not on a worktree branch yet, the implementer should create one before starting Task 1. See `superpowers:using-git-worktrees`.)
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --title "feat: update detection + RemovePluginResult reshape (Phase 2a backend)" --body "$(cat <<'EOF'
+## Summary
+
+Phase 2a of the plugin lifecycle. Adds `MarketplaceService::detect_plugin_updates` (hybrid hash + version detection over installed plugins) plus a Tauri command, and reshapes \`RemovePluginResult\` from opaque counts into per-content-type sub-results (A2 — bundled here per Phase 1.5 design's deferral). Backend-only; Phase 2b (UI) ships separately.
+
+Background: Phase 1 design's Phase 2 sketch (\`2026-04-29-plugin-first-install-design.md\`) deferred the implementation plan until Phase 1 shipped. Phase 1.5 (PR #95) closed the swap-arg footgun so Phase 2's APIs use \`MarketplaceName\` / \`PluginName\` newtypes from day one.
+
+## What's in scope
+
+- **Detection: hybrid hash + version.** Hash drives "update available?"; version provides the human-readable label. Catches author-hygiene gaps where content drifts without a manifest version bump (markdown-heavy plugins).
+- **Per-plugin failure surfacing.** \`DetectUpdatesResult { updates, failures }\` matches the A-12 cascade pattern. A single unreachable marketplace doesn't knock out scan visibility for the rest.
+- **\`UpdateChangeSignal\`** discriminated enum (\`#[serde(tag = "kind", rename_all = "snake_case")]\`) — complies with the \`ffi-enum-serde-tag\` plan-lint gate (PR #91).
+- **Legacy fallback** for pre-Stage-1 installs (\`source_hash: None\`) — drop back to version-only comparison; same versions = no entry (drift undetectable until next install).
+- **A2: \`RemovePluginResult\` reshape** — symmetric with \`InstallPluginResult\`'s sub-results; \`RemoveItemFailure\` shared across the three sub-results (parent type expresses the discriminator).
+
+## What's NOT in scope
+
+- Phase 2b UI work (Update indicator, Update button wiring, refreshed Remove toast)
+- Hash memoization in marketplace cache (perf optimization)
+- Per-content-type update granularity (rejected per design)
+- Auto-update / background polling (rejected per design)
+- HashMap-key newtypes, \`From<CoreError>\` exhaustiveness fix, cross-marketplace idempotency edge — separate phases per Phase 2a design's "Out of scope"
+
+## Test plan
+
+- [x] \`cargo fmt --all --check\` clean
+- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
+- [x] \`cargo test --workspace\` all green (8 new behavioral detection tests + 4 detection JSON-shape locks + 9 sub-result JSON-shape locks + restructured \`remove_plugin\` rstests)
+- [x] \`cargo xtask plan-lint\` all gates OK (including \`ffi-enum-serde-tag\` for the new \`UpdateChangeSignal\`)
+- [x] \`npm run check\` clean (frontend types via regenerated \`bindings.ts\`)
+
+## References
+
+- Design: \`docs/plans/2026-04-30-phase-2a-update-detection-design.md\`
+- Plan: \`docs/plans/2026-05-01-phase-2a-update-detection-plan.md\`
+- Predecessor: PR #95 (Phase 1.5, MarketplaceName/PluginName newtypes)
+- Phase 1 design's Phase 2 sketch: \`2026-04-29-plugin-first-install-design.md\` (lines 185-233)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Design section | Covered by |
+|---|---|
+| `DetectUpdatesResult`, `PluginUpdateInfo`, `PluginUpdateFailure`, `UpdateChangeSignal` types | Task 1 |
+| Detection logic (hybrid hash + version) | Task 2 |
+| Legacy fallback | Task 2 (tests + impl) |
+| Per-plugin failure surfacing | Task 2 (tests + impl) |
+| Tauri `detect_plugin_updates` command | Task 3 |
+| New sub-result types (A2 prep) | Task 4 |
+| `RemovePluginResult` restructure + `KiroProject::remove_plugin` cascade migration | Task 5 |
+| `RemovePluginFailure` removal | Task 5 |
+| Tauri `remove_plugin` consumer update | Task 6 |
+| `bindings.ts` regen | Task 7 |
+| Pre-commit gates + PR open | Task 7 |
+| 5-gates self-review | Task 7 (during pre-commit) |
+
+All design requirements have a task.
+
+### Placeholder scan
+
+- No "TBD" / "TODO" / "implement later" entries.
+- One `todo!()` macro in Task 2's `scan_plugin_for_content_drift` skeleton — intentional, with a detailed implementer note explaining what to fill in (the implementer is expected to use LSP to finalize the tracking-file accessor signatures).
+- All commit messages have actual content (no "fill in details").
+
+### Type consistency
+
+- `DetectUpdatesResult { updates, failures }` consistent across Task 1 (definition), Task 2 (impl), Task 3 (Tauri tests), Task 7 (bindings.ts verification).
+- `UpdateChangeSignal::VersionBumped` / `ContentChanged` consistent across Task 1 (enum definition), Task 2 (test assertions), Task 7 (bindings.ts shape verification).
+- `RemovePluginResult { skills, steering, agents }` consistent across Task 4 (sub-result types), Task 5 (parent restructure + cascade migration), Task 6 (Tauri consumer update), Task 7 (bindings.ts).
+- `RemoveItemFailure { item, error }` consistent across all sub-results.
+- The compile-state warnings ("Tauri crate doesn't compile after Task 5 — Task 6 fixes") align with the actual ripple — Task 5 changes the core type, Task 6 updates the Tauri consumer.
+
+### Bite-sized granularity
+
+Each task has 4-7 numbered steps; each step is a single action (write tests / run / implement / lint / commit). Commit cadence per task ≈ 1 commit; total ≈ 7 commits.
+
+---
+
+**Plan complete.** Suggested execution: subagent-driven, one task per fresh subagent, two-stage review between tasks per the `superpowers:subagent-driven-development` skill. Tasks 2 and 5 are the heavy lifts; Tasks 1, 3, 4, 6, 7 are smaller focused commits. Apply the 5-gates checklist to this plan before kicking off Task 1 — capture any drift in `2026-05-01-phase-2a-update-detection-plan-amendments.md` per the Phase 1 + 1.5 precedent.

--- a/xtask/src/plan_lint.rs
+++ b/xtask/src/plan_lint.rs
@@ -352,13 +352,13 @@ const ALLOWED_SITES: &[AllowedSite] = &[
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 54,
+        line: 55,
         reason: "Tauri scaffolding pattern — debug-only `specta_typescript::Typescript::default().export(...)` failure at app startup. Refactoring to `?` propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
     AllowedSite {
         gate: "no-unwrap-in-production",
         path: "crates/kiro-control-center/src-tauri/src/lib.rs",
-        line: 65,
+        line: 66,
         reason: "Tauri scaffolding pattern — `tauri::Builder::run` failure at app startup. Replacing with Result propagation would only move the panic into `fn main()`. Idiomatic Rust at the binary entry point.",
     },
 ];
@@ -1306,7 +1306,7 @@ mod tests {
     fn is_allowed_matches_gate_path_and_line_exactly() {
         let f = Finding {
             path: "crates/kiro-control-center/src-tauri/src/lib.rs".to_string(),
-            line: 54,
+            line: 55,
             qualified_name: "run".to_string(),
             signature: Some("expect".to_string()),
         };


### PR DESCRIPTION
## Summary

Phase 2a of the plugin lifecycle. Adds `MarketplaceService::detect_plugin_updates` (hybrid hash + version detection over installed plugins) plus a Tauri command, and reshapes `RemovePluginResult` from opaque counts into per-content-type sub-results (A2 — bundled here per Phase 1.5 design's deferral). Backend-only; Phase 2b (UI) ships separately.

Background: Phase 1 design's Phase 2 sketch (`2026-04-29-plugin-first-install-design.md`) deferred the implementation plan until Phase 1 shipped. Phase 1.5 (PR #95) closed the swap-arg footgun so Phase 2's APIs use `MarketplaceName` / `PluginName` newtypes from day one.

## What's in scope

- **Detection: hybrid hash + version.** Hash drives "update available?"; version provides the human-readable label. Catches author-hygiene gaps where content drifts without a manifest version bump (markdown-heavy plugins).
- **Per-plugin failure surfacing.** `DetectUpdatesResult { updates, failures }` matches the A-12 cascade pattern. A single unreachable marketplace doesn't knock out scan visibility for the rest.
- **`UpdateChangeSignal`** discriminated enum (`#[serde(tag = "kind", rename_all = "snake_case")]`) — complies with the `ffi-enum-serde-tag` plan-lint gate (PR #91).
- **Legacy fallback** for pre-Stage-1 installs (`source_hash: None`) — drop back to version-only comparison; same versions = no entry (drift undetectable until next install).
- **A2: `RemovePluginResult` reshape** — symmetric with `InstallPluginResult`'s sub-results; `RemoveItemFailure` shared across the three sub-results (parent type expresses the discriminator).

## What's NOT in scope

- Phase 2b UI work (Update indicator, Update button wiring, refreshed Remove toast)
- Hash memoization in marketplace cache (perf optimization)
- Per-content-type update granularity (rejected per design)
- Auto-update / background polling (rejected per design)
- HashMap-key newtypes, `From<CoreError>` exhaustiveness fix, cross-marketplace idempotency edge — separate phases per Phase 2a design's "Out of scope"

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` all green (8 new behavioral detection tests + 4 detection JSON-shape locks + 9 sub-result JSON-shape locks + restructured `remove_plugin` rstests)
- [x] `cargo xtask plan-lint` all gates OK (including `ffi-enum-serde-tag` for the new `UpdateChangeSignal`)
- [x] `npm run check` clean (frontend types via regenerated `bindings.ts`)

## References

- Design: `docs/plans/2026-04-30-phase-2a-update-detection-design.md`
- Plan: `docs/plans/2026-05-01-phase-2a-update-detection-plan.md`
- Predecessor: PR #95 (Phase 1.5, MarketplaceName/PluginName newtypes)
- Phase 1 design's Phase 2 sketch: `docs/plans/2026-04-29-plugin-first-install-design.md` (lines 185-233)

🤖 Generated with [Claude Code](https://claude.com/claude-code)