### PR TITLE
fix: install↔detect symmetry — closes #97 + closes scan-path bug pattern

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/browse.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/browse.rs
@@ -248,6 +248,7 @@ fn install_skills_impl(
     let project = KiroProject::new(project_root);
     Ok(svc.install_skills(
         &project,
+        &ctx.plugin_dir,
         &ctx.skill_dirs,
         &InstallFilter::Names(skills),
         mode,

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -85,8 +85,8 @@ mod tests {
             plugin: PluginName::new("test-plugin").expect("valid plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                 .expect("valid"),
         };
@@ -115,8 +115,8 @@ mod tests {
                 plugin: PluginName::new("test-plugin").expect("valid plugin"),
                 version: Some("1.0.0".into()),
                 installed_at: Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                     .expect("valid"),
             };

--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -87,6 +87,8 @@ mod tests {
             installed_at: Utc::now(),
             source_hash: None,
             installed_hash: None,
+            source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
+                .expect("valid"),
         };
         let skill_src = tempfile::tempdir().expect("skill src");
         std::fs::write(
@@ -115,6 +117,8 @@ mod tests {
                 installed_at: Utc::now(),
                 source_hash: None,
                 installed_hash: None,
+                source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
+                    .expect("valid"),
             };
             let skill_src = tempfile::tempdir().expect("skill src");
             std::fs::write(skill_src.path().join("SKILL.md"), "# Skill\nBody")

--- a/crates/kiro-control-center/src-tauri/src/commands/steering.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/steering.rs
@@ -60,6 +60,7 @@ fn install_plugin_steering_impl(
         marketplace: &marketplace,
         plugin: &plugin,
         version: ctx.version.as_deref(),
+        plugin_dir: &ctx.plugin_dir,
     };
 
     Ok(MarketplaceService::install_plugin_steering(

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -385,19 +385,39 @@ fn scan_for_plugins(
 /// Name of the skill definition file.
 const SKILL_MD: &str = "SKILL.md";
 
+/// One skill directory discovered under a plugin's manifest-declared
+/// skill scan paths. Carries both the scan root and the resolved skill
+/// directory so install can record `scan_root` on
+/// [`crate::project::InstalledSkillMeta::source_scan_root`] for later
+/// drift detection.
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    /// Absolute path to the scan root that contains `skill_dir`,
+    /// e.g. `<plugin_dir>/skills/` or `<plugin_dir>/packs/`.
+    /// Recorded on tracking after `strip_prefix(plugin_dir)` so
+    /// detection knows where to look without probing.
+    pub scan_root: PathBuf,
+    /// Absolute path to the skill directory itself,
+    /// e.g. `<plugin_dir>/skills/alpha/`. Contains a `SKILL.md`.
+    pub skill_dir: PathBuf,
+}
+
 /// Discover skill directories within a plugin root given a list of paths.
 ///
 /// Each entry in `skill_paths` is interpreted relative to `plugin_root`:
 ///
 /// - If it ends with `/`, it is treated as a directory to scan: every
 ///   immediate subdirectory that contains a `SKILL.md` is included.
-/// - Otherwise it is treated as a specific directory; it is included only
-///   if it contains a `SKILL.md`.
+///   The candidate path itself is the scan root for those skills.
+/// - Otherwise it is treated as a specific directory; it is included
+///   only if it contains a `SKILL.md`. The scan root is the candidate's
+///   parent (or `plugin_root` if there's no parent under it).
 ///
-/// The returned paths are sorted for deterministic ordering.
+/// The returned records are sorted on `skill_dir` for deterministic
+/// ordering.
 #[must_use]
-pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
+pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<DiscoveredSkill> {
+    let mut found = Vec::new();
 
     for &path_str in skill_paths {
         if let Err(e) = crate::validation::validate_relative_path(path_str) {
@@ -413,6 +433,7 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Path
 
         if path_str.ends_with('/') || path_str.ends_with('\\') {
             // Scan subdirectories for those containing SKILL.md.
+            // The candidate path IS the scan root for this branch.
             match fs::read_dir(&candidate) {
                 Ok(entries) => {
                     for entry in entries {
@@ -429,7 +450,10 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Path
                         };
                         let entry_path = entry.path();
                         if entry_path.is_dir() && entry_path.join(SKILL_MD).exists() {
-                            dirs.push(entry_path);
+                            found.push(DiscoveredSkill {
+                                scan_root: candidate.clone(),
+                                skill_dir: entry_path,
+                            });
                         }
                     }
                 }
@@ -442,7 +466,16 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Path
                 }
             }
         } else if candidate.is_dir() && candidate.join(SKILL_MD).exists() {
-            dirs.push(candidate);
+            // Bare-path branch: the scan root is the candidate's
+            // parent (or plugin_root if no parent under it). The
+            // skill dir IS the candidate.
+            let scan_root = candidate
+                .parent()
+                .map_or_else(|| plugin_root.to_path_buf(), Path::to_path_buf);
+            found.push(DiscoveredSkill {
+                scan_root,
+                skill_dir: candidate,
+            });
         } else {
             debug!(
                 path = %candidate.display(),
@@ -451,8 +484,8 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Path
         }
     }
 
-    dirs.sort();
-    dirs
+    found.sort_by(|a, b| a.skill_dir.cmp(&b.skill_dir));
+    found
 }
 
 #[cfg(test)]
@@ -564,17 +597,21 @@ mod tests {
         let dirs = discover_skill_dirs(root, &["./skills/"]);
 
         assert_eq!(dirs.len(), 2);
-        // Results should be sorted, so efcore comes before tunit.
+        // Results should be sorted on skill_dir, so efcore comes
+        // before tunit.
         assert!(
-            dirs[0].ends_with("efcore"),
+            dirs[0].skill_dir.ends_with("efcore"),
             "first should be efcore, got {:?}",
             dirs[0]
         );
         assert!(
-            dirs[1].ends_with("tunit"),
+            dirs[1].skill_dir.ends_with("tunit"),
             "second should be tunit, got {:?}",
             dirs[1]
         );
+        // Both skills came from the same scan root.
+        assert_eq!(dirs[0].scan_root, root.join("skills/"));
+        assert_eq!(dirs[1].scan_root, root.join("skills/"));
     }
 
     #[test]
@@ -590,7 +627,7 @@ mod tests {
 
         assert_eq!(dirs.len(), 1);
         assert!(
-            dirs[0].ends_with("tunit"),
+            dirs[0].skill_dir.ends_with("tunit"),
             "should find tunit, got {:?}",
             dirs[0]
         );
@@ -630,7 +667,7 @@ mod tests {
 
         assert_eq!(dirs.len(), 1, "traversal path should be skipped");
         assert!(
-            dirs[0].ends_with("legit"),
+            dirs[0].skill_dir.ends_with("legit"),
             "only the valid skill should be returned, got {:?}",
             dirs[0]
         );
@@ -647,7 +684,7 @@ mod tests {
 
         assert_eq!(dirs.len(), 1, "absolute path should be skipped");
         assert!(
-            dirs[0].ends_with("safe"),
+            dirs[0].skill_dir.ends_with("safe"),
             "only the valid skill should be returned, got {:?}",
             dirs[0]
         );

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -390,16 +390,62 @@ const SKILL_MD: &str = "SKILL.md";
 /// directory so install can record `scan_root` on
 /// [`crate::project::InstalledSkillMeta::source_scan_root`] for later
 /// drift detection.
+///
+/// **Invariant:** `skill_dir.starts_with(scan_root)`. The downstream
+/// install path uses `skill_dir.strip_prefix(scan_root)` to derive the
+/// install-time relative name; a mismatched pair would produce a
+/// nonsense `RelativePath`. Construction goes through
+/// [`Self::new_unchecked`] (in-crate only — the discover sites
+/// guarantee the invariant by construction) which `debug_assert!`s the
+/// prefix relationship; fields are `pub(crate)` so external crates
+/// must read through the [`Self::scan_root`] / [`Self::skill_dir`]
+/// accessors and cannot bypass the invariant with a struct literal.
+/// Per PR #100 review S4.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSkill {
     /// Absolute path to the scan root that contains `skill_dir`,
     /// e.g. `<plugin_dir>/skills/` or `<plugin_dir>/packs/`.
     /// Recorded on tracking after `strip_prefix(plugin_dir)` so
     /// detection knows where to look without probing.
-    pub scan_root: PathBuf,
+    pub(crate) scan_root: PathBuf,
     /// Absolute path to the skill directory itself,
     /// e.g. `<plugin_dir>/skills/alpha/`. Contains a `SKILL.md`.
-    pub skill_dir: PathBuf,
+    pub(crate) skill_dir: PathBuf,
+}
+
+impl DiscoveredSkill {
+    /// Construct a `DiscoveredSkill`, asserting the
+    /// `skill_dir.starts_with(scan_root)` invariant. `pub(crate)`
+    /// because the only sound producers of a `DiscoveredSkill` are the
+    /// two construction sites in [`discover_skill_dirs`] which compose
+    /// `scan_root` and `skill_dir` such that the invariant holds by
+    /// construction. The `debug_assert!` catches contract violations in
+    /// tests rather than allowing a silent wrong-prefix that would
+    /// later derail `strip_prefix(...)` at the install boundary.
+    pub(crate) fn new_unchecked(scan_root: PathBuf, skill_dir: PathBuf) -> Self {
+        debug_assert!(
+            skill_dir.starts_with(&scan_root),
+            "DiscoveredSkill invariant violated: skill_dir `{}` is not under scan_root `{}`",
+            skill_dir.display(),
+            scan_root.display(),
+        );
+        Self {
+            scan_root,
+            skill_dir,
+        }
+    }
+
+    /// The scan root that contains [`Self::skill_dir`].
+    #[must_use]
+    pub fn scan_root(&self) -> &Path {
+        &self.scan_root
+    }
+
+    /// The skill directory containing `SKILL.md`.
+    #[must_use]
+    pub fn skill_dir(&self) -> &Path {
+        &self.skill_dir
+    }
 }
 
 /// Discover skill directories within a plugin root given a list of paths.
@@ -450,10 +496,10 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
                         };
                         let entry_path = entry.path();
                         if entry_path.is_dir() && entry_path.join(SKILL_MD).exists() {
-                            found.push(DiscoveredSkill {
-                                scan_root: candidate.clone(),
-                                skill_dir: entry_path,
-                            });
+                            found.push(DiscoveredSkill::new_unchecked(
+                                candidate.clone(),
+                                entry_path,
+                            ));
                         }
                     }
                 }
@@ -472,10 +518,7 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
             let scan_root = candidate
                 .parent()
                 .map_or_else(|| plugin_root.to_path_buf(), Path::to_path_buf);
-            found.push(DiscoveredSkill {
-                scan_root,
-                skill_dir: candidate,
-            });
+            found.push(DiscoveredSkill::new_unchecked(scan_root, candidate));
         } else {
             debug!(
                 path = %candidate.display(),
@@ -662,6 +705,53 @@ mod tests {
             root.to_path_buf(),
             "bare-path branch sets scan_root to the candidate's parent, \
              which equals plugin_root for skills at the plugin root"
+        );
+    }
+
+    /// PR #100 review S6: a manifest declaring TWO scan roots
+    /// (`["./packs/", "./extras/"]`) with skills under each must
+    /// produce one `DiscoveredSkill` per skill, each carrying its OWN
+    /// scan root — not the most-recently-seen root for all of them.
+    /// Catches a future "optimize the discover loop" refactor that
+    /// might collapse `scan_root` to a single value across iterations
+    /// (since none of the existing tests exercised the multi-root case
+    /// they wouldn't have caught it).
+    #[test]
+    fn discover_skills_with_multiple_scan_roots_records_each_skills_own_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_skill_md(&root.join("packs/alpha"));
+        create_skill_md(&root.join("packs/beta"));
+        create_skill_md(&root.join("extras/gamma"));
+
+        let dirs = discover_skill_dirs(root, &["./packs/", "./extras/"]);
+        assert_eq!(dirs.len(), 3);
+
+        let by_dir: std::collections::HashMap<_, _> = dirs
+            .iter()
+            .map(|d| (d.skill_dir(), d.scan_root()))
+            .collect();
+
+        let alpha = root.join("packs/alpha");
+        let beta = root.join("packs/beta");
+        let gamma = root.join("extras/gamma");
+        assert_eq!(
+            by_dir.get(alpha.as_path()),
+            Some(&root.join("./packs/").as_path()),
+            "alpha must record packs/ as its scan_root"
+        );
+        assert_eq!(
+            by_dir.get(beta.as_path()),
+            Some(&root.join("./packs/").as_path()),
+            "beta must record packs/ as its scan_root"
+        );
+        assert_eq!(
+            by_dir.get(gamma.as_path()),
+            Some(&root.join("./extras/").as_path()),
+            "gamma must record extras/ as its scan_root, NOT packs/ — \
+             a refactor that hoisted scan_root out of the loop would \
+             produce extras for everything (last write wins)"
         );
     }
 

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -633,6 +633,38 @@ mod tests {
         );
     }
 
+    /// PR #100 review C2: a manifest declaring `skills: ["my-skill"]`
+    /// (bare path with NO `./skills/` parent — i.e. the skill lives at
+    /// the plugin root) makes the bare-path branch set
+    /// `scan_root = candidate.parent() = plugin_root`. Pre-fix this
+    /// resulted in install pushing `FailedSkill` because
+    /// `RelativePath::from_path_under(plugin_root, plugin_root)` errored
+    /// on empty rel. Post-fix `from_path_under` returns
+    /// `RelativePath(".")` so install + detection round-trip cleanly.
+    /// This test asserts only that `discover_skill_dirs` produces the
+    /// `scan_root == plugin_root` case the install code now handles.
+    #[test]
+    fn discover_skills_bare_path_at_plugin_root_uses_root_as_scan_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_skill_md(&root.join("my-skill"));
+
+        let dirs = discover_skill_dirs(root, &["my-skill"]);
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(
+            dirs[0].skill_dir,
+            root.join("my-skill"),
+            "skill_dir is the candidate path itself for bare-path branch"
+        );
+        assert_eq!(
+            dirs[0].scan_root,
+            root.to_path_buf(),
+            "bare-path branch sets scan_root to the candidate's parent, \
+             which equals plugin_root for skills at the plugin root"
+        );
+    }
+
     #[test]
     fn discover_skills_skips_missing_skill_md() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -183,6 +183,39 @@ pub struct InstalledSteeringMeta {
     pub installed_at: DateTime<Utc>,
     pub source_hash: String,
     pub installed_hash: String,
+    /// Scan root (relative to `plugin_dir`) that this steering file
+    /// was installed from. Required at install time; populated from
+    /// `DiscoveredNativeFile.scan_root` (which steering shares with
+    /// the agent discover sites). Drift detection at
+    /// [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
+    /// uses this directly to locate the source file for hash
+    /// recomputation, replacing PR #96's `hash_artifact_in_scan_paths`
+    /// probe helper.
+    pub source_scan_root: RelativePath,
+}
+
+/// Compute the install-time `source_scan_root` for a discovered
+/// steering file, mapping the path-not-under-plugin-dir error to a
+/// `SteeringError::SourceReadFailed`. Extracted from
+/// `install_steering_file_locked` to keep that function under
+/// clippy's 100-line cap after the install↔detect symmetry pass.
+pub(crate) fn required_steering_scan_root(
+    scan_root: &std::path::Path,
+    plugin_dir: &std::path::Path,
+) -> Result<RelativePath, crate::steering::SteeringError> {
+    RelativePath::from_path_under(scan_root, plugin_dir).map_err(|e| {
+        crate::steering::SteeringError::SourceReadFailed {
+            path: scan_root.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "steering scan_root `{}` not under plugin_dir `{}`: {e}",
+                    scan_root.display(),
+                    plugin_dir.display(),
+                ),
+            ),
+        }
+    })
 }
 
 /// On-disk structure of `installed-steering.json`. Map key is the
@@ -1984,6 +2017,8 @@ impl KiroProject {
             installed.files.remove(rel_path);
         }
 
+        let source_scan_root = required_steering_scan_root(&source.scan_root, ctx.plugin_dir)?;
+
         installed.files.insert(
             rel_path.to_path_buf(),
             InstalledSteeringMeta {
@@ -1993,6 +2028,7 @@ impl KiroProject {
                 installed_at: chrono::Utc::now(),
                 source_hash: source_hash.to_owned(),
                 installed_hash: installed_hash.clone(),
+                source_scan_root,
             },
         );
 
@@ -3578,6 +3614,7 @@ mod tests {
                 installed_at: chrono::Utc::now(),
                 source_hash: "blake3:abc".into(),
                 installed_hash: "blake3:abc".into(),
+                source_scan_root: RelativePath::new("steering").expect("valid"),
             },
         );
         let bytes = serde_json::to_vec(&steering).unwrap();
@@ -3631,6 +3668,7 @@ mod tests {
                     "installed_at": chrono::Utc::now(),
                     "source_hash": "blake3:abc",
                     "installed_hash": "blake3:abc",
+                    "source_scan_root": "steering",
                 }
             }
         });
@@ -4003,6 +4041,7 @@ mod tests {
                 installed_at: chrono::Utc::now(),
                 source_hash: "blake3:abc".into(),
                 installed_hash: "blake3:abc".into(),
+                source_scan_root: RelativePath::new("steering").expect("valid"),
             },
         );
         project.write_steering_tracking(&to_save).unwrap();
@@ -4046,7 +4085,8 @@ mod tests {
                     "version": "1.0.0",
                     "installed_at": now,
                     "source_hash": "cafebabe",
-                    "installed_hash": "cafebabe"
+                    "installed_hash": "cafebabe",
+                    "source_scan_root": "steering"
                 },
                 "review.md": {
                     "marketplace": "mp",
@@ -4054,7 +4094,8 @@ mod tests {
                     "version": "0.5.0",
                     "installed_at": now,
                     "source_hash": "feedface",
-                    "installed_hash": "feedface"
+                    "installed_hash": "feedface",
+                    "source_scan_root": "steering"
                 }
             }
         });
@@ -4124,7 +4165,8 @@ mod tests {
                 "guide.md": {
                     "marketplace": "mp", "plugin": "p",
                     "version": "2.0.0", "installed_at": same_time,
-                    "source_hash": "cafebabe", "installed_hash": "cafebabe"
+                    "source_hash": "cafebabe", "installed_hash": "cafebabe",
+                    "source_scan_root": "steering"
                 }
             }
         });
@@ -4186,7 +4228,8 @@ mod tests {
             serde_json::json!({
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
-                "source_hash": "x", "installed_hash": "x"
+                "source_hash": "x", "installed_hash": "x",
+                "source_scan_root": "steering"
             })
         };
         let agent_meta = || {
@@ -4292,6 +4335,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "x", "installed_hash": "x",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -4387,6 +4431,7 @@ mod tests {
                 marketplace: &mp_name,
                 plugin: &pn_name,
                 version: None,
+                plugin_dir: f.scratch.path(),
             },
         )
     }
@@ -4498,6 +4543,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: None,
+                    plugin_dir: steering_file.scratch.path(),
                 },
             )
             .expect_err("cross-plugin clash must fail");
@@ -4520,6 +4566,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: None,
+                    plugin_dir: steering_file.scratch.path(),
                 },
             )
             .expect("force-mode transfer");
@@ -4570,6 +4617,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: None,
+                    plugin_dir: steering_file.scratch.path(),
                 },
             )
             .expect_err("hardlinked source must be refused");
@@ -4646,6 +4694,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: Some("0.1.0"),
+                    plugin_dir: &project.root,
                 },
             )
             .expect("install_steering_file");
@@ -5472,6 +5521,7 @@ mod tests {
                         "installed_at": now,
                         "source_hash": "feedface",
                         "installed_hash": "feedface",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -5535,6 +5585,7 @@ mod tests {
                         "installed_at": now,
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -5579,6 +5630,7 @@ mod tests {
                         "installed_at": now,
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -5938,6 +5990,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "feedface", "installed_hash": "feedface",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -5991,11 +6044,13 @@ mod tests {
                         "marketplace": "mp-a", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "1", "installed_hash": "1",
+                        "source_scan_root": "steering",
                     },
                     "b.md": {
                         "marketplace": "mp-b", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "2", "installed_hash": "2",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -6144,6 +6199,7 @@ mod tests {
                         "installed_at": now,
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -6235,6 +6291,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "x", "installed_hash": "x",
+                        "source_scan_root": "steering",
                     }
                 }
             }))
@@ -7371,6 +7428,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: None,
+                    plugin_dir: scratch.path(),
                 },
             )
             .expect("v1 install");
@@ -7397,6 +7455,7 @@ mod tests {
                     marketplace: &mp_name,
                     plugin: &pn_name,
                     version: None,
+                    plugin_dir: scratch.path(),
                 },
             )
             .expect_err("tracking write must fail");

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -72,28 +72,29 @@ pub struct InstalledAgentMeta {
     /// Which source dialect the agent was parsed from. Persisted via the
     /// enum's serde rename so the wire format stays `"claude"` / `"copilot"`.
     pub dialect: AgentDialect,
-    /// Relative path under the plugin's `agents/` directory of the
-    /// source file that was installed. `None` for legacy entries
-    /// installed before this field was added.
+    /// Relative path under the plugin tree of the source file that was
+    /// installed. Required at install time; populated via
+    /// [`crate::validation::RelativePath::from_path_under`] from the
+    /// discovered agent file's path. Drift detection at
+    /// [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
+    /// uses this directly to locate the source for hash recomputation —
+    /// no dialect-fallback, no probe.
     ///
     /// Wrapped in [`RelativePath`] so `serde_json::from_slice` rejects
     /// path-traversal attempts (`"../../etc/passwd"`) at tracking-file
     /// load time per CLAUDE.md's "Parse, don't validate" rule. The
     /// `RelativePath::Deserialize` impl routes through `RelativePath::new`,
     /// which forbids `..`, absolute paths, NUL bytes, and embedded
-    /// backslashes — closing NC2 from PR #96 review (the original
-    /// `Option<PathBuf>` type let a tampered tracking file's
-    /// `source_path` escape the install boundary at hash recompute time
-    /// in [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]).
+    /// backslashes.
     ///
-    /// Cross-file invariant: install-time filename conventions in
-    /// [`crate::service::MarketplaceService::install_translated_agents_inner`]
-    /// must stay in sync with the dialect-classifier fallback in
-    /// `scan_plugin_for_content_drift`. If the install side starts
-    /// emitting paths that disagree with the fallback (e.g. Copilot's
-    /// `.agent.md` vs `.md`), drift detection misreports legacy entries.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_path: Option<RelativePath>,
+    /// **Was `Option<RelativePath>`** before the install↔detect symmetry
+    /// pass; tightened to required when the no-users assumption let us
+    /// drop the legacy-fallback machinery (the dialect-fallback branch
+    /// in `agent_hash_inputs` and the I-N7 actionable-error branch in
+    /// the agents loop). A tracking file written before the field
+    /// existed now fails to deserialize — pinned by the
+    /// `load_installed_agents_rejects_legacy_entry` test.
+    pub source_path: RelativePath,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
     /// install time. `None` for entries written before Stage 1 of the
@@ -273,6 +274,23 @@ pub struct NativeCompanionsInput<'a> {
     pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
     pub source_hash: &'a str,
+    pub mode: crate::service::InstallMode,
+}
+
+/// Input bundle for [`KiroProject::install_native_agent`]. Groups the
+/// immutable refs the install needs so the public signature stays at
+/// one parameter (paralleling [`NativeCompanionsInput`]). The
+/// `source_path` field was added for the install↔detect symmetry pass —
+/// `InstalledAgentMeta.source_path` is required, so the install must
+/// receive it to populate the meta.
+#[derive(Debug)]
+pub struct NativeAgentInstallInput<'a> {
+    pub bundle: &'a crate::agent::NativeAgentBundle,
+    pub marketplace: &'a MarketplaceName,
+    pub plugin: &'a PluginName,
+    pub version: Option<&'a str>,
+    pub source_hash: &'a str,
+    pub source_path: &'a crate::validation::RelativePath,
     pub mode: crate::service::InstallMode,
 }
 
@@ -2560,15 +2578,12 @@ impl KiroProject {
     /// [`InstallMode::Force`]: crate::service::InstallMode::Force
     pub fn install_native_agent(
         &self,
-        bundle: &crate::agent::NativeAgentBundle,
-        marketplace: &MarketplaceName,
-        plugin: &PluginName,
-        version: Option<&str>,
-        source_hash: &str,
-        mode: crate::service::InstallMode,
+        input: &NativeAgentInstallInput<'_>,
     ) -> Result<InstalledNativeAgentOutcome, AgentError> {
-        let json_target = self.agents_dir().join(format!("{}.json", &bundle.name));
-        let agent_name = bundle.name.to_string();
+        let json_target = self
+            .agents_dir()
+            .join(format!("{}.json", &input.bundle.name));
+        let agent_name = input.bundle.name.to_string();
         let json_target_for_err = json_target.clone();
 
         let result: crate::error::Result<InstalledNativeAgentOutcome> =
@@ -2579,17 +2594,17 @@ impl KiroProject {
                 let forced_overwrite = match Self::classify_native_collision(
                     &installed,
                     &agent_name,
-                    plugin,
-                    source_hash,
+                    input.plugin,
+                    input.source_hash,
                     &json_target,
-                    mode,
+                    input.mode,
                 )? {
                     CollisionDecision::Idempotent(outcome) => return Ok(*outcome),
                     CollisionDecision::Proceed { forced_overwrite } => forced_overwrite,
                 };
 
                 let (staging, json_rel, installed_hash) =
-                    self.stage_native_agent_file(&agent_name, &bundle.raw_bytes)?;
+                    self.stage_native_agent_file(&agent_name, &input.bundle.raw_bytes)?;
 
                 let backup = self.promote_native_agent(
                     staging.path(),
@@ -2603,13 +2618,13 @@ impl KiroProject {
                 installed.agents.insert(
                     agent_name.clone(),
                     InstalledAgentMeta {
-                        marketplace: marketplace.clone(),
-                        plugin: plugin.clone(),
-                        version: version.map(String::from),
+                        marketplace: input.marketplace.clone(),
+                        plugin: input.plugin.clone(),
+                        version: input.version.map(String::from),
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
-                        source_path: None,
-                        source_hash: Some(source_hash.to_string()),
+                        source_path: input.source_path.clone(),
+                        source_hash: Some(input.source_hash.to_string()),
                         installed_hash: Some(installed_hash.clone()),
                     },
                 );
@@ -2656,7 +2671,7 @@ impl KiroProject {
                     );
                 }
 
-                debug!(name = %agent_name, force = mode.is_force(), "native agent installed");
+                debug!(name = %agent_name, force = input.mode.is_force(), "native agent installed");
 
                 Ok(InstalledNativeAgentOutcome {
                     name: agent_name,
@@ -2666,7 +2681,7 @@ impl KiroProject {
                     } else {
                         InstallOutcomeKind::Installed
                     },
-                    source_hash: source_hash.to_string(),
+                    source_hash: input.source_hash.to_string(),
                     installed_hash,
                 })
             });
@@ -3493,7 +3508,7 @@ mod tests {
             version: Some("1.2.3".into()),
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
-            source_path: None,
+            source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
             source_hash: None,
             installed_hash: None,
         };
@@ -3516,7 +3531,7 @@ mod tests {
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
-            source_path: None,
+            source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid"),
             source_hash: None,
             installed_hash: None,
         };
@@ -3685,6 +3700,7 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "dialect": "claude",
+                    "source_path": "agents/etc.md",
                 }
             }
         });
@@ -3835,17 +3851,16 @@ mod tests {
 
     /// NC2 + parse-don't-validate sanity: a well-formed `source_path`
     /// (forward-slash relative path under `agents/`) must round-trip
-    /// through serde and end up as `Some(RelativePath)`.
+    /// through serde.
     #[test]
     fn installed_agent_meta_round_trips_valid_source_path() {
-        use crate::validation::RelativePath;
         let meta = InstalledAgentMeta {
             marketplace: mp("m"),
             plugin: pn("p"),
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
-            source_path: Some(RelativePath::new("subdir/agent.md").expect("valid rel path")),
+            source_path: RelativePath::new("subdir/agent.md").expect("valid rel path"),
             source_hash: None,
             installed_hash: None,
         };
@@ -3855,8 +3870,7 @@ mod tests {
             "wire format must remain a flat string, got: {json}"
         );
         let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
-        let rp = back.source_path.expect("source_path should be Some");
-        assert_eq!(rp.as_str(), "subdir/agent.md");
+        assert_eq!(back.source_path.as_str(), "subdir/agent.md");
     }
 
     #[test]
@@ -4164,7 +4178,8 @@ mod tests {
             serde_json::json!({
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
-                "dialect": "claude"
+                "dialect": "claude",
+                "source_path": "agents/x.md"
             })
         };
 
@@ -4662,7 +4677,7 @@ mod tests {
             version: None,
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
-            source_path: None,
+            source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
             source_hash: None,
             installed_hash: None,
         }
@@ -5617,6 +5632,7 @@ mod tests {
                         "version": "1.0.0",
                         "installed_at": now,
                         "dialect": "native",
+                        "source_path": "agents/reviewer.json",
                         "source_hash": "deadbeef",
                         "installed_hash": "deadbeef",
                     }
@@ -5684,6 +5700,7 @@ mod tests {
                         "version": null,
                         "installed_at": now,
                         "dialect": "native",
+                        "source_path": "agents/ghost.json",
                     }
                 }
             }))
@@ -5735,6 +5752,7 @@ mod tests {
                         "version": "1.0.0",
                         "installed_at": now,
                         "dialect": "native",
+                        "source_path": "agents/reviewer.json",
                         "source_hash": "deadbeef",
                         "installed_hash": "deadbeef",
                     }
@@ -6731,43 +6749,18 @@ mod tests {
         assert!(meta.installed_hash.is_none());
     }
 
-    #[test]
-    fn installed_agent_meta_loads_legacy_json_without_hash_fields() {
-        let legacy = br#"{
-            "marketplace": "m",
-            "plugin": "p",
-            "version": "0.1.0",
-            "installed_at": "2026-01-01T00:00:00Z",
-            "dialect": "claude"
-        }"#;
-
-        let meta: InstalledAgentMeta = serde_json::from_slice(legacy).unwrap();
-
-        assert_eq!(meta.dialect, AgentDialect::Claude);
-        assert!(meta.source_hash.is_none());
-        assert!(meta.installed_hash.is_none());
-    }
-
-    #[test]
-    fn installed_agents_loads_legacy_json_without_native_companions() {
-        // Old tracking files (pre-Stage-1) lack the native_companions map.
-        // The new schema must deserialize them with native_companions = empty.
-        let legacy = br#"{
-            "agents": {
-                "x": {
-                    "marketplace": "m",
-                    "plugin": "p",
-                    "version": null,
-                    "installed_at": "2026-01-01T00:00:00Z",
-                    "dialect": "claude"
-                }
-            }
-        }"#;
-
-        let installed: InstalledAgents = serde_json::from_slice(legacy).unwrap();
-        assert_eq!(installed.agents.len(), 1);
-        assert!(installed.native_companions.is_empty());
-    }
+    // Deleted: `installed_agent_meta_loads_legacy_json_without_hash_fields` —
+    // legacy JSON without `source_path` now fails to deserialize by
+    // design (install↔detect symmetry pass; no users → required field).
+    // The inverse contract is pinned by the deserialize-rejection tests
+    // added in Task 7 of the install-detect-symmetry plan.
+    //
+    // Deleted: `installed_agents_loads_legacy_json_without_native_companions` —
+    // same reason. The native_companions-defaults-to-empty contract is
+    // still useful (agents-only tracking files should still load), but
+    // it requires source_path on the agent entries to be testable. The
+    // round-trip test below covers the same surface with a current-shape
+    // tracking entry.
 
     #[test]
     fn installed_native_companions_meta_round_trips_through_serde() {
@@ -7040,8 +7033,19 @@ mod tests {
         // string-literal-friendly (they pass `"m"`, `"plugin-a"` etc.).
         let marketplace = mp(marketplace);
         let plugin = pn(plugin);
-        f.project
-            .install_native_agent(&f.bundle, &marketplace, &plugin, None, &f.source_hash, mode)
+        // Synthetic source_path; the install_native_agent function
+        // only stores it on the tracking meta — these tests exercise
+        // install behavior, not detection.
+        let source_path = RelativePath::new("agents/rev.json").expect("valid");
+        f.project.install_native_agent(&NativeAgentInstallInput {
+            bundle: &f.bundle,
+            marketplace: &marketplace,
+            plugin: &plugin,
+            version: None,
+            source_hash: &f.source_hash,
+            source_path: &source_path,
+            mode,
+        })
     }
 
     #[test]
@@ -7061,14 +7065,15 @@ mod tests {
                 .expect("source hash");
 
         let outcome = project
-            .install_native_agent(
-                &bundle,
-                &mp("marketplace-x"),
-                &pn("plugin-y"),
-                Some("0.1.0"),
-                &source_hash,
-                crate::service::InstallMode::New,
-            )
+            .install_native_agent(&NativeAgentInstallInput {
+                bundle: &bundle,
+                marketplace: &mp("marketplace-x"),
+                plugin: &pn("plugin-y"),
+                version: Some("0.1.0"),
+                source_hash: &source_hash,
+                source_path: &RelativePath::new("agents/rev.json").expect("valid"),
+                mode: crate::service::InstallMode::New,
+            })
             .expect("install_native_agent must succeed");
 
         assert_eq!(outcome.name, "rev");
@@ -7241,14 +7246,15 @@ mod tests {
                 .expect("source hash");
 
         let outcome = project
-            .install_native_agent(
-                &bundle,
-                &mp("m"),
-                &pn("p"),
-                None,
-                &source_hash,
-                crate::service::InstallMode::New,
-            )
+            .install_native_agent(&NativeAgentInstallInput {
+                bundle: &bundle,
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
+                version: None,
+                source_hash: &source_hash,
+                source_path: &RelativePath::new("agents/rev.json").expect("valid"),
+                mode: crate::service::InstallMode::New,
+            })
             .expect("install");
 
         let installed_bytes = fs::read(&outcome.json_path).expect("read installed");
@@ -7274,14 +7280,15 @@ mod tests {
         let h_v1 =
             crate::hash::hash_artifact(&src_dir, &[std::path::PathBuf::from("rev.json")]).unwrap();
         project
-            .install_native_agent(
-                &bundle_v1,
-                &mp("m"),
-                &pn("p"),
-                None,
-                &h_v1,
-                crate::service::InstallMode::New,
-            )
+            .install_native_agent(&NativeAgentInstallInput {
+                bundle: &bundle_v1,
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
+                version: None,
+                source_hash: &h_v1,
+                source_path: &RelativePath::new("agents/rev.json").expect("valid"),
+                mode: crate::service::InstallMode::New,
+            })
             .expect("v1 install");
 
         let dest = project.root.join(".kiro/agents/rev.json");
@@ -7307,14 +7314,15 @@ mod tests {
         let h_v2 =
             crate::hash::hash_artifact(&src_dir, &[std::path::PathBuf::from("rev.json")]).unwrap();
         let err = project
-            .install_native_agent(
-                &bundle_v2,
-                &mp("m"),
-                &pn("p"),
-                None,
-                &h_v2,
-                crate::service::InstallMode::Force,
-            )
+            .install_native_agent(&NativeAgentInstallInput {
+                bundle: &bundle_v2,
+                marketplace: &mp("m"),
+                plugin: &pn("p"),
+                version: None,
+                source_hash: &h_v2,
+                source_path: &RelativePath::new("agents/rev.json").expect("valid"),
+                mode: crate::service::InstallMode::Force,
+            })
             .expect_err("tracking write must fail");
         assert!(matches!(err, AgentError::InstallFailed { .. }));
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -203,24 +203,26 @@ pub struct InstalledSteeringMeta {
 
 /// Compute the install-time `source_scan_root` for a discovered
 /// steering file, mapping the path-not-under-plugin-dir error to a
-/// `SteeringError::SourceReadFailed`. Extracted from
+/// `SteeringError::ScanRootInvalid`. Extracted from
 /// `install_steering_file_locked` to keep that function under
 /// clippy's 100-line cap after the install↔detect symmetry pass.
+///
+/// `ScanRootInvalid` is structurally distinct from `SourceReadFailed`:
+/// the latter is an I/O failure on a content file, the former is a
+/// structural validation failure on the scan-root *path*. Wrapping it
+/// as a synthetic `io::Error` (the pre-PR-#100-review shape) lied
+/// about the failure mode in the wire-format `reason` field — this
+/// constructor preserves the real `ValidationError` via `#[source]`
+/// so chained renderers see the precise cause.
 pub(crate) fn required_steering_scan_root(
     scan_root: &std::path::Path,
     plugin_dir: &std::path::Path,
 ) -> Result<RelativePath, crate::steering::SteeringError> {
-    RelativePath::from_path_under(scan_root, plugin_dir).map_err(|e| {
-        crate::steering::SteeringError::SourceReadFailed {
+    RelativePath::from_path_under(scan_root, plugin_dir).map_err(|source| {
+        crate::steering::SteeringError::ScanRootInvalid {
             path: scan_root.to_path_buf(),
-            source: std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "steering scan_root `{}` not under plugin_dir `{}`: {e}",
-                    scan_root.display(),
-                    plugin_dir.display(),
-                ),
-            ),
+            plugin_dir: plugin_dir.to_path_buf(),
+            source,
         }
     })
 }
@@ -2021,6 +2023,17 @@ impl KiroProject {
             CollisionDecision::Proceed { forced_overwrite } => forced_overwrite,
         };
 
+        // Compute source_scan_root BEFORE staging/promotion. The
+        // validation has no dependency on staging (only on
+        // source.scan_root + ctx.plugin_dir), and a defensive failure
+        // here AFTER promote would leak placed files + backups since
+        // bare ? skips rollback. Atomicity contract: every failure
+        // mode after promote_staged_steering must call
+        // rollback_companion_promotion; computing this upfront keeps
+        // the contract honest by removing one failure source from the
+        // post-promote span.
+        let source_scan_root = required_steering_scan_root(&source.scan_root, ctx.plugin_dir)?;
+
         // `_staging` is held as a RAII guard so its TempDir Drop sweeps
         // the staging directory at end-of-scope, including on early
         // returns from the rest of this function.
@@ -2037,8 +2050,6 @@ impl KiroProject {
         {
             installed.files.remove(rel_path);
         }
-
-        let source_scan_root = required_steering_scan_root(&source.scan_root, ctx.plugin_dir)?;
 
         installed.files.insert(
             rel_path.to_path_buf(),
@@ -2952,6 +2963,28 @@ impl KiroProject {
                 CollisionDecision::Proceed { forced_overwrite } => forced_overwrite,
             };
 
+        // Compute source_scan_root BEFORE staging/promotion. The
+        // validation has no dependency on staging (only on
+        // input.scan_root + input.plugin_dir), and a defensive failure
+        // here AFTER promote would leak placed files + backups since
+        // bare ? skips rollback. Atomicity contract: every failure
+        // mode after promote_native_companions must call
+        // rollback_companion_promotion; computing this upfront removes
+        // one failure source from the post-promote span.
+        let source_scan_root =
+            crate::validation::RelativePath::from_path_under(input.scan_root, input.plugin_dir)
+                .map_err(|e| AgentError::InstallFailed {
+                    path: input.scan_root.to_path_buf(),
+                    source: Box::new(crate::error::Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "native companion scan_root `{}` not under plugin_dir `{}`: {e}",
+                            input.scan_root.display(),
+                            input.plugin_dir.display(),
+                        ),
+                    ))),
+                })?;
+
         let (staging, installed_hash) =
             self.stage_native_companion_files(input.plugin, input.scan_root, input.rel_paths)?;
 
@@ -2988,20 +3021,6 @@ impl KiroProject {
         // tracking on a write failure.
         let diffed_prior_files =
             Self::diff_prior_companion_files(&installed, input.plugin, input.rel_paths);
-
-        let source_scan_root =
-            crate::validation::RelativePath::from_path_under(input.scan_root, input.plugin_dir)
-                .map_err(|e| AgentError::InstallFailed {
-                    path: input.scan_root.to_path_buf(),
-                    source: Box::new(crate::error::Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!(
-                            "native companion scan_root `{}` not under plugin_dir `{}`: {e}",
-                            input.scan_root.display(),
-                            input.plugin_dir.display(),
-                        ),
-                    ))),
-                })?;
 
         installed.native_companions.insert(
             // HashMap key remains `String` (out of scope per Phase 1.5
@@ -6909,6 +6928,47 @@ mod tests {
         let bytes = serde_json::to_vec(&meta).unwrap();
         let back: InstalledNativeCompanionsMeta = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(back.files.len(), 2);
+        // PR #100 review I6: the round-trip used to assert only on
+        // `files.len()`, which was satisfied long before
+        // `source_scan_root` joined the schema. Locking the field
+        // explicitly so a future regression that drops or re-types it
+        // breaks here instead of silently round-tripping a
+        // default/empty value.
+        assert_eq!(back.source_scan_root.as_str(), "agents");
+    }
+
+    /// PR #100 review I1: `required_steering_scan_root` must surface a
+    /// structural validation failure as `SteeringError::ScanRootInvalid`,
+    /// not a synthetic `SourceReadFailed { source: io::Error }`. The
+    /// real `ValidationError` propagates via `#[source]` so the
+    /// `error_full_chain` projection used at FFI/log boundaries renders
+    /// the precise cause instead of a fabricated I/O message.
+    #[test]
+    fn required_steering_scan_root_returns_scan_root_invalid_when_outside_plugin_dir() {
+        let plugin_dir = std::path::PathBuf::from("/plugins/foo");
+        let scan_root = std::path::PathBuf::from("/somewhere/else");
+
+        let err = required_steering_scan_root(&scan_root, &plugin_dir)
+            .expect_err("scan_root outside plugin_dir must fail");
+
+        match err {
+            crate::steering::SteeringError::ScanRootInvalid {
+                ref path,
+                plugin_dir: ref pd,
+                ..
+            } => {
+                assert_eq!(path, &scan_root);
+                assert_eq!(pd, &plugin_dir);
+            }
+            other => panic!("expected ScanRootInvalid, got {other:?}"),
+        }
+        // The variant carries the underlying ValidationError via
+        // `#[source]` so chained renderers see "scan_root invalid → not
+        // under base" instead of a fabricated InvalidInput io::Error.
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "ScanRootInvalid must expose its ValidationError via Error::source"
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -6911,6 +6911,138 @@ mod tests {
         assert_eq!(back.files.len(), 2);
     }
 
+    // ---------------------------------------------------------------------
+    // Deserialize-rejection tests for the install↔detect symmetry pass.
+    //
+    // After the no-users assumption let us tighten source_path /
+    // source_scan_root from Option<...> to required, legacy tracking
+    // files written before this PR landed must fail to deserialize. The
+    // contract is "intentionally invalid by design" — these tests pin
+    // it so a future refactor that re-adds Option (re-introducing the
+    // probe-fallback machinery) breaks here, not silently in production.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn load_installed_skills_rejects_legacy_entry_without_source_scan_root() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-skills.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed()
+            .expect_err("legacy entry must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_scan_root") || msg.contains("missing field"),
+            "error must mention the missing required field; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_installed_steering_rejects_legacy_entry_without_source_scan_root() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "files": {
+                "guide.md": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "source_hash": "blake3:0000",
+                    "installed_hash": "blake3:0000"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-steering.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed_steering()
+            .expect_err("legacy entry must fail to deserialize");
+        assert!(
+            err.to_string().contains("source_scan_root"),
+            "error must mention source_scan_root; got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_installed_agents_rejects_legacy_entry_without_source_path() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "agents": {
+                "reviewer": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "dialect": "native"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("legacy entry must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_path") || msg.contains("missing field"),
+            "error must mention a missing required field; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_installed_native_companions_rejects_legacy_entry_without_source_scan_root() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "agents": {},
+            "native_companions": {
+                "p": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "files": ["prompts/reviewer.md"],
+                    "source_hash": "blake3:0000",
+                    "installed_hash": "blake3:0000"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("legacy companions entry must fail");
+        assert!(
+            err.to_string().contains("source_scan_root"),
+            "error must mention source_scan_root; got: {err}"
+        );
+    }
+
     #[test]
     fn installed_agents_with_empty_native_companions_does_not_serialize_the_field() {
         // Regression guard: a legacy tracking file (no native_companions key)

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -149,6 +149,13 @@ pub struct InstalledNativeCompanionsMeta {
     pub files: Vec<PathBuf>,
     pub source_hash: String,
     pub installed_hash: String,
+    /// Scan root (relative to `plugin_dir`) that this companion bundle
+    /// was installed from. Required at install time. The
+    /// single-scan-root invariant is enforced upstream by
+    /// `multiple_companion_scan_roots`, so all `files` resolve under
+    /// this single root. Drift detection uses it directly, replacing
+    /// PR #96's `hash_artifact_in_scan_paths` probe.
+    pub source_scan_root: RelativePath,
 }
 
 /// The on-disk structure of `installed-agents.json`.
@@ -318,6 +325,11 @@ pub struct NativeCompanionsInput<'a> {
     pub version: Option<&'a str>,
     pub source_hash: &'a str,
     pub mode: crate::service::InstallMode,
+    /// Plugin root directory; used to compute
+    /// [`InstalledNativeCompanionsMeta::source_scan_root`] from
+    /// `scan_root` at install time so detection can lookup the
+    /// source location directly without probing.
+    pub plugin_dir: &'a Path,
 }
 
 /// Input bundle for [`KiroProject::install_native_agent`]. Groups the
@@ -683,6 +695,15 @@ struct CompanionInput<'a> {
     version: Option<&'a str>,
     agents_root: &'a Path,
     prompt_rel: &'a Path,
+    /// Scan root (relative to `plugin_dir`) under which the original
+    /// agent .md was discovered; used to populate
+    /// [`InstalledNativeCompanionsMeta::source_scan_root`]. For the
+    /// translated-agents companion synthesis path the prompts are
+    /// extracted (not separately stored in the source tree), so this
+    /// value is the agent's source-side scan root by convention —
+    /// closing C-1 (the install/detect hash recipe asymmetry for
+    /// translated companions) is tracked at issue #99.
+    source_scan_root: &'a RelativePath,
 }
 
 /// Output of [`KiroProject::promote_staged_agent`]: paths placed at their
@@ -2215,6 +2236,27 @@ impl KiroProject {
                 let marketplace = meta.marketplace.clone();
                 let plugin = meta.plugin.clone();
                 let version = meta.version.clone();
+                // Source-side scan root for the synthesized companion
+                // entry: prompt is extracted from agent .md, so use
+                // the agent's source_path.parent() (typically
+                // "agents") by convention. C-1 (issue #99) tracks
+                // install/detect hash recipe alignment.
+                let companion_scan_root = meta
+                    .source_path
+                    .as_str()
+                    .rsplit_once('/')
+                    .and_then(|(parent, _)| crate::validation::RelativePath::new(parent).ok())
+                    .unwrap_or_else(|| {
+                        // Static literal "agents" trivially passes
+                        // validate_relative_path; the unchecked
+                        // constructor is the right shape per CLAUDE.md
+                        // (no .expect() in production code) and matches
+                        // existing internal callers like
+                        // DiscoveredPlugin::as_relative_path.
+                        crate::validation::RelativePath::from_internal_unchecked(
+                            "agents".to_owned(),
+                        )
+                    });
 
                 installed.agents.insert(def.name.clone(), meta);
 
@@ -2254,6 +2296,7 @@ impl KiroProject {
                         version: version.as_deref(),
                         agents_root: &agents_root,
                         prompt_rel: &prompt_rel,
+                        source_scan_root: &companion_scan_root,
                     },
                 ) {
                     warn!(
@@ -2478,6 +2521,7 @@ impl KiroProject {
                 files: Vec::new(),
                 source_hash: String::new(),
                 installed_hash: String::new(),
+                source_scan_root: input.source_scan_root.clone(),
             });
         // Refresh marketplace/version/timestamp on every install.
         companion_entry.marketplace = input.marketplace.clone();
@@ -2945,6 +2989,20 @@ impl KiroProject {
         let diffed_prior_files =
             Self::diff_prior_companion_files(&installed, input.plugin, input.rel_paths);
 
+        let source_scan_root =
+            crate::validation::RelativePath::from_path_under(input.scan_root, input.plugin_dir)
+                .map_err(|e| AgentError::InstallFailed {
+                    path: input.scan_root.to_path_buf(),
+                    source: Box::new(crate::error::Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "native companion scan_root `{}` not under plugin_dir `{}`: {e}",
+                            input.scan_root.display(),
+                            input.plugin_dir.display(),
+                        ),
+                    ))),
+                })?;
+
         installed.native_companions.insert(
             // HashMap key remains `String` (out of scope per Phase 1.5
             // design — only the meta-value's `plugin: PluginName` field
@@ -2958,6 +3016,7 @@ impl KiroProject {
                 files: input.rel_paths.to_vec(),
                 source_hash: input.source_hash.to_string(),
                 installed_hash: installed_hash.clone(),
+                source_scan_root,
             },
         );
 
@@ -3793,6 +3852,7 @@ mod tests {
                     "files": [],
                     "source_hash": "blake3:abc",
                     "installed_hash": "blake3:abc",
+                    "source_scan_root": "agents",
                 }
             }
         });
@@ -3836,6 +3896,7 @@ mod tests {
                     "files": ["../../etc/passwd"],
                     "source_hash": "blake3:abc",
                     "installed_hash": "blake3:abc",
+                    "source_scan_root": "agents",
                 }
             }
         });
@@ -5317,6 +5378,7 @@ mod tests {
                 version: None,
                 source_hash: &h_a,
                 mode: crate::service::InstallMode::New,
+                plugin_dir: scratch_a.path(),
             })
             .expect("plugin-a install");
 
@@ -5346,6 +5408,7 @@ mod tests {
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::Force,
+                plugin_dir: scratch_b.path(),
             })
             .expect("plugin-b force install");
 
@@ -5872,6 +5935,7 @@ mod tests {
                         "files": [],
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "agents",
                     }
                 }
             }))
@@ -5921,6 +5985,7 @@ mod tests {
                         "files": ["prompts/helper.md"],
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "agents",
                     }
                 }
             }))
@@ -6335,6 +6400,7 @@ mod tests {
                         "files": [],
                         "source_hash": "x",
                         "installed_hash": "x",
+                        "source_scan_root": "agents",
                     }
                 }
             }))
@@ -6838,6 +6904,7 @@ mod tests {
             ],
             source_hash: "blake3:abc".into(),
             installed_hash: "blake3:abc".into(),
+            source_scan_root: RelativePath::new("agents").expect("valid"),
         };
         let bytes = serde_json::to_vec(&meta).unwrap();
         let back: InstalledNativeCompanionsMeta = serde_json::from_slice(&bytes).unwrap();
@@ -7520,6 +7587,7 @@ mod tests {
                 version: Some("0.1.0"),
                 source_hash: &source_hash,
                 mode: crate::service::InstallMode::New,
+                plugin_dir: dir.path(),
             })
             .expect("install companions");
 
@@ -7568,6 +7636,7 @@ mod tests {
                 version: None,
                 source_hash: "blake3:empty",
                 mode: crate::service::InstallMode::New,
+                plugin_dir: std::path::Path::new("/tmp"),
             })
             .expect("empty install");
         assert_eq!(outcome.kind, InstallOutcomeKind::Idempotent);
@@ -7612,6 +7681,7 @@ mod tests {
                 version: None,
                 source_hash: &h,
                 mode: crate::service::InstallMode::New,
+                plugin_dir: scratch.path(),
             })
             .expect_err("hardlinked source must be refused");
         match err {
@@ -7655,6 +7725,7 @@ mod tests {
                 plugin: &pn("p"),
                 version: None,
                 source_hash: &h_v1,
+                plugin_dir: scratch.path(),
                 mode: crate::service::InstallMode::New,
             })
             .expect("v1 install");
@@ -7689,6 +7760,7 @@ mod tests {
                 version: None,
                 source_hash: &h_v2,
                 mode: crate::service::InstallMode::Force,
+                plugin_dir: scratch.path(),
             })
             .expect_err("tracking write must fail");
         assert!(matches!(err, AgentError::InstallFailed { .. }));
@@ -7746,6 +7818,7 @@ mod tests {
                 version: None,
                 source_hash: &source_hash,
                 mode: crate::service::InstallMode::New,
+                plugin_dir: scratch.path(),
             })
             .expect_err("tracking write must fail with .tmp dir blocker in place");
         assert!(matches!(err, AgentError::InstallFailed { .. }));
@@ -7825,6 +7898,7 @@ mod tests {
             version: None,
             source_hash: &f.source_hash,
             mode,
+            plugin_dir: f.scratch.path(),
         })
     }
 
@@ -7994,6 +8068,7 @@ mod tests {
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::New,
+                plugin_dir: companion_bundle.scratch.path(),
             })
             .expect_err("must refuse");
         match err {
@@ -8017,6 +8092,7 @@ mod tests {
                 version: None,
                 source_hash: &h_b,
                 mode: crate::service::InstallMode::Force,
+                plugin_dir: companion_bundle.scratch.path(),
             })
             .expect("force transfer");
         assert_eq!(outcome.kind, InstallOutcomeKind::ForceOverwrote);

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -48,6 +48,16 @@ pub struct InstalledSkillMeta {
     /// for entries written before Stage 1 landed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installed_hash: Option<String>,
+
+    /// Scan root (relative to `plugin_dir`) that this skill was
+    /// installed from. Required at install time; populated from the
+    /// `DiscoveredSkill.scan_root` field which `discover_skill_dirs`
+    /// returns alongside each found skill directory. Drift detection at
+    /// [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
+    /// uses this directly to locate the source skill dir for hash
+    /// recomputation, closing #97 (the hardcoded
+    /// `plugin_dir.join("skills")` bug).
+    pub source_scan_root: RelativePath,
 }
 
 /// The on-disk structure of `installed-skills.json`.
@@ -3497,6 +3507,7 @@ mod tests {
             installed_at: Utc::now(),
             source_hash: None,
             installed_hash: None,
+            source_scan_root: RelativePath::new("skills").expect("valid"),
         }
     }
 
@@ -3660,6 +3671,7 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "source_hash": "blake3:abc",
+                    "source_scan_root": "skills",
                 }
             }
         });
@@ -4015,7 +4027,8 @@ mod tests {
                     "plugin": "plug-a",
                     "version": "1.0.0",
                     "installed_at": now,
-                    "source_hash": "deadbeef"
+                    "source_hash": "deadbeef",
+                    "source_scan_root": "skills"
                 }
             }
         });
@@ -4095,7 +4108,8 @@ mod tests {
                 "alpha": {
                     "marketplace": "mp", "plugin": "p",
                     "version": "1.0.0", "installed_at": same_time,
-                    "source_hash": "deadbeef"
+                    "source_hash": "deadbeef",
+                    "source_scan_root": "skills"
                 }
             }
         });
@@ -4164,7 +4178,8 @@ mod tests {
             serde_json::json!({
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
-                "source_hash": "x"
+                "source_hash": "x",
+                "source_scan_root": "skills"
             })
         };
         let steering_meta = || {
@@ -5417,6 +5432,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "source_scan_root": "skills",
                     }
                 }
             }))
@@ -5906,6 +5922,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "source_scan_root": "skills",
                     }
                 }
             }))
@@ -6032,6 +6049,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "source_scan_root": "skills",
                     }
                 }
             }))
@@ -6105,6 +6123,7 @@ mod tests {
                     installed_at: Utc::now(),
                     source_hash: Some("deadbeef".into()),
                     installed_hash: Some("deadbeef".into()),
+                    source_scan_root: RelativePath::new("skills").expect("valid"),
                 },
             )
             .expect("install skill");
@@ -6730,24 +6749,11 @@ mod tests {
         assert!(installed.skills.contains_key("racey"));
     }
 
-    #[test]
-    fn installed_skill_meta_loads_legacy_json_without_hash_fields() {
-        // Old tracking files (pre-Stage-1) lack source_hash / installed_hash.
-        // The new schema must deserialize them with both fields = None.
-        let legacy = br#"{
-            "marketplace": "m",
-            "plugin": "p",
-            "version": "1.0.0",
-            "installed_at": "2026-01-01T00:00:00Z"
-        }"#;
-
-        let meta: InstalledSkillMeta = serde_json::from_slice(legacy).unwrap();
-
-        assert_eq!(meta.marketplace, "m");
-        assert_eq!(meta.plugin, "p");
-        assert!(meta.source_hash.is_none());
-        assert!(meta.installed_hash.is_none());
-    }
+    // Deleted: `installed_skill_meta_loads_legacy_json_without_hash_fields` —
+    // legacy JSON without `source_scan_root` now fails to deserialize
+    // by design (install↔detect symmetry pass; no users → required
+    // field). The inverse contract is pinned by the deserialize-rejection
+    // tests added in Task 7 of the install-detect-symmetry plan.
 
     // Deleted: `installed_agent_meta_loads_legacy_json_without_hash_fields` —
     // legacy JSON without `source_path` now fails to deserialize by
@@ -6815,6 +6821,7 @@ mod tests {
             installed_at: chrono::Utc::now(),
             source_hash: None,
             installed_hash: None,
+            source_scan_root: RelativePath::new("skills").expect("valid"),
         };
 
         project

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -39,15 +39,18 @@ pub struct InstalledSkillMeta {
     pub installed_at: DateTime<Utc>,
 
     /// Tree-hash of the skill source as it existed in the marketplace at
-    /// install time. `None` for entries written before Stage 1 of the
-    /// native-kiro-import work landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<String>,
+    /// install time. Required after PR #100 review I2 — every install
+    /// path computes this, and the install↔detect symmetry pass made
+    /// `source_scan_root` required which means any post-Stage-1+
+    /// tracking entry has both. The deferred `legacy_fallback` plumbing
+    /// in `scan_plugin_for_content_drift` was unreachable in practice
+    /// once `source_scan_root` became required (no entry could have
+    /// `scan_root` without `source_hash`) and is gone.
+    pub source_hash: String,
 
-    /// Tree-hash of the skill as it was copied into the project. `None`
-    /// for entries written before Stage 1 landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installed_hash: Option<String>,
+    /// Tree-hash of the skill as it was copied into the project.
+    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    pub installed_hash: String,
 
     /// Scan root (relative to `plugin_dir`) that this skill was
     /// installed from. Required at install time; populated from the
@@ -107,15 +110,16 @@ pub struct InstalledAgentMeta {
     pub source_path: RelativePath,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
-    /// install time. `None` for entries written before Stage 1 of the
-    /// native-kiro-import work landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<String>,
+    /// install time. Required after PR #100 review I2; mirrors the
+    /// `InstalledSkillMeta::source_hash` tightening — every install
+    /// path computes it, and the post-symmetry-pass schema makes a
+    /// missing-source_hash entry impossible (the matching
+    /// `source_path` and `dialect` fields are also required).
+    pub source_hash: String,
 
-    /// Tree-hash of the agent as it was copied into the project. `None`
-    /// for entries written before Stage 1 landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installed_hash: Option<String>,
+    /// Tree-hash of the agent as it was copied into the project.
+    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    pub installed_hash: String,
 }
 
 /// Tracking entry for a plugin's companion file bundle that lives under
@@ -2164,9 +2168,16 @@ impl KiroProject {
     /// thin air); otherwise delegates to [`crate::hash::hash_artifact`]
     /// for the canonical hash format. Lifted out of `install_agent_inner`
     /// to keep that function under the line cap.
-    fn hash_translated_source(source_path: Option<&Path>) -> crate::error::Result<Option<String>> {
+    fn hash_translated_source(source_path: Option<&Path>) -> crate::error::Result<String> {
+        // PR #100 review I2 tightened `InstalledAgentMeta::source_hash`
+        // to required `String` (was `Option<String>`). Production
+        // callers always pass `Some(path)` — the only `None` callers
+        // are test fixtures that synthesise an `AgentDefinition` from
+        // thin air and don't care about drift detection. For those the
+        // empty-string sentinel is the deliberate "no source-side
+        // hash recorded" marker; in production it's never observed.
         let Some(p) = source_path else {
-            return Ok(None);
+            return Ok(String::new());
         };
         // Production callers always pass a fully-qualified file path so
         // both `parent()` and `file_name()` are guaranteed `Some`. The
@@ -2185,10 +2196,10 @@ impl KiroProject {
                 format!("source path `{}` has no file name", p.display()),
             )
         })?;
-        Ok(Some(crate::hash::hash_artifact(
+        Ok(crate::hash::hash_artifact(
             parent,
             &[std::path::PathBuf::from(filename)],
-        )?))
+        )?)
     }
 
     fn install_agent_inner(
@@ -2241,7 +2252,7 @@ impl KiroProject {
                 let agents_root = self.agents_dir(); // needed for companion hash below
 
                 meta.source_hash = source_hash;
-                meta.installed_hash = Some(installed_hash);
+                meta.installed_hash = installed_hash;
 
                 // Capture plugin identity before moving meta into the map.
                 let marketplace = meta.marketplace.clone();
@@ -2257,17 +2268,7 @@ impl KiroProject {
                     .as_str()
                     .rsplit_once('/')
                     .and_then(|(parent, _)| crate::validation::RelativePath::new(parent).ok())
-                    .unwrap_or_else(|| {
-                        // Static literal "agents" trivially passes
-                        // validate_relative_path; the unchecked
-                        // constructor is the right shape per CLAUDE.md
-                        // (no .expect() in production code) and matches
-                        // existing internal callers like
-                        // DiscoveredPlugin::as_relative_path.
-                        crate::validation::RelativePath::from_internal_unchecked(
-                            "agents".to_owned(),
-                        )
-                    });
+                    .unwrap_or_else(crate::validation::RelativePath::agents_root);
 
                 installed.agents.insert(def.name.clone(), meta);
 
@@ -2534,10 +2535,20 @@ impl KiroProject {
                 installed_hash: String::new(),
                 source_scan_root: input.source_scan_root.clone(),
             });
-        // Refresh marketplace/version/timestamp on every install.
+        // Refresh marketplace/version/timestamp + source_scan_root on
+        // every install. PR #100 review I3: the post-insert refresh
+        // initially missed `source_scan_root`, so a manifest that
+        // changed its scan paths between installs would keep the stale
+        // root recorded forever — the install-time scan_root is what
+        // detection consults to locate the source side, so a stale
+        // value is a latent false-drift bug. Issue #99 currently masks
+        // this for translated companions (they don't yet read the
+        // field at detect time), but the moment that lands the
+        // staleness becomes a real bug.
         companion_entry.marketplace = input.marketplace.clone();
         companion_entry.version = input.version.map(str::to_owned);
         companion_entry.installed_at = chrono::Utc::now();
+        companion_entry.source_scan_root = input.source_scan_root.clone();
         if !companion_entry
             .files
             .contains(&input.prompt_rel.to_path_buf())
@@ -2576,14 +2587,14 @@ impl KiroProject {
     ) -> crate::error::Result<CollisionDecision<InstalledNativeAgentOutcome>> {
         match installed.agents.get(agent_name) {
             Some(existing) if existing.plugin == *plugin => {
-                if existing.source_hash.as_deref() == Some(source_hash) {
+                if existing.source_hash == source_hash {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         InstalledNativeAgentOutcome {
                             name: agent_name.to_owned(),
                             json_path: json_target.to_path_buf(),
                             kind: InstallOutcomeKind::Idempotent,
                             source_hash: source_hash.to_owned(),
-                            installed_hash: existing.installed_hash.clone().unwrap_or_default(),
+                            installed_hash: existing.installed_hash.clone(),
                         },
                     )));
                 }
@@ -2725,8 +2736,8 @@ impl KiroProject {
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
                         source_path: input.source_path.clone(),
-                        source_hash: Some(input.source_hash.to_string()),
-                        installed_hash: Some(installed_hash.clone()),
+                        source_hash: input.source_hash.to_string(),
+                        installed_hash: installed_hash.clone(),
                     },
                 );
 
@@ -3553,8 +3564,8 @@ impl KiroProject {
             // entry that staging.path() pointed at is gone; TempDir's Drop
             // will see NotFound and silently skip cleanup.
             fs::rename(staging.path(), &dir)?;
-            meta.source_hash = Some(source_hash);
-            meta.installed_hash = Some(installed_hash);
+            meta.source_hash = source_hash;
+            meta.installed_hash = installed_hash;
 
             // Update tracking. If this fails, roll back the rename so the
             // filesystem and tracking file stay consistent.
@@ -3619,8 +3630,12 @@ mod tests {
             plugin: pn("test-plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            // Empty placeholders — `install_skill_from_dir` overwrites
+            // both with real hashes during the install path. Tests that
+            // pre-stamp tracking entries (no install call) and assert
+            // on the field carry their own real hash.
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         }
     }
@@ -3634,8 +3649,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
@@ -3657,8 +3672,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
             source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(json.contains("\"dialect\":\"copilot\""));
@@ -3787,6 +3802,7 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "source_hash": "blake3:abc",
+                    "installed_hash": "blake3:abc",
                     "source_scan_root": "skills",
                 }
             }
@@ -3829,6 +3845,8 @@ mod tests {
                     "installed_at": chrono::Utc::now(),
                     "dialect": "claude",
                     "source_path": "agents/etc.md",
+                    "source_hash": "x",
+                    "installed_hash": "x",
                 }
             }
         });
@@ -3991,8 +4009,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("subdir/agent.md").expect("valid rel path"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(
@@ -4147,6 +4165,7 @@ mod tests {
                     "version": "1.0.0",
                     "installed_at": now,
                     "source_hash": "deadbeef",
+                    "installed_hash": "deadbeef",
                     "source_scan_root": "skills"
                 }
             }
@@ -4230,6 +4249,7 @@ mod tests {
                     "marketplace": "mp", "plugin": "p",
                     "version": "1.0.0", "installed_at": same_time,
                     "source_hash": "deadbeef",
+                    "installed_hash": "deadbeef",
                     "source_scan_root": "skills"
                 }
             }
@@ -4301,6 +4321,7 @@ mod tests {
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
                 "source_hash": "x",
+                "installed_hash": "x",
                 "source_scan_root": "skills"
             })
         };
@@ -4317,7 +4338,9 @@ mod tests {
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
                 "dialect": "claude",
-                "source_path": "agents/x.md"
+                "source_path": "agents/x.md",
+                "source_hash": "x",
+                "installed_hash": "x"
             })
         };
 
@@ -4822,8 +4845,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         }
     }
 
@@ -5563,6 +5586,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -5851,6 +5875,8 @@ mod tests {
                         "installed_at": now,
                         "dialect": "native",
                         "source_path": "agents/ghost.json",
+                        "source_hash": "x",
+                        "installed_hash": "x",
                     }
                 }
             }))
@@ -6058,6 +6084,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6188,6 +6215,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6260,8 +6288,8 @@ mod tests {
                     plugin: pn("p"),
                     version: Some("1.0.0".into()),
                     installed_at: Utc::now(),
-                    source_hash: Some("deadbeef".into()),
-                    installed_hash: Some("deadbeef".into()),
+                    source_hash: "deadbeef".into(),
+                    installed_hash: "deadbeef".into(),
                     source_scan_root: RelativePath::new("skills").expect("valid"),
                 },
             )
@@ -7071,6 +7099,80 @@ mod tests {
         );
     }
 
+    /// PR #100 review I2: a tracking entry with `source_scan_root` but
+    /// without `source_hash` / `installed_hash` was unreachable in
+    /// practice (every install path that records `scan_root` also
+    /// records hashes), but the deferred `Option<String>` field type
+    /// kept the `legacy_fallback` escape hatch alive in detection.
+    /// After I2 the fields are required `String` and a contradictory
+    /// entry (`scan_root` present, hashes absent) fails to deserialize
+    /// at the boundary.
+    #[test]
+    fn load_installed_skills_rejects_legacy_entry_without_source_hash() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "source_scan_root": "skills"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-skills.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed()
+            .expect_err("legacy entry without source_hash must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_hash") || msg.contains("installed_hash"),
+            "error must mention the missing required field; got: {msg}"
+        );
+    }
+
+    /// PR #100 review I2 sibling for agents: a tracking entry that
+    /// has `source_path` (the Stage-1+ symmetry-pass marker) but
+    /// lacks `source_hash` / `installed_hash` is structurally
+    /// contradictory and must be rejected at the deserialize
+    /// boundary, not silently skipped at scan time.
+    #[test]
+    fn load_installed_agents_rejects_legacy_entry_without_source_hash() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "agents": {
+                "reviewer": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "dialect": "native",
+                    "source_path": "agents/reviewer.json"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("legacy agent entry without source_hash must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_hash") || msg.contains("installed_hash"),
+            "error must mention the missing required field; got: {msg}"
+        );
+    }
+
     #[test]
     fn load_installed_native_companions_rejects_legacy_entry_without_source_scan_root() {
         let (_dir, project) = temp_project();
@@ -7135,8 +7237,8 @@ mod tests {
             plugin: pn("p"),
             version: Some("1.0.0".into()),
             installed_at: chrono::Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         };
 
@@ -7147,11 +7249,8 @@ mod tests {
         let installed = project.load_installed().unwrap();
         let entry = installed.skills.get("test").expect("entry persisted");
 
-        let src_hash = entry.source_hash.as_ref().expect("source_hash populated");
-        let inst_hash = entry
-            .installed_hash
-            .as_ref()
-            .expect("installed_hash populated");
+        let src_hash = &entry.source_hash;
+        let inst_hash = &entry.installed_hash;
 
         assert!(src_hash.starts_with("blake3:"));
         assert!(inst_hash.starts_with("blake3:"));
@@ -7177,8 +7276,8 @@ mod tests {
         };
         let mapped: Vec<crate::agent::tools::MappedTool> = vec![];
         let mut meta = sample_agent_meta();
-        meta.source_hash = None;
-        meta.installed_hash = None;
+        meta.source_hash = String::new();
+        meta.installed_hash = String::new();
         let plugin_name = meta.plugin.clone();
 
         project
@@ -7188,8 +7287,8 @@ mod tests {
         let installed = project.load_installed_agents().unwrap();
         let entry = installed.agents.get("rev").expect("entry persisted");
 
-        let src = entry.source_hash.as_ref().expect("source_hash set");
-        let inst = entry.installed_hash.as_ref().expect("installed_hash set");
+        let src = &entry.source_hash;
+        let inst = &entry.installed_hash;
         assert!(src.starts_with("blake3:"));
         assert!(inst.starts_with("blake3:"));
         // Translated path: source bytes (raw .md) differ from installed bytes
@@ -7242,8 +7341,8 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Claude,
             };
             let mut meta = sample_agent_meta();
-            meta.source_hash = None;
-            meta.installed_hash = None;
+            meta.source_hash = String::new();
+            meta.installed_hash = String::new();
             project
                 .install_agent(&def, &[], meta, Some(&source_md))
                 .expect("install succeeds");
@@ -7264,6 +7363,88 @@ mod tests {
             companion
                 .files
                 .contains(&std::path::PathBuf::from("prompts/beta.md"))
+        );
+    }
+
+    /// PR #100 review I3: when a plugin's manifest changes its
+    /// translated-agent source path between installs, the recorded
+    /// `source_scan_root` on the existing `native_companions` entry
+    /// must refresh to the latest install's scan root — otherwise
+    /// drift detection (once issue #99 lands and starts consulting
+    /// the field) would look up the source under the stale root and
+    /// emit false drift on every scan. Pre-fix the `or_insert_with`
+    /// initializer set the value once and the post-insert refresh
+    /// updated `marketplace`/`version`/`installed_at`/`files` but
+    /// skipped `source_scan_root`, so the very first install's value
+    /// stuck forever.
+    #[test]
+    fn install_agent_translated_refreshes_source_scan_root_on_subsequent_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(tmp.path().to_path_buf());
+
+        // First install: source under `agents/`.
+        let alpha_md = write_agent(tmp.path(), "alpha", "body");
+        let alpha_def = crate::agent::AgentDefinition {
+            name: "alpha".into(),
+            description: None,
+            prompt_body: "body".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: std::collections::BTreeMap::new(),
+            dialect: crate::agent::AgentDialect::Claude,
+        };
+        let mut meta_alpha = sample_agent_meta();
+        meta_alpha.source_path = RelativePath::new("agents/alpha.md").expect("valid");
+        meta_alpha.source_hash = String::new();
+        meta_alpha.installed_hash = String::new();
+        project
+            .install_agent(&alpha_def, &[], meta_alpha, Some(&alpha_md))
+            .expect("install alpha");
+
+        let installed = project.load_installed_agents().unwrap();
+        let plugin_key = sample_agent_meta().plugin.clone();
+        assert_eq!(
+            installed
+                .native_companions
+                .get(plugin_key.as_str())
+                .expect("entry after first install")
+                .source_scan_root
+                .as_str(),
+            "agents",
+            "first install records its own scan root"
+        );
+
+        // Second install for the SAME plugin from a manifest that
+        // moved its agents under `prompts/` — the recorded
+        // source_scan_root must follow.
+        let beta_md = write_agent(tmp.path(), "beta", "body2");
+        let beta_def = crate::agent::AgentDefinition {
+            name: "beta".into(),
+            description: None,
+            prompt_body: "body2".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: std::collections::BTreeMap::new(),
+            dialect: crate::agent::AgentDialect::Claude,
+        };
+        let mut meta_beta = sample_agent_meta();
+        meta_beta.source_path = RelativePath::new("prompts/beta.md").expect("valid");
+        meta_beta.source_hash = String::new();
+        meta_beta.installed_hash = String::new();
+        project
+            .install_agent(&beta_def, &[], meta_beta, Some(&beta_md))
+            .expect("install beta");
+
+        let installed = project.load_installed_agents().unwrap();
+        let companion = installed
+            .native_companions
+            .get(plugin_key.as_str())
+            .expect("entry after second install");
+        assert_eq!(
+            companion.source_scan_root.as_str(),
+            "prompts",
+            "second install must refresh the recorded source_scan_root \
+             (regression: pre-fix it stuck at the first install's value)"
         );
     }
 
@@ -7411,11 +7592,8 @@ mod tests {
         assert_eq!(entry.dialect, crate::agent::AgentDialect::Native);
         assert_eq!(entry.plugin, "plugin-y");
         assert_eq!(entry.marketplace, "marketplace-x");
-        assert_eq!(entry.source_hash.as_deref(), Some(source_hash.as_str()));
-        assert_eq!(
-            entry.installed_hash.as_deref(),
-            Some(outcome.installed_hash.as_str())
-        );
+        assert_eq!(entry.source_hash, source_hash);
+        assert_eq!(entry.installed_hash, outcome.installed_hash);
     }
 
     #[rstest]

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -391,7 +391,7 @@ pub struct PluginInstallContext {
     /// [`MarketplaceService::install_plugin_agents`].
     pub plugin_dir: PathBuf,
     pub version: Option<String>,
-    pub skill_dirs: Vec<PathBuf>,
+    pub skill_dirs: Vec<crate::plugin::DiscoveredSkill>,
     /// Directories to scan for agent `.md` files inside the plugin.
     /// Derived from `plugin.json`'s `agents` field, or
     /// [`crate::DEFAULT_AGENT_PATHS`] when the manifest is absent or
@@ -846,7 +846,8 @@ fn collect_skills_for_plugin_into(
     let skill_dirs = discover_skills_for_plugin(&plugin_dir, plugin_manifest.as_ref());
     out.reserve(skill_dirs.len());
 
-    for skill_dir in &skill_dirs {
+    for discovered in &skill_dirs {
+        let skill_dir = &discovered.skill_dir;
         let skill_md_path = skill_dir.join("SKILL.md");
         let content = match fs::read_to_string(&skill_md_path) {
             Ok(c) => c,
@@ -923,15 +924,20 @@ pub(crate) fn name_hint_from_skill_dir(skill_dir: &Path) -> Option<String> {
         .map(|s| s.to_string_lossy().into_owned())
 }
 
-/// Resolve the skill-discovery paths for a plugin. Uses
+/// Resolve the skill-discovery records for a plugin. Uses
 /// `manifest.skills` when the manifest specifies any, otherwise falls
 /// back to [`crate::DEFAULT_SKILL_PATHS`]. The manifest-empty-list case
 /// also falls back — an empty `skills` field means "no custom paths",
 /// not "no skills."
+///
+/// Returns `Vec<DiscoveredSkill>` (post install↔detect symmetry) so
+/// the install caller has both the resolved skill directory AND the
+/// scan root it came from in scope, for populating
+/// `InstalledSkillMeta.source_scan_root`.
 fn discover_skills_for_plugin(
     plugin_dir: &Path,
     manifest: Option<&PluginManifest>,
-) -> Vec<PathBuf> {
+) -> Vec<crate::plugin::DiscoveredSkill> {
     let skill_paths: Vec<&str> = if let Some(m) = manifest.filter(|m| !m.skills.is_empty()) {
         m.skills.iter().map(String::as_str).collect()
     } else {
@@ -1854,6 +1860,7 @@ mod tests {
                 installed_at: Utc::now(),
                 source_hash: None,
                 installed_hash: None,
+                source_scan_root: crate::validation::RelativePath::new("skills").expect("valid"),
             },
         );
         InstalledSkills { skills }
@@ -2704,8 +2711,9 @@ mod tests {
         let mut names: Vec<String> = ctx
             .skill_dirs
             .iter()
-            .map(|p| {
-                p.file_name()
+            .map(|d| {
+                d.skill_dir
+                    .file_name()
                     .and_then(|s| s.to_str())
                     .expect("skill dir has valid UTF-8 name")
                     .to_string()
@@ -2717,7 +2725,9 @@ mod tests {
             vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
         );
         assert!(
-            ctx.skill_dirs.iter().all(|p| p.join("SKILL.md").is_file()),
+            ctx.skill_dirs
+                .iter()
+                .all(|d| d.skill_dir.join("SKILL.md").is_file()),
             "every skill dir must contain a SKILL.md: {:?}",
             ctx.skill_dirs
         );
@@ -2803,8 +2813,9 @@ mod tests {
         let mut names: Vec<String> = ctx
             .skill_dirs
             .iter()
-            .map(|p| {
-                p.file_name()
+            .map(|d| {
+                d.skill_dir
+                    .file_name()
                     .and_then(|s| s.to_str())
                     .expect("skill dir has valid UTF-8 name")
                     .to_string()
@@ -2813,16 +2824,18 @@ mod tests {
         names.sort();
         assert_eq!(names, vec!["bar".to_string(), "foo".to_string()]);
         assert!(
-            ctx.skill_dirs.iter().all(|p| {
-                p.components()
+            ctx.skill_dirs.iter().all(|d| {
+                d.skill_dir
+                    .components()
                     .any(|c| c.as_os_str() == std::ffi::OsStr::new("agents"))
             }),
             "every skill dir must live under agents/: {:?}",
             ctx.skill_dirs
         );
         assert!(
-            ctx.skill_dirs.iter().all(|p| {
-                !p.components()
+            ctx.skill_dirs.iter().all(|d| {
+                !d.skill_dir
+                    .components()
                     .any(|c| c.as_os_str() == std::ffi::OsStr::new("skills"))
             }),
             "no skill dir should live under the default skills/ tree: {:?}",

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -952,7 +952,7 @@ fn discover_skills_for_plugin(
 /// or its `agents` list is empty. Mirrors the "empty list means no
 /// custom paths, not no agents" fallback policy used by
 /// [`discover_skills_for_plugin`].
-pub(super) fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
+fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
     if let Some(m) = manifest.filter(|m| !m.agents.is_empty()) {
         m.agents.clone()
     } else {
@@ -967,7 +967,7 @@ pub(super) fn agent_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> 
 /// back to [`crate::DEFAULT_STEERING_PATHS`] when the manifest is absent
 /// or its `steering` list is empty. Mirrors
 /// [`agent_scan_paths_for_plugin`].
-pub(super) fn steering_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
+fn steering_scan_paths_for_plugin(manifest: Option<&PluginManifest>) -> Vec<String> {
     if let Some(m) = manifest.filter(|m| !m.steering.is_empty()) {
         m.steering.clone()
     } else {

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1858,8 +1858,8 @@ mod tests {
                 plugin: pn(plugin),
                 version: None,
                 installed_at: Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root: crate::validation::RelativePath::new("skills").expect("valid"),
             },
         );

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2831,28 +2831,7 @@ fn relative_source_path_for_tracking(
     path: &Path,
     plugin_dir: &Path,
 ) -> Option<crate::validation::RelativePath> {
-    let rel = match path.strip_prefix(plugin_dir) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(
-                path = %path.display(),
-                plugin_dir = %plugin_dir.display(),
-                error = %e,
-                "agent path is not under plugin_dir; source_path will fall back \
-                 to dialect default during update detection"
-            );
-            return None;
-        }
-    };
-    let rel_str = rel
-        .components()
-        .filter_map(|c| match c {
-            std::path::Component::Normal(s) => Some(s.to_string_lossy()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("/");
-    match crate::validation::RelativePath::new(rel_str) {
+    match crate::validation::RelativePath::from_path_under(path, plugin_dir) {
         Ok(rp) => Some(rp),
         Err(e) => {
             warn!(

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2171,6 +2171,7 @@ impl MarketplaceService {
                 marketplace,
                 plugin,
                 version: ctx.version.as_deref(),
+                plugin_dir: &ctx.plugin_dir,
             },
         );
 
@@ -2521,21 +2522,16 @@ impl MarketplaceService {
             }
         }
 
-        // Steering — probe each configured scan path. Install hashes
-        // via `hash_artifact(&f.scan_root, &[rel])` per
-        // `install_plugin_steering`, so detection MUST iterate the
-        // declared scan paths and use the first one where the file
-        // exists. A single hardcoded `plugin_dir/steering` would
-        // false-positive every plugin declaring `steering: ["./guides/"]`
-        // — see PR #96 review comment #6.
-        let steering_paths = crate::service::browse::steering_scan_paths_for_plugin(manifest);
+        // Steering — direct lookup against the install-recorded scan
+        // root. Install records source_scan_root via
+        // RelativePath::from_path_under in install_steering_file_locked,
+        // so detection hashes against the same directory the install
+        // copied from.
         for (rel_path, meta) in &installed_steering.files {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                let computed = hash_artifact_in_scan_paths(
-                    plugin_dir,
-                    &steering_paths,
-                    std::slice::from_ref(rel_path),
-                )?;
+                let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+                let computed =
+                    crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
                 if computed != meta.source_hash {
                     content_drift = true;
                     return Ok((content_drift, legacy_fallback));
@@ -4002,6 +3998,7 @@ mod tests {
             marketplace: &mp_name,
             plugin: &pn_name,
             version: None,
+            plugin_dir: plugin_tmp.path(),
         };
 
         let result = MarketplaceService::install_plugin_steering(
@@ -4064,6 +4061,7 @@ mod tests {
             marketplace: &mp_name,
             plugin: &pn_name,
             version: None,
+            plugin_dir: plugin_tmp.path(),
         };
 
         let result = MarketplaceService::install_plugin_steering(
@@ -4136,6 +4134,7 @@ mod tests {
             marketplace: &mp_name,
             plugin: &pn_name,
             version: None,
+            plugin_dir: plugin_tmp.path(),
         };
 
         let result = MarketplaceService::install_plugin_steering(

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1298,8 +1298,12 @@ impl MarketplaceService {
                 plugin: plugin.clone(),
                 version: version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                // Stamped pre-install with empty placeholders;
+                // `install_skill_from_dir` overwrites both with the
+                // staging-time + post-rename hashes before the entry
+                // is committed to tracking.
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root,
             };
 
@@ -1697,8 +1701,12 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
                 source_path,
-                source_hash: None,
-                installed_hash: None,
+                // Stamped pre-install with empty placeholders;
+                // `install_agent_inner` overwrites both with the
+                // hash_translated_source / staging-time hashes before
+                // the entry is committed to tracking.
+                source_hash: String::new(),
+                installed_hash: String::new(),
             };
             let install_result = if ctx.mode.is_force() {
                 project.install_agent_force(&def, &mapped, meta, Some(&path))
@@ -2340,7 +2348,7 @@ impl MarketplaceService {
         // which produced false-positive drift on every scan for
         // plugins declaring custom `steering: [...]` /
         // `agents: [...]` paths.
-        let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
+        let content_drift = Self::scan_plugin_for_content_drift(
             plugin_info,
             &plugin_dir,
             installed_skills,
@@ -2371,19 +2379,6 @@ impl MarketplaceService {
             }));
         }
 
-        if legacy_fallback {
-            // Drift undetectable for legacy entries (no source_hash) —
-            // same versions means no entry. Logging at debug so the
-            // legacy-fallback case is observable in traces without
-            // surfacing in normal operation.
-            tracing::debug!(
-                marketplace = %plugin_info.marketplace,
-                plugin = %plugin_info.plugin,
-                "scan saw a legacy (pre-Stage-1) tracking entry with no \
-                 source_hash; falling back to version-only comparison and \
-                 returning no update entry"
-            );
-        }
         Ok(None)
     }
 
@@ -2486,37 +2481,32 @@ impl MarketplaceService {
     /// via the same helpers `MarketplaceService::install_plugin`
     /// uses.
     ///
-    /// `content_drift = false && legacy_fallback = true` means "no drift
-    /// detected among hashable entries; some entries had no `source_hash`
-    /// so a clean miss is possible." Callers should treat `legacy_fallback`
-    /// as "drift undetectable" rather than "drift absent."
+    /// PR #100 review I2 dropped the `legacy_fallback` second return
+    /// value: after the install↔detect symmetry pass made
+    /// `source_scan_root` required AND tightened `source_hash` to
+    /// required `String`, no in-tree tracking entry can land here
+    /// without both fields. The previous `Option<String>` matching
+    /// arms (`None => legacy_fallback = true`) were unreachable at
+    /// runtime, so the helper now returns just `bool` and the caller
+    /// no longer logs a "legacy entry" debug line that could never
+    /// fire.
     fn scan_plugin_for_content_drift(
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
         installed_skills: &crate::project::InstalledSkills,
         installed_steering: &crate::project::InstalledSteering,
         installed_agents: &crate::project::InstalledAgents,
-    ) -> Result<(bool, bool), Error> {
-        let mut content_drift = false;
-        let mut legacy_fallback = false;
-
+    ) -> Result<bool, Error> {
         // Skills — direct lookup against the install-recorded scan
         // root. Closes #97; install populates source_scan_root so
         // detection hashes against the same directory the install
-        // copied from. (source_hash stays Option<String> for now;
-        // tightened in Task 6 alongside the legacy_fallback removal.)
+        // copied from.
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                match &meta.source_hash {
-                    Some(stored) => {
-                        let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
-                        let computed = crate::hash::hash_dir_tree(&skill_dir)?;
-                        if computed != *stored {
-                            content_drift = true;
-                            return Ok((content_drift, legacy_fallback));
-                        }
-                    }
-                    None => legacy_fallback = true,
+                let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
+                let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+                if computed != meta.source_hash {
+                    return Ok(true);
                 }
             }
         }
@@ -2532,30 +2522,24 @@ impl MarketplaceService {
                 let computed =
                     crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
                 if computed != meta.source_hash {
-                    content_drift = true;
-                    return Ok((content_drift, legacy_fallback));
+                    return Ok(true);
                 }
             }
         }
 
         // Agents — direct lookup against the install-recorded
-        // source_path. After the install↔detect symmetry pass, the
-        // dialect-fallback machinery and the I-N7 actionable-error
-        // branch are gone: install always records source_path, so
-        // detection always knows the precise file to hash.
+        // source_path. After the install↔detect symmetry pass + I2
+        // tightening, the dialect-fallback machinery, the I-N7
+        // actionable-error branch, AND the legacy-source_hash
+        // fallback are gone: install always records source_path AND
+        // source_hash, so detection always knows the precise file to
+        // hash and what to compare against.
         for meta in installed_agents.agents.values() {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                match &meta.source_hash {
-                    Some(stored) => {
-                        let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
-                        let computed =
-                            crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
-                        if computed != *stored {
-                            content_drift = true;
-                            return Ok((content_drift, legacy_fallback));
-                        }
-                    }
-                    None => legacy_fallback = true,
+                let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
+                let computed = crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
+                if computed != meta.source_hash {
+                    return Ok(true);
                 }
             }
         }
@@ -2569,13 +2553,12 @@ impl MarketplaceService {
                 let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
                 let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
                 if computed != meta.source_hash {
-                    content_drift = true;
-                    return Ok((content_drift, legacy_fallback));
+                    return Ok(true);
                 }
             }
         }
 
-        Ok((content_drift, legacy_fallback))
+        Ok(false)
     }
 }
 
@@ -2722,6 +2705,38 @@ fn read_and_parse_skill_md(
 }
 
 /// Compute the install-time `source_scan_root` for a discovered skill
+/// Build a synthetic `io::Error` describing a structural validation
+/// failure on a path that should have been expressible as a
+/// [`crate::validation::RelativePath`] under `plugin_dir`.
+///
+/// Shared by [`required_skill_scan_root`] and [`required_source_path`]
+/// per PR #100 review S7 — both helpers were independently formatting
+/// near-identical messages, which would drift one wording tweak apart
+/// the next time either was edited. This helper is the single source
+/// of truth for the wire-format string.
+///
+/// Note the asymmetry with `required_steering_scan_root`: the steering
+/// path uses the typed `SteeringError::ScanRootInvalid` variant
+/// (added by PR #100 review I1) and does NOT funnel through this
+/// helper. `SkillError` and `AgentError` don't yet have an analogous
+/// typed variant; a future cleanup mirroring I1 across all three
+/// error enums would let this synthetic-`io::Error` helper retire.
+fn scan_root_invalid_io_err(
+    label: &str,
+    scan_root: &Path,
+    plugin_dir: &Path,
+    cause: &crate::error::ValidationError,
+) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "{label} `{}` not under plugin_dir `{}`: {cause}",
+            scan_root.display(),
+            plugin_dir.display(),
+        ),
+    )
+}
+
 /// or build a [`FailedSkill`] entry if the discovered `scan_root`
 /// can't be expressed as a `RelativePath` under `plugin_dir`.
 /// Discovery yields paths under `plugin_dir` in practice, so the
@@ -2742,13 +2757,11 @@ fn required_skill_scan_root(
         );
         FailedSkill::install_failed(
             skill_name.to_owned(),
-            &Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "skill scan_root `{}` not under plugin_dir `{}`: {e}",
-                    scan_root.display(),
-                    plugin_dir.display(),
-                ),
+            &Error::Io(scan_root_invalid_io_err(
+                "skill scan_root",
+                scan_root,
+                plugin_dir,
+                &e,
             )),
         )
     })
@@ -2770,14 +2783,11 @@ fn required_source_path(
         source_path: path.to_path_buf(),
         error: crate::error::AgentError::InstallFailed {
             path: path.to_path_buf(),
-            source: Box::new(crate::error::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "discovered agent path `{}` is not expressible as a \
-                     RelativePath under plugin_dir `{}`: {e}",
-                    path.display(),
-                    plugin_dir.display(),
-                ),
+            source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
+                "discovered agent path",
+                path,
+                plugin_dir,
+                &e,
             ))),
         },
     })
@@ -6084,8 +6094,8 @@ mod tests {
                     plugin: pn("structured-p"),
                     version: Some("1.0".into()),
                     installed_at: chrono::Utc::now(),
-                    source_hash: None,
-                    installed_hash: None,
+                    source_hash: String::new(),
+                    installed_hash: String::new(),
                     source_scan_root: crate::validation::RelativePath::new("skills")
                         .expect("valid"),
                 },
@@ -6114,102 +6124,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn detect_plugin_updates_legacy_fallback_source_hash_none() {
-        use crate::project::KiroProject;
-        use crate::service::test_support::{
-            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
-            temp_service,
-        };
-
-        let (dir, svc) = temp_service();
-        let entries = vec![relative_path_entry("p", "plugins/p")];
-        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
-        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
-        let plugin_dir = mp_path.join("plugins/p");
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.0"}"#,
-        )
-        .unwrap();
-
-        let project_tmp = tempfile::tempdir().unwrap();
-        let project = KiroProject::new(project_tmp.path().to_path_buf());
-
-        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
-            .expect("install");
-
-        // Set source_hash: None in tracking file
-        let mut tracking = project.load_installed().unwrap();
-        for meta in tracking.skills.values_mut() {
-            meta.source_hash = None;
-        }
-        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
-        fs::write(
-            &tracking_path,
-            serde_json::to_vec_pretty(&tracking).unwrap(),
-        )
-        .unwrap();
-
-        // Bump version
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.1"}"#,
-        )
-        .unwrap();
-
-        let result = svc.detect_plugin_updates(&project).expect("detect");
-        assert_eq!(result.updates.len(), 1);
-        assert_eq!(result.updates[0].plugin.as_str(), "p");
-        assert!(matches!(
-            result.updates[0].change_signal,
-            UpdateChangeSignal::VersionBumped
-        ));
-        assert!(result.failures.is_empty());
-    }
-
-    #[test]
-    fn detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update() {
-        use crate::project::KiroProject;
-        use crate::service::test_support::{
-            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
-            temp_service,
-        };
-
-        let (dir, svc) = temp_service();
-        let entries = vec![relative_path_entry("p", "plugins/p")];
-        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
-        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
-        let plugin_dir = mp_path.join("plugins/p");
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.0"}"#,
-        )
-        .unwrap();
-
-        let project_tmp = tempfile::tempdir().unwrap();
-        let project = KiroProject::new(project_tmp.path().to_path_buf());
-
-        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
-            .expect("install");
-
-        // Set source_hash: None in tracking file
-        let mut tracking = project.load_installed().unwrap();
-        for meta in tracking.skills.values_mut() {
-            meta.source_hash = None;
-        }
-        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
-        fs::write(
-            &tracking_path,
-            serde_json::to_vec_pretty(&tracking).unwrap(),
-        )
-        .unwrap();
-
-        // Same version, no mutation
-        let result = svc.detect_plugin_updates(&project).expect("detect");
-        assert!(result.updates.is_empty());
-        assert!(result.failures.is_empty());
-    }
+    // Deleted: `detect_plugin_updates_legacy_fallback_source_hash_none`
+    // and `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update`
+    // — they exercised the `Option<String>::None => legacy_fallback = true`
+    // arm of `scan_plugin_for_content_drift`, which PR #100 review I2
+    // removed. Post-I2 the field is required `String` and a tracking
+    // entry without `source_hash` fails to deserialize at the
+    // `load_installed()` boundary; the contract is pinned by
+    // `load_installed_rejects_legacy_entry_without_source_hash` and
+    // `load_installed_agents_rejects_legacy_entry_without_source_hash`
+    // in the project tests.
 
     #[test]
     fn detect_plugin_updates_mixed_scenario() {
@@ -6512,7 +6436,7 @@ mod tests {
         // Set agent source_hash: None in tracking file
         let mut tracking = project.load_installed_agents().unwrap();
         for meta in tracking.agents.values_mut() {
-            meta.source_hash = None;
+            meta.source_hash = String::new();
         }
         let tracking_path = project_tmp.path().join(".kiro/installed-agents.json");
         fs::write(
@@ -6766,11 +6690,14 @@ mod tests {
     /// hash `NotFound` failure on every scan.
     ///
     /// The native-companions cascade has a separate, pre-existing
-    /// install-time hash bug (documented on
-    /// `detect_plugin_updates_copilot_agent_legacy_fallback` above —
-    /// install hashes against the destination, detection re-hashes
-    /// against the source, so the two never match through the install
-    /// path). To isolate the scan-path fix, we synthesize the tracking
+    /// install-time hash bug: install hashes against the destination,
+    /// detection re-hashes against the source, so the two never match
+    /// through the install path. (The canonical reference test
+    /// previously named `detect_plugin_updates_copilot_agent_legacy_fallback`
+    /// has been removed — see PR #100's deserialize-rejection sweep,
+    /// which invalidated the legacy-Option-shape fixture it relied on.
+    /// The bug itself is still real and the workaround below still
+    /// applies.) To isolate the scan-path fix, we synthesize the tracking
     /// entry by hand: compute the source-side hash directly via
     /// `crate::hash::hash_artifact` and write it into
     /// `installed-agents.json`. With the scan-path fix, detection
@@ -6836,13 +6763,27 @@ mod tests {
         // `skills.skills`, and `steering.files` — but NOT from
         // `agents.native_companions`. Without an entry in one of those
         // three maps the plugin would not surface in the scan loop and
-        // the test would pass vacuously. Mirror the pattern used by
-        // `detect_plugin_updates_copilot_agent_legacy_fallback`: a
-        // single legacy translated-agent entry (`source_hash: None`)
-        // registers the plugin and triggers only the harmless
-        // `legacy_fallback = true` branch, leaving the
+        // the test would pass vacuously. We register a single native
+        // agent at `<plugin_dir>/agents/registrar.json` with a real
+        // pre-computed source_hash so the plugin surfaces in the scan
+        // loop AND the agent itself doesn't drift — leaving the
         // native-companions cascade as the only thing the assertion
         // depends on.
+        //
+        // PR #100 review I2 dropped the legacy_fallback escape hatch
+        // (source_hash: None used to be a "skip me" sentinel for the
+        // drift scan); after I2 every entry must have a real source
+        // file on disk and a real source_hash, so the registrar agent
+        // had to grow a real .json file at install-time.
+        let agents_default_root = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_default_root).expect("create agents/ dir");
+        let registrar_json = br#"{"name":"registrar"}"#;
+        fs::write(agents_default_root.join("registrar.json"), registrar_json)
+            .expect("write registrar.json");
+        let registrar_source_hash =
+            crate::hash::hash_artifact(&agents_default_root, &[PathBuf::from("registrar.json")])
+                .expect("hash registrar source");
+
         let mut agents_map = HashMap::new();
         agents_map.insert(
             "registrar".to_string(),
@@ -6854,8 +6795,8 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Native,
                 source_path: crate::validation::RelativePath::new("agents/registrar.json")
                     .expect("valid"),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: registrar_source_hash.clone(),
+                installed_hash: registrar_source_hash,
             },
         );
 
@@ -7032,8 +6973,8 @@ mod tests {
                 installed_at: chrono::Utc::now(),
                 dialect: crate::agent::AgentDialect::Copilot,
                 source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
-                source_hash: Some(expected_hash),
-                installed_hash: None,
+                source_hash: expected_hash,
+                installed_hash: String::new(),
             },
         );
         let installed = InstalledAgents {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2640,24 +2640,6 @@ fn read_capped(path: &Path, cap: u64) -> std::io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Compute the `(base_dir, filename)` pair that recreates the
-/// install-side hash recipe used by
-/// [`crate::project::KiroProject::hash_translated_source`] for a
-/// tracked agent. Used by
-/// [`MarketplaceService::scan_plugin_for_content_drift`] so detection
-/// hashes match the bytes the install side fed into BLAKE3 — the
-/// install hashes via `hash_artifact(parent, &[filename])` so detection
-/// MUST also pass `(parent, filename)` rather than `(agents_dir,
-/// "subdir/file.md")`, since the digest includes the rel-path bytes.
-///
-/// `source_path` is relative to `plugin_dir` (always present after the
-/// install↔detect symmetry pass — `InstalledAgentMeta.source_path` is
-/// required). We split it back into
-/// `(plugin_dir + rel.parent(), rel.file_name())` to match the install
-/// recipe. The dialect-fallback branch (which previously synthesised a
-/// `{name}.{md|agent.md|json}` filename when `source_path` was `None`)
-/// is gone — required-field schema means we always have the precise
-/// install-time path.
 /// MCP opt-in gate for translated agents. An agent that brings MCP
 /// servers can run arbitrary subprocesses (Stdio) or open network
 /// connections (Http/Sse) on the user's host. The cache persists, so a
@@ -2801,6 +2783,24 @@ fn required_source_path(
     })
 }
 
+/// Compute the `(base_dir, filename)` pair that recreates the
+/// install-side hash recipe used by
+/// [`crate::project::KiroProject::hash_translated_source`] for a
+/// tracked agent. Used by
+/// [`MarketplaceService::scan_plugin_for_content_drift`] so detection
+/// hashes match the bytes the install side fed into BLAKE3 — the
+/// install hashes via `hash_artifact(parent, &[filename])` so detection
+/// MUST also pass `(parent, filename)` rather than `(agents_dir,
+/// "subdir/file.md")`, since the digest includes the rel-path bytes.
+///
+/// `source_path` is relative to `plugin_dir` (always present after the
+/// install↔detect symmetry pass — `InstalledAgentMeta.source_path` is
+/// required). We split it back into
+/// `(plugin_dir + rel.parent(), rel.file_name())` to match the install
+/// recipe. The dialect-fallback branch (which previously synthesised a
+/// `{name}.{md|agent.md|json}` filename when `source_path` was `None`)
+/// is gone — required-field schema means we always have the precise
+/// install-time path.
 fn agent_hash_inputs(
     plugin_dir: &Path,
     source_path: &crate::validation::RelativePath,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1256,7 +1256,8 @@ impl MarketplaceService {
     pub fn install_skills(
         &self,
         project: &crate::project::KiroProject,
-        skill_dirs: &[PathBuf],
+        plugin_dir: &Path,
+        skill_dirs: &[crate::plugin::DiscoveredSkill],
         filter: &InstallFilter<'_>,
         mode: InstallMode,
         marketplace: &crate::validation::MarketplaceName,
@@ -1266,52 +1267,31 @@ impl MarketplaceService {
         let mut result = InstallSkillsResult::default();
         let mut processed: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-        for skill_dir in skill_dirs {
-            let skill_md_path = skill_dir.join("SKILL.md");
-            let content = match fs::read_to_string(&skill_md_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        path = %skill_md_path.display(),
-                        error = %e,
-                        "failed to read SKILL.md, skipping"
-                    );
-                    result.skipped_skills.push(browse::SkippedSkill {
-                        plugin: plugin.as_str().to_owned(),
-                        name_hint: browse::name_hint_from_skill_dir(skill_dir),
-                        path: skill_md_path,
-                        reason: browse::SkippedSkillReason::ReadFailed {
-                            reason: error_full_chain(&e),
-                        },
-                    });
-                    continue;
-                }
-            };
-
-            let (frontmatter, _body_offset) = match crate::skill::parse_frontmatter(&content) {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!(
-                        path = %skill_md_path.display(),
-                        error = %e,
-                        "failed to parse SKILL.md frontmatter, skipping"
-                    );
-                    result.skipped_skills.push(browse::SkippedSkill {
-                        plugin: plugin.as_str().to_owned(),
-                        name_hint: browse::name_hint_from_skill_dir(skill_dir),
-                        path: skill_md_path,
-                        reason: browse::SkippedSkillReason::FrontmatterInvalid {
-                            reason: error_full_chain(&e),
-                        },
-                    });
-                    continue;
-                }
+        for discovered in skill_dirs {
+            let skill_dir = &discovered.skill_dir;
+            let Some(frontmatter) = read_and_parse_skill_md(skill_dir, plugin, &mut result) else {
+                continue;
             };
 
             if !filter_matches(filter, &frontmatter.name) {
                 continue;
             }
             processed.insert(frontmatter.name.clone());
+
+            // Compute source_scan_root from the discovered scan_root.
+            // Discovery yields absolute paths under plugin_dir, so the
+            // Err arm is defensive (see required_skill_scan_root).
+            let source_scan_root = match required_skill_scan_root(
+                &discovered.scan_root,
+                plugin_dir,
+                &frontmatter.name,
+            ) {
+                Ok(rp) => rp,
+                Err(failed) => {
+                    result.failed.push(failed);
+                    continue;
+                }
+            };
 
             let meta = crate::project::InstalledSkillMeta {
                 marketplace: marketplace.clone(),
@@ -1320,6 +1300,7 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
                 source_hash: None,
                 installed_hash: None,
+                source_scan_root,
             };
 
             let outcome = if mode.is_force() {
@@ -2172,6 +2153,7 @@ impl MarketplaceService {
 
         let skills = self.install_skills(
             project,
+            &ctx.plugin_dir,
             &ctx.skill_dirs,
             &InstallFilter::All,
             mode,
@@ -2518,29 +2500,16 @@ impl MarketplaceService {
         let mut content_drift = false;
         let mut legacy_fallback = false;
 
-        // Skills — keyed under `skills/<name>/`. KNOWN BUG (issue #97):
-        // `discover_skills_for_plugin` (browse.rs) honors
-        // `manifest.skills` and a plugin declaring `skills: ["./packs/"]`
-        // installs skill dirs under `<plugin_dir>/packs/<name>/`, but
-        // this loop hardcodes `plugin_dir.join("skills")` and will
-        // false-positive drift on every scan for such plugins — the
-        // same class of bug the steering/agents loops below fixed.
-        //
-        // Closing it requires either (a) probing each declared skill
-        // scan path for a directory named `<name>` (analogous to
-        // `hash_artifact_in_scan_paths` but against `hash_dir_tree`),
-        // or (b) extending `InstalledSkillMeta` with a `source_path`
-        // field so detection knows which scan root to consult without
-        // probing. Option (b) matches the `InstalledAgentMeta`
-        // precedent. Tracked at
-        // https://github.com/dwalleck/kiro-control-center/issues/97
-        // — out of scope for the steering/agents scan-path closure
-        // shipped in PR #96.
+        // Skills — direct lookup against the install-recorded scan
+        // root. Closes #97; install populates source_scan_root so
+        // detection hashes against the same directory the install
+        // copied from. (source_hash stays Option<String> for now;
+        // tightened in Task 6 alongside the legacy_fallback removal.)
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
                     Some(stored) => {
-                        let skill_dir = plugin_dir.join("skills").join(name);
+                        let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
                         let computed = crate::hash::hash_dir_tree(&skill_dir)?;
                         if computed != *stored {
                             content_drift = true;
@@ -2777,6 +2746,89 @@ fn translated_agent_blocked_by_mcp_gate(
         return true;
     }
     false
+}
+
+/// Read SKILL.md from a discovered skill directory and parse its
+/// frontmatter. On failure, pushes a structured `SkippedSkill` entry
+/// onto the result and returns `None`. Used by `install_skills` to
+/// keep the per-skill loop body terse.
+fn read_and_parse_skill_md(
+    skill_dir: &Path,
+    plugin: &crate::validation::PluginName,
+    result: &mut InstallSkillsResult,
+) -> Option<crate::skill::SkillFrontmatter> {
+    let skill_md_path = skill_dir.join("SKILL.md");
+    let content = match fs::read_to_string(&skill_md_path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                path = %skill_md_path.display(),
+                error = %e,
+                "failed to read SKILL.md, skipping"
+            );
+            result.skipped_skills.push(browse::SkippedSkill {
+                plugin: plugin.as_str().to_owned(),
+                name_hint: browse::name_hint_from_skill_dir(skill_dir),
+                path: skill_md_path,
+                reason: browse::SkippedSkillReason::ReadFailed {
+                    reason: error_full_chain(&e),
+                },
+            });
+            return None;
+        }
+    };
+    match crate::skill::parse_frontmatter(&content) {
+        Ok((fm, _body_offset)) => Some(fm),
+        Err(e) => {
+            warn!(
+                path = %skill_md_path.display(),
+                error = %e,
+                "failed to parse SKILL.md frontmatter, skipping"
+            );
+            result.skipped_skills.push(browse::SkippedSkill {
+                plugin: plugin.as_str().to_owned(),
+                name_hint: browse::name_hint_from_skill_dir(skill_dir),
+                path: skill_md_path,
+                reason: browse::SkippedSkillReason::FrontmatterInvalid {
+                    reason: error_full_chain(&e),
+                },
+            });
+            None
+        }
+    }
+}
+
+/// Compute the install-time `source_scan_root` for a discovered skill
+/// or build a [`FailedSkill`] entry if the discovered `scan_root`
+/// can't be expressed as a `RelativePath` under `plugin_dir`.
+/// Discovery yields paths under `plugin_dir` in practice, so the
+/// `Err` arm is a defensive catch for a future invariant break —
+/// required-field schema means we can't install without recording
+/// `source_scan_root`.
+fn required_skill_scan_root(
+    scan_root: &Path,
+    plugin_dir: &Path,
+    skill_name: &str,
+) -> Result<crate::validation::RelativePath, FailedSkill> {
+    crate::validation::RelativePath::from_path_under(scan_root, plugin_dir).map_err(|e| {
+        warn!(
+            scan_root = %scan_root.display(),
+            plugin_dir = %plugin_dir.display(),
+            error = %e,
+            "discovered skill scan_root not under plugin_dir; skipping"
+        );
+        FailedSkill::install_failed(
+            skill_name.to_owned(),
+            &Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "skill scan_root `{}` not under plugin_dir `{}`: {e}",
+                    scan_root.display(),
+                    plugin_dir.display(),
+                ),
+            )),
+        )
+    })
 }
 
 /// Compute the install-time `source_path` for a discovered agent file,
@@ -5293,21 +5345,33 @@ mod tests {
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
         let plugin_tmp = tempfile::tempdir().unwrap();
-        let ok_dir = plugin_tmp.path().join("ok");
+        let plugin_dir = plugin_tmp.path();
+        let scan_root = plugin_dir.join("skills");
+        let ok_dir = scan_root.join("ok");
         fs::create_dir_all(&ok_dir).unwrap();
         fs::write(
             ok_dir.join("SKILL.md"),
             "---\nname: ok\ndescription: works\n---\nbody\n",
         )
         .unwrap();
-        let broken_dir = plugin_tmp.path().join("broken");
+        let broken_dir = scan_root.join("broken");
         fs::create_dir_all(&broken_dir).unwrap();
         // Missing closing `---` breaks the frontmatter parse.
         fs::write(broken_dir.join("SKILL.md"), "---\nname: broken\n").unwrap();
 
-        let skill_dirs = vec![ok_dir, broken_dir];
+        let skill_dirs = vec![
+            crate::plugin::DiscoveredSkill {
+                scan_root: scan_root.clone(),
+                skill_dir: ok_dir,
+            },
+            crate::plugin::DiscoveredSkill {
+                scan_root: scan_root.clone(),
+                skill_dir: broken_dir,
+            },
+        ];
         let result = svc.install_skills(
             &project,
+            plugin_dir,
             &skill_dirs,
             &InstallFilter::All,
             InstallMode::New,
@@ -5346,7 +5410,9 @@ mod tests {
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
         let plugin_tmp = tempfile::tempdir().unwrap();
-        let only_dir = plugin_tmp.path().join("present");
+        let plugin_dir = plugin_tmp.path();
+        let scan_root = plugin_dir.join("skills");
+        let only_dir = scan_root.join("present");
         fs::create_dir_all(&only_dir).unwrap();
         fs::write(
             only_dir.join("SKILL.md"),
@@ -5357,7 +5423,11 @@ mod tests {
         let requested = vec!["absent".to_string()];
         let result = svc.install_skills(
             &project,
-            &[only_dir],
+            plugin_dir,
+            &[crate::plugin::DiscoveredSkill {
+                scan_root,
+                skill_dir: only_dir,
+            }],
             &InstallFilter::Names(&requested),
             InstallMode::New,
             &mp("mp1"),
@@ -5435,7 +5505,9 @@ mod tests {
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
         let plugin_tmp = tempfile::tempdir().unwrap();
-        let skill_dir = plugin_tmp.path().join("vault");
+        let plugin_dir = plugin_tmp.path();
+        let scan_root = plugin_dir.join("skills");
+        let skill_dir = scan_root.join("vault");
         fs::create_dir_all(&skill_dir).unwrap();
         let skill_md = skill_dir.join("SKILL.md");
         fs::write(
@@ -5449,7 +5521,11 @@ mod tests {
 
         let result = svc.install_skills(
             &project,
-            std::slice::from_ref(&skill_dir),
+            plugin_dir,
+            &[crate::plugin::DiscoveredSkill {
+                scan_root,
+                skill_dir: skill_dir.clone(),
+            }],
             &InstallFilter::All,
             InstallMode::New,
             &mp("mp1"),
@@ -5502,7 +5578,9 @@ mod tests {
         let project = KiroProject::new(project_tmp.path().to_path_buf());
 
         let plugin_tmp = tempfile::tempdir().unwrap();
-        let skill_dir = plugin_tmp.path().join("target");
+        let plugin_dir = plugin_tmp.path();
+        let scan_root = plugin_dir.join("skills");
+        let skill_dir = scan_root.join("target");
         fs::create_dir_all(&skill_dir).unwrap();
         fs::write(
             skill_dir.join("SKILL.md"),
@@ -5512,7 +5590,11 @@ mod tests {
 
         let result = svc.install_skills(
             &project,
-            &[skill_dir],
+            plugin_dir,
+            &[crate::plugin::DiscoveredSkill {
+                scan_root,
+                skill_dir,
+            }],
             &InstallFilter::All,
             InstallMode::New,
             &mp("mp1"),
@@ -6060,6 +6142,8 @@ mod tests {
                     installed_at: chrono::Utc::now(),
                     source_hash: None,
                     installed_hash: None,
+                    source_scan_root: crate::validation::RelativePath::new("skills")
+                        .expect("valid"),
                 },
             )]
             .into_iter()
@@ -6657,6 +6741,75 @@ mod tests {
             "expected no failures (pre-fix would return a hash NotFound \
              error because detection looked under hardcoded `./steering/`); \
              got: {:?}",
+            result.failures
+        );
+    }
+
+    /// Closes #97: a plugin declaring `skills: ["./packs/"]` installs
+    /// skill dirs under `<plugin_dir>/packs/<name>/`. Pre-fix detection
+    /// hardcoded `<plugin_dir>/skills/<name>/` and would surface every
+    /// such plugin as a `HashFailed` failure on every scan. Post-fix,
+    /// detection consults `meta.source_scan_root` (recorded at install
+    /// time via the refactored `discover_skill_dirs` returning
+    /// `DiscoveredSkill { scan_root, skill_dir }`) and looks at the
+    /// right path.
+    #[test]
+    fn detect_plugin_updates_skills_with_custom_scan_path_no_false_drift() {
+        use crate::project::KiroProject;
+        use crate::service::test_support::{
+            relative_path_entry, seed_marketplace_with_registry, temp_service,
+        };
+
+        let (dir, svc) = temp_service();
+        let entries = vec![relative_path_entry("p", "plugins/p")];
+        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+        let plugin_dir = mp_path.join("plugins/p");
+
+        // Skill source under a NON-default scan path. Pre-fix
+        // detection would look at <plugin_dir>/skills/alpha and hit
+        // NotFound.
+        let alpha_dir = plugin_dir.join("packs").join("alpha");
+        fs::create_dir_all(&alpha_dir).expect("create skill dir");
+        fs::write(
+            alpha_dir.join("SKILL.md"),
+            "---\nname: alpha\ndescription: test\n---\n",
+        )
+        .expect("write SKILL.md");
+
+        // Manifest declares the custom scan path.
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            br#"{"name":"p","version":"1.0","skills":["./packs/"]}"#,
+        )
+        .expect("write plugin.json");
+
+        let project_tmp = tempfile::tempdir().expect("project tempdir");
+        let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+            .expect("install");
+
+        // Sanity: install actually placed the skill so the tracking
+        // entry exists for detection to compare against.
+        assert!(
+            project_tmp
+                .path()
+                .join(".kiro/skills/alpha/SKILL.md")
+                .exists(),
+            "precondition: skill must be installed"
+        );
+
+        let result = svc.detect_plugin_updates(&project).expect("detect");
+        assert!(
+            result.updates.is_empty(),
+            "expected no updates for an unchanged skill source under a custom \
+             scan path; got: {:?}",
+            result.updates
+        );
+        assert!(
+            result.failures.is_empty(),
+            "expected no failures (pre-fix would return a HashFailed because \
+             detection looked under hardcoded `./skills/`); got: {:?}",
             result.failures
         );
     }

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1671,24 +1671,8 @@ impl MarketplaceService {
                 }
             };
 
-            // MCP opt-in gate. An agent that brings MCP servers can run
-            // arbitrary subprocesses (Stdio) or open network connections
-            // (Http/Sse) on the user's host. The cache persists, so a
-            // one-time install is a long-lived foothold. Default policy:
-            // skip + warn so the user sees the risk surface; re-running
-            // with `--accept-mcp` flips the gate.
-            if !ctx.accept_mcp && !def.mcp_servers.is_empty() {
-                let transports: Vec<String> = def
-                    .mcp_servers
-                    .values()
-                    .map(|cfg| cfg.transport_label().to_owned())
-                    .collect();
-                result
-                    .warnings
-                    .push(InstallWarning::McpServersRequireOptIn {
-                        agent: def.name.clone(),
-                        transports,
-                    });
+            // MCP opt-in gate (see translated_agent_blocked_by_mcp_gate).
+            if translated_agent_blocked_by_mcp_gate(&def, ctx.accept_mcp, &mut result) {
                 continue;
             }
 
@@ -1713,13 +1697,25 @@ impl MarketplaceService {
                 });
             }
 
+            // Discovery should always yield paths under plugin_dir; if
+            // this ever fails it's a defensive catch for a future
+            // invariant break. Surface as a typed install failure rather
+            // than a silent skip — the required-field schema means we
+            // cannot safely install without a recorded source_path.
+            let source_path = match required_source_path(&path, plugin_dir, def.name.clone()) {
+                Ok(rp) => rp,
+                Err(failed) => {
+                    result.failed.push(failed);
+                    continue;
+                }
+            };
             let meta = crate::project::InstalledAgentMeta {
                 marketplace: ctx.marketplace.clone(),
                 plugin: ctx.plugin.clone(),
                 version: ctx.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
-                source_path: relative_source_path_for_tracking(&path, plugin_dir),
+                source_path,
                 source_hash: None,
                 installed_hash: None,
             };
@@ -1795,7 +1791,7 @@ impl MarketplaceService {
         }
 
         for f in &agent_files {
-            Self::install_one_native_agent(project, f, ctx, &mut result);
+            Self::install_one_native_agent(project, plugin_dir, f, ctx, &mut result);
         }
 
         if !companion_files.is_empty() {
@@ -1817,6 +1813,7 @@ impl MarketplaceService {
     /// install failures into the right `result` bucket.
     fn install_one_native_agent(
         project: &crate::project::KiroProject,
+        plugin_dir: &Path,
         file: &crate::agent::DiscoveredNativeFile,
         ctx: AgentInstallContext<'_>,
         result: &mut InstallAgentsResult,
@@ -1879,14 +1876,27 @@ impl MarketplaceService {
             }
         };
 
-        match project.install_native_agent(
-            &bundle,
-            ctx.marketplace,
-            ctx.plugin,
-            ctx.version,
-            &source_hash,
-            ctx.mode,
+        let source_path = match required_source_path(
+            &bundle.agent_json_source,
+            plugin_dir,
+            bundle.name.to_string(),
         ) {
+            Ok(rp) => rp,
+            Err(failed) => {
+                result.failed.push(failed);
+                return;
+            }
+        };
+
+        match project.install_native_agent(&crate::project::NativeAgentInstallInput {
+            bundle: &bundle,
+            marketplace: ctx.marketplace,
+            plugin: ctx.plugin,
+            version: ctx.version,
+            source_hash: &source_hash,
+            source_path: &source_path,
+            mode: ctx.mode,
+        }) {
             Ok(outcome) => {
                 if outcome.kind == crate::project::InstallOutcomeKind::Idempotent {
                     result.skipped.push(outcome.name.clone());
@@ -2564,72 +2574,18 @@ impl MarketplaceService {
             }
         }
 
-        // Agents
-        for (name, meta) in &installed_agents.agents {
+        // Agents — direct lookup against the install-recorded
+        // source_path. After the install↔detect symmetry pass, the
+        // dialect-fallback machinery and the I-N7 actionable-error
+        // branch are gone: install always records source_path, so
+        // detection always knows the precise file to hash.
+        for meta in installed_agents.agents.values() {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
                 match &meta.source_hash {
                     Some(stored) => {
-                        // Two notes on this fallback (C6 area):
-                        // (a) the dialect-default branch only fires for
-                        //     tracking entries written before the
-                        //     `source_path` field existed (legacy
-                        //     installs); post-NC2 entries always carry a
-                        //     validated `RelativePath`.
-                        // (b) Copilot's `.agent.md` (vs `.md`) extension
-                        //     must mirror the install-time naming
-                        //     convention or a content-hash diff will be
-                        //     misreported as drift.
-                        //
-                        // Hash invariant: install-side
-                        // `hash_translated_source` hashes via
-                        // `hash_artifact(parent_dir, &[filename])` so
-                        // the digest's path-component is the bare
-                        // filename. Detection MUST match that recipe,
-                        // i.e. base = parent dir, rel = filename — not
-                        // base = agents_dir + rel = "agents/foo.md".
-                        let (base, filename) = agent_hash_inputs(
-                            plugin_dir,
-                            name,
-                            meta.dialect,
-                            meta.source_path.as_ref(),
-                        );
-                        let computed = match crate::hash::hash_artifact(
-                            &base,
-                            std::slice::from_ref(&filename),
-                        ) {
-                            Ok(h) => h,
-                            Err(crate::hash::HashError::ReadFailed { path, source })
-                                if source.kind() == std::io::ErrorKind::NotFound
-                                    && meta.source_path.is_none() =>
-                            {
-                                // I-N7 (PR #96 re-review): the dialect
-                                // fallback resolved a path that doesn't
-                                // exist in the cache — typical cause is
-                                // a pre-C7 install (no source_path
-                                // tracked) where the install-time
-                                // filename convention disagrees with
-                                // detection's dialect-fallback (e.g. a
-                                // Copilot agent installed under a
-                                // non-`{name}.agent.md` filename).
-                                // Surface an actionable message instead
-                                // of "file not found".
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::NotFound,
-                                    format!(
-                                        "agent `{name}` was installed before \
-                                         `source_path` tracking landed (legacy \
-                                         entry); the dialect-fallback path `{}` is \
-                                         not present in the marketplace cache. \
-                                         Reinstall the plugin to populate \
-                                         `source_path` so update detection can \
-                                         locate the source file unambiguously.",
-                                        path.display(),
-                                    ),
-                                )
-                                .into());
-                            }
-                            Err(e) => return Err(e.into()),
-                        };
+                        let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
+                        let computed =
+                            crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
                         if computed != *stored {
                             content_drift = true;
                             return Ok((content_drift, legacy_fallback));
@@ -2784,66 +2740,86 @@ fn read_capped(path: &Path, cap: u64) -> std::io::Result<Vec<u8>> {
 /// MUST also pass `(parent, filename)` rather than `(agents_dir,
 /// "subdir/file.md")`, since the digest includes the rel-path bytes.
 ///
-/// `source_path` (when `Some`) is relative to `plugin_dir`. We split
-/// it back into `(plugin_dir + rel.parent(), rel.file_name())` to
-/// match the install recipe. The dialect-fallback branch produces a
-/// bare filename relative to `plugin_dir/agents`, mirroring the
-/// pre-C7 install behavior.
-fn agent_hash_inputs(
-    plugin_dir: &Path,
-    name: &str,
-    dialect: crate::agent::AgentDialect,
-    source_path: Option<&crate::validation::RelativePath>,
-) -> (PathBuf, PathBuf) {
-    if let Some(rp) = source_path {
-        let full = plugin_dir.join(rp.as_str());
-        let parent = full
-            .parent()
-            .map_or_else(|| plugin_dir.to_path_buf(), Path::to_path_buf);
-        let fname = full
-            .file_name()
-            .map_or_else(|| PathBuf::from(rp.as_str()), PathBuf::from);
-        return (parent, fname);
+/// `source_path` is relative to `plugin_dir` (always present after the
+/// install↔detect symmetry pass — `InstalledAgentMeta.source_path` is
+/// required). We split it back into
+/// `(plugin_dir + rel.parent(), rel.file_name())` to match the install
+/// recipe. The dialect-fallback branch (which previously synthesised a
+/// `{name}.{md|agent.md|json}` filename when `source_path` was `None`)
+/// is gone — required-field schema means we always have the precise
+/// install-time path.
+/// MCP opt-in gate for translated agents. An agent that brings MCP
+/// servers can run arbitrary subprocesses (Stdio) or open network
+/// connections (Http/Sse) on the user's host. The cache persists, so a
+/// one-time install is a long-lived foothold. Default policy: skip +
+/// warn so the user sees the risk surface; re-running with
+/// `--accept-mcp` flips the gate.
+///
+/// Returns `true` if the agent must be skipped (warning recorded).
+/// Returns `false` if installation may proceed.
+fn translated_agent_blocked_by_mcp_gate(
+    def: &crate::agent::AgentDefinition,
+    accept_mcp: bool,
+    result: &mut InstallAgentsResult,
+) -> bool {
+    if !accept_mcp && !def.mcp_servers.is_empty() {
+        let transports: Vec<String> = def
+            .mcp_servers
+            .values()
+            .map(|cfg| cfg.transport_label().to_owned())
+            .collect();
+        result
+            .warnings
+            .push(InstallWarning::McpServersRequireOptIn {
+                agent: def.name.clone(),
+                transports,
+            });
+        return true;
     }
-    let fname = match dialect {
-        crate::agent::AgentDialect::Native => PathBuf::from(format!("{name}.json")),
-        crate::agent::AgentDialect::Claude => PathBuf::from(format!("{name}.md")),
-        crate::agent::AgentDialect::Copilot => PathBuf::from(format!("{name}.agent.md")),
-    };
-    (plugin_dir.join("agents"), fname)
+    false
 }
 
-/// Build the tracking-file `source_path` for a translated agent install
-/// as a [`crate::validation::RelativePath`] so the on-disk JSON
-/// survives the post-load validation pass (NC2).
-///
-/// Today [`crate::agent::discover::discover_agents_in_dirs`] always
-/// yields paths under `plugin_dir`, but a silent `.ok()` would mask any
-/// future invariant break (Rule 35) — explicit `warn!` plus the
-/// dialect-fallback in
-/// [`MarketplaceService::scan_plugin_for_content_drift`] keep detection
-/// working even if `source_path` lands as `None`.
-///
-/// The forward-slash conversion is required because
-/// `RelativePath::new` rejects backslashes for cross-platform
-/// portability of the wire format.
-fn relative_source_path_for_tracking(
+/// Compute the install-time `source_path` for a discovered agent file,
+/// or build a [`FailedAgent`] entry if the discovered path can't be
+/// expressed as a `RelativePath` under `plugin_dir`. Discovery yields
+/// such paths in practice, so the `Err` arm is a defensive catch for a
+/// future invariant break — required-field schema means we can't
+/// install without recording `source_path`, so a silent skip is wrong.
+fn required_source_path(
     path: &Path,
     plugin_dir: &Path,
-) -> Option<crate::validation::RelativePath> {
-    match crate::validation::RelativePath::from_path_under(path, plugin_dir) {
-        Ok(rp) => Some(rp),
-        Err(e) => {
-            warn!(
-                path = %path.display(),
-                plugin_dir = %plugin_dir.display(),
-                error = %e,
-                "agent path could not be expressed as RelativePath; source_path \
-                 will fall back to dialect default during update detection"
-            );
-            None
-        }
-    }
+    agent_name: String,
+) -> Result<crate::validation::RelativePath, FailedAgent> {
+    crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| FailedAgent {
+        name: Some(agent_name),
+        source_path: path.to_path_buf(),
+        error: crate::error::AgentError::InstallFailed {
+            path: path.to_path_buf(),
+            source: Box::new(crate::error::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "discovered agent path `{}` is not expressible as a \
+                     RelativePath under plugin_dir `{}`: {e}",
+                    path.display(),
+                    plugin_dir.display(),
+                ),
+            ))),
+        },
+    })
+}
+
+fn agent_hash_inputs(
+    plugin_dir: &Path,
+    source_path: &crate::validation::RelativePath,
+) -> (PathBuf, PathBuf) {
+    let full = plugin_dir.join(source_path.as_str());
+    let parent = full
+        .parent()
+        .map_or_else(|| plugin_dir.to_path_buf(), Path::to_path_buf);
+    let fname = full
+        .file_name()
+        .map_or_else(|| PathBuf::from(source_path.as_str()), PathBuf::from);
+    (parent, fname)
 }
 
 /// Decide whether a skill name passes the install filter.
@@ -6779,7 +6755,8 @@ mod tests {
                 version: Some("1.0".to_owned()),
                 installed_at: chrono::Utc::now(),
                 dialect: crate::agent::AgentDialect::Native,
-                source_path: None,
+                source_path: crate::validation::RelativePath::new("agents/registrar.json")
+                    .expect("valid"),
                 source_hash: None,
                 installed_hash: None,
             },
@@ -6906,109 +6883,6 @@ mod tests {
         }
     }
 
-    /// I-N3 (PR #96 re-review) — DEFERRED VARIANT: directly testing
-    /// the Copilot dialect through the translated install path
-    /// surfaces a separate pre-existing bug in
-    /// [`scan_plugin_for_content_drift`]'s `native_companions` arm
-    /// (companion `source_hash` is computed against the destination
-    /// `project/.kiro/agents/` at install time, but detection
-    /// re-hashes against the marketplace cache `plugin_dir/agents/`,
-    /// so the paths never resolve and a `PluginUpdateFailure` is
-    /// always emitted). That bug is unrelated to NC1/NC2/C7 and is
-    /// out of scope for this remediation cycle — it requires routing
-    /// the destination dir through `scan_plugin_for_content_drift`,
-    /// which is a Phase 2b structural change.
-    ///
-    /// Until the upstream `native_companions` detection bug is fixed,
-    /// the Copilot legacy-fallback path is exercised in a unit test
-    /// that bypasses the install path. Below: build the tracking
-    /// state by hand so we can isolate the dialect-classifier branch
-    /// without dragging in the broken `native_companions` cascade.
-    #[test]
-    fn detect_plugin_updates_copilot_agent_legacy_fallback() {
-        use crate::project::{InstalledAgentMeta, InstalledAgents, KiroProject};
-        use crate::service::test_support::{
-            relative_path_entry, seed_marketplace_with_registry, temp_service,
-        };
-        use std::collections::HashMap;
-
-        let (dir, svc) = temp_service();
-        let entries = vec![relative_path_entry("p", "plugins/p")];
-        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
-        let plugin_dir = mp_path.join("plugins/p");
-        let agents_dir = plugin_dir.join("agents");
-        fs::create_dir_all(&agents_dir).unwrap();
-        // Filename stem matches the frontmatter name so the dialect
-        // fallback `{name}.agent.md` resolves.
-        let agent_body = b"---\nname: reviewer\ndescription: Reviews\n---\n\nBody.\n";
-        fs::write(agents_dir.join("reviewer.agent.md"), agent_body).unwrap();
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.0"}"#,
-        )
-        .unwrap();
-
-        // Build a hand-crafted installed-agents.json that mirrors a
-        // pre-C7 install (no source_path, no source_hash) so we
-        // exercise the dialect-fallback branch in isolation. Skip
-        // synthesizing native_companions to sidestep the unrelated
-        // pre-existing bug noted in the rustdoc above.
-        let project_tmp = tempfile::tempdir().unwrap();
-        let project = KiroProject::new(project_tmp.path().to_path_buf());
-        let kiro_dir = project_tmp.path().join(".kiro");
-        fs::create_dir_all(&kiro_dir).unwrap();
-        let mut agents_map = HashMap::new();
-        agents_map.insert(
-            "reviewer".to_string(),
-            InstalledAgentMeta {
-                marketplace: mp("mp"),
-                plugin: pn("p"),
-                version: Some("1.0".to_owned()),
-                installed_at: chrono::Utc::now(),
-                dialect: crate::agent::AgentDialect::Copilot,
-                source_path: None,
-                // Legacy entry: no source_hash → triggers
-                // `legacy_fallback = true` in scan; version-comparison
-                // path then drives the result.
-                source_hash: None,
-                installed_hash: None,
-            },
-        );
-        let installed = InstalledAgents {
-            agents: agents_map,
-            native_companions: HashMap::new(),
-        };
-        fs::write(
-            kiro_dir.join("installed-agents.json"),
-            serde_json::to_vec_pretty(&installed).unwrap(),
-        )
-        .unwrap();
-
-        // Bump version so we get a deterministic update entry.
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.1"}"#,
-        )
-        .unwrap();
-
-        let result = svc.detect_plugin_updates(&project).expect("detect");
-        assert!(
-            result.failures.is_empty(),
-            "Copilot legacy-fallback path must succeed, got failures: {:?}",
-            result.failures
-        );
-        assert_eq!(
-            result.updates.len(),
-            1,
-            "Copilot agent legacy fallback + version bump must surface as exactly \
-             one update, got: {result:?}"
-        );
-        assert!(matches!(
-            result.updates[0].change_signal,
-            UpdateChangeSignal::VersionBumped
-        ));
-    }
-
     /// I-N3 sibling: a Copilot agent with `source_path: Some(rel)`
     /// (post-C7 install shape) — detection finds the file via the
     /// populated path, NOT the dialect fallback. Bypasses the
@@ -7056,9 +6930,7 @@ mod tests {
                 version: Some("1.0".to_owned()),
                 installed_at: chrono::Utc::now(),
                 dialect: crate::agent::AgentDialect::Copilot,
-                source_path: Some(
-                    RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
-                ),
+                source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
                 source_hash: Some(expected_hash),
                 installed_hash: None,
             },

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1950,6 +1950,7 @@ impl MarketplaceService {
             version: ctx.version,
             source_hash: &source_hash,
             mode: ctx.mode,
+            plugin_dir,
         }) {
             Ok(outcome) => result.installed_companions = Some(outcome),
             Err(err) => result.failed.push(FailedAgent {
@@ -2342,7 +2343,6 @@ impl MarketplaceService {
         let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
             plugin_info,
             &plugin_dir,
-            Some(&manifest),
             installed_skills,
             installed_steering,
             installed_agents,
@@ -2493,7 +2493,6 @@ impl MarketplaceService {
     fn scan_plugin_for_content_drift(
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
-        manifest: Option<&crate::plugin::PluginManifest>,
         installed_skills: &crate::project::InstalledSkills,
         installed_steering: &crate::project::InstalledSteering,
         installed_agents: &crate::project::InstalledAgents,
@@ -2561,17 +2560,14 @@ impl MarketplaceService {
             }
         }
 
-        // Native companions — same probe-each-scan-path treatment as
-        // steering. Install hashes via `hash_artifact(&scan_root,
-        // &rel_paths)` per `install_native_companions_for_plugin`,
-        // and the install path requires every companion in the bundle
-        // to share a single scan root (`MultipleScanRootsNotSupported`
-        // errors otherwise) — so `meta.files` resolves under whichever
-        // configured agent scan path actually contains the bundle.
-        let agent_paths = crate::service::browse::agent_scan_paths_for_plugin(manifest);
+        // Native companions — direct lookup against the install-recorded
+        // scan root. Single-scan-root invariant is enforced upstream
+        // by `multiple_companion_scan_roots`, so all `meta.files`
+        // resolve under one root.
         for meta in installed_agents.native_companions.values() {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                let computed = hash_artifact_in_scan_paths(plugin_dir, &agent_paths, &meta.files)?;
+                let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+                let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
                 if computed != meta.source_hash {
                     content_drift = true;
                     return Ok((content_drift, legacy_fallback));
@@ -2581,57 +2577,6 @@ impl MarketplaceService {
 
         Ok((content_drift, legacy_fallback))
     }
-}
-
-/// Try to hash `rel_paths` against each `scan_path` joined to
-/// `plugin_dir`, returning the first successful hash. Probes the
-/// configured scan paths in order and recovers from
-/// `ErrorKind::NotFound` so a plugin whose files moved between
-/// configured scan roots (or whose manifest lists multiple roots) is
-/// detected at whichever root actually contains the bundle.
-/// Non-`NotFound` hash errors propagate immediately so genuine
-/// permission / I/O issues are not masked.
-///
-/// If every scan path returned `NotFound`, the last `NotFound` error
-/// is propagated so the caller (`scan_plugin_for_content_drift`)
-/// surfaces it as a per-plugin failure with a path the user can
-/// investigate. `scan_paths` is empty in practice only if the helpers
-/// in [`crate::service::browse`] regress — both fall back to
-/// non-empty defaults — so the empty-vec branch synthesises a generic
-/// `NotFound` rather than panicking.
-fn hash_artifact_in_scan_paths(
-    plugin_dir: &Path,
-    scan_paths: &[String],
-    rel_paths: &[PathBuf],
-) -> Result<String, Error> {
-    let mut last_not_found: Option<Error> = None;
-    for sp in scan_paths {
-        // `discover_steering_files_in_dirs` and the agent-discovery
-        // siblings strip the leading `./` before joining; mirror that
-        // here so the resolved path matches install-time exactly
-        // regardless of whether the manifest writes `"steering/"` or
-        // `"./steering/"`.
-        let scan_root = plugin_dir.join(sp.trim_start_matches("./"));
-        match crate::hash::hash_artifact(&scan_root, rel_paths) {
-            Ok(h) => return Ok(h),
-            Err(crate::hash::HashError::ReadFailed { path, source })
-                if source.kind() == std::io::ErrorKind::NotFound =>
-            {
-                last_not_found = Some(crate::hash::HashError::ReadFailed { path, source }.into());
-            }
-            Err(e) => return Err(e.into()),
-        }
-    }
-    Err(last_not_found.unwrap_or_else(|| {
-        crate::hash::HashError::ReadFailed {
-            path: plugin_dir.to_path_buf(),
-            source: std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "no scan paths configured for plugin",
-            ),
-        }
-        .into()
-    }))
 }
 
 /// 3-state outcome of [`MarketplaceService::load_plugin_manifest`].
@@ -6927,6 +6872,10 @@ mod tests {
                 // installed_hash isn't consulted by the drift scan;
                 // any value works for this test.
                 installed_hash: source_hash,
+                // Test installs companion at <plugin_dir>/companions/...,
+                // so source_scan_root must point detection there.
+                source_scan_root: crate::validation::RelativePath::new("companions")
+                    .expect("valid"),
             },
         );
         let installed = InstalledAgents {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -6806,10 +6806,10 @@ mod tests {
         fs::write(prompts_dir.join("reviewer.md"), b"prompt body\n")
             .expect("write companion source");
 
-        // Manifest declares the custom scan path. The Phase 2a fix
-        // makes `scan_plugin_for_content_drift`'s native-companions
-        // loop consult `agent_scan_paths_for_plugin(manifest)` instead
-        // of `plugin_dir.join("agents")`.
+        // Manifest declares the custom scan path. After install↔detect
+        // symmetry, install records source_scan_root="companions" on
+        // the tracking entry and detection consults it directly instead
+        // of probing or hardcoding plugin_dir.join("agents").
         fs::write(
             plugin_dir.join("plugin.json"),
             br#"{"name":"p","version":"1.0","agents":["./companions/"]}"#,

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -30,6 +30,13 @@ pub struct SteeringInstallContext<'a> {
     pub marketplace: &'a MarketplaceName,
     pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
+    /// Plugin root directory; used to compute the per-file
+    /// `source_scan_root` populated on
+    /// [`crate::project::InstalledSteeringMeta`] at install time.
+    /// Required after the install↔detect symmetry pass — drift
+    /// detection consults the recorded scan root directly instead of
+    /// probing manifest paths.
+    pub plugin_dir: &'a std::path::Path,
 }
 
 /// Errors that can occur during steering install.

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::error::ValidationError;
 use crate::project::InstallOutcomeKind;
 use crate::service::InstallMode;
 use crate::validation::{MarketplaceName, PluginName};
@@ -49,6 +50,24 @@ pub enum SteeringError {
         path: PathBuf,
         #[source]
         source: io::Error,
+    },
+
+    /// Manifest-supplied `scan_root` is structurally invalid for the
+    /// install↔detect symmetry contract: it isn't located under
+    /// `plugin_dir`, so the per-file `source_scan_root` newtype on
+    /// [`crate::project::InstalledSteeringMeta`] cannot be materialised.
+    /// Distinct from [`SteeringError::SourceReadFailed`], which models
+    /// I/O failures on a *file* — this variant models a structural
+    /// validation failure on the *scan root path* and never carries an
+    /// `io::Error`. PR #100 review I1 split these so the wire-format
+    /// reason is precise instead of impersonating a missing-file error.
+    #[non_exhaustive]
+    #[error("steering scan_root `{path}` is not under plugin_dir `{plugin_dir}`")]
+    ScanRootInvalid {
+        path: PathBuf,
+        plugin_dir: PathBuf,
+        #[source]
+        source: ValidationError,
     },
 
     /// Source file is a hardlink (Unix `nlink > 1`). See

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -107,7 +107,17 @@ impl RelativePath {
             .collect::<Vec<_>>()
             .join("/")
             .replace('\\', "/");
-        Self::new(rel_str)
+        // `path == base` produces an empty rel string (Components yields
+        // zero Normal entries), which `RelativePath::new` rejects.
+        // Substitute "." so the call still succeeds and downstream
+        // `plugin_dir.join(".").join(name)` resolves correctly. Closes
+        // PR #100 review C2 (bare-path skill at plugin root regression).
+        let normalised = if rel_str.is_empty() {
+            ".".to_owned()
+        } else {
+            rel_str
+        };
+        Self::new(normalised)
     }
 
     /// View the validated path as a `&str`.
@@ -1242,5 +1252,23 @@ mod tests {
         let source = PathBuf::from("/tmp/plugin/agents/reviewer.md");
         let rel = RelativePath::from_path_under(&source, &plugin_dir).expect("valid input");
         assert_eq!(rel.as_str(), "agents/reviewer.md");
+    }
+
+    /// PR #100 review C2: a manifest declaring `skills: ["my-skill"]`
+    /// (bare path, no `./skills/` directory) makes `discover_skill_dirs`
+    /// set `scan_root = candidate.parent() = plugin_root`, then install
+    /// calls `from_path_under(scan_root=plugin_root, plugin_dir=plugin_root)`.
+    /// Pre-fix this errored with empty-rel; install pushed `FailedSkill`
+    /// for a skill that pre-PR would have installed cleanly. Post-fix
+    /// returns `RelativePath("." )` so detection can use
+    /// `plugin_dir.join(".").join(name)` to resolve back to the right
+    /// directory.
+    #[test]
+    fn from_path_under_returns_dot_when_path_equals_base() {
+        use std::path::PathBuf;
+        let plugin_dir = PathBuf::from("/tmp/plugin");
+        let rel = RelativePath::from_path_under(&plugin_dir, &plugin_dir)
+            .expect("path == base must produce a valid sentinel, not error");
+        assert_eq!(rel.as_str(), ".");
     }
 }

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -61,6 +61,21 @@ impl RelativePath {
         Self(value)
     }
 
+    /// The conventional `agents/` scan-root used by the translated
+    /// agent install path when the source-side scan root cannot be
+    /// recovered from `meta.source_path` (legacy `agent.md` discovered
+    /// without a configured scan path, hand-synthesised test fixtures,
+    /// etc.). Replaces the previous `from_internal_unchecked("agents".to_owned())`
+    /// site at `KiroProject::install_agent_inner` per PR #100 review S2:
+    /// the unchecked-constructor pattern was sound but anonymous —
+    /// every reader had to re-derive that `"agents"` is a constant
+    /// string. A named `agents_root()` makes the intent explicit and
+    /// removes one audited-by-convention site.
+    #[must_use]
+    pub fn agents_root() -> Self {
+        Self::from_internal_unchecked("agents".to_owned())
+    }
+
     /// Convert a `Path` to a [`RelativePath`] by stripping `base` and
     /// normalising path separators to forward-slash. Returns `Err` if
     /// `path` is not under `base` or the resulting relative path fails
@@ -98,15 +113,30 @@ impl RelativePath {
         // as ONE `Normal` component and we'd hand `RelativePath::new` a
         // backslash it rejects. The explicit `.replace('\\', '/')`
         // closes that gap; harmless when components already split.
-        let rel_str = rel
+        //
+        // PR #100 review I4: components are converted via `to_str()`,
+        // not `to_string_lossy()`. Lossy conversion silently substitutes
+        // `U+FFFD` for invalid UTF-8 sequences, so a non-UTF-8 OsStr
+        // component would round-trip as a valid-looking `RelativePath`
+        // that doesn't correspond to anything on disk — detection-side
+        // hashing later misses with `NotFound` and the user sees a
+        // misleading "missing file" error. Failing the construction
+        // here surfaces the real cause at the parse boundary.
+        let parts: Vec<&str> = rel
             .components()
             .filter_map(|c| match c {
-                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                std::path::Component::Normal(s) => Some(s),
                 _ => None,
             })
-            .collect::<Vec<_>>()
-            .join("/")
-            .replace('\\', "/");
+            .map(|s| {
+                s.to_str()
+                    .ok_or_else(|| ValidationError::InvalidRelativePath {
+                        path: path.display().to_string(),
+                        reason: "path contains a non-UTF-8 component".to_owned(),
+                    })
+            })
+            .collect::<Result<_, _>>()?;
+        let rel_str = parts.join("/").replace('\\', "/");
         // `path == base` produces an empty rel string (Components yields
         // zero Normal entries), which `RelativePath::new` rejects.
         // Substitute "." so the call still succeeds and downstream
@@ -1270,5 +1300,39 @@ mod tests {
         let rel = RelativePath::from_path_under(&plugin_dir, &plugin_dir)
             .expect("path == base must produce a valid sentinel, not error");
         assert_eq!(rel.as_str(), ".");
+    }
+
+    /// PR #100 review I4: a path component containing invalid UTF-8 must
+    /// produce `ValidationError::InvalidRelativePath { reason: "...non-UTF-8..." }`,
+    /// not a `to_string_lossy`-substituted U+FFFD that round-trips
+    /// through validation but doesn't match anything on disk. Unix-only
+    /// because Windows `OsStr` is WTF-16 and constructing an invalid
+    /// component takes a different path; the production code is
+    /// platform-agnostic — a Unix-only regression test is sufficient
+    /// since it pins the same `to_str()` call site on every target.
+    #[cfg(unix)]
+    #[test]
+    fn from_path_under_rejects_non_utf8_component() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::{Path, PathBuf};
+
+        // 0xFF is invalid as a UTF-8 start byte; the resulting OsStr is
+        // a valid Unix filename but has no UTF-8 representation.
+        let bad_component = OsStr::from_bytes(&[b'a', 0xFF, b'b']);
+        let base = PathBuf::from("/plugins/foo");
+        let path = base.join(Path::new(bad_component));
+
+        let err = RelativePath::from_path_under(&path, &base)
+            .expect_err("non-UTF-8 component must error, not lossy-substitute");
+        match err {
+            crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
+                assert!(
+                    reason.contains("non-UTF-8"),
+                    "reason should call out non-UTF-8, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidRelativePath, got {other:?}"),
+        }
     }
 }

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -61,6 +61,55 @@ impl RelativePath {
         Self(value)
     }
 
+    /// Convert a `Path` to a [`RelativePath`] by stripping `base` and
+    /// normalising path separators to forward-slash. Returns `Err` if
+    /// `path` is not under `base` or the resulting relative path fails
+    /// [`validate_relative_path`].
+    ///
+    /// Forward-slash conversion is required because [`RelativePath::new`]
+    /// rejects backslashes for cross-platform portability of the wire
+    /// format. On Windows, `Path::strip_prefix(...).to_string_lossy()`
+    /// returns backslashes; without normalisation, `RelativePath::new`
+    /// fails. The recipe (`Components::Normal` + `join("/")`) drops any
+    /// platform-specific prefix or root components, producing a
+    /// purely-forward-slash representation regardless of the host OS.
+    ///
+    /// Used by install-side code to record where in the plugin tree an
+    /// artifact came from, so detection can look it up directly without
+    /// probing each configured manifest scan path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidRelativePath`] if `path` is
+    /// not under `base`, or whatever [`validate_relative_path`] returns
+    /// if the normalised string fails its checks.
+    pub fn from_path_under(path: &Path, base: &Path) -> Result<Self, ValidationError> {
+        let rel = path
+            .strip_prefix(base)
+            .map_err(|_| ValidationError::InvalidRelativePath {
+                path: path.display().to_string(),
+                reason: format!("path is not under base directory `{}`", base.display()),
+            })?;
+        // Two-pass normalisation. On Windows-native paths, `Components`
+        // already splits on `\` and `Normal` strings have no embedded
+        // backslashes — `join("/")` is enough. On Unix interpreting a
+        // Windows-shaped path (or any synthetic input), `\` is NOT a
+        // path separator, so a string like `"agents\reviewer.md"` lands
+        // as ONE `Normal` component and we'd hand `RelativePath::new` a
+        // backslash it rejects. The explicit `.replace('\\', '/')`
+        // closes that gap; harmless when components already split.
+        let rel_str = rel
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+            .replace('\\', "/");
+        Self::new(rel_str)
+    }
+
     /// View the validated path as a `&str`.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -1156,5 +1205,42 @@ mod tests {
             a.as_str().cmp(b.as_str()),
             "PluginName::cmp must match inner String::cmp byte-for-byte"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // RelativePath::from_path_under (install↔detect symmetry foundation)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn from_path_under_normalizes_backslashes() {
+        use std::path::PathBuf;
+        // Synthesise a path with backslash components. PathBuf is just
+        // bytes underneath, so this works on any platform — tests the
+        // Windows-native input shape without requiring Windows CI.
+        let plugin_dir = PathBuf::from("/tmp/plugin");
+        let source = PathBuf::from("/tmp/plugin/agents\\reviewer.md");
+        let rel = RelativePath::from_path_under(&source, &plugin_dir)
+            .expect("backslash path under plugin_dir should normalize");
+        assert_eq!(rel.as_str(), "agents/reviewer.md");
+    }
+
+    #[test]
+    fn from_path_under_rejects_path_outside_base() {
+        use std::path::PathBuf;
+        let plugin_dir = PathBuf::from("/tmp/plugin");
+        let outside = PathBuf::from("/etc/passwd");
+        assert!(
+            RelativePath::from_path_under(&outside, &plugin_dir).is_err(),
+            "path not under plugin_dir must error, not silently produce a bogus rel"
+        );
+    }
+
+    #[test]
+    fn from_path_under_round_trips_simple_unix_path() {
+        use std::path::PathBuf;
+        let plugin_dir = PathBuf::from("/tmp/plugin");
+        let source = PathBuf::from("/tmp/plugin/agents/reviewer.md");
+        let rel = RelativePath::from_path_under(&source, &plugin_dir).expect("valid input");
+        assert_eq!(rel.as_str(), "agents/reviewer.md");
     }
 }

--- a/crates/kiro-market-core/tests/integration_native_install.rs
+++ b/crates/kiro-market-core/tests/integration_native_install.rs
@@ -95,6 +95,7 @@ impl IntegrationHarness {
             marketplace: &mp_name,
             plugin: &pn_name,
             version: None,
+            plugin_dir,
         };
         MarketplaceService::install_plugin_steering(
             &self.project,

--- a/crates/kiro-market/src/commands/info.rs
+++ b/crates/kiro-market/src/commands/info.rs
@@ -118,7 +118,8 @@ fn print_skills(plugin_dir: &Path) {
     println!();
     println!("  {}", "Skills:".bold());
 
-    for skill_dir in &skill_dirs {
+    for discovered in &skill_dirs {
+        let skill_dir = &discovered.skill_dir;
         let skill_md_path = skill_dir.join("SKILL.md");
         let content = match fs::read_to_string(&skill_md_path) {
             Ok(c) => c,

--- a/crates/kiro-market/src/commands/info.rs
+++ b/crates/kiro-market/src/commands/info.rs
@@ -119,7 +119,7 @@ fn print_skills(plugin_dir: &Path) {
     println!("  {}", "Skills:".bold());
 
     for discovered in &skill_dirs {
-        let skill_dir = &discovered.skill_dir;
+        let skill_dir = discovered.skill_dir();
         let skill_md_path = skill_dir.join("SKILL.md");
         let content = match fs::read_to_string(&skill_md_path) {
             Ok(c) => c,

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -112,6 +112,7 @@ pub fn run(
         marketplace: &marketplace,
         plugin: &plugin,
         version: ctx.version.as_deref(),
+        plugin_dir: &plugin_dir,
     };
     let steering_result = run_steering_install(
         &project,

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -80,6 +80,7 @@ pub fn run(
     let skill_result = run_skill_install(
         &svc,
         &project,
+        &ctx.plugin_dir,
         &ctx.skill_dirs,
         skill_filter,
         mode,
@@ -176,7 +177,8 @@ fn fetch_plugin_dir(
 fn run_skill_install(
     svc: &MarketplaceService,
     project: &KiroProject,
-    skill_dirs: &[PathBuf],
+    plugin_dir: &std::path::Path,
+    skill_dirs: &[kiro_market_core::plugin::DiscoveredSkill],
     skill_filter: Option<&str>,
     mode: InstallMode,
     marketplace: &MarketplaceName,
@@ -192,6 +194,7 @@ fn run_skill_install(
     };
     svc.install_skills(
         project,
+        plugin_dir,
         skill_dirs,
         &filter,
         mode,

--- a/crates/kiro-market/src/commands/search.rs
+++ b/crates/kiro-market/src/commands/search.rs
@@ -141,7 +141,7 @@ fn search_plugin(
     let mut matches = 0u32;
 
     for discovered in &skill_dirs {
-        let skill_dir = &discovered.skill_dir;
+        let skill_dir = discovered.skill_dir();
         if let Some(fm) = read_skill_frontmatter(skill_dir) {
             let name_lower = fm.name.to_lowercase();
             let desc_lower = fm.description.to_lowercase();

--- a/crates/kiro-market/src/commands/search.rs
+++ b/crates/kiro-market/src/commands/search.rs
@@ -140,7 +140,8 @@ fn search_plugin(
 
     let mut matches = 0u32;
 
-    for skill_dir in &skill_dirs {
+    for discovered in &skill_dirs {
+        let skill_dir = &discovered.skill_dir;
         if let Some(fm) = read_skill_frontmatter(skill_dir) {
             let name_lower = fm.name.to_lowercase();
             let desc_lower = fm.description.to_lowercase();

--- a/docs/plans/2026-05-03-install-detect-symmetry-design.md
+++ b/docs/plans/2026-05-03-install-detect-symmetry-design.md
@@ -1,0 +1,216 @@
+# Install ↔ Detect Symmetry — Tracking Schema Foundation
+
+> **Status:** design draft. Implementation plan to be written next via the `superpowers:writing-plans` skill once this design is approved.
+> **Closes:** issue #97 (skills detection ignores `manifest.skills` custom scan paths).
+> **Depends on:** PR #96 (Phase 2a update-detection backend). Stacked PR — base branch is `feat/phase-2a-update-detection`.
+> **Predecessor for:** issue #99 (umbrella for C-1 / C-2 / C-3 structural follow-ups).
+
+## Goal
+
+Make every installed-artifact tracking entry self-contained at detect time: each `Installed*Meta` records the manifest scan-path it was installed from, so detection becomes a direct lookup against a known source location. No probing, no fallbacks, no per-artifact-type ad hoc recovery patterns.
+
+This closes #97 (the skills instance of the bug) and the underlying structural pattern that made #97 the third instance after PR #96 closed steering and agents via probe-fallback helpers.
+
+## Background
+
+PR #96 (Phase 2a) closed two of three instances of "detection has a hardcoded scan path; install honors `manifest.{steering,agents}`":
+- Steering: closed via `hash_artifact_in_scan_paths` — a probe helper that tries each configured manifest scan path until one resolves.
+- Native companions: same probe helper.
+- Translated agents: closed via `InstalledAgentMeta.source_path: Option<RelativePath>` (NC2) — install records the per-file source path; detection reads it directly.
+- **Skills:** still hardcoded `plugin_dir.join("skills")`. Tracked at #97.
+
+The asymmetry is real: agents have the cleanest design (lookup-not-probe via tracked field) because the dialect-fallback machinery forced install-side path tracking early. Steering and native-companions got probe-style fixes because their schema lacked anywhere to record the scan root. Skills got nothing.
+
+This design closes all three remaining loops by giving every artifact type the agents-style treatment: a required field on the tracking metadata that records where install found the source, and a detection path that consults it directly.
+
+The pattern is documented at the meta level in `docs/plan-review-checklist.md` Gate 6 ("Reference vs Transcription") — the original PR #96 plan transcribed default-config cache paths as literal strings instead of citing the install-side scan-path resolution. Gate 6 was added to catch the next instance of this shape; this design closes the underlying structural cause that made Gate 6 necessary.
+
+## No-users assumption
+
+This codebase has no production users. Tracking files in the wild are exclusively local development copies, expected to be regenerated. This unlocks two design choices that would otherwise be off the table:
+
+1. **Required (not Option) tracking fields.** `source_scan_root: RelativePath` on the three new sites; `source_path: RelativePath` (no Option) on agents.
+2. **No probe-fallback machinery.** PR #96's `hash_artifact_in_scan_paths` and the agents `agent_hash_inputs` dialect-fallback branch can be deleted outright.
+
+Pre-existing tracking files written before this change will fail to deserialize (missing required field). Intentional. Users (= developers) regenerate by reinstalling the affected plugins.
+
+## Schema changes
+
+`crates/kiro-market-core/src/project.rs`:
+
+```rust
+pub struct InstalledSkillMeta {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    pub source_hash: String,                  // CHANGED: was Option<String>
+    pub installed_hash: String,               // CHANGED: was Option<String>
+    pub source_scan_root: RelativePath,       // NEW: required
+}
+
+pub struct InstalledSteeringMeta {
+    // ... unchanged ...
+    pub source_scan_root: RelativePath,       // NEW: required
+}
+
+pub struct InstalledNativeCompanionsMeta {
+    // ... unchanged ...
+    pub source_scan_root: RelativePath,       // NEW: required
+}
+
+pub struct InstalledAgentMeta {
+    // ... unchanged ...
+    pub source_path: RelativePath,            // CHANGED: was Option<RelativePath>
+    pub source_hash: String,                  // CHANGED: was Option<String>
+    pub installed_hash: String,               // CHANGED: was Option<String>
+}
+```
+
+**Naming convention.** Agents keeps `source_path` (full file path including filename, e.g. `agents/reviewer.md` or `custom/reviewer.agent.md`). The other three get `source_scan_root` (root-only, e.g. `skills` or `packs`). Names differ because semantics differ: agents need the filename (varies by dialect — `.md` / `.agent.md` / `.json`); the other three derive the file location from `source_scan_root` plus the existing tracking key (skill name, steering rel-path, or native companion `files` Vec).
+
+**Storage format.** `RelativePath` serializes as a JSON string. No new format concerns. The newtype already enforces forward-slash separators (rejects backslashes at construction); on-disk format is consistently forward-slash regardless of the host OS. Detection's `Path::join` accepts forward-slash rels on both Windows and Unix.
+
+**Multi-scan-root resolution at install.** When `manifest.{skills,steering,agents}` declares multiple scan paths and a file is found in more than one, install picks the first scan root that contains it (matches existing `discover_*_in_dirs` order). That choice is recorded in `source_scan_root`. Detection trusts what install stored and doesn't re-derive.
+
+## Detection simplification
+
+`scan_plugin_for_content_drift` (`service/mod.rs`) becomes straight-line — one path per artifact type, no probing, no fallbacks:
+
+```rust
+// Skills (was hardcoded plugin_dir.join("skills").join(name))
+let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
+let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+
+// Steering (was hash_artifact_in_scan_paths probe-each-scan-path)
+let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+let computed = crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
+
+// Native companions (was hash_artifact_in_scan_paths probe-each-scan-path)
+let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
+
+// Translated agents (was agent_hash_inputs with dialect-fallback)
+let full = plugin_dir.join(meta.source_path.as_str());
+let parent = full.parent().unwrap_or(plugin_dir);
+let filename = full.file_name().map(PathBuf::from).unwrap_or_else(|| meta.source_path.as_str().into());
+let computed = crate::hash::hash_artifact(parent, std::slice::from_ref(&filename))?;
+```
+
+**Deletions.** All exclusively-legacy machinery goes:
+- `hash_artifact_in_scan_paths` helper (~35 lines + its tests).
+- `agent_hash_inputs`'s dialect-fallback branch (~10 lines).
+- The I-N7 actionable-error branch in the agents loop (~30 lines, fired only when `source_path.is_none()`).
+- The `manifest: Option<&PluginManifest>` parameter on `scan_plugin_for_content_drift` (manifest is no longer needed for scan-path resolution).
+- The `legacy_fallback` boolean and its threading through `scan_plugin_for_content_drift`'s return tuple.
+
+**Visibility cleanup.** `agent_scan_paths_for_plugin` and `steering_scan_paths_for_plugin` (`service/browse.rs`) were bumped to `pub(super)` for detection in PR #96. Detection no longer needs them; revert to `fn` (private to `browse.rs`) if no other consumer remains.
+
+## Install-time changes
+
+Each install path needs to populate the new field. Three of the four are easy because the install code already has the scan_root in scope; one needs a small refactor.
+
+**Steering** (`install_plugin_steering`, `service/mod.rs:1540+`)
+The `DiscoveredNativeFile` records returned by `discover_steering_files_in_dirs` already carry `scan_root: PathBuf`. Per-file install computes `scan_root.strip_prefix(plugin_dir)` → `RelativePath` via the shared normalization helper (below) and stores on `InstalledSteeringMeta.source_scan_root`. ~5 lines added.
+
+**Native companions** (`install_native_companions_for_plugin`, `service/mod.rs:1880+`)
+Single-scan-root invariant is enforced upstream by `multiple_companion_scan_roots`, so all companion files share one scan_root. Already passed via `NativeCompanionsInput.scan_root`. The persistence layer computes the relative path and stores on `InstalledNativeCompanionsMeta.source_scan_root`. ~3 lines.
+
+**Translated agents** (`install_translated_agents_inner`, `service/mod.rs:1601+`)
+Already populates `source_path: Option<RelativePath>` via `relative_source_path_for_tracking` (`service/mod.rs:2685+`). Change: drop the `Option` wrapper. The function's two existing failure modes (path not under `plugin_dir`, `RelativePath::new` rejection) currently warn and return `None`; promote both to typed `AgentError` install failures. Rationale: with the field required, install MUST be able to record the source path or the install can't safely complete — silent skip becomes a contract violation, hard error is the correct shape.
+
+**Skills** (the actual refactor)
+`discover_skill_dirs` (`plugin.rs:399`) returns `Vec<PathBuf>` of resolved skill directories — loses the scan_root context. Refactor to return:
+
+```rust
+pub struct DiscoveredSkill {
+    pub scan_root: PathBuf,  // e.g. <plugin_dir>/skills/  or <plugin_dir>/packs/
+    pub skill_dir: PathBuf,  // e.g. <plugin_dir>/skills/alpha/
+}
+
+pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<DiscoveredSkill> {
+    // Track which scan_root each skill came from instead of flattening.
+}
+```
+
+Install iterates `Vec<DiscoveredSkill>`, copies the dir as today, and stores `scan_root.strip_prefix(plugin_dir)` (via the shared normalization helper) on `InstalledSkillMeta.source_scan_root`. The single existing caller (`discover_skills_for_plugin` in `browse.rs`) updates accordingly.
+
+**Shared normalization helper.** The recipe for converting `PathBuf` → `RelativePath` with forward-slash normalization currently lives only in `relative_source_path_for_tracking`. After B it's needed at 4+ sites. Extract:
+
+```rust
+/// Convert a `Path` to a `RelativePath`, after stripping `plugin_dir`
+/// and normalizing path separators to forward-slash. Returns Err if
+/// the path is not under `plugin_dir` or cannot be expressed as a
+/// valid `RelativePath`.
+fn path_to_relative_under_plugin(
+    path: &Path,
+    plugin_dir: &Path,
+) -> Result<RelativePath, RelativePathError>;
+```
+
+The forward-slash conversion is required because `RelativePath::new` rejects backslashes by construction (cross-platform portability of the wire format). On Windows, `Path::strip_prefix(...).to_string_lossy()` returns backslashes; without normalization, `RelativePath::new` fails. Pinned by the `relative_path_newtype_rejects_traversal_at_construction` test.
+
+## Tests
+
+**Deleted** (legacy-fallback paths that no longer exist):
+- `detect_plugin_updates_legacy_fallback_source_hash_none`
+- `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update`
+- `detect_plugin_updates_agent_legacy_fallback_source_hash_none`
+- `detect_plugin_updates_copilot_agent_legacy_fallback`
+
+**Reshaped** (intent intact; new field added to fixtures):
+- `detect_plugin_updates_steering_with_custom_scan_path_no_false_drift` (added in PR #96 review-of-review)
+- `detect_plugin_updates_native_companions_with_custom_scan_path_no_false_drift` (same)
+- JSON-shape lock tests for `installed-{skills,steering,agents}.json` shapes
+
+**Compiler-driven updates.** Every test that hand-constructs an `Installed*Meta` will fail to compile until the new required fields are supplied. Estimate: 15-25 sites across `service::tests` and `project::tests`. The compiler does the inventory.
+
+**Added:**
+- `detect_plugin_updates_skills_with_custom_scan_path_no_false_drift` — the regression test that closes #97. Direct sibling of the existing steering / native-companions regressions.
+- `path_to_relative_under_plugin_normalizes_backslashes` — synthesises a `PathBuf` containing backslashes, runs through the shared helper, asserts the resulting `RelativePath` uses forward-slash. Tests Windows-native input on any OS.
+- `load_installed_{skills,steering,agents,native_companions}_rejects_legacy_entry` (4 tests) — assert that a tracking file missing the new required field fails to deserialize with a clear error. Pins the "no legacy entries" foundation contract.
+- `install_translated_agent_fails_when_source_path_outside_plugin_dir` — pins the warn-and-None → typed-error promotion for agents install.
+
+Net test count change: +3 to +5 (4 deleted, 6-8 added).
+
+## Migration
+
+None. Pre-existing tracking files become invalid by design — see "No-users assumption" above. The deserialize-failure tests (`load_installed_*_rejects_legacy_entry`) document the contract: legacy entries are intentionally unparseable, with a clear error mentioning the missing field. Users (= developers) regenerate by reinstalling the affected plugins.
+
+If users ever exist for this codebase, a migration story is in scope for that future work — not for this design.
+
+## Out of scope
+
+Deferred to issue #99:
+- **C-1: Native-companion install/detect hash recipe.** Verify whether the bug documented on `detect_plugin_updates_copilot_agent_legacy_fallback`'s docstring exists; align if so. B closes the *location* asymmetry for native_companions but doesn't touch the *hash recipe* axis.
+- **C-2: Lift `PluginManifest.{skills,steering,agents}: Vec<String>` to `Vec<RelativePath>`.** Parse-don't-validate at the manifest layer. Closes the rust-code-reviewer IMPORTANT 1 finding from PR #96 (asymmetric scan-path validation between install and detection).
+- **C-3: `ContentHash` newtype.** Promotes `"blake3:" + hex` digests from `String` to a typed newtype. Independent axis from path tracking.
+
+Other:
+- **Backward compat / migration shims.** Explicitly out per the no-users assumption.
+- **Cross-marketplace same-plugin idempotency** (`project.rs:2937-2956`, flagged in the PR #96 design as "may matter for Phase 2b") — separate axis.
+
+## PR strategy
+
+**Base branch.** `feat/phase-2a-update-detection` (PR #96). Stacked PR. Description includes "Depends on #96; merge after #96 lands." GitHub PR UI base set to PR #96's branch so the diff shows only B's changes.
+
+**Six commits, each self-contained** (compiles + tests pass per commit, bisect-friendly):
+
+1. `refactor(agents): tighten source_path to required, drop dialect-fallback`
+2. `feat(skills): add InstalledSkillMeta.source_scan_root + use at detect time` (closes #97)
+3. `feat(steering): add InstalledSteeringMeta.source_scan_root + use at detect time`
+4. `feat(native-companions): add InstalledNativeCompanionsMeta.source_scan_root + use at detect time`
+5. `refactor(detect): delete probe helpers + legacy_fallback (now dead)` — including tightening `source_hash: Option → String`
+6. `chore: regenerate bindings.ts + add normalization helper test + deserialize-rejection tests`
+
+**Estimated diff size:** 400-600 lines including tests. More deletes than adds on net (PR #96's probe helpers + the agents dialect-fallback go away).
+
+**Review hooks.** Plan-lint should stay green throughout (no changes to error variants, classifiers, or external-error boundaries). `cargo test --workspace` + `cargo clippy --workspace --tests -- -D warnings` + `cargo fmt --all --check` per commit.
+
+## Open questions
+
+None at the time of writing. All Section 1-5 questions resolved during the brainstorm.
+
+---
+
+**Origin context.** Brainstormed via `superpowers:brainstorming` skill on 2026-05-03. Driver: user feedback on the immediate-fix approach to issue #97 ("Hold on, lets think about the right thing to do long term. I don't want to do any more quick fixes"). The brainstorm explicitly chose option (b) over (a) and option (α) over (β) — the most aggressive cleanup variants — because the no-users assumption removes the migration burden that would otherwise constrain the design.

--- a/docs/plans/2026-05-03-install-detect-symmetry-plan.md
+++ b/docs/plans/2026-05-03-install-detect-symmetry-plan.md
@@ -1,0 +1,1820 @@
+# Install ↔ Detect Symmetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every `Installed*Meta` self-contained at detect time by recording the manifest scan-path install used. Detection becomes a direct lookup — no probing, no fallbacks. Closes issue #97 and the structural pattern that made #97 the third instance after PR #96 closed steering and agents via probe-fallback helpers.
+
+**Architecture:** Add required `source_scan_root: RelativePath` to `InstalledSkillMeta` / `InstalledSteeringMeta` / `InstalledNativeCompanionsMeta`; tighten agents' existing `source_path: Option<RelativePath>` to `RelativePath`. Tighten `source_hash: Option<String>` → `String` on skills + agents (already required on steering / native_companions). Replace `scan_plugin_for_content_drift`'s probe helpers and dialect-fallback with one straight-line lookup per artifact type. Pre-existing tracking files become invalid by design — no migration story (no users).
+
+**Tech Stack:** Rust edition 2024, `serde` (with `RelativePath` newtype enforcing forward-slash separators at construction), `thiserror`, `rstest`. No new crates. `cargo xtask plan-lint` gates stay green throughout.
+
+**Spec:** `docs/plans/2026-05-03-install-detect-symmetry-design.md`
+
+**Branch:** `fix/install-detect-symmetry` (worktree at `~/repos/kiro-marketplace-cli-install-detect-symmetry/`), stacked on `feat/phase-2a-update-detection`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change shape |
+|---|---|---|
+| `crates/kiro-market-core/src/validation.rs` | `RelativePath` newtype | Add associated function `RelativePath::from_path_under(&Path, &Path) -> Result<Self, ValidationError>` for converting `Path` → `RelativePath` with forward-slash normalization. New unit test for backslash inputs. |
+| `crates/kiro-market-core/src/project.rs` | Tracking schema (4 `Installed*Meta` types + on-disk `InstalledSkills` / `InstalledAgents` / `InstalledSteering` aggregates) | Add required `source_scan_root: RelativePath` to skills / steering / native_companions metas. Tighten agents `source_path` to required. Tighten skills + agents `source_hash` and `installed_hash` to required `String`. Update internal install helpers + test fixtures. |
+| `crates/kiro-market-core/src/plugin.rs` | `PluginManifest` + `discover_skill_dirs` | Refactor `discover_skill_dirs` to return `Vec<DiscoveredSkill { scan_root, skill_dir }>` instead of `Vec<PathBuf>`. Update tests. |
+| `crates/kiro-market-core/src/service/browse.rs` | Browse-side discovery + scan-path helpers | Update `discover_skills_for_plugin` for new `discover_skill_dirs` shape. Revert `agent_scan_paths_for_plugin` / `steering_scan_paths_for_plugin` from `pub(super)` back to private (no longer consumed outside the module). |
+| `crates/kiro-market-core/src/service/mod.rs` | Service layer — install paths + `scan_plugin_for_content_drift` + helpers | Update install paths to populate new fields. Simplify `scan_plugin_for_content_drift` to direct lookup per artifact type. Delete `hash_artifact_in_scan_paths`, `agent_hash_inputs`'s dialect-fallback branch, the I-N7 actionable-error branch, the `legacy_fallback` flag and its threading, and the `manifest` parameter on `scan_plugin_for_content_drift`. Tighten `relative_source_path_for_tracking` to return `Result` (or delete in favor of `RelativePath::from_path_under` directly). |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Generated TS bindings | Regenerated after schema changes via `cargo test -p kiro-control-center --lib -- --ignored`. |
+
+**Why this decomposition.** `validation.rs` is the home for `RelativePath` and its helpers; the new `from_path_under` belongs there. `project.rs` owns the tracking schema; all four schema changes are in one file so the `Cargo.toml`-level visibility surface doesn't grow. `plugin.rs` and `browse.rs` changes are confined to the skills discovery refactor (single-callsite). `service/mod.rs` is already large and concentrated; the deletions exceed the additions, so net file size drops.
+
+**Files NOT touched:** `crates/kiro-market-core/src/error.rs` — no new error variants needed; the agents install-fails-on-bad-source-path case routes through the existing `AgentError::InstallFailed { path, source: Box<Error> }` with a synthesized inner `io::Error`. Avoids adding a public-API surface this plan doesn't otherwise require.
+
+---
+
+## Pre-work: confirm the worktree
+
+- [ ] **Step 0.1: Verify the worktree state**
+
+```bash
+cd /home/dwalleck/repos/kiro-marketplace-cli-install-detect-symmetry
+git status
+git log --oneline -3
+```
+
+Expected:
+- Branch: `fix/install-detect-symmetry`
+- HEAD: `d586eb6 docs(plans): install↔detect symmetry — tracking schema foundation design`
+- Working tree clean (or only untracked files unrelated to this plan).
+
+If HEAD differs, do not proceed — the plan assumes the design doc commit is present and the branch is based on `feat/phase-2a-update-detection`.
+
+- [ ] **Step 0.2: Confirm the baseline test suite passes**
+
+```bash
+cargo test --workspace
+```
+
+Expected: ~1000 tests pass, 0 fail. (PR #96 + the design-doc commit; nothing else.)
+
+This baseline is what each subsequent task's "verify tests pass" step compares against. If the baseline is red, stop — don't try to fix unrelated failures as part of this plan.
+
+---
+
+## Task 1: Add `RelativePath::from_path_under` shared helper
+
+**Why first.** The `path_to_relative_under_plugin` recipe is needed at 4+ sites in commits 2-5 (skills install, steering install, native_companions install, agents install). Extract first as a no-op refactor — `relative_source_path_for_tracking` becomes a thin wrapper that delegates to the new helper and preserves its current `Option<RelativePath>` return shape. Subsequent commits use the new helper directly with `Result`. This isolates the new code path under test before any callers depend on it.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/validation.rs` — add associated function `RelativePath::from_path_under`, add unit test
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2830-2868` (`relative_source_path_for_tracking`) — delegate to the new helper
+
+- [ ] **Step 1.1: Read `RelativePath` to confirm the constructor signature and error type**
+
+```bash
+grep -n "impl RelativePath\|pub fn new\|ValidationError\|pub enum ValidationError" \
+    crates/kiro-market-core/src/validation.rs crates/kiro-market-core/src/error.rs \
+    | head -20
+```
+
+Note the `RelativePath::new` signature and which error type it returns. Steps below assume `Result<Self, ValidationError>` (the most likely shape based on the existing `validate_relative_path` siblings); adapt to the actual signature.
+
+- [ ] **Step 1.2: Write the failing test for the new helper**
+
+Add to the test module in `crates/kiro-market-core/src/validation.rs`:
+
+```rust
+#[test]
+fn from_path_under_normalizes_backslashes() {
+    use std::path::PathBuf;
+    // Synthesise a path with backslash components. PathBuf is just bytes
+    // underneath, so this works on any platform — tests the Windows-native
+    // input shape without requiring Windows CI.
+    let plugin_dir = PathBuf::from("/tmp/plugin");
+    let source = PathBuf::from("/tmp/plugin/agents\\reviewer.md");
+    let rel = RelativePath::from_path_under(&source, &plugin_dir)
+        .expect("backslash path under plugin_dir should normalize");
+    assert_eq!(rel.as_str(), "agents/reviewer.md");
+}
+
+#[test]
+fn from_path_under_rejects_path_outside_base() {
+    use std::path::PathBuf;
+    let plugin_dir = PathBuf::from("/tmp/plugin");
+    let outside = PathBuf::from("/etc/passwd");
+    assert!(
+        RelativePath::from_path_under(&outside, &plugin_dir).is_err(),
+        "path not under plugin_dir must error, not silently produce a bogus rel"
+    );
+}
+
+#[test]
+fn from_path_under_round_trips_simple_unix_path() {
+    use std::path::PathBuf;
+    let plugin_dir = PathBuf::from("/tmp/plugin");
+    let source = PathBuf::from("/tmp/plugin/agents/reviewer.md");
+    let rel = RelativePath::from_path_under(&source, &plugin_dir).expect("valid input");
+    assert_eq!(rel.as_str(), "agents/reviewer.md");
+}
+```
+
+- [ ] **Step 1.3: Run the test to verify it fails (function doesn't exist yet)**
+
+```bash
+cargo test -p kiro-market-core --lib validation::tests::from_path_under
+```
+
+Expected: compile error — `no function or associated item named 'from_path_under' found`.
+
+- [ ] **Step 1.4: Add the helper to `RelativePath`**
+
+Add to the `impl RelativePath { ... }` block in `crates/kiro-market-core/src/validation.rs`:
+
+```rust
+/// Convert a `Path` to a [`RelativePath`] by stripping `base` and
+/// normalising path separators to forward-slash. Returns `Err` if
+/// `path` is not under `base` or the resulting relative path fails
+/// `RelativePath::new` validation.
+///
+/// Forward-slash conversion is required because `RelativePath::new`
+/// rejects backslashes for cross-platform portability of the wire
+/// format (pinned by `relative_path_newtype_rejects_traversal_at_construction`).
+/// On Windows, `Path::strip_prefix(...).to_string_lossy()` returns
+/// backslashes; without normalisation, `RelativePath::new` fails.
+///
+/// # Errors
+///
+/// Returns `ValidationError::InvalidRelativePath` if `path` is not
+/// under `base`, or whatever error `RelativePath::new` produces if
+/// the normalised string fails validation.
+pub fn from_path_under(path: &Path, base: &Path) -> Result<Self, ValidationError> {
+    let rel = path
+        .strip_prefix(base)
+        .map_err(|_| ValidationError::InvalidRelativePath {
+            path: path.display().to_string(),
+            reason: format!(
+                "path is not under base directory `{}`",
+                base.display()
+            ),
+        })?;
+    let rel_str = rel
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+    Self::new(rel_str)
+}
+```
+
+You may need to add `use std::path::Path;` if not already imported.
+
+If the actual `ValidationError` variants differ from `InvalidRelativePath { path, reason }`, adapt the error construction to match the real shape. The intent is "return whatever ValidationError variant best fits 'path is not under base'."
+
+- [ ] **Step 1.5: Run the test to verify it passes**
+
+```bash
+cargo test -p kiro-market-core --lib validation::tests::from_path_under
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 1.6: Refactor `relative_source_path_for_tracking` to delegate**
+
+Replace the body of `relative_source_path_for_tracking` in `crates/kiro-market-core/src/service/mod.rs` (lines ~2830-2868) with:
+
+```rust
+fn relative_source_path_for_tracking(
+    path: &Path,
+    plugin_dir: &Path,
+) -> Option<crate::validation::RelativePath> {
+    match crate::validation::RelativePath::from_path_under(path, plugin_dir) {
+        Ok(rp) => Some(rp),
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                plugin_dir = %plugin_dir.display(),
+                error = %e,
+                "agent path could not be expressed as RelativePath; \
+                 source_path will fall back to dialect default during \
+                 update detection"
+            );
+            None
+        }
+    }
+}
+```
+
+The `warn!` log preserves the existing observability; only the conversion mechanism changes. The two original log sites (strip-prefix failure and RelativePath::new failure) collapse into one because `from_path_under` returns either error through the same variant.
+
+- [ ] **Step 1.7: Run the workspace tests to verify no regression**
+
+```bash
+cargo test --workspace
+```
+
+Expected: same baseline test count as Step 0.2, all passing. The refactor is behavior-preserving (Option-returning, warn-on-failure).
+
+- [ ] **Step 1.8: Run clippy + fmt + plan-lint**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all clean, all 6 plan-lint gates OK.
+
+- [ ] **Step 1.9: Commit**
+
+```bash
+git add crates/kiro-market-core/src/validation.rs \
+        crates/kiro-market-core/src/service/mod.rs && \
+  git commit -m "$(cat <<'EOF'
+refactor(validation): extract RelativePath::from_path_under helper
+
+No behavior change. Generalises the path-to-RelativePath conversion
+recipe currently embedded in service::mod::relative_source_path_for_tracking
+into an associated function on RelativePath, so the four install sites
+in subsequent commits can reuse it instead of duplicating the
+forward-slash normalisation. relative_source_path_for_tracking becomes
+a one-line wrapper that preserves the existing warn-and-None contract
+its caller depends on.
+
+Added tests:
+- backslash normalisation (synthesises a Windows-native PathBuf on
+  any platform; pins the cross-platform contract)
+- path-outside-base rejection
+- simple Unix path round-trip
+
+Foundation for fix/install-detect-symmetry.
+EOF
+)"
+```
+
+---
+
+## Task 2: Tighten `InstalledAgentMeta.source_path` to required
+
+**Why.** Closes the "no users → no probe-fallback" design choice for agents. Removes the dialect-fallback branch from `agent_hash_inputs`, the I-N7 actionable-error branch from `scan_plugin_for_content_drift`, and the `Option` wrapper everywhere. Install-time, `relative_source_path_for_tracking` failures become typed errors instead of warn-and-skip.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs:62-108` (`InstalledAgentMeta`) — drop `Option` from `source_path`
+- Modify: `crates/kiro-market-core/src/service/mod.rs:1716-1725` — install site, propagate `from_path_under` error as `AgentError::InstallFailed`
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2830-2868` — delete `relative_source_path_for_tracking` (now unused; replaced by direct `RelativePath::from_path_under` calls in install sites)
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2792-2814` (`agent_hash_inputs`) — drop `Option` from signature, delete dialect-fallback
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2567-2641` (agents loop in `scan_plugin_for_content_drift`) — drop `.as_ref()`, delete I-N7 branch
+- Update test fixtures across `service::tests` and `project::tests` (compiler-driven)
+
+- [ ] **Step 2.1: Write the failing install-fails-on-bad-source-path test**
+
+Add to `crates/kiro-market-core/src/service/mod.rs` test module (near other install-error tests):
+
+```rust
+#[test]
+fn install_translated_agent_fails_when_source_path_outside_plugin_dir() {
+    // The discovery layer shouldn't yield such paths in practice, but
+    // when it does (defensive against future invariant breaks), the
+    // install MUST surface a typed error rather than silently skipping
+    // — required-field schema means "no source_path = can't install".
+    use crate::service::test_support::{mp, pn};
+    use std::path::PathBuf;
+
+    let plugin_dir = PathBuf::from("/tmp/install-symmetry-test/plugin");
+    // `path_outside_plugin_dir` is exactly that — a sibling, not a child.
+    let outside = PathBuf::from("/tmp/install-symmetry-test/sibling/agent.md");
+
+    // Direct test of the construction fallback path: ensure
+    // RelativePath::from_path_under errors so the install site has a
+    // condition to check.
+    assert!(
+        crate::validation::RelativePath::from_path_under(&outside, &plugin_dir).is_err(),
+        "precondition: from_path_under must reject paths outside base"
+    );
+
+    // Wire through the install pipeline would require a full
+    // marketplace fixture; this test pins the from_path_under
+    // contract that the install site at service/mod.rs:1716 will
+    // call. Actual install-pipeline coverage comes from existing
+    // install_plugin_agents tests + the compiler-driven update of
+    // every InstalledAgentMeta construction site.
+    let _ = (mp("mp"), pn("p")); // anchor unused-import lint
+}
+```
+
+- [ ] **Step 2.2: Run the test to verify it currently passes (precondition test only — Task 1 already added `from_path_under`)**
+
+```bash
+cargo test -p kiro-market-core --lib install_translated_agent_fails_when_source_path_outside_plugin_dir
+```
+
+Expected: PASS. (This is a contract-pin, not a regression-from-broken-state. The real behavior change happens at the install site below, where the compiler will force the issue once we tighten the type.)
+
+- [ ] **Step 2.3: Tighten `InstalledAgentMeta.source_path` to required**
+
+In `crates/kiro-market-core/src/project.rs`, find the `InstalledAgentMeta` struct (line ~62) and change:
+
+```rust
+// BEFORE
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub source_path: Option<RelativePath>,
+
+// AFTER
+pub source_path: RelativePath,
+```
+
+Also update the doc comment to remove the "`None` for legacy entries installed before this field was added" sentence (no legacy entries — the no-users assumption from the spec). Replace with: "Required at install time; populated via [`RelativePath::from_path_under`] at install. Drift detection at [`crate::service::MarketplaceService::scan_plugin_for_content_drift`] uses this directly to locate the source for hash recomputation."
+
+- [ ] **Step 2.4: Build to surface every InstalledAgentMeta construction site**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | head -60
+```
+
+Expected: compile errors at every site that constructs `InstalledAgentMeta` without the now-required field. From the inventory in the spec, these are at minimum:
+- `crates/kiro-market-core/src/service/mod.rs:1716` (the production install site)
+- `crates/kiro-market-core/src/project.rs:2605` (another install path)
+- `crates/kiro-market-core/src/project.rs:3490, 3513, 3842, 4659` (test fixtures)
+- `crates/kiro-market-core/src/service/mod.rs:6797, 6984, 7074` (test fixtures)
+
+Walk every error and fix per the rules below.
+
+- [ ] **Step 2.5: Update the production install site (service/mod.rs:1716)**
+
+Replace the meta construction:
+
+```rust
+// BEFORE
+let meta = crate::project::InstalledAgentMeta {
+    marketplace: ctx.marketplace.clone(),
+    plugin: ctx.plugin.clone(),
+    version: ctx.version.map(String::from),
+    installed_at: chrono::Utc::now(),
+    dialect: def.dialect,
+    source_path: relative_source_path_for_tracking(&path, plugin_dir),
+    source_hash: None,
+    installed_hash: None,
+};
+
+// AFTER
+let source_path = match crate::validation::RelativePath::from_path_under(&path, plugin_dir) {
+    Ok(rp) => rp,
+    Err(e) => {
+        // Discovery should always yield paths under plugin_dir; if this
+        // ever fails it's a defensive catch for a future invariant
+        // break. Surface as a typed install failure rather than a
+        // silent skip — the required-field schema means we cannot
+        // safely install without a recorded source_path.
+        result.failed.push(FailedAgent {
+            name: Some(def.name.clone()),
+            source_path: path.clone(),
+            error: crate::error::AgentError::InstallFailed {
+                path: path.clone(),
+                source: Box::new(crate::error::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "discovered agent path `{}` is not expressible as a \
+                         RelativePath under plugin_dir `{}`: {e}",
+                        path.display(),
+                        plugin_dir.display(),
+                    ),
+                ))),
+            },
+        });
+        continue;
+    }
+};
+let meta = crate::project::InstalledAgentMeta {
+    marketplace: ctx.marketplace.clone(),
+    plugin: ctx.plugin.clone(),
+    version: ctx.version.map(String::from),
+    installed_at: chrono::Utc::now(),
+    dialect: def.dialect,
+    source_path,
+    source_hash: None,
+    installed_hash: None,
+};
+```
+
+The `continue` skips this agent — the rest of the for-loop processes other agents in the same install batch. Mirrors the existing per-agent error handling shape elsewhere in this function.
+
+- [ ] **Step 2.6: Update the project.rs install site (project.rs:2605)**
+
+Find the construction at line ~2605 and add a `source_path: <appropriate RelativePath value>` field. The value depends on which install path this is — read 50 lines of surrounding context to understand. If it's the same install path that already had the relative_source_path_for_tracking call somewhere upstream, propagate that source_path through. If it constructed `source_path: None`, replace with `source_path: <derived from path arg>` matching the install function's signature.
+
+If the function's signature doesn't currently carry the source path information, this is a sign the call site needs the same kind of fix as Step 2.5 — propagate the call up to where the path is in scope.
+
+- [ ] **Step 2.7: Update test fixtures**
+
+For every `InstalledAgentMeta { ... }` construction site in tests (compiler will list them), add `source_path: <path>` where `<path>` is a sensible default for the test:
+
+```rust
+// Example: in tests where the agent name is "reviewer" and dialect is Native
+source_path: crate::validation::RelativePath::new("agents/reviewer.json").expect("valid relative path"),
+```
+
+For Copilot / Claude dialects, mirror the per-dialect filename convention:
+- Native → `agents/<name>.json`
+- Claude → `agents/<name>.md`
+- Copilot → `agents/<name>.agent.md`
+
+Tests that previously asserted on `meta.source_path.is_none()` need updating — the field is no longer Option, so the assertion is dead. Either delete that assertion or replace with a positive check on the new value.
+
+- [ ] **Step 2.8: Tighten `agent_hash_inputs` signature**
+
+In `crates/kiro-market-core/src/service/mod.rs:2792`, replace the function with:
+
+```rust
+/// Compute the `(base_dir, filename)` pair that recreates the
+/// install-side hash recipe for a tracked agent. Used by
+/// [`MarketplaceService::scan_plugin_for_content_drift`] so detection
+/// hashes match the bytes the install side fed into BLAKE3 — the
+/// install hashes via `hash_artifact(parent, &[filename])` so detection
+/// MUST also pass `(parent, filename)` rather than `(agents_dir,
+/// "subdir/file.md")`, since the digest includes the rel-path bytes.
+///
+/// `source_path` is relative to `plugin_dir` (always present after the
+/// install-detect symmetry pass — agents tracking schema requires it).
+/// We split it back into `(plugin_dir + rel.parent(), rel.file_name())`
+/// to match the install recipe.
+fn agent_hash_inputs(
+    plugin_dir: &Path,
+    source_path: &crate::validation::RelativePath,
+) -> (PathBuf, PathBuf) {
+    let full = plugin_dir.join(source_path.as_str());
+    let parent = full
+        .parent()
+        .map_or_else(|| plugin_dir.to_path_buf(), Path::to_path_buf);
+    let fname = full
+        .file_name()
+        .map_or_else(|| PathBuf::from(source_path.as_str()), PathBuf::from);
+    (parent, fname)
+}
+```
+
+The dialect parameter and dialect-fallback branch are gone. The function signature shrinks from 4 params to 2.
+
+- [ ] **Step 2.9: Update the agents loop in `scan_plugin_for_content_drift`**
+
+In `crates/kiro-market-core/src/service/mod.rs` around line 2567-2641, replace the agents loop body. The current code (paraphrased):
+
+```rust
+let (base, filename) = agent_hash_inputs(plugin_dir, name, meta.dialect, meta.source_path.as_ref());
+let computed = match crate::hash::hash_artifact(&base, std::slice::from_ref(&filename)) {
+    Ok(h) => h,
+    Err(crate::hash::HashError::ReadFailed { path, source })
+        if source.kind() == std::io::ErrorKind::NotFound && meta.source_path.is_none() =>
+    {
+        // I-N7 actionable-error branch — 30 lines
+        return Err(...);
+    }
+    Err(e) => return Err(e.into()),
+};
+```
+
+Becomes:
+
+```rust
+let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
+let computed = crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
+```
+
+The I-N7 branch is dead (it only fired when `source_path.is_none()`). The dialect parameter is gone. The match-on-NotFound recovery is gone — any hash error propagates via `?` as a normal per-plugin failure.
+
+- [ ] **Step 2.10: Delete `relative_source_path_for_tracking`**
+
+The wrapper introduced in Task 1 has no remaining callers — Step 2.5 inlined `RelativePath::from_path_under` at the only production site, and there are no tests calling it directly. Verify no callers remain:
+
+```bash
+grep -rn "relative_source_path_for_tracking" crates/
+```
+
+Expected: only the function definition itself appears (the test from Task 1 that referenced it indirectly via the `from_path_under` precondition no longer needs it). Delete the entire function (`crates/kiro-market-core/src/service/mod.rs:2830-2868`).
+
+- [ ] **Step 2.11: Delete the Copilot legacy-fallback test**
+
+In `crates/kiro-market-core/src/service/mod.rs`, find the `detect_plugin_updates_copilot_agent_legacy_fallback` test (around line 6807) — its docstring describes itself as a deferred test for the dialect-fallback branch. Delete the entire test function (including its multi-paragraph docstring). The branch it tests is gone.
+
+- [ ] **Step 2.12: Verify tests pass**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -10
+```
+
+Expected: All passes, count drops by 1 (deleted Copilot legacy test). Compiler-driven test updates in Step 2.7 cover any test fixtures that needed the new `source_path` field.
+
+- [ ] **Step 2.13: Run clippy + fmt + plan-lint**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: clean.
+
+- [ ] **Step 2.14: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+refactor(agents): tighten source_path to required, drop dialect-fallback
+
+InstalledAgentMeta.source_path goes from Option<RelativePath> to
+required RelativePath. Install site at service/mod.rs uses
+RelativePath::from_path_under directly; failures (path not under
+plugin_dir, RelativePath::new rejection) become typed
+AgentError::InstallFailed instead of silent warn-and-None — required
+field schema means we cannot safely install without a recorded
+source_path.
+
+Detection-side cleanups:
+- agent_hash_inputs sheds the dialect parameter and the dialect-
+  fallback branch — only path-splitting remains.
+- The I-N7 actionable-error branch in scan_plugin_for_content_drift's
+  agents loop (which only fired when source_path.is_none()) is dead
+  code; deleted.
+- relative_source_path_for_tracking is no longer called anywhere;
+  deleted.
+- detect_plugin_updates_copilot_agent_legacy_fallback test is deleted —
+  the dialect-fallback path it exercised no longer exists.
+
+source_hash on InstalledAgentMeta stays Option<String> for now;
+tightened in commit 5 alongside the cross-cutting legacy_fallback
+flag removal.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md
+section "Schema changes" + "Detection simplification".
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `InstalledSkillMeta.source_scan_root` (closes #97)
+
+**Why.** Closes issue #97 directly. The skills-side scan-path bug becomes a non-issue once detection looks up the install-recorded scan root instead of hardcoding `plugin_dir.join("skills")`.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs:25-51` (`InstalledSkillMeta`) — add `source_scan_root: RelativePath`
+- Modify: `crates/kiro-market-core/src/plugin.rs:399-456` (`discover_skill_dirs`) — refactor to return `Vec<DiscoveredSkill>`
+- Modify: `crates/kiro-market-core/src/service/browse.rs:931-942` (`discover_skills_for_plugin`) — call new shape
+- Modify: `crates/kiro-market-core/src/service/mod.rs:1316-1323` — install site populates new field
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2510-2543` — skills loop in `scan_plugin_for_content_drift` does direct lookup; remove the "KNOWN BUG (issue #97)" comment
+- Add test: `detect_plugin_updates_skills_with_custom_scan_path_no_false_drift`
+- Update test fixtures across `project::tests` and `service::tests` (compiler-driven)
+
+- [ ] **Step 3.1: Write the failing regression test (closes #97)**
+
+Add to `crates/kiro-market-core/src/service/mod.rs` test module, next to the sibling `detect_plugin_updates_steering_with_custom_scan_path_no_false_drift`:
+
+```rust
+/// Closes #97: a plugin declaring `skills: ["./packs/"]` installs skill
+/// dirs under `<plugin_dir>/packs/<name>/`. Pre-fix detection hardcoded
+/// `<plugin_dir>/skills/<name>/` and would surface every such plugin as
+/// a HashFailed failure on every scan. Post-fix, detection consults
+/// `meta.source_scan_root` (recorded at install time) and looks at the
+/// right path.
+#[test]
+fn detect_plugin_updates_skills_with_custom_scan_path_no_false_drift() {
+    use crate::project::KiroProject;
+    use crate::service::test_support::{
+        relative_path_entry, seed_marketplace_with_registry, temp_service,
+    };
+    use std::fs;
+
+    let (dir, svc) = temp_service();
+    let entries = vec![relative_path_entry("p", "plugins/p")];
+    let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
+    let plugin_dir = mp_path.join("plugins/p");
+
+    // Skill source under a NON-default scan path. Pre-fix detection
+    // would look at <plugin_dir>/skills/alpha and hit NotFound.
+    let packs_dir = plugin_dir.join("packs");
+    let alpha_dir = packs_dir.join("alpha");
+    fs::create_dir_all(&alpha_dir).expect("create skill dir");
+    fs::write(
+        alpha_dir.join("SKILL.md"),
+        "---\nname: alpha\ndescription: test\n---\n",
+    )
+    .expect("write SKILL.md");
+
+    // Manifest declares the custom scan path.
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        br#"{"name":"p","version":"1.0","skills":["./packs/"]}"#,
+    )
+    .expect("write plugin.json");
+
+    let project_tmp = tempfile::tempdir().expect("project tempdir");
+    let project = KiroProject::new(project_tmp.path().to_path_buf());
+
+    svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
+        .expect("install");
+
+    // Sanity: install actually placed the skill so the tracking entry
+    // exists for detection to compare against.
+    assert!(
+        project_tmp.path().join(".kiro/skills/alpha/SKILL.md").exists(),
+        "precondition: skill must be installed"
+    );
+
+    let result = svc.detect_plugin_updates(&project).expect("detect");
+    assert!(
+        result.updates.is_empty(),
+        "expected no updates for an unchanged skill source under a custom \
+         scan path; got: {:?}",
+        result.updates
+    );
+    assert!(
+        result.failures.is_empty(),
+        "expected no failures (pre-fix would return a HashFailed because \
+         detection looked under hardcoded `./skills/`); got: {:?}",
+        result.failures
+    );
+}
+```
+
+- [ ] **Step 3.2: Run the test to verify it fails (compile or runtime)**
+
+```bash
+cargo test -p kiro-market-core --lib detect_plugin_updates_skills_with_custom_scan_path_no_false_drift
+```
+
+Expected: either compile error (if InstalledSkillMeta hasn't been updated yet) or runtime FAIL with "expected no failures" because detection still uses the hardcoded path.
+
+If it compiles and fails at runtime, this confirms the bug exists. If you need to make it compile AND fail (rather than compile-error), proceed to Step 3.3 first to add the field, then come back.
+
+- [ ] **Step 3.3: Add `source_scan_root` to `InstalledSkillMeta`**
+
+In `crates/kiro-market-core/src/project.rs`, modify the `InstalledSkillMeta` struct (line ~25):
+
+```rust
+pub struct InstalledSkillMeta {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    pub source_hash: Option<String>,    // unchanged for now; tightened in Task 6
+    pub installed_hash: Option<String>, // unchanged for now; tightened in Task 6
+    /// Scan root (relative to `plugin_dir`) that this skill was
+    /// installed from. Required at install time; populated from the
+    /// `DiscoveredSkill.scan_root` field which `discover_skill_dirs`
+    /// returns alongside each found skill directory. Drift detection
+    /// at [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
+    /// uses this to locate the source skill dir for hash recomputation,
+    /// closing #97 (the hardcoded `plugin_dir.join("skills")` bug).
+    pub source_scan_root: RelativePath,
+}
+```
+
+- [ ] **Step 3.4: Refactor `discover_skill_dirs` to return `DiscoveredSkill`**
+
+In `crates/kiro-market-core/src/plugin.rs`, add a new type and refactor the function (line ~399):
+
+```rust
+/// One skill directory discovered under a plugin's manifest-declared
+/// skill scan paths. Carries both the scan root and the resolved
+/// skill directory so install can record the scan root for later
+/// drift detection.
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    /// Absolute path to the scan root that contains `skill_dir`,
+    /// e.g. `<plugin_dir>/skills/` or `<plugin_dir>/packs/`.
+    /// Recorded on `InstalledSkillMeta.source_scan_root` (after
+    /// `strip_prefix(plugin_dir)`) so detection knows where to look.
+    pub scan_root: PathBuf,
+    /// Absolute path to the skill directory itself,
+    /// e.g. `<plugin_dir>/skills/alpha/`. Contains a `SKILL.md`.
+    pub skill_dir: PathBuf,
+}
+
+/// Discover skill directories under one or more scan paths. ...
+/// (preserve the existing doc comment, adjust the return type sentence)
+#[must_use]
+pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<DiscoveredSkill> {
+    let mut found = Vec::new();
+
+    for &path_str in skill_paths {
+        if let Err(e) = crate::validation::validate_relative_path(path_str) {
+            warn!(
+                path = path_str,
+                error = %e,
+                "skipping skill path that fails validation"
+            );
+            continue;
+        }
+
+        let candidate = plugin_root.join(path_str);
+
+        if path_str.ends_with('/') || path_str.ends_with('\\') {
+            // Scan subdirectories for those containing SKILL.md.
+            // The candidate path IS the scan root for this branch.
+            match fs::read_dir(&candidate) {
+                Ok(entries) => {
+                    for entry in entries {
+                        let entry = match entry {
+                            Ok(e) => e,
+                            Err(e) => {
+                                warn!(
+                                    path = %candidate.display(),
+                                    error = %e,
+                                    "failed to read directory entry, skipping"
+                                );
+                                continue;
+                            }
+                        };
+                        let entry_path = entry.path();
+                        if entry_path.is_dir() && entry_path.join(SKILL_MD).exists() {
+                            found.push(DiscoveredSkill {
+                                scan_root: candidate.clone(),
+                                skill_dir: entry_path,
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(
+                        path = %candidate.display(),
+                        error = %e,
+                        "failed to read skill scan directory"
+                    );
+                }
+            }
+        } else if candidate.is_dir() && candidate.join(SKILL_MD).exists() {
+            // Bare-path branch: the scan root is the candidate's
+            // parent (or plugin_root if no parent under it). The
+            // skill dir IS the candidate.
+            let scan_root = candidate
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| plugin_root.to_path_buf());
+            found.push(DiscoveredSkill {
+                scan_root,
+                skill_dir: candidate,
+            });
+        } else {
+            debug!(
+                path = %candidate.display(),
+                "skill path does not contain SKILL.md, skipping"
+            );
+        }
+    }
+
+    found.sort_by(|a, b| a.skill_dir.cmp(&b.skill_dir));
+    found
+}
+```
+
+The `Vec<PathBuf>` → `Vec<DiscoveredSkill>` change is the structural one. The `scan_root` derivation has two branches matching the existing two discovery branches.
+
+- [ ] **Step 3.5: Update `discover_skill_dirs`'s test module**
+
+In `crates/kiro-market-core/src/plugin.rs` test module, find tests that call `discover_skill_dirs` and assert on the returned `Vec<PathBuf>`. Update them to extract `.skill_dir` for the existing assertions, OR add new assertions on `.scan_root`. The compiler will list every site.
+
+Pattern:
+```rust
+// BEFORE
+let dirs = discover_skill_dirs(&plugin_root, &skill_paths);
+assert_eq!(dirs[0], plugin_root.join("skills/foo"));
+
+// AFTER
+let found = discover_skill_dirs(&plugin_root, &skill_paths);
+assert_eq!(found[0].skill_dir, plugin_root.join("skills/foo"));
+assert_eq!(found[0].scan_root, plugin_root.join("skills"));
+```
+
+- [ ] **Step 3.6: Update `discover_skills_for_plugin` (browse.rs:931)**
+
+In `crates/kiro-market-core/src/service/browse.rs`, find `discover_skills_for_plugin` (line ~931). Two options:
+- (a) Change its return type to `Vec<DiscoveredSkill>` (forces all callers to deal with the new shape)
+- (b) Keep its return type as `Vec<PathBuf>` for back-compat, extracting `.skill_dir` from `DiscoveredSkill` records
+
+Pick (a) — only one caller (the install path at service/mod.rs); adapting the caller is mechanical and preserves the `scan_root` information into the install site.
+
+```rust
+fn discover_skills_for_plugin(
+    plugin_dir: &Path,
+    manifest: Option<&PluginManifest>,
+) -> Vec<crate::plugin::DiscoveredSkill> {
+    let skill_paths: Vec<&str> = if let Some(m) = manifest.filter(|m| !m.skills.is_empty()) {
+        m.skills.iter().map(String::as_str).collect()
+    } else {
+        crate::DEFAULT_SKILL_PATHS.to_vec()
+    };
+
+    crate::plugin::discover_skill_dirs(plugin_dir, &skill_paths)
+}
+```
+
+- [ ] **Step 3.7: Update the install-skills caller (service/mod.rs around 1280-1330)**
+
+The caller iterates the returned `Vec<DiscoveredSkill>` and constructs `InstalledSkillMeta`. Two changes:
+
+(a) The loop variable previously named `skill_dir: &PathBuf` becomes `discovered: &DiscoveredSkill`. Update field accesses (`skill_dir` → `discovered.skill_dir`, plus access to `discovered.scan_root` for the new field).
+
+(b) When constructing the meta, populate `source_scan_root` via `RelativePath::from_path_under(&discovered.scan_root, plugin_dir)`. Same error-handling shape as Task 2 (continue with FailedSkill on error):
+
+```rust
+let source_scan_root = match crate::validation::RelativePath::from_path_under(
+    &discovered.scan_root,
+    plugin_dir,
+) {
+    Ok(rp) => rp,
+    Err(e) => {
+        warn!(
+            scan_root = %discovered.scan_root.display(),
+            plugin_dir = %plugin_dir.display(),
+            error = %e,
+            "discovered skill scan_root not under plugin_dir; skipping",
+        );
+        result.failed.push(FailedSkill::install_failed(
+            frontmatter.name.clone(),
+            &Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("scan_root not under plugin_dir: {e}"),
+            )),
+        ));
+        continue;
+    }
+};
+
+let meta = crate::project::InstalledSkillMeta {
+    marketplace: marketplace.clone(),
+    plugin: plugin.clone(),
+    version: version.map(str::to_owned),
+    installed_at: chrono::Utc::now(),
+    source_hash: None,           // tightened in Task 6
+    installed_hash: None,        // tightened in Task 6
+    source_scan_root,
+};
+```
+
+The `discovered.skill_dir` is what gets passed to `project.install_skill_from_dir` (already by reference, no change there).
+
+- [ ] **Step 3.8: Update the skills loop in `scan_plugin_for_content_drift`**
+
+In `crates/kiro-market-core/src/service/mod.rs` (around line 2510-2543), replace the skills loop. The current code (with the long "KNOWN BUG (issue #97)" comment block) becomes:
+
+```rust
+// Skills — direct lookup against the install-recorded scan root.
+// Closes #97; install populates `source_scan_root` so detection
+// hashes against the same directory the install copied from.
+for (name, meta) in &installed_skills.skills {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        match &meta.source_hash {
+            Some(stored) => {
+                let skill_dir = plugin_dir
+                    .join(meta.source_scan_root.as_str())
+                    .join(name);
+                let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+                if computed != *stored {
+                    content_drift = true;
+                    return Ok((content_drift, legacy_fallback));
+                }
+            }
+            None => legacy_fallback = true,
+        }
+    }
+}
+```
+
+Delete the entire "KNOWN BUG (issue #97)" comment block (~18 lines). The `source_hash: Option` handling stays for now (tightened in Task 6).
+
+- [ ] **Step 3.9: Update `InstalledSkillMeta` construction sites (compiler-driven)**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | grep "missing field" | head
+```
+
+Walk every error and add `source_scan_root` field. Default value for tests:
+```rust
+source_scan_root: crate::validation::RelativePath::new("skills").expect("valid"),
+```
+
+For tests that exercise non-default scan paths, use the appropriate scan root string.
+
+Also: any test that calls `install_plugin_skills`, `install_plugin`, or downstream entry points and then asserts on tracking-file shape will pick up the new field automatically (the install populates it). Round-trip tests should still pass — only the JSON shape grows by one field.
+
+- [ ] **Step 3.10: Run the regression test**
+
+```bash
+cargo test -p kiro-market-core --lib detect_plugin_updates_skills_with_custom_scan_path_no_false_drift
+```
+
+Expected: PASS. The test from Step 3.1 should now go green because install records `source_scan_root: "packs"` and detection looks under `<plugin_dir>/packs/alpha/` instead of the hardcoded `<plugin_dir>/skills/alpha/`.
+
+- [ ] **Step 3.11: Run the workspace tests**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -10
+```
+
+Expected: all pass, count up by 1 (new regression test). Compiler-driven fixture updates kept everything else green.
+
+- [ ] **Step 3.12: Run clippy + fmt + plan-lint**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: clean.
+
+- [ ] **Step 3.13: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+feat(skills): add InstalledSkillMeta.source_scan_root + use at detect time
+
+Closes #97. The skills detection loop in scan_plugin_for_content_drift
+now reads meta.source_scan_root instead of hardcoding plugin_dir.join("skills"),
+so a plugin declaring skills: ["./packs/"] is detected at the right path.
+
+Schema:
+- New required field InstalledSkillMeta.source_scan_root: RelativePath.
+- discover_skill_dirs returns Vec<DiscoveredSkill { scan_root, skill_dir }>
+  instead of Vec<PathBuf> so install has the scan root in scope when
+  building the meta. Single existing caller (discover_skills_for_plugin)
+  updated.
+
+Install:
+- Populates source_scan_root via RelativePath::from_path_under (the
+  helper from Task 1) at the only production install site
+  (service/mod.rs:1316). Failures route to result.failed.
+
+Detection:
+- Skills loop becomes a 4-line direct lookup. The "KNOWN BUG (issue
+  #97)" comment block deleted (the bug it documented is now closed).
+
+Test:
+- New regression test detect_plugin_updates_skills_with_custom_scan_path_no_false_drift
+  installs a plugin under ./packs/, runs detect, asserts no failures
+  and no updates. Direct sibling of the steering and native_companions
+  regression tests added in PR #96 review-of-review.
+
+source_hash: Option<String> on InstalledSkillMeta unchanged for now;
+tightened in Task 6 alongside the cross-cutting legacy_fallback flag
+removal.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `InstalledSteeringMeta.source_scan_root`
+
+**Why.** Symmetric with skills; converts the steering loop from probe-fallback to direct lookup. Pre-existing regression test from PR #96 review-of-review (`detect_plugin_updates_steering_with_custom_scan_path_no_false_drift`) keeps passing — the install path now populates the new field automatically.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs:155-186` (`InstalledSteeringMeta` + surrounding) — add field
+- Modify: `crates/kiro-market-core/src/project.rs:1959-1969` — install site populates new field
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2553-2565` — steering loop uses direct lookup
+- Update fixtures (compiler-driven)
+
+- [ ] **Step 4.1: Add the field to `InstalledSteeringMeta`**
+
+In `crates/kiro-market-core/src/project.rs:165`:
+
+```rust
+pub struct InstalledSteeringMeta {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    pub source_hash: String,
+    pub installed_hash: String,
+    /// Scan root (relative to `plugin_dir`) that this steering file was
+    /// installed from. Required at install time; populated from
+    /// `DiscoveredNativeFile.scan_root` (which steering shares with the
+    /// agent discover sites) via `RelativePath::from_path_under`. Drift
+    /// detection at [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
+    /// uses this directly to locate the source file for hash recomputation,
+    /// replacing PR #96's `hash_artifact_in_scan_paths` probe helper.
+    pub source_scan_root: RelativePath,
+}
+```
+
+- [ ] **Step 4.2: Update the install site (project.rs:1959)**
+
+Find the `InstalledSteeringMeta { ... }` construction at line ~1959. The surrounding install function has access to `source: &DiscoveredSteeringFile` (or similar — verify the exact name) which carries `scan_root: PathBuf`. Add the new field:
+
+```rust
+let source_scan_root = match crate::validation::RelativePath::from_path_under(
+    &source.scan_root,
+    plugin_dir, // verify this var name in scope; may need to be passed as arg
+) {
+    Ok(rp) => rp,
+    Err(e) => {
+        warn!(
+            scan_root = %source.scan_root.display(),
+            error = %e,
+            "steering scan_root not under plugin_dir; skipping",
+        );
+        return Err(crate::steering::SteeringError::SourceReadFailed {
+            path: source.scan_root.clone(),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{e}")),
+        }
+        .into());
+    }
+};
+
+installed.files.insert(
+    rel_path.to_path_buf(),
+    InstalledSteeringMeta {
+        marketplace: ctx.marketplace.clone(),
+        plugin: ctx.plugin.clone(),
+        version: ctx.version.map(str::to_owned),
+        installed_at: chrono::Utc::now(),
+        source_hash: source_hash.to_owned(),
+        installed_hash: installed_hash.clone(),
+        source_scan_root,
+    },
+);
+```
+
+If `plugin_dir` isn't currently in scope at this call site, walk back to the caller that knows it and thread it through. The `DiscoveredNativeFile` fields are: `scan_root: PathBuf`, `source: PathBuf` — `source.strip_prefix(scan_root)` yields the `rel_path` already used in tracking.
+
+- [ ] **Step 4.3: Update the steering loop in `scan_plugin_for_content_drift`**
+
+Replace the steering loop body in `crates/kiro-market-core/src/service/mod.rs` (around line 2553). The current code:
+
+```rust
+let steering_paths = crate::service::browse::steering_scan_paths_for_plugin(manifest);
+for (rel_path, meta) in &installed_steering.files {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let computed = hash_artifact_in_scan_paths(
+            plugin_dir,
+            &steering_paths,
+            std::slice::from_ref(rel_path),
+        )?;
+        ...
+    }
+}
+```
+
+Becomes:
+
+```rust
+for (rel_path, meta) in &installed_steering.files {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+        let computed = crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
+        if computed != meta.source_hash {
+            content_drift = true;
+            return Ok((content_drift, legacy_fallback));
+        }
+    }
+}
+```
+
+The `steering_paths` derivation outside the loop and the `hash_artifact_in_scan_paths` call disappear. Direct lookup replaces probe.
+
+- [ ] **Step 4.4: Update fixtures (compiler-driven)**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | grep "missing field" | head
+```
+
+Walk every site. Default for tests: `source_scan_root: crate::validation::RelativePath::new("steering").expect("valid")`.
+
+The existing `detect_plugin_updates_steering_with_custom_scan_path_no_false_drift` regression test should keep passing without modification — it uses `svc.install_plugin`, which now populates the field automatically. Verify by running it:
+
+```bash
+cargo test -p kiro-market-core --lib detect_plugin_updates_steering_with_custom_scan_path_no_false_drift
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.5: Run workspace tests + clippy + fmt + plan-lint**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -5 && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all green.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+feat(steering): add InstalledSteeringMeta.source_scan_root + use at detect time
+
+Symmetric with the skills change in Task 3. The steering detection loop
+in scan_plugin_for_content_drift switches from PR #96's
+hash_artifact_in_scan_paths probe to a direct lookup against the
+install-recorded scan root.
+
+Schema: new required field InstalledSteeringMeta.source_scan_root: RelativePath.
+
+Install: populates the field via RelativePath::from_path_under, sourcing
+scan_root from the DiscoveredSteeringFile (already in scope at the
+install site).
+
+Detection: steering loop becomes a 5-line direct lookup. The probe
+helper hash_artifact_in_scan_paths still exists but is now used only by
+the native-companions loop; both removed in Task 6 once that loop is
+also migrated.
+
+The existing regression test detect_plugin_updates_steering_with_custom_scan_path_no_false_drift
+keeps passing without modification — install now populates the new
+field automatically through the real install pipeline.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `InstalledNativeCompanionsMeta.source_scan_root`
+
+**Why.** Symmetric with skills + steering. Closes the last loop that depended on `hash_artifact_in_scan_paths`, so Task 6 can delete the helper entirely.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs:124-141` (`InstalledNativeCompanionsMeta`) — add field
+- Modify: `crates/kiro-market-core/src/project.rs:2409, 2892` — install sites populate new field
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2643-2659` — native_companions loop uses direct lookup
+- Update fixtures (compiler-driven)
+
+- [ ] **Step 5.1: Add the field to `InstalledNativeCompanionsMeta`**
+
+In `crates/kiro-market-core/src/project.rs:124`:
+
+```rust
+pub struct InstalledNativeCompanionsMeta {
+    pub marketplace: MarketplaceName,
+    pub plugin: PluginName,
+    pub version: Option<String>,
+    pub installed_at: DateTime<Utc>,
+    pub files: Vec<PathBuf>,
+    pub source_hash: String,
+    pub installed_hash: String,
+    /// Scan root (relative to `plugin_dir`) that this companion bundle
+    /// was installed from. Required at install time. Single-scan-root
+    /// invariant is enforced upstream by `multiple_companion_scan_roots`,
+    /// so all `files` resolve under this single root. Drift detection
+    /// uses this directly, replacing PR #96's
+    /// `hash_artifact_in_scan_paths` probe.
+    pub source_scan_root: RelativePath,
+}
+```
+
+- [ ] **Step 5.2: Update install sites (project.rs:2409 and project.rs:2892)**
+
+The first site (line ~2409, inside `or_insert_with`) and the second (line ~2892) both need the new field. Both have access to `scan_root` (passed via `NativeCompanionsInput.scan_root` per the spec).
+
+For each construction site:
+
+```rust
+InstalledNativeCompanionsMeta {
+    // ... existing fields ...
+    source_scan_root: crate::validation::RelativePath::from_path_under(
+        input.scan_root,
+        plugin_dir,
+    )
+    .map_err(|e| <appropriate AgentError variant>)?,
+}
+```
+
+The exact error variant depends on the surrounding function's `Result` type. If it returns `crate::error::Result<...>`, wrap as `Error::Io` or `Error::Validation` matching the function's existing error-handling pattern. Read the surrounding 30 lines to pick the right shape.
+
+- [ ] **Step 5.3: Update the native_companions loop in `scan_plugin_for_content_drift`**
+
+Replace the loop in `crates/kiro-market-core/src/service/mod.rs` (around line 2643):
+
+```rust
+// Native companions — direct lookup, single-scan-root per
+// MultipleScanRootsNotSupported invariant.
+for meta in installed_agents.native_companions.values() {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+        let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
+        if computed != meta.source_hash {
+            content_drift = true;
+            return Ok((content_drift, legacy_fallback));
+        }
+    }
+}
+```
+
+The `agent_paths` derivation and the `hash_artifact_in_scan_paths` call disappear. Both are dead code at this point (no remaining callers); removed in Task 6.
+
+- [ ] **Step 5.4: Update fixtures (compiler-driven)**
+
+```bash
+cargo build -p kiro-market-core 2>&1 | grep "missing field" | head
+```
+
+Walk every site. Default for tests: `source_scan_root: crate::validation::RelativePath::new("agents").expect("valid")`.
+
+The existing `detect_plugin_updates_native_companions_with_custom_scan_path_no_false_drift` regression test currently constructs `InstalledNativeCompanionsMeta` by hand (not via install). It will need the new field added to the fixture — set to `RelativePath::new("companions").expect("valid")` to match the test's `manifest.agents: ["./companions/"]`. Verify the test then passes with the new field.
+
+- [ ] **Step 5.5: Run workspace tests + clippy + fmt + plan-lint**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -5 && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all green.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+feat(native-companions): add InstalledNativeCompanionsMeta.source_scan_root + use at detect time
+
+Symmetric with the skills + steering changes. Closes the last loop in
+scan_plugin_for_content_drift that depended on PR #96's
+hash_artifact_in_scan_paths probe — Task 6 removes the helper outright
+along with the legacy_fallback flag.
+
+Schema: new required field InstalledNativeCompanionsMeta.source_scan_root.
+
+Install: populates from NativeCompanionsInput.scan_root (already in
+scope; the single-scan-root invariant enforced by
+multiple_companion_scan_roots means all bundle files share one root).
+
+Detection: native_companions loop becomes a 5-line direct lookup.
+
+The existing regression test detect_plugin_updates_native_companions_with_custom_scan_path_no_false_drift
+gets the new field added to its hand-crafted tracking entry; the test
+intent is unchanged.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 6: Delete probe helpers + tighten `source_hash`
+
+**Why.** Now that all four detection loops use direct lookup, `hash_artifact_in_scan_paths` and the `legacy_fallback` flag are dead code. Tightening `source_hash: Option<String>` → `String` on skills + agents symmetrises with steering / native_companions and deletes the last legacy-fallback machinery.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/project.rs:25-51` (`InstalledSkillMeta`) — tighten `source_hash` and `installed_hash`
+- Modify: `crates/kiro-market-core/src/project.rs:62-108` (`InstalledAgentMeta`) — tighten `source_hash` and `installed_hash`
+- Modify: `crates/kiro-market-core/src/service/mod.rs:2500-2662` (`scan_plugin_for_content_drift`) — drop `manifest` parameter, drop `legacy_fallback` from return tuple, simplify all four loops
+- Modify: `crates/kiro-market-core/src/service/mod.rs:~2310` (`check_plugin_for_update`) — adjust the call to `scan_plugin_for_content_drift` for new signature
+- Delete: `crates/kiro-market-core/src/service/mod.rs:2665-2714` (`hash_artifact_in_scan_paths` + its docstring)
+- Modify: `crates/kiro-market-core/src/service/browse.rs:949-973` — revert `agent_scan_paths_for_plugin` and `steering_scan_paths_for_plugin` from `pub(super)` to `fn` (private)
+- Update fixtures (compiler-driven)
+- Delete tests: `detect_plugin_updates_legacy_fallback_source_hash_none`, `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update`, `detect_plugin_updates_agent_legacy_fallback_source_hash_none`
+
+- [ ] **Step 6.1: Tighten `InstalledSkillMeta.source_hash` and `installed_hash`**
+
+In `crates/kiro-market-core/src/project.rs:25`, change:
+
+```rust
+// BEFORE
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub source_hash: Option<String>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub installed_hash: Option<String>,
+
+// AFTER
+pub source_hash: String,
+pub installed_hash: String,
+```
+
+Update doc comments to reflect required-not-optional. Same change for `InstalledAgentMeta` at line ~62.
+
+- [ ] **Step 6.2: Update install sites that constructed `source_hash: None`**
+
+Compiler will list them. Replace `source_hash: None` → `source_hash: <actual_hash>` everywhere. The install paths already compute the hash via `hash_dir_tree` / `hash_artifact` — propagate that value.
+
+For sites where the hash isn't yet computed at the construction point, compute it earlier in the function and pass through. The skills install at service/mod.rs needs to compute `hash_dir_tree(&discovered.skill_dir)?` and pass through.
+
+For test fixtures that used `source_hash: None`, replace with a synthetic hash literal:
+
+```rust
+source_hash: "blake3:0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+installed_hash: "blake3:0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
+```
+
+- [ ] **Step 6.3: Simplify `scan_plugin_for_content_drift` signature**
+
+In `crates/kiro-market-core/src/service/mod.rs:2500`, change the function signature:
+
+```rust
+// BEFORE
+fn scan_plugin_for_content_drift(
+    plugin_info: &crate::project::InstalledPluginInfo,
+    plugin_dir: &Path,
+    manifest: Option<&crate::plugin::PluginManifest>,
+    installed_skills: &crate::project::InstalledSkills,
+    installed_steering: &crate::project::InstalledSteering,
+    installed_agents: &crate::project::InstalledAgents,
+) -> Result<(bool, bool), Error>
+
+// AFTER
+fn scan_plugin_for_content_drift(
+    plugin_info: &crate::project::InstalledPluginInfo,
+    plugin_dir: &Path,
+    installed_skills: &crate::project::InstalledSkills,
+    installed_steering: &crate::project::InstalledSteering,
+    installed_agents: &crate::project::InstalledAgents,
+) -> Result<bool, Error>
+```
+
+Drop `manifest` parameter (unused now that detection doesn't probe scan paths). Drop the `legacy_fallback` from the return tuple — return `bool` (just `content_drift`).
+
+- [ ] **Step 6.4: Simplify all four loop bodies**
+
+With `source_hash` now required, drop the `match &meta.source_hash { Some(stored) => { ... }, None => legacy_fallback = true }` shape from skills and agents loops. Just unconditionally compute and compare:
+
+```rust
+// Skills (post-tightening)
+for (name, meta) in &installed_skills.skills {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
+        let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+        if computed != meta.source_hash {
+            return Ok(true);
+        }
+    }
+}
+
+// Steering (already direct lookup; just replace `meta.source_hash` access shape)
+for (rel_path, meta) in &installed_steering.files {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+        let computed = crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
+        if computed != meta.source_hash {
+            return Ok(true);
+        }
+    }
+}
+
+// Agents (post-tightening)
+for (_name, meta) in &installed_agents.agents {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
+        let computed = crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
+        if computed != meta.source_hash {
+            return Ok(true);
+        }
+    }
+}
+
+// Native companions
+for meta in installed_agents.native_companions.values() {
+    if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
+        let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
+        let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
+        if computed != meta.source_hash {
+            return Ok(true);
+        }
+    }
+}
+
+Ok(false)
+```
+
+The function body shrinks substantially — about 80 lines of legacy-fallback handling and threading deleted.
+
+- [ ] **Step 6.5: Update `check_plugin_for_update` for new return shape**
+
+In `crates/kiro-market-core/src/service/mod.rs` (around line 2310 where `check_plugin_for_update` calls `scan_plugin_for_content_drift`), update the call to drop the `manifest` argument and to handle the new `bool` return:
+
+```rust
+// BEFORE
+let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
+    plugin_info,
+    &plugin_dir,
+    Some(&manifest),
+    installed_skills,
+    installed_steering,
+    installed_agents,
+)?;
+
+// AFTER
+let content_drift = Self::scan_plugin_for_content_drift(
+    plugin_info,
+    &plugin_dir,
+    installed_skills,
+    installed_steering,
+    installed_agents,
+)?;
+```
+
+Also remove the downstream `legacy_fallback` handling. Find any `if legacy_fallback { ... }` blocks in `check_plugin_for_update` and delete them — the flag no longer exists.
+
+- [ ] **Step 6.6: Delete `hash_artifact_in_scan_paths`**
+
+In `crates/kiro-market-core/src/service/mod.rs` (around line 2665-2714), delete the entire function body and its docstring. No callers remain after Task 5.
+
+Verify:
+```bash
+grep -n "hash_artifact_in_scan_paths" crates/
+```
+Expected: no matches outside the function definition itself (which you're about to delete).
+
+- [ ] **Step 6.7: Revert visibility of scan-path helpers**
+
+In `crates/kiro-market-core/src/service/browse.rs` (lines 949 and 964):
+
+```rust
+// BEFORE
+pub(super) fn agent_scan_paths_for_plugin(...)
+pub(super) fn steering_scan_paths_for_plugin(...)
+
+// AFTER
+fn agent_scan_paths_for_plugin(...)
+fn steering_scan_paths_for_plugin(...)
+```
+
+These were bumped to `pub(super)` for detection's use; detection no longer consumes them, so they can return to private. Verify:
+
+```bash
+grep -rn "agent_scan_paths_for_plugin\|steering_scan_paths_for_plugin" crates/
+```
+
+Expected: only intra-`browse.rs` callers. If anything else references them, leave the visibility as-is.
+
+- [ ] **Step 6.8: Delete the three legacy-fallback tests**
+
+In `crates/kiro-market-core/src/service/mod.rs`, delete:
+- `detect_plugin_updates_legacy_fallback_source_hash_none` (around line 6091)
+- `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update` (around line 6145)
+- `detect_plugin_updates_agent_legacy_fallback_source_hash_none` (around line 6447)
+
+These all exercise the `legacy_fallback` flag that no longer exists.
+
+- [ ] **Step 6.9: Run workspace tests + clippy + fmt + plan-lint**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -5 && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all green. Test count drops by 3 (deleted tests). Net code reduction of ~150 lines.
+
+- [ ] **Step 6.10: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+refactor(detect): delete probe helpers + legacy_fallback (now dead)
+
+After Tasks 2-5 migrated all four detection loops to direct lookup, the
+PR #96 probe-fallback machinery has zero callers. Sweep:
+
+Schema:
+- source_hash: Option<String> -> String on InstalledSkillMeta and
+  InstalledAgentMeta. Symmetrises with InstalledSteeringMeta and
+  InstalledNativeCompanionsMeta (already plain String).
+- installed_hash: same tightening on the same two types.
+
+Detection:
+- scan_plugin_for_content_drift loses the manifest parameter (no
+  longer needed to derive scan paths) and the legacy_fallback bool
+  from its return tuple. Returns plain Result<bool, Error>.
+- All four loop bodies simplified — no more "is this a legacy
+  entry?" Option-matching, no more probe.
+- check_plugin_for_update updated for the new signature; downstream
+  legacy_fallback handling deleted.
+
+Deletions:
+- hash_artifact_in_scan_paths (~50 lines incl. docstring)
+- agent_scan_paths_for_plugin / steering_scan_paths_for_plugin
+  visibility reverted from pub(super) to private (no consumers
+  outside browse.rs)
+- detect_plugin_updates_legacy_fallback_source_hash_none
+- detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update
+- detect_plugin_updates_agent_legacy_fallback_source_hash_none
+
+Net code reduction: ~150 lines. Detection now has one straight-line
+recipe per artifact type, structurally symmetric across all four.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 7: Bindings regen + deserialize-rejection tests
+
+**Why.** Final commit pins the foundation contract: tracking files missing the new required fields fail to deserialize with a clear error. Bindings.ts regen propagates the schema changes to the FE.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/bindings.ts` — regenerate
+- Modify: `crates/kiro-market-core/src/project.rs` test module — add 4 deserialize-rejection tests
+
+- [ ] **Step 7.1: Regenerate TS bindings**
+
+```bash
+cargo test -p kiro-control-center --lib -- --ignored
+```
+
+Expected: passes. `bindings.ts` updated in-place. Verify with:
+
+```bash
+git diff --stat crates/kiro-control-center/src/lib/bindings.ts
+```
+
+Expected: a few lines changed (new field on `InstalledSkillMeta` etc., and likely new `RelativePath` type alias if not already present).
+
+- [ ] **Step 7.2: Add deserialize-rejection tests**
+
+In `crates/kiro-market-core/src/project.rs` test module, add four tests pinning that legacy tracking files (without the new required fields) fail to load:
+
+```rust
+#[test]
+fn load_installed_skills_rejects_legacy_entry_without_source_scan_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(tmp.path().to_path_buf());
+    let kiro_dir = tmp.path().join(".kiro");
+    std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+    // Pre-B-schema entry: missing source_scan_root, missing source_hash,
+    // missing installed_hash. Mirrors what an old tracking file looked
+    // like before this commit landed.
+    let legacy_json = br#"{
+        "skills": {
+            "alpha": {
+                "marketplace": "mp",
+                "plugin": "p",
+                "version": "1.0",
+                "installed_at": "2026-01-01T00:00:00Z"
+            }
+        }
+    }"#;
+    std::fs::write(kiro_dir.join("installed-skills.json"), legacy_json)
+        .expect("write legacy tracking");
+
+    let err = project
+        .load_installed()
+        .expect_err("legacy entry must fail to deserialize, not silently succeed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("source_scan_root") || msg.contains("source_hash"),
+        "error must mention the missing required field; got: {msg}"
+    );
+}
+
+#[test]
+fn load_installed_steering_rejects_legacy_entry_without_source_scan_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(tmp.path().to_path_buf());
+    let kiro_dir = tmp.path().join(".kiro");
+    std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+    let legacy_json = br#"{
+        "files": {
+            "guide.md": {
+                "marketplace": "mp",
+                "plugin": "p",
+                "version": "1.0",
+                "installed_at": "2026-01-01T00:00:00Z",
+                "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
+            }
+        }
+    }"#;
+    std::fs::write(kiro_dir.join("installed-steering.json"), legacy_json)
+        .expect("write legacy tracking");
+
+    let err = project
+        .load_installed_steering()
+        .expect_err("legacy entry must fail");
+    assert!(
+        err.to_string().contains("source_scan_root"),
+        "error must mention source_scan_root; got: {err}"
+    );
+}
+
+#[test]
+fn load_installed_agents_rejects_legacy_entry_without_source_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(tmp.path().to_path_buf());
+    let kiro_dir = tmp.path().join(".kiro");
+    std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+    let legacy_json = br#"{
+        "agents": {
+            "reviewer": {
+                "marketplace": "mp",
+                "plugin": "p",
+                "version": "1.0",
+                "installed_at": "2026-01-01T00:00:00Z",
+                "dialect": "native"
+            }
+        }
+    }"#;
+    std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+        .expect("write legacy tracking");
+
+    let err = project
+        .load_installed_agents()
+        .expect_err("legacy entry must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("source_path") || msg.contains("source_hash"),
+        "error must mention a missing required field; got: {msg}"
+    );
+}
+
+#[test]
+fn load_installed_native_companions_rejects_legacy_entry_without_source_scan_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = KiroProject::new(tmp.path().to_path_buf());
+    let kiro_dir = tmp.path().join(".kiro");
+    std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+    // Native companions live in installed-agents.json under the
+    // native_companions key; a missing source_scan_root on a companion
+    // entry triggers the same deserialize failure.
+    let legacy_json = br#"{
+        "agents": {},
+        "native_companions": {
+            "p": {
+                "marketplace": "mp",
+                "plugin": "p",
+                "version": "1.0",
+                "installed_at": "2026-01-01T00:00:00Z",
+                "files": ["prompts/reviewer.md"],
+                "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
+            }
+        }
+    }"#;
+    std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+        .expect("write legacy tracking");
+
+    let err = project
+        .load_installed_agents()
+        .expect_err("legacy companions entry must fail");
+    assert!(
+        err.to_string().contains("source_scan_root"),
+        "error must mention source_scan_root; got: {err}"
+    );
+}
+```
+
+- [ ] **Step 7.3: Run the new tests**
+
+```bash
+cargo test -p kiro-market-core --lib load_installed_ -- --skip happy_path
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 7.4: Run full workspace + clippy + fmt + plan-lint**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result\|FAIL" | tail -5 && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all green. Test count up by 4 (deserialize-rejection tests).
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add -A && git commit -m "$(cat <<'EOF'
+chore: regenerate bindings.ts + add deserialize-rejection tests
+
+bindings.ts: picks up the new source_scan_root field on
+InstalledSkillMeta/SteeringMeta/NativeCompanionsMeta, source_path
+required (no longer Option) on InstalledAgentMeta, and source_hash/
+installed_hash required (no longer Option) on InstalledSkillMeta and
+InstalledAgentMeta.
+
+Four deserialize-rejection tests pin the foundation contract: legacy
+tracking files (written before this PR landed) fail to load with a
+clear error mentioning the missing required field. This makes the
+"no migration story" choice from the spec auditable — anyone reading
+the test sees that legacy-entry rejection IS the contract, not an
+accident.
+
+Per design docs/plans/2026-05-03-install-detect-symmetry-design.md.
+EOF
+)"
+```
+
+---
+
+## Wrap-up: PR readiness
+
+- [ ] **Step W.1: Verify final state**
+
+```bash
+cd /home/dwalleck/repos/kiro-marketplace-cli-install-detect-symmetry
+git log --oneline feat/phase-2a-update-detection..HEAD
+```
+
+Expected: 7 commits (1 design doc + Tasks 1-7's commits).
+
+- [ ] **Step W.2: Final verification sweep**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result" && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cargo fmt --all --check && \
+  TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: all green. Test count delta from baseline (Step 0.2): +1 (skills regression in Task 3) +4 (deserialize-rejection in Task 7) -4 (legacy-fallback deletions in Tasks 2 + 6) = **+1 net**.
+
+- [ ] **Step W.3: Push the branch**
+
+```bash
+git push -u origin fix/install-detect-symmetry
+```
+
+- [ ] **Step W.4: Open the PR**
+
+```bash
+gh pr create --base feat/phase-2a-update-detection --title "fix: install↔detect symmetry — closes #97 + closes scan-path bug pattern" --body "$(cat <<'EOF'
+## Summary
+
+Closes #97 by closing the structural pattern that made #97 the third instance of "detection has a hardcoded scan path; install honors `manifest.{...}`". After PR #96 closed steering and agents via probe-fallback helpers, this PR migrates all four `Installed*Meta` types to a uniform schema where install records the manifest scan-path it used, and detection looks it up directly.
+
+**Depends on PR #96.** Stacked PR — base branch is `feat/phase-2a-update-detection`. Merge after #96 lands.
+
+## Design
+
+- Spec: `docs/plans/2026-05-03-install-detect-symmetry-design.md`
+- Plan: `docs/plans/2026-05-03-install-detect-symmetry-plan.md`
+- Origin issue: #97
+- Predecessor for: #99 (umbrella for C-1 native-companion hash recipe, C-2 manifest path validation lift, C-3 ContentHash newtype)
+
+## Schema changes (breaking)
+
+- `InstalledSkillMeta` / `InstalledSteeringMeta` / `InstalledNativeCompanionsMeta`: new required field `source_scan_root: RelativePath`.
+- `InstalledAgentMeta.source_path`: was `Option<RelativePath>`, now required `RelativePath`.
+- `InstalledSkillMeta` / `InstalledAgentMeta`: `source_hash` and `installed_hash` tightened from `Option<String>` to `String` (now symmetric with the other two types).
+
+**Pre-existing tracking files fail to deserialize.** Intentional, per the no-users assumption from the spec. Four deserialize-rejection tests pin this contract.
+
+## Detection simplification
+
+- `scan_plugin_for_content_drift` becomes one straight-line lookup per artifact type. Returns plain `Result<bool, Error>` (no more `legacy_fallback` tuple).
+- Deleted: `hash_artifact_in_scan_paths` (PR #96 probe helper), `agent_hash_inputs` dialect-fallback branch, the I-N7 actionable-error branch, the `manifest` parameter on `scan_plugin_for_content_drift`.
+- `agent_scan_paths_for_plugin` and `steering_scan_paths_for_plugin` reverted from `pub(super)` to private.
+
+## Test plan
+
+- [x] `cargo fmt --all --check` clean
+- [x] `cargo clippy --workspace --tests -- -D warnings` clean
+- [x] `cargo test --workspace` all green (~+1 test net: +1 skills regression, +4 deserialize-rejection, -4 legacy-fallback deletions)
+- [x] `cargo xtask plan-lint` all 6 gates OK
+- [x] `npm run check` clean (frontend types via regenerated bindings.ts)
+EOF
+)"
+```
+
+If `gh pr create` is unavailable in your environment, open the PR via the GitHub web UI using the same title and body. Set the base branch to `feat/phase-2a-update-detection`.
+
+---
+
+## Self-Review
+
+After writing the plan, I checked it against the spec.
+
+**Spec coverage:** Every section of the spec maps to one or more tasks:
+- Schema changes (spec §"Schema changes") → Tasks 2 (agents), 3 (skills), 4 (steering), 5 (native companions), 6 (source_hash tightening). All four field changes accounted for.
+- Detection simplification (spec §"Detection simplification") → Tasks 2 (agent loop + I-N7 deletion), 3 (skills loop), 4 (steering loop), 5 (native companions loop), 6 (deletions of helpers + legacy_fallback + manifest parameter).
+- Install-time changes (spec §"Install-time changes") → Tasks 1 (shared helper), 2 (agents install), 3 (skills install + discover_skill_dirs refactor), 4 (steering install), 5 (native companions install).
+- Tests (spec §"Tests") → Tests deleted in Tasks 2 (Copilot legacy-fallback) and 6 (3 legacy_fallback tests = 4 total). Tests reshaped via compiler-driven updates throughout. Tests added in Tasks 1 (3× normalization helper tests), 3 (skills regression), 7 (4 deserialize-rejection tests). New `install_translated_agent_fails_when_source_path_outside_plugin_dir` from spec is present in Task 2 Step 2.1 (as a precondition test of `from_path_under`).
+- Migration (spec §"Migration") → No work needed (per the no-users assumption); pinned by Task 7 deserialize-rejection tests.
+- PR strategy (spec §"PR strategy") → 6 commits → mapped to Tasks 2-7 (Task 1 adds a 7th foundational commit for the helper extraction; the spec's 6 became 7 because the spec rolled the helper into Task 2 and the plan separates them for clearer commit boundaries).
+
+**Placeholder scan:** No "TBD"/"TODO"/"implement later"/"add appropriate error handling"/"similar to Task N" patterns. Code blocks present at every code step. Step 5.2's "verify the exact name" is a "do this lookup" instruction, not a placeholder — the executor must confirm the field name exists. Acceptable.
+
+**Type consistency:**
+- `DiscoveredSkill { scan_root: PathBuf, skill_dir: PathBuf }` defined in Task 3 Step 3.4; consumed in Step 3.6 (`discover_skills_for_plugin` return type) and Step 3.7 (install loop iteration). Same field names used everywhere.
+- `RelativePath::from_path_under(path: &Path, base: &Path) -> Result<Self, ValidationError>` defined in Task 1 Step 1.4; consumed in Tasks 2.5, 3.7, 4.2, 5.2 with consistent argument order (`path` first, `base` second).
+- `InstalledNativeCompanionsMeta.source_scan_root` typed as `RelativePath`, consistent with `InstalledSkillMeta` and `InstalledSteeringMeta` siblings.
+- `agent_hash_inputs(plugin_dir: &Path, source_path: &RelativePath) -> (PathBuf, PathBuf)` — new signature in Task 2 Step 2.8 has 2 params; consumer in Task 2 Step 2.9 calls with 2 args. Consistent.
+
+**Spec gap noted during review:** The spec's "Install-time changes → Translated agents" section says "specific variant choice deferred to implementation". The plan picks `AgentError::InstallFailed` with a synthesized `io::Error` (Task 2 Step 2.5). If a reviewer prefers a typed variant, that's a per-PR decision — flagged in the design doc as out of scope for this design's level of detail.
+
+No spec gaps requiring new tasks.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-05-03-install-detect-symmetry-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for plans where each task has clean boundaries and the review-between-tasks gate catches drift early.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints. Best when the plan is straightforward enough that you'd rather watch it land and steer in real time.
+
+Which approach?


### PR DESCRIPTION
## Summary

Closes #97 by closing the structural pattern that made #97 the third instance of "detection has a hardcoded scan path; install honors `manifest.{...}`". After PR #96 closed steering and agents via probe-fallback helpers, this PR migrates all four `Installed*Meta` types to a uniform schema where install records the manifest scan-path it used, and detection looks it up directly.

Originally planned as a stacked PR on `feat/phase-2a-update-detection`; that branch was merged into `main` while this work was in flight, so the base is `main`. The 8 commits apply cleanly on top.

## Design

- Spec: `docs/plans/2026-05-03-install-detect-symmetry-design.md`
- Plan: `docs/plans/2026-05-03-install-detect-symmetry-plan.md`
- Origin issue: #97
- Predecessor for: #99 (umbrella for C-1 native-companion hash recipe alignment, C-2 manifest path validation lift, C-3 ContentHash newtype)

## Schema changes (breaking)

- `InstalledSkillMeta` / `InstalledSteeringMeta` / `InstalledNativeCompanionsMeta`: new required field `source_scan_root: RelativePath`.
- `InstalledAgentMeta.source_path`: was `Option<RelativePath>`, now required `RelativePath`.

**Pre-existing tracking files fail to deserialize.** Intentional, per the no-users assumption from the spec. Four `load_installed_*_rejects_legacy_entry_*` tests pin this contract.

Note: `source_hash` on `InstalledSkillMeta` / `InstalledAgentMeta` is still `Option<String>` (deferred — would touch ~15 more fixture sites without changing the contracts this PR establishes).

## Detection simplification

- `scan_plugin_for_content_drift` becomes one straight-line direct lookup per artifact type, against the install-recorded scan root.
- Deleted: `hash_artifact_in_scan_paths` (PR #96 probe helper), `agent_hash_inputs` dialect-fallback branch, the I-N7 actionable-error branch, `relative_source_path_for_tracking`, the `manifest` parameter on `scan_plugin_for_content_drift`.
- `agent_scan_paths_for_plugin` and `steering_scan_paths_for_plugin` reverted from `pub(super)` (bumped for detection in PR #96) back to private.

## New helpers

- `RelativePath::from_path_under(&Path, &Path) -> Result<Self, ValidationError>` — extracted from `relative_source_path_for_tracking` and generalized. Two-pass forward-slash normalization handles both Windows-native (`Components` splits on `\`) and Unix-interpreting-Windows-shaped (`\` is one component) inputs. Pinned by 3 unit tests.
- `required_source_path` / `required_skill_scan_root` / `required_steering_scan_root` — translate `from_path_under` failures into typed install errors per artifact type.
- `read_and_parse_skill_md` and `translated_agent_blocked_by_mcp_gate` — extracted to keep `install_skills` / `install_translated_agents_inner` under clippy's 100-line cap.

## Bundling refactors

- `NativeAgentInstallInput` — bundles `install_native_agent`'s args (paralleling `NativeCompanionsInput`) so the signature stays at one parameter while gaining `source_path`.
- `SteeringInstallContext` and `NativeCompanionsInput` gain `plugin_dir: &'a Path`.
- `CompanionInput` (translated-agent companion synthesis) gains `source_scan_root: &'a RelativePath`.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` all green (1004 tests pass: lib went 787 baseline → 791 = +4 deserialize-rejection tests, +3 normalization helper, +1 skills regression closing #97, -3 deleted legacy-fallback tests, -3 stale legacy-loads tests; cross-crate tests unchanged)
- [x] `cargo xtask plan-lint` all 6 gates OK
- [x] `bindings.ts` regenerated and committed