### PR TITLE
fix: PR #100 review wave 2 (I2/I3/I4 + S1/S2/S4/S6/S7)

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -85,8 +85,8 @@ mod tests {
             plugin: PluginName::new("test-plugin").expect("valid plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                 .expect("valid"),
         };
@@ -115,8 +115,8 @@ mod tests {
                 plugin: PluginName::new("test-plugin").expect("valid plugin"),
                 version: Some("1.0.0".into()),
                 installed_at: Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                     .expect("valid"),
             };

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -390,16 +390,62 @@ const SKILL_MD: &str = "SKILL.md";
 /// directory so install can record `scan_root` on
 /// [`crate::project::InstalledSkillMeta::source_scan_root`] for later
 /// drift detection.
+///
+/// **Invariant:** `skill_dir.starts_with(scan_root)`. The downstream
+/// install path uses `skill_dir.strip_prefix(scan_root)` to derive the
+/// install-time relative name; a mismatched pair would produce a
+/// nonsense `RelativePath`. Construction goes through
+/// [`Self::new_unchecked`] (in-crate only — the discover sites
+/// guarantee the invariant by construction) which `debug_assert!`s the
+/// prefix relationship; fields are `pub(crate)` so external crates
+/// must read through the [`Self::scan_root`] / [`Self::skill_dir`]
+/// accessors and cannot bypass the invariant with a struct literal.
+/// Per PR #100 review S4.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSkill {
     /// Absolute path to the scan root that contains `skill_dir`,
     /// e.g. `<plugin_dir>/skills/` or `<plugin_dir>/packs/`.
     /// Recorded on tracking after `strip_prefix(plugin_dir)` so
     /// detection knows where to look without probing.
-    pub scan_root: PathBuf,
+    pub(crate) scan_root: PathBuf,
     /// Absolute path to the skill directory itself,
     /// e.g. `<plugin_dir>/skills/alpha/`. Contains a `SKILL.md`.
-    pub skill_dir: PathBuf,
+    pub(crate) skill_dir: PathBuf,
+}
+
+impl DiscoveredSkill {
+    /// Construct a `DiscoveredSkill`, asserting the
+    /// `skill_dir.starts_with(scan_root)` invariant. `pub(crate)`
+    /// because the only sound producers of a `DiscoveredSkill` are the
+    /// two construction sites in [`discover_skill_dirs`] which compose
+    /// `scan_root` and `skill_dir` such that the invariant holds by
+    /// construction. The `debug_assert!` catches contract violations in
+    /// tests rather than allowing a silent wrong-prefix that would
+    /// later derail `strip_prefix(...)` at the install boundary.
+    pub(crate) fn new_unchecked(scan_root: PathBuf, skill_dir: PathBuf) -> Self {
+        debug_assert!(
+            skill_dir.starts_with(&scan_root),
+            "DiscoveredSkill invariant violated: skill_dir `{}` is not under scan_root `{}`",
+            skill_dir.display(),
+            scan_root.display(),
+        );
+        Self {
+            scan_root,
+            skill_dir,
+        }
+    }
+
+    /// The scan root that contains [`Self::skill_dir`].
+    #[must_use]
+    pub fn scan_root(&self) -> &Path {
+        &self.scan_root
+    }
+
+    /// The skill directory containing `SKILL.md`.
+    #[must_use]
+    pub fn skill_dir(&self) -> &Path {
+        &self.skill_dir
+    }
 }
 
 /// Discover skill directories within a plugin root given a list of paths.
@@ -450,10 +496,10 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
                         };
                         let entry_path = entry.path();
                         if entry_path.is_dir() && entry_path.join(SKILL_MD).exists() {
-                            found.push(DiscoveredSkill {
-                                scan_root: candidate.clone(),
-                                skill_dir: entry_path,
-                            });
+                            found.push(DiscoveredSkill::new_unchecked(
+                                candidate.clone(),
+                                entry_path,
+                            ));
                         }
                     }
                 }
@@ -472,10 +518,7 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
             let scan_root = candidate
                 .parent()
                 .map_or_else(|| plugin_root.to_path_buf(), Path::to_path_buf);
-            found.push(DiscoveredSkill {
-                scan_root,
-                skill_dir: candidate,
-            });
+            found.push(DiscoveredSkill::new_unchecked(scan_root, candidate));
         } else {
             debug!(
                 path = %candidate.display(),
@@ -662,6 +705,53 @@ mod tests {
             root.to_path_buf(),
             "bare-path branch sets scan_root to the candidate's parent, \
              which equals plugin_root for skills at the plugin root"
+        );
+    }
+
+    /// PR #100 review S6: a manifest declaring TWO scan roots
+    /// (`["./packs/", "./extras/"]`) with skills under each must
+    /// produce one `DiscoveredSkill` per skill, each carrying its OWN
+    /// scan root — not the most-recently-seen root for all of them.
+    /// Catches a future "optimize the discover loop" refactor that
+    /// might collapse `scan_root` to a single value across iterations
+    /// (since none of the existing tests exercised the multi-root case
+    /// they wouldn't have caught it).
+    #[test]
+    fn discover_skills_with_multiple_scan_roots_records_each_skills_own_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+
+        create_skill_md(&root.join("packs/alpha"));
+        create_skill_md(&root.join("packs/beta"));
+        create_skill_md(&root.join("extras/gamma"));
+
+        let dirs = discover_skill_dirs(root, &["./packs/", "./extras/"]);
+        assert_eq!(dirs.len(), 3);
+
+        let by_dir: std::collections::HashMap<_, _> = dirs
+            .iter()
+            .map(|d| (d.skill_dir(), d.scan_root()))
+            .collect();
+
+        let alpha = root.join("packs/alpha");
+        let beta = root.join("packs/beta");
+        let gamma = root.join("extras/gamma");
+        assert_eq!(
+            by_dir.get(alpha.as_path()),
+            Some(&root.join("./packs/").as_path()),
+            "alpha must record packs/ as its scan_root"
+        );
+        assert_eq!(
+            by_dir.get(beta.as_path()),
+            Some(&root.join("./packs/").as_path()),
+            "beta must record packs/ as its scan_root"
+        );
+        assert_eq!(
+            by_dir.get(gamma.as_path()),
+            Some(&root.join("./extras/").as_path()),
+            "gamma must record extras/ as its scan_root, NOT packs/ — \
+             a refactor that hoisted scan_root out of the loop would \
+             produce extras for everything (last write wins)"
         );
     }
 

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -39,15 +39,18 @@ pub struct InstalledSkillMeta {
     pub installed_at: DateTime<Utc>,
 
     /// Tree-hash of the skill source as it existed in the marketplace at
-    /// install time. `None` for entries written before Stage 1 of the
-    /// native-kiro-import work landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<String>,
+    /// install time. Required after PR #100 review I2 — every install
+    /// path computes this, and the install↔detect symmetry pass made
+    /// `source_scan_root` required which means any post-Stage-1+
+    /// tracking entry has both. The deferred `legacy_fallback` plumbing
+    /// in `scan_plugin_for_content_drift` was unreachable in practice
+    /// once `source_scan_root` became required (no entry could have
+    /// `scan_root` without `source_hash`) and is gone.
+    pub source_hash: String,
 
-    /// Tree-hash of the skill as it was copied into the project. `None`
-    /// for entries written before Stage 1 landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installed_hash: Option<String>,
+    /// Tree-hash of the skill as it was copied into the project.
+    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    pub installed_hash: String,
 
     /// Scan root (relative to `plugin_dir`) that this skill was
     /// installed from. Required at install time; populated from the
@@ -107,15 +110,16 @@ pub struct InstalledAgentMeta {
     pub source_path: RelativePath,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
-    /// install time. `None` for entries written before Stage 1 of the
-    /// native-kiro-import work landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<String>,
+    /// install time. Required after PR #100 review I2; mirrors the
+    /// `InstalledSkillMeta::source_hash` tightening — every install
+    /// path computes it, and the post-symmetry-pass schema makes a
+    /// missing-source_hash entry impossible (the matching
+    /// `source_path` and `dialect` fields are also required).
+    pub source_hash: String,
 
-    /// Tree-hash of the agent as it was copied into the project. `None`
-    /// for entries written before Stage 1 landed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub installed_hash: Option<String>,
+    /// Tree-hash of the agent as it was copied into the project.
+    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    pub installed_hash: String,
 }
 
 /// Tracking entry for a plugin's companion file bundle that lives under
@@ -2164,9 +2168,16 @@ impl KiroProject {
     /// thin air); otherwise delegates to [`crate::hash::hash_artifact`]
     /// for the canonical hash format. Lifted out of `install_agent_inner`
     /// to keep that function under the line cap.
-    fn hash_translated_source(source_path: Option<&Path>) -> crate::error::Result<Option<String>> {
+    fn hash_translated_source(source_path: Option<&Path>) -> crate::error::Result<String> {
+        // PR #100 review I2 tightened `InstalledAgentMeta::source_hash`
+        // to required `String` (was `Option<String>`). Production
+        // callers always pass `Some(path)` — the only `None` callers
+        // are test fixtures that synthesise an `AgentDefinition` from
+        // thin air and don't care about drift detection. For those the
+        // empty-string sentinel is the deliberate "no source-side
+        // hash recorded" marker; in production it's never observed.
         let Some(p) = source_path else {
-            return Ok(None);
+            return Ok(String::new());
         };
         // Production callers always pass a fully-qualified file path so
         // both `parent()` and `file_name()` are guaranteed `Some`. The
@@ -2185,10 +2196,10 @@ impl KiroProject {
                 format!("source path `{}` has no file name", p.display()),
             )
         })?;
-        Ok(Some(crate::hash::hash_artifact(
+        Ok(crate::hash::hash_artifact(
             parent,
             &[std::path::PathBuf::from(filename)],
-        )?))
+        )?)
     }
 
     fn install_agent_inner(
@@ -2241,7 +2252,7 @@ impl KiroProject {
                 let agents_root = self.agents_dir(); // needed for companion hash below
 
                 meta.source_hash = source_hash;
-                meta.installed_hash = Some(installed_hash);
+                meta.installed_hash = installed_hash;
 
                 // Capture plugin identity before moving meta into the map.
                 let marketplace = meta.marketplace.clone();
@@ -2257,17 +2268,7 @@ impl KiroProject {
                     .as_str()
                     .rsplit_once('/')
                     .and_then(|(parent, _)| crate::validation::RelativePath::new(parent).ok())
-                    .unwrap_or_else(|| {
-                        // Static literal "agents" trivially passes
-                        // validate_relative_path; the unchecked
-                        // constructor is the right shape per CLAUDE.md
-                        // (no .expect() in production code) and matches
-                        // existing internal callers like
-                        // DiscoveredPlugin::as_relative_path.
-                        crate::validation::RelativePath::from_internal_unchecked(
-                            "agents".to_owned(),
-                        )
-                    });
+                    .unwrap_or_else(crate::validation::RelativePath::agents_root);
 
                 installed.agents.insert(def.name.clone(), meta);
 
@@ -2534,10 +2535,20 @@ impl KiroProject {
                 installed_hash: String::new(),
                 source_scan_root: input.source_scan_root.clone(),
             });
-        // Refresh marketplace/version/timestamp on every install.
+        // Refresh marketplace/version/timestamp + source_scan_root on
+        // every install. PR #100 review I3: the post-insert refresh
+        // initially missed `source_scan_root`, so a manifest that
+        // changed its scan paths between installs would keep the stale
+        // root recorded forever — the install-time scan_root is what
+        // detection consults to locate the source side, so a stale
+        // value is a latent false-drift bug. Issue #99 currently masks
+        // this for translated companions (they don't yet read the
+        // field at detect time), but the moment that lands the
+        // staleness becomes a real bug.
         companion_entry.marketplace = input.marketplace.clone();
         companion_entry.version = input.version.map(str::to_owned);
         companion_entry.installed_at = chrono::Utc::now();
+        companion_entry.source_scan_root = input.source_scan_root.clone();
         if !companion_entry
             .files
             .contains(&input.prompt_rel.to_path_buf())
@@ -2576,14 +2587,14 @@ impl KiroProject {
     ) -> crate::error::Result<CollisionDecision<InstalledNativeAgentOutcome>> {
         match installed.agents.get(agent_name) {
             Some(existing) if existing.plugin == *plugin => {
-                if existing.source_hash.as_deref() == Some(source_hash) {
+                if existing.source_hash == source_hash {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         InstalledNativeAgentOutcome {
                             name: agent_name.to_owned(),
                             json_path: json_target.to_path_buf(),
                             kind: InstallOutcomeKind::Idempotent,
                             source_hash: source_hash.to_owned(),
-                            installed_hash: existing.installed_hash.clone().unwrap_or_default(),
+                            installed_hash: existing.installed_hash.clone(),
                         },
                     )));
                 }
@@ -2725,8 +2736,8 @@ impl KiroProject {
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
                         source_path: input.source_path.clone(),
-                        source_hash: Some(input.source_hash.to_string()),
-                        installed_hash: Some(installed_hash.clone()),
+                        source_hash: input.source_hash.to_string(),
+                        installed_hash: installed_hash.clone(),
                     },
                 );
 
@@ -3553,8 +3564,8 @@ impl KiroProject {
             // entry that staging.path() pointed at is gone; TempDir's Drop
             // will see NotFound and silently skip cleanup.
             fs::rename(staging.path(), &dir)?;
-            meta.source_hash = Some(source_hash);
-            meta.installed_hash = Some(installed_hash);
+            meta.source_hash = source_hash;
+            meta.installed_hash = installed_hash;
 
             // Update tracking. If this fails, roll back the rename so the
             // filesystem and tracking file stay consistent.
@@ -3619,8 +3630,12 @@ mod tests {
             plugin: pn("test-plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            // Empty placeholders — `install_skill_from_dir` overwrites
+            // both with real hashes during the install path. Tests that
+            // pre-stamp tracking entries (no install call) and assert
+            // on the field carry their own real hash.
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         }
     }
@@ -3634,8 +3649,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
@@ -3657,8 +3672,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
             source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(json.contains("\"dialect\":\"copilot\""));
@@ -3787,6 +3802,7 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "source_hash": "blake3:abc",
+                    "installed_hash": "blake3:abc",
                     "source_scan_root": "skills",
                 }
             }
@@ -3829,6 +3845,8 @@ mod tests {
                     "installed_at": chrono::Utc::now(),
                     "dialect": "claude",
                     "source_path": "agents/etc.md",
+                    "source_hash": "x",
+                    "installed_hash": "x",
                 }
             }
         });
@@ -3991,8 +4009,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("subdir/agent.md").expect("valid rel path"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(
@@ -4147,6 +4165,7 @@ mod tests {
                     "version": "1.0.0",
                     "installed_at": now,
                     "source_hash": "deadbeef",
+                    "installed_hash": "deadbeef",
                     "source_scan_root": "skills"
                 }
             }
@@ -4230,6 +4249,7 @@ mod tests {
                     "marketplace": "mp", "plugin": "p",
                     "version": "1.0.0", "installed_at": same_time,
                     "source_hash": "deadbeef",
+                    "installed_hash": "deadbeef",
                     "source_scan_root": "skills"
                 }
             }
@@ -4301,6 +4321,7 @@ mod tests {
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
                 "source_hash": "x",
+                "installed_hash": "x",
                 "source_scan_root": "skills"
             })
         };
@@ -4317,7 +4338,9 @@ mod tests {
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
                 "dialect": "claude",
-                "source_path": "agents/x.md"
+                "source_path": "agents/x.md",
+                "source_hash": "x",
+                "installed_hash": "x"
             })
         };
 
@@ -4822,8 +4845,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
         }
     }
 
@@ -5563,6 +5586,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -5851,6 +5875,8 @@ mod tests {
                         "installed_at": now,
                         "dialect": "native",
                         "source_path": "agents/ghost.json",
+                        "source_hash": "x",
+                        "installed_hash": "x",
                     }
                 }
             }))
@@ -6058,6 +6084,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6188,6 +6215,7 @@ mod tests {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
                         "source_hash": "deadbeef",
+                        "installed_hash": "deadbeef",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6260,8 +6288,8 @@ mod tests {
                     plugin: pn("p"),
                     version: Some("1.0.0".into()),
                     installed_at: Utc::now(),
-                    source_hash: Some("deadbeef".into()),
-                    installed_hash: Some("deadbeef".into()),
+                    source_hash: "deadbeef".into(),
+                    installed_hash: "deadbeef".into(),
                     source_scan_root: RelativePath::new("skills").expect("valid"),
                 },
             )
@@ -7071,6 +7099,80 @@ mod tests {
         );
     }
 
+    /// PR #100 review I2: a tracking entry with `source_scan_root` but
+    /// without `source_hash` / `installed_hash` was unreachable in
+    /// practice (every install path that records `scan_root` also
+    /// records hashes), but the deferred `Option<String>` field type
+    /// kept the `legacy_fallback` escape hatch alive in detection.
+    /// After I2 the fields are required `String` and a contradictory
+    /// entry (`scan_root` present, hashes absent) fails to deserialize
+    /// at the boundary.
+    #[test]
+    fn load_installed_skills_rejects_legacy_entry_without_source_hash() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "skills": {
+                "alpha": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "source_scan_root": "skills"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-skills.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed()
+            .expect_err("legacy entry without source_hash must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_hash") || msg.contains("installed_hash"),
+            "error must mention the missing required field; got: {msg}"
+        );
+    }
+
+    /// PR #100 review I2 sibling for agents: a tracking entry that
+    /// has `source_path` (the Stage-1+ symmetry-pass marker) but
+    /// lacks `source_hash` / `installed_hash` is structurally
+    /// contradictory and must be rejected at the deserialize
+    /// boundary, not silently skipped at scan time.
+    #[test]
+    fn load_installed_agents_rejects_legacy_entry_without_source_hash() {
+        let (_dir, project) = temp_project();
+        let kiro_dir = project.kiro_dir();
+        std::fs::create_dir_all(&kiro_dir).expect("create .kiro");
+
+        let legacy_json = br#"{
+            "agents": {
+                "reviewer": {
+                    "marketplace": "mp",
+                    "plugin": "p",
+                    "version": "1.0",
+                    "installed_at": "2026-01-01T00:00:00Z",
+                    "dialect": "native",
+                    "source_path": "agents/reviewer.json"
+                }
+            }
+        }"#;
+        std::fs::write(kiro_dir.join("installed-agents.json"), legacy_json)
+            .expect("write legacy tracking");
+
+        let err = project
+            .load_installed_agents()
+            .expect_err("legacy agent entry without source_hash must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source_hash") || msg.contains("installed_hash"),
+            "error must mention the missing required field; got: {msg}"
+        );
+    }
+
     #[test]
     fn load_installed_native_companions_rejects_legacy_entry_without_source_scan_root() {
         let (_dir, project) = temp_project();
@@ -7135,8 +7237,8 @@ mod tests {
             plugin: pn("p"),
             version: Some("1.0.0".into()),
             installed_at: chrono::Utc::now(),
-            source_hash: None,
-            installed_hash: None,
+            source_hash: String::new(),
+            installed_hash: String::new(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         };
 
@@ -7147,11 +7249,8 @@ mod tests {
         let installed = project.load_installed().unwrap();
         let entry = installed.skills.get("test").expect("entry persisted");
 
-        let src_hash = entry.source_hash.as_ref().expect("source_hash populated");
-        let inst_hash = entry
-            .installed_hash
-            .as_ref()
-            .expect("installed_hash populated");
+        let src_hash = &entry.source_hash;
+        let inst_hash = &entry.installed_hash;
 
         assert!(src_hash.starts_with("blake3:"));
         assert!(inst_hash.starts_with("blake3:"));
@@ -7177,8 +7276,8 @@ mod tests {
         };
         let mapped: Vec<crate::agent::tools::MappedTool> = vec![];
         let mut meta = sample_agent_meta();
-        meta.source_hash = None;
-        meta.installed_hash = None;
+        meta.source_hash = String::new();
+        meta.installed_hash = String::new();
         let plugin_name = meta.plugin.clone();
 
         project
@@ -7188,8 +7287,8 @@ mod tests {
         let installed = project.load_installed_agents().unwrap();
         let entry = installed.agents.get("rev").expect("entry persisted");
 
-        let src = entry.source_hash.as_ref().expect("source_hash set");
-        let inst = entry.installed_hash.as_ref().expect("installed_hash set");
+        let src = &entry.source_hash;
+        let inst = &entry.installed_hash;
         assert!(src.starts_with("blake3:"));
         assert!(inst.starts_with("blake3:"));
         // Translated path: source bytes (raw .md) differ from installed bytes
@@ -7242,8 +7341,8 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Claude,
             };
             let mut meta = sample_agent_meta();
-            meta.source_hash = None;
-            meta.installed_hash = None;
+            meta.source_hash = String::new();
+            meta.installed_hash = String::new();
             project
                 .install_agent(&def, &[], meta, Some(&source_md))
                 .expect("install succeeds");
@@ -7264,6 +7363,88 @@ mod tests {
             companion
                 .files
                 .contains(&std::path::PathBuf::from("prompts/beta.md"))
+        );
+    }
+
+    /// PR #100 review I3: when a plugin's manifest changes its
+    /// translated-agent source path between installs, the recorded
+    /// `source_scan_root` on the existing `native_companions` entry
+    /// must refresh to the latest install's scan root — otherwise
+    /// drift detection (once issue #99 lands and starts consulting
+    /// the field) would look up the source under the stale root and
+    /// emit false drift on every scan. Pre-fix the `or_insert_with`
+    /// initializer set the value once and the post-insert refresh
+    /// updated `marketplace`/`version`/`installed_at`/`files` but
+    /// skipped `source_scan_root`, so the very first install's value
+    /// stuck forever.
+    #[test]
+    fn install_agent_translated_refreshes_source_scan_root_on_subsequent_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = KiroProject::new(tmp.path().to_path_buf());
+
+        // First install: source under `agents/`.
+        let alpha_md = write_agent(tmp.path(), "alpha", "body");
+        let alpha_def = crate::agent::AgentDefinition {
+            name: "alpha".into(),
+            description: None,
+            prompt_body: "body".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: std::collections::BTreeMap::new(),
+            dialect: crate::agent::AgentDialect::Claude,
+        };
+        let mut meta_alpha = sample_agent_meta();
+        meta_alpha.source_path = RelativePath::new("agents/alpha.md").expect("valid");
+        meta_alpha.source_hash = String::new();
+        meta_alpha.installed_hash = String::new();
+        project
+            .install_agent(&alpha_def, &[], meta_alpha, Some(&alpha_md))
+            .expect("install alpha");
+
+        let installed = project.load_installed_agents().unwrap();
+        let plugin_key = sample_agent_meta().plugin.clone();
+        assert_eq!(
+            installed
+                .native_companions
+                .get(plugin_key.as_str())
+                .expect("entry after first install")
+                .source_scan_root
+                .as_str(),
+            "agents",
+            "first install records its own scan root"
+        );
+
+        // Second install for the SAME plugin from a manifest that
+        // moved its agents under `prompts/` — the recorded
+        // source_scan_root must follow.
+        let beta_md = write_agent(tmp.path(), "beta", "body2");
+        let beta_def = crate::agent::AgentDefinition {
+            name: "beta".into(),
+            description: None,
+            prompt_body: "body2".into(),
+            model: None,
+            source_tools: vec![],
+            mcp_servers: std::collections::BTreeMap::new(),
+            dialect: crate::agent::AgentDialect::Claude,
+        };
+        let mut meta_beta = sample_agent_meta();
+        meta_beta.source_path = RelativePath::new("prompts/beta.md").expect("valid");
+        meta_beta.source_hash = String::new();
+        meta_beta.installed_hash = String::new();
+        project
+            .install_agent(&beta_def, &[], meta_beta, Some(&beta_md))
+            .expect("install beta");
+
+        let installed = project.load_installed_agents().unwrap();
+        let companion = installed
+            .native_companions
+            .get(plugin_key.as_str())
+            .expect("entry after second install");
+        assert_eq!(
+            companion.source_scan_root.as_str(),
+            "prompts",
+            "second install must refresh the recorded source_scan_root \
+             (regression: pre-fix it stuck at the first install's value)"
         );
     }
 
@@ -7411,11 +7592,8 @@ mod tests {
         assert_eq!(entry.dialect, crate::agent::AgentDialect::Native);
         assert_eq!(entry.plugin, "plugin-y");
         assert_eq!(entry.marketplace, "marketplace-x");
-        assert_eq!(entry.source_hash.as_deref(), Some(source_hash.as_str()));
-        assert_eq!(
-            entry.installed_hash.as_deref(),
-            Some(outcome.installed_hash.as_str())
-        );
+        assert_eq!(entry.source_hash, source_hash);
+        assert_eq!(entry.installed_hash, outcome.installed_hash);
     }
 
     #[rstest]

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1858,8 +1858,8 @@ mod tests {
                 plugin: pn(plugin),
                 version: None,
                 installed_at: Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root: crate::validation::RelativePath::new("skills").expect("valid"),
             },
         );

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1298,8 +1298,12 @@ impl MarketplaceService {
                 plugin: plugin.clone(),
                 version: version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
-                source_hash: None,
-                installed_hash: None,
+                // Stamped pre-install with empty placeholders;
+                // `install_skill_from_dir` overwrites both with the
+                // staging-time + post-rename hashes before the entry
+                // is committed to tracking.
+                source_hash: String::new(),
+                installed_hash: String::new(),
                 source_scan_root,
             };
 
@@ -1697,8 +1701,12 @@ impl MarketplaceService {
                 installed_at: chrono::Utc::now(),
                 dialect: def.dialect,
                 source_path,
-                source_hash: None,
-                installed_hash: None,
+                // Stamped pre-install with empty placeholders;
+                // `install_agent_inner` overwrites both with the
+                // hash_translated_source / staging-time hashes before
+                // the entry is committed to tracking.
+                source_hash: String::new(),
+                installed_hash: String::new(),
             };
             let install_result = if ctx.mode.is_force() {
                 project.install_agent_force(&def, &mapped, meta, Some(&path))
@@ -2340,7 +2348,7 @@ impl MarketplaceService {
         // which produced false-positive drift on every scan for
         // plugins declaring custom `steering: [...]` /
         // `agents: [...]` paths.
-        let (content_drift, legacy_fallback) = Self::scan_plugin_for_content_drift(
+        let content_drift = Self::scan_plugin_for_content_drift(
             plugin_info,
             &plugin_dir,
             installed_skills,
@@ -2371,19 +2379,6 @@ impl MarketplaceService {
             }));
         }
 
-        if legacy_fallback {
-            // Drift undetectable for legacy entries (no source_hash) —
-            // same versions means no entry. Logging at debug so the
-            // legacy-fallback case is observable in traces without
-            // surfacing in normal operation.
-            tracing::debug!(
-                marketplace = %plugin_info.marketplace,
-                plugin = %plugin_info.plugin,
-                "scan saw a legacy (pre-Stage-1) tracking entry with no \
-                 source_hash; falling back to version-only comparison and \
-                 returning no update entry"
-            );
-        }
         Ok(None)
     }
 
@@ -2486,37 +2481,32 @@ impl MarketplaceService {
     /// via the same helpers `MarketplaceService::install_plugin`
     /// uses.
     ///
-    /// `content_drift = false && legacy_fallback = true` means "no drift
-    /// detected among hashable entries; some entries had no `source_hash`
-    /// so a clean miss is possible." Callers should treat `legacy_fallback`
-    /// as "drift undetectable" rather than "drift absent."
+    /// PR #100 review I2 dropped the `legacy_fallback` second return
+    /// value: after the install↔detect symmetry pass made
+    /// `source_scan_root` required AND tightened `source_hash` to
+    /// required `String`, no in-tree tracking entry can land here
+    /// without both fields. The previous `Option<String>` matching
+    /// arms (`None => legacy_fallback = true`) were unreachable at
+    /// runtime, so the helper now returns just `bool` and the caller
+    /// no longer logs a "legacy entry" debug line that could never
+    /// fire.
     fn scan_plugin_for_content_drift(
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
         installed_skills: &crate::project::InstalledSkills,
         installed_steering: &crate::project::InstalledSteering,
         installed_agents: &crate::project::InstalledAgents,
-    ) -> Result<(bool, bool), Error> {
-        let mut content_drift = false;
-        let mut legacy_fallback = false;
-
+    ) -> Result<bool, Error> {
         // Skills — direct lookup against the install-recorded scan
         // root. Closes #97; install populates source_scan_root so
         // detection hashes against the same directory the install
-        // copied from. (source_hash stays Option<String> for now;
-        // tightened in Task 6 alongside the legacy_fallback removal.)
+        // copied from.
         for (name, meta) in &installed_skills.skills {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                match &meta.source_hash {
-                    Some(stored) => {
-                        let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
-                        let computed = crate::hash::hash_dir_tree(&skill_dir)?;
-                        if computed != *stored {
-                            content_drift = true;
-                            return Ok((content_drift, legacy_fallback));
-                        }
-                    }
-                    None => legacy_fallback = true,
+                let skill_dir = plugin_dir.join(meta.source_scan_root.as_str()).join(name);
+                let computed = crate::hash::hash_dir_tree(&skill_dir)?;
+                if computed != meta.source_hash {
+                    return Ok(true);
                 }
             }
         }
@@ -2532,30 +2522,24 @@ impl MarketplaceService {
                 let computed =
                     crate::hash::hash_artifact(&scan_root, std::slice::from_ref(rel_path))?;
                 if computed != meta.source_hash {
-                    content_drift = true;
-                    return Ok((content_drift, legacy_fallback));
+                    return Ok(true);
                 }
             }
         }
 
         // Agents — direct lookup against the install-recorded
-        // source_path. After the install↔detect symmetry pass, the
-        // dialect-fallback machinery and the I-N7 actionable-error
-        // branch are gone: install always records source_path, so
-        // detection always knows the precise file to hash.
+        // source_path. After the install↔detect symmetry pass + I2
+        // tightening, the dialect-fallback machinery, the I-N7
+        // actionable-error branch, AND the legacy-source_hash
+        // fallback are gone: install always records source_path AND
+        // source_hash, so detection always knows the precise file to
+        // hash and what to compare against.
         for meta in installed_agents.agents.values() {
             if meta.marketplace == plugin_info.marketplace && meta.plugin == plugin_info.plugin {
-                match &meta.source_hash {
-                    Some(stored) => {
-                        let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
-                        let computed =
-                            crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
-                        if computed != *stored {
-                            content_drift = true;
-                            return Ok((content_drift, legacy_fallback));
-                        }
-                    }
-                    None => legacy_fallback = true,
+                let (base, filename) = agent_hash_inputs(plugin_dir, &meta.source_path);
+                let computed = crate::hash::hash_artifact(&base, std::slice::from_ref(&filename))?;
+                if computed != meta.source_hash {
+                    return Ok(true);
                 }
             }
         }
@@ -2569,13 +2553,12 @@ impl MarketplaceService {
                 let scan_root = plugin_dir.join(meta.source_scan_root.as_str());
                 let computed = crate::hash::hash_artifact(&scan_root, &meta.files)?;
                 if computed != meta.source_hash {
-                    content_drift = true;
-                    return Ok((content_drift, legacy_fallback));
+                    return Ok(true);
                 }
             }
         }
 
-        Ok((content_drift, legacy_fallback))
+        Ok(false)
     }
 }
 
@@ -2722,6 +2705,38 @@ fn read_and_parse_skill_md(
 }
 
 /// Compute the install-time `source_scan_root` for a discovered skill
+/// Build a synthetic `io::Error` describing a structural validation
+/// failure on a path that should have been expressible as a
+/// [`crate::validation::RelativePath`] under `plugin_dir`.
+///
+/// Shared by [`required_skill_scan_root`] and [`required_source_path`]
+/// per PR #100 review S7 — both helpers were independently formatting
+/// near-identical messages, which would drift one wording tweak apart
+/// the next time either was edited. This helper is the single source
+/// of truth for the wire-format string.
+///
+/// Note the asymmetry with `required_steering_scan_root`: the steering
+/// path uses the typed `SteeringError::ScanRootInvalid` variant
+/// (added by PR #100 review I1) and does NOT funnel through this
+/// helper. `SkillError` and `AgentError` don't yet have an analogous
+/// typed variant; a future cleanup mirroring I1 across all three
+/// error enums would let this synthetic-`io::Error` helper retire.
+fn scan_root_invalid_io_err(
+    label: &str,
+    scan_root: &Path,
+    plugin_dir: &Path,
+    cause: &crate::error::ValidationError,
+) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "{label} `{}` not under plugin_dir `{}`: {cause}",
+            scan_root.display(),
+            plugin_dir.display(),
+        ),
+    )
+}
+
 /// or build a [`FailedSkill`] entry if the discovered `scan_root`
 /// can't be expressed as a `RelativePath` under `plugin_dir`.
 /// Discovery yields paths under `plugin_dir` in practice, so the
@@ -2742,13 +2757,11 @@ fn required_skill_scan_root(
         );
         FailedSkill::install_failed(
             skill_name.to_owned(),
-            &Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "skill scan_root `{}` not under plugin_dir `{}`: {e}",
-                    scan_root.display(),
-                    plugin_dir.display(),
-                ),
+            &Error::Io(scan_root_invalid_io_err(
+                "skill scan_root",
+                scan_root,
+                plugin_dir,
+                &e,
             )),
         )
     })
@@ -2770,14 +2783,11 @@ fn required_source_path(
         source_path: path.to_path_buf(),
         error: crate::error::AgentError::InstallFailed {
             path: path.to_path_buf(),
-            source: Box::new(crate::error::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "discovered agent path `{}` is not expressible as a \
-                     RelativePath under plugin_dir `{}`: {e}",
-                    path.display(),
-                    plugin_dir.display(),
-                ),
+            source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
+                "discovered agent path",
+                path,
+                plugin_dir,
+                &e,
             ))),
         },
     })
@@ -6084,8 +6094,8 @@ mod tests {
                     plugin: pn("structured-p"),
                     version: Some("1.0".into()),
                     installed_at: chrono::Utc::now(),
-                    source_hash: None,
-                    installed_hash: None,
+                    source_hash: String::new(),
+                    installed_hash: String::new(),
                     source_scan_root: crate::validation::RelativePath::new("skills")
                         .expect("valid"),
                 },
@@ -6114,102 +6124,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn detect_plugin_updates_legacy_fallback_source_hash_none() {
-        use crate::project::KiroProject;
-        use crate::service::test_support::{
-            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
-            temp_service,
-        };
-
-        let (dir, svc) = temp_service();
-        let entries = vec![relative_path_entry("p", "plugins/p")];
-        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
-        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
-        let plugin_dir = mp_path.join("plugins/p");
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.0"}"#,
-        )
-        .unwrap();
-
-        let project_tmp = tempfile::tempdir().unwrap();
-        let project = KiroProject::new(project_tmp.path().to_path_buf());
-
-        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
-            .expect("install");
-
-        // Set source_hash: None in tracking file
-        let mut tracking = project.load_installed().unwrap();
-        for meta in tracking.skills.values_mut() {
-            meta.source_hash = None;
-        }
-        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
-        fs::write(
-            &tracking_path,
-            serde_json::to_vec_pretty(&tracking).unwrap(),
-        )
-        .unwrap();
-
-        // Bump version
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.1"}"#,
-        )
-        .unwrap();
-
-        let result = svc.detect_plugin_updates(&project).expect("detect");
-        assert_eq!(result.updates.len(), 1);
-        assert_eq!(result.updates[0].plugin.as_str(), "p");
-        assert!(matches!(
-            result.updates[0].change_signal,
-            UpdateChangeSignal::VersionBumped
-        ));
-        assert!(result.failures.is_empty());
-    }
-
-    #[test]
-    fn detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update() {
-        use crate::project::KiroProject;
-        use crate::service::test_support::{
-            make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
-            temp_service,
-        };
-
-        let (dir, svc) = temp_service();
-        let entries = vec![relative_path_entry("p", "plugins/p")];
-        let mp_path = seed_marketplace_with_registry(dir.path(), &svc, "mp", &entries);
-        make_plugin_with_skills(&mp_path, "p", &["alpha"]);
-        let plugin_dir = mp_path.join("plugins/p");
-        fs::write(
-            plugin_dir.join("plugin.json"),
-            br#"{"name":"p","version":"1.0"}"#,
-        )
-        .unwrap();
-
-        let project_tmp = tempfile::tempdir().unwrap();
-        let project = KiroProject::new(project_tmp.path().to_path_buf());
-
-        svc.install_plugin(&project, &mp("mp"), &pn("p"), InstallMode::New, false)
-            .expect("install");
-
-        // Set source_hash: None in tracking file
-        let mut tracking = project.load_installed().unwrap();
-        for meta in tracking.skills.values_mut() {
-            meta.source_hash = None;
-        }
-        let tracking_path = project_tmp.path().join(".kiro/installed-skills.json");
-        fs::write(
-            &tracking_path,
-            serde_json::to_vec_pretty(&tracking).unwrap(),
-        )
-        .unwrap();
-
-        // Same version, no mutation
-        let result = svc.detect_plugin_updates(&project).expect("detect");
-        assert!(result.updates.is_empty());
-        assert!(result.failures.is_empty());
-    }
+    // Deleted: `detect_plugin_updates_legacy_fallback_source_hash_none`
+    // and `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update`
+    // — they exercised the `Option<String>::None => legacy_fallback = true`
+    // arm of `scan_plugin_for_content_drift`, which PR #100 review I2
+    // removed. Post-I2 the field is required `String` and a tracking
+    // entry without `source_hash` fails to deserialize at the
+    // `load_installed()` boundary; the contract is pinned by
+    // `load_installed_rejects_legacy_entry_without_source_hash` and
+    // `load_installed_agents_rejects_legacy_entry_without_source_hash`
+    // in the project tests.
 
     #[test]
     fn detect_plugin_updates_mixed_scenario() {
@@ -6512,7 +6436,7 @@ mod tests {
         // Set agent source_hash: None in tracking file
         let mut tracking = project.load_installed_agents().unwrap();
         for meta in tracking.agents.values_mut() {
-            meta.source_hash = None;
+            meta.source_hash = String::new();
         }
         let tracking_path = project_tmp.path().join(".kiro/installed-agents.json");
         fs::write(
@@ -6766,11 +6690,14 @@ mod tests {
     /// hash `NotFound` failure on every scan.
     ///
     /// The native-companions cascade has a separate, pre-existing
-    /// install-time hash bug (documented on
-    /// `detect_plugin_updates_copilot_agent_legacy_fallback` above —
-    /// install hashes against the destination, detection re-hashes
-    /// against the source, so the two never match through the install
-    /// path). To isolate the scan-path fix, we synthesize the tracking
+    /// install-time hash bug: install hashes against the destination,
+    /// detection re-hashes against the source, so the two never match
+    /// through the install path. (The canonical reference test
+    /// previously named `detect_plugin_updates_copilot_agent_legacy_fallback`
+    /// has been removed — see PR #100's deserialize-rejection sweep,
+    /// which invalidated the legacy-Option-shape fixture it relied on.
+    /// The bug itself is still real and the workaround below still
+    /// applies.) To isolate the scan-path fix, we synthesize the tracking
     /// entry by hand: compute the source-side hash directly via
     /// `crate::hash::hash_artifact` and write it into
     /// `installed-agents.json`. With the scan-path fix, detection
@@ -6836,13 +6763,27 @@ mod tests {
         // `skills.skills`, and `steering.files` — but NOT from
         // `agents.native_companions`. Without an entry in one of those
         // three maps the plugin would not surface in the scan loop and
-        // the test would pass vacuously. Mirror the pattern used by
-        // `detect_plugin_updates_copilot_agent_legacy_fallback`: a
-        // single legacy translated-agent entry (`source_hash: None`)
-        // registers the plugin and triggers only the harmless
-        // `legacy_fallback = true` branch, leaving the
+        // the test would pass vacuously. We register a single native
+        // agent at `<plugin_dir>/agents/registrar.json` with a real
+        // pre-computed source_hash so the plugin surfaces in the scan
+        // loop AND the agent itself doesn't drift — leaving the
         // native-companions cascade as the only thing the assertion
         // depends on.
+        //
+        // PR #100 review I2 dropped the legacy_fallback escape hatch
+        // (source_hash: None used to be a "skip me" sentinel for the
+        // drift scan); after I2 every entry must have a real source
+        // file on disk and a real source_hash, so the registrar agent
+        // had to grow a real .json file at install-time.
+        let agents_default_root = plugin_dir.join("agents");
+        fs::create_dir_all(&agents_default_root).expect("create agents/ dir");
+        let registrar_json = br#"{"name":"registrar"}"#;
+        fs::write(agents_default_root.join("registrar.json"), registrar_json)
+            .expect("write registrar.json");
+        let registrar_source_hash =
+            crate::hash::hash_artifact(&agents_default_root, &[PathBuf::from("registrar.json")])
+                .expect("hash registrar source");
+
         let mut agents_map = HashMap::new();
         agents_map.insert(
             "registrar".to_string(),
@@ -6854,8 +6795,8 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Native,
                 source_path: crate::validation::RelativePath::new("agents/registrar.json")
                     .expect("valid"),
-                source_hash: None,
-                installed_hash: None,
+                source_hash: registrar_source_hash.clone(),
+                installed_hash: registrar_source_hash,
             },
         );
 
@@ -7032,8 +6973,8 @@ mod tests {
                 installed_at: chrono::Utc::now(),
                 dialect: crate::agent::AgentDialect::Copilot,
                 source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
-                source_hash: Some(expected_hash),
-                installed_hash: None,
+                source_hash: expected_hash,
+                installed_hash: String::new(),
             },
         );
         let installed = InstalledAgents {

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -61,6 +61,21 @@ impl RelativePath {
         Self(value)
     }
 
+    /// The conventional `agents/` scan-root used by the translated
+    /// agent install path when the source-side scan root cannot be
+    /// recovered from `meta.source_path` (legacy `agent.md` discovered
+    /// without a configured scan path, hand-synthesised test fixtures,
+    /// etc.). Replaces the previous `from_internal_unchecked("agents".to_owned())`
+    /// site at `KiroProject::install_agent_inner` per PR #100 review S2:
+    /// the unchecked-constructor pattern was sound but anonymous —
+    /// every reader had to re-derive that `"agents"` is a constant
+    /// string. A named `agents_root()` makes the intent explicit and
+    /// removes one audited-by-convention site.
+    #[must_use]
+    pub fn agents_root() -> Self {
+        Self::from_internal_unchecked("agents".to_owned())
+    }
+
     /// Convert a `Path` to a [`RelativePath`] by stripping `base` and
     /// normalising path separators to forward-slash. Returns `Err` if
     /// `path` is not under `base` or the resulting relative path fails
@@ -98,15 +113,30 @@ impl RelativePath {
         // as ONE `Normal` component and we'd hand `RelativePath::new` a
         // backslash it rejects. The explicit `.replace('\\', '/')`
         // closes that gap; harmless when components already split.
-        let rel_str = rel
+        //
+        // PR #100 review I4: components are converted via `to_str()`,
+        // not `to_string_lossy()`. Lossy conversion silently substitutes
+        // `U+FFFD` for invalid UTF-8 sequences, so a non-UTF-8 OsStr
+        // component would round-trip as a valid-looking `RelativePath`
+        // that doesn't correspond to anything on disk — detection-side
+        // hashing later misses with `NotFound` and the user sees a
+        // misleading "missing file" error. Failing the construction
+        // here surfaces the real cause at the parse boundary.
+        let parts: Vec<&str> = rel
             .components()
             .filter_map(|c| match c {
-                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                std::path::Component::Normal(s) => Some(s),
                 _ => None,
             })
-            .collect::<Vec<_>>()
-            .join("/")
-            .replace('\\', "/");
+            .map(|s| {
+                s.to_str()
+                    .ok_or_else(|| ValidationError::InvalidRelativePath {
+                        path: path.display().to_string(),
+                        reason: "path contains a non-UTF-8 component".to_owned(),
+                    })
+            })
+            .collect::<Result<_, _>>()?;
+        let rel_str = parts.join("/").replace('\\', "/");
         // `path == base` produces an empty rel string (Components yields
         // zero Normal entries), which `RelativePath::new` rejects.
         // Substitute "." so the call still succeeds and downstream
@@ -1270,5 +1300,39 @@ mod tests {
         let rel = RelativePath::from_path_under(&plugin_dir, &plugin_dir)
             .expect("path == base must produce a valid sentinel, not error");
         assert_eq!(rel.as_str(), ".");
+    }
+
+    /// PR #100 review I4: a path component containing invalid UTF-8 must
+    /// produce `ValidationError::InvalidRelativePath { reason: "...non-UTF-8..." }`,
+    /// not a `to_string_lossy`-substituted U+FFFD that round-trips
+    /// through validation but doesn't match anything on disk. Unix-only
+    /// because Windows `OsStr` is WTF-16 and constructing an invalid
+    /// component takes a different path; the production code is
+    /// platform-agnostic — a Unix-only regression test is sufficient
+    /// since it pins the same `to_str()` call site on every target.
+    #[cfg(unix)]
+    #[test]
+    fn from_path_under_rejects_non_utf8_component() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::{Path, PathBuf};
+
+        // 0xFF is invalid as a UTF-8 start byte; the resulting OsStr is
+        // a valid Unix filename but has no UTF-8 representation.
+        let bad_component = OsStr::from_bytes(&[b'a', 0xFF, b'b']);
+        let base = PathBuf::from("/plugins/foo");
+        let path = base.join(Path::new(bad_component));
+
+        let err = RelativePath::from_path_under(&path, &base)
+            .expect_err("non-UTF-8 component must error, not lossy-substitute");
+        match err {
+            crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
+                assert!(
+                    reason.contains("non-UTF-8"),
+                    "reason should call out non-UTF-8, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidRelativePath, got {other:?}"),
+        }
     }
 }

--- a/crates/kiro-market/src/commands/info.rs
+++ b/crates/kiro-market/src/commands/info.rs
@@ -119,7 +119,7 @@ fn print_skills(plugin_dir: &Path) {
     println!("  {}", "Skills:".bold());
 
     for discovered in &skill_dirs {
-        let skill_dir = &discovered.skill_dir;
+        let skill_dir = discovered.skill_dir();
         let skill_md_path = skill_dir.join("SKILL.md");
         let content = match fs::read_to_string(&skill_md_path) {
             Ok(c) => c,

--- a/crates/kiro-market/src/commands/search.rs
+++ b/crates/kiro-market/src/commands/search.rs
@@ -141,7 +141,7 @@ fn search_plugin(
     let mut matches = 0u32;
 
     for discovered in &skill_dirs {
-        let skill_dir = &discovered.skill_dir;
+        let skill_dir = discovered.skill_dir();
         if let Some(fm) = read_skill_frontmatter(skill_dir) {
             let name_lower = fm.name.to_lowercase();
             let desc_lower = fm.description.to_lowercase();


### PR DESCRIPTION
## Summary

Stacked on #100. Addresses the remaining review items not bundled into the first wave (commit \`2ae9dba\` on #100, which closed C1+C2+C3+I1+I6).

**Important issues:**
- **I2** — \`source_hash\` / \`installed_hash\` tightened to required \`String\` for skills + agents. Drops the unreachable \`legacy_fallback\` plumbing in \`scan_plugin_for_content_drift\`. Two new deserialize-rejection tests pin the contract.
- **I3** — \`synthesize_companion_entry\` refreshes \`source_scan_root\` on every install (was set-once). Regression test installs two translated agents under different scan roots and asserts the latest install's value wins.
- **I4** — \`RelativePath::from_path_under\` rejects non-UTF-8 path components instead of \`to_string_lossy\`-substituting U+FFFD. Unix-only regression test.
- **I5** — resolved transitively by #100's C2 fix; documented inline.

**Suggestions:**
- **S1** — stale references to deleted \`detect_plugin_updates_copilot_agent_legacy_fallback\` test rewritten.
- **S2** — \`RelativePath::agents_root()\` constructor replaces the anonymous \`from_internal_unchecked("agents".to_owned())\` site.
- **S3** — REJECTED. Tried it, \`#[non_exhaustive]\` on bundles whose fields are all required is net-worse ergonomics (still breaks consumers when fields are added; forces \`new(N args)\` constructors). Detailed reasoning in commit body.
- **S4** — \`DiscoveredSkill\` fields now \`pub(crate)\` with accessors + \`new_unchecked\` constructor that asserts the \`skill_dir.starts_with(scan_root)\` invariant.
- **S5** — bindings.ts regen produced zero diff (verified). None of the changes flow through Tauri.
- **S6** — multi-scan-root regression test for \`discover_skill_dirs\`.
- **S7** — extracted \`scan_root_invalid_io_err\` shared between \`required_skill_scan_root\` and \`required_source_path\`.

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --tests -- -D warnings
- [x] cargo test --workspace (797 passed in core, all crates green)
- [x] cargo xtask plan-lint (all 6 gates green)
- [x] cargo test -p kiro-control-center --lib -- --ignored (bindings.ts regen)
- [x] npm run check (svelte-check zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)