### PR TITLE
refactor(hash): BlakeHash newtype + post-merge review polish

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/installed.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/installed.rs
@@ -85,8 +85,8 @@ mod tests {
             plugin: PluginName::new("test-plugin").expect("valid plugin"),
             version: Some("1.0.0".into()),
             installed_at: Utc::now(),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: kiro_market_core::hash::BlakeHash::placeholder(),
+            installed_hash: kiro_market_core::hash::BlakeHash::placeholder(),
             source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                 .expect("valid"),
         };
@@ -115,8 +115,8 @@ mod tests {
                 plugin: PluginName::new("test-plugin").expect("valid plugin"),
                 version: Some("1.0.0".into()),
                 installed_at: Utc::now(),
-                source_hash: String::new(),
-                installed_hash: String::new(),
+                source_hash: kiro_market_core::hash::BlakeHash::placeholder(),
+                installed_hash: kiro_market_core::hash::BlakeHash::placeholder(),
                 source_scan_root: kiro_market_core::validation::RelativePath::new("skills")
                     .expect("valid"),
             };

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -192,6 +192,24 @@ export const commands = {
 
 /* Types */
 /**
+ *  Canonical content hash for installed artifacts.
+ * 
+ *  Stored on disk as the string `"blake3:" + 64 ASCII hex chars`. The
+ *  type wraps a `String` with a private inner field so the only ways
+ *  to construct one are (a) `BlakeHash::new` (validates the format),
+ *  (b) the artifact-hash producers in this module ([`hash_artifact`]
+ *  / [`hash_dir_tree`], which build the canonical form by
+ *  construction), or (c) the [`BlakeHash::placeholder`] constructor used
+ *  during install scaffolding (and in test fixtures that don't care about
+ *  the actual content).
+ * 
+ *  The `Deserialize` impl routes through `new`, so a tracking file
+ *  containing `"source_hash": ""` (or any other malformed value) fails
+ *  to load instead of being silently accepted as a sentinel.
+ */
+export type BlakeHash = string;
+
+/**
  *  Result of a marketplace-wide skill listing. The bulk path continues
  *  past per-plugin errors (missing directory, malformed manifest) to
  *  preserve the partial listing; `skipped` records plugin-level drops
@@ -727,8 +745,8 @@ export type InstalledNativeAgentOutcome = {
 	name: string,
 	json_path: string,
 	kind: InstallOutcomeKind,
-	source_hash: string,
-	installed_hash: string,
+	source_hash: BlakeHash,
+	installed_hash: BlakeHash,
 };
 
 /**
@@ -743,8 +761,8 @@ export type InstalledNativeCompanionsOutcome = {
 	plugin: string,
 	files: string[],
 	kind: InstallOutcomeKind,
-	source_hash: string,
-	installed_hash: string,
+	source_hash: BlakeHash,
+	installed_hash: BlakeHash,
 };
 
 /**
@@ -836,8 +854,8 @@ export type InstalledSteeringOutcome = {
 	source: string,
 	destination: string,
 	kind: InstallOutcomeKind,
-	source_hash: string,
-	installed_hash: string,
+	source_hash: BlakeHash,
+	installed_hash: BlakeHash,
 };
 
 // Result of adding a new marketplace.

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -199,9 +199,9 @@ export const commands = {
  *  to construct one are (a) `BlakeHash::new` (validates the format),
  *  (b) the artifact-hash producers in this module ([`hash_artifact`]
  *  / [`hash_dir_tree`], which build the canonical form by
- *  construction), or (c) the [`BlakeHash::placeholder`] constructor used
- *  during install scaffolding (and in test fixtures that don't care about
- *  the actual content).
+ *  construction), or (c) the `placeholder` constructor used during
+ *  install scaffolding (and in test fixtures that don't care about the
+ *  actual content).
  * 
  *  The `Deserialize` impl routes through `new`, so a tracking file
  *  containing `"source_hash": ""` (or any other malformed value) fails

--- a/crates/kiro-market-core/src/hash.rs
+++ b/crates/kiro-market-core/src/hash.rs
@@ -12,7 +12,131 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Canonical content hash for installed artifacts.
+///
+/// Stored on disk as the string `"blake3:" + 64 ASCII hex chars`. The
+/// type wraps a `String` with a private inner field so the only ways
+/// to construct one are (a) `BlakeHash::new` (validates the format),
+/// (b) the artifact-hash producers in this module ([`hash_artifact`]
+/// / [`hash_dir_tree`], which build the canonical form by
+/// construction), or (c) the [`BlakeHash::placeholder`] constructor used
+/// during install scaffolding (and in test fixtures that don't care about
+/// the actual content).
+///
+/// The `Deserialize` impl routes through `new`, so a tracking file
+/// containing `"source_hash": ""` (or any other malformed value) fails
+/// to load instead of being silently accepted as a sentinel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct BlakeHash(String);
+
+const BLAKE_HASH_PREFIX: &str = "blake3:";
+const BLAKE_HASH_HEX_LEN: usize = 64;
+
+impl BlakeHash {
+    /// Construct a `BlakeHash` from a string, validating the canonical
+    /// `"blake3:" + 64 hex` format.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlakeHashParseError`] if `value` doesn't start with
+    /// `"blake3:"`, isn't exactly 64 hex chars after the prefix, or
+    /// contains non-ASCII-hex characters.
+    pub fn new(value: String) -> Result<Self, BlakeHashParseError> {
+        validate_blake_hash(&value)?;
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Build a `BlakeHash` directly from a finalized blake3 digest.
+    /// Crate-internal because the caller holds the raw digest bytes —
+    /// no string parsing involved, format invariant holds by
+    /// construction.
+    pub(crate) fn from_blake3_digest(digest: &blake3::Hash) -> Self {
+        Self(format!(
+            "{BLAKE_HASH_PREFIX}{}",
+            hex::encode(digest.as_bytes())
+        ))
+    }
+}
+
+impl std::fmt::Display for BlakeHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for BlakeHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl BlakeHash {
+    /// A canonical-but-content-meaningless `BlakeHash`, used for two
+    /// patterns:
+    ///
+    /// 1. **Install scaffolding**: an `InstalledSkillMeta` /
+    ///    `InstalledAgentMeta` / `InstalledNativeCompanionsMeta` is
+    ///    constructed before its hashes are known, then the hash
+    ///    fields are overwritten against the staged content before
+    ///    the entry is committed to tracking. The placeholder is
+    ///    well-formed (it will round-trip through `Deserialize`) but
+    ///    must never reach disk — the install-finalisation step is
+    ///    responsible for the overwrite.
+    /// 2. **Test fixtures** that synthesise a meta value from thin
+    ///    air and don't exercise drift detection. Tests asserting
+    ///    drift behaviour should compute a real hash via
+    ///    [`hash_artifact`] instead.
+    #[must_use]
+    pub fn placeholder() -> Self {
+        Self(format!(
+            "{BLAKE_HASH_PREFIX}{}",
+            "0".repeat(BLAKE_HASH_HEX_LEN)
+        ))
+    }
+}
+
+/// Validation failure for [`BlakeHash::new`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid blake3 content hash `{value}`: {reason}")]
+pub struct BlakeHashParseError {
+    pub value: String,
+    pub reason: &'static str,
+}
+
+fn validate_blake_hash(value: &str) -> Result<(), BlakeHashParseError> {
+    let Some(hex) = value.strip_prefix(BLAKE_HASH_PREFIX) else {
+        return Err(BlakeHashParseError {
+            value: value.to_owned(),
+            reason: "missing `blake3:` prefix",
+        });
+    };
+    if hex.len() != BLAKE_HASH_HEX_LEN {
+        return Err(BlakeHashParseError {
+            value: value.to_owned(),
+            reason: "hex payload must be exactly 64 chars",
+        });
+    }
+    if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(BlakeHashParseError {
+            value: value.to_owned(),
+            reason: "hex payload must be ASCII hex digits",
+        });
+    }
+    Ok(())
+}
 
 /// Errors that can occur while computing an artifact hash.
 #[derive(Debug, Error)]
@@ -42,14 +166,15 @@ pub enum HashError {
 /// into the hasher. The NUL separators prevent file-rename collisions
 /// (`a/b` + content `XY` would otherwise collide with `a` + content `b\0XY`).
 ///
-/// Returns `"blake3:" + hex_encoded_digest`. The `"blake3:"` prefix lets a
-/// future migration to a different algorithm be schema-compatible.
+/// Returns a [`BlakeHash`] in canonical `"blake3:" + hex_encoded_digest` form.
+/// The `"blake3:"` prefix lets a future migration to a different algorithm
+/// be schema-compatible.
 ///
 /// # Errors
 ///
 /// Returns `HashError::ReadFailed` if any file in `relative_paths` cannot be
 /// read.
-pub fn hash_artifact(base: &Path, relative_paths: &[PathBuf]) -> Result<String, HashError> {
+pub fn hash_artifact(base: &Path, relative_paths: &[PathBuf]) -> Result<BlakeHash, HashError> {
     let mut sorted: Vec<&PathBuf> = relative_paths.iter().collect();
     sorted.sort();
 
@@ -99,8 +224,7 @@ pub fn hash_artifact(base: &Path, relative_paths: &[PathBuf]) -> Result<String, 
         hasher.update(&bytes);
         hasher.update(&[0u8]);
     }
-    let digest = hasher.finalize();
-    Ok(format!("blake3:{}", hex::encode(digest.as_bytes())))
+    Ok(BlakeHash::from_blake3_digest(&hasher.finalize()))
 }
 
 /// Hash an entire directory tree by walking it and feeding each regular
@@ -113,7 +237,7 @@ pub fn hash_artifact(base: &Path, relative_paths: &[PathBuf]) -> Result<String, 
 ///
 /// - `HashError::WalkFailed` if directory traversal fails.
 /// - `HashError::ReadFailed` if a file in the tree cannot be read.
-pub fn hash_dir_tree(root: &Path) -> Result<String, HashError> {
+pub fn hash_dir_tree(root: &Path) -> Result<BlakeHash, HashError> {
     let mut relative_paths: Vec<PathBuf> = Vec::new();
     walk_collect(root, root, &mut relative_paths)?;
     hash_artifact(root, &relative_paths)
@@ -184,9 +308,9 @@ mod tests {
 
         let h = hash_artifact(base, &[PathBuf::from("a.txt")]).unwrap();
 
-        assert!(h.starts_with("blake3:"), "got: {h}");
+        assert!(h.as_str().starts_with("blake3:"), "got: {h}");
         // 32-byte blake3 → 64 hex chars + "blake3:" prefix = 71 chars.
-        assert_eq!(h.len(), "blake3:".len() + 64);
+        assert_eq!(h.as_str().len(), "blake3:".len() + 64);
     }
 
     #[test]
@@ -272,7 +396,7 @@ mod tests {
         let h2 = hash_dir_tree(root).unwrap();
 
         assert_eq!(h1, h2, "same tree must produce same hash");
-        assert!(h1.starts_with("blake3:"));
+        assert!(h1.as_str().starts_with("blake3:"));
     }
 
     #[test]
@@ -311,7 +435,8 @@ mod tests {
         let expected = format!("blake3:{}", hex::encode(hasher.finalize().as_bytes()));
 
         assert_eq!(
-            h, expected,
+            h.as_str(),
+            expected,
             "hash must use forward-slash canonical path form in the hasher input"
         );
     }
@@ -340,5 +465,91 @@ mod tests {
             h_with_link, h_without,
             "symlinks must not contribute to the directory hash"
         );
+    }
+
+    #[test]
+    fn blake_hash_new_accepts_canonical_form() {
+        let canonical = format!("blake3:{}", "a".repeat(64));
+        let h = BlakeHash::new(canonical.clone()).expect("canonical form must parse");
+        assert_eq!(h.as_str(), canonical);
+    }
+
+    #[test]
+    fn blake_hash_new_rejects_empty_string() {
+        let err = BlakeHash::new(String::new()).expect_err("empty string must be rejected");
+        assert_eq!(err.reason, "missing `blake3:` prefix");
+    }
+
+    #[test]
+    fn blake_hash_new_rejects_missing_prefix() {
+        let err = BlakeHash::new("a".repeat(64)).expect_err("missing prefix must be rejected");
+        assert_eq!(err.reason, "missing `blake3:` prefix");
+    }
+
+    #[test]
+    fn blake_hash_new_rejects_short_payload() {
+        let err = BlakeHash::new(format!("blake3:{}", "a".repeat(63)))
+            .expect_err("63-char payload must be rejected");
+        assert_eq!(err.reason, "hex payload must be exactly 64 chars");
+    }
+
+    #[test]
+    fn blake_hash_new_rejects_long_payload() {
+        let err = BlakeHash::new(format!("blake3:{}", "a".repeat(65)))
+            .expect_err("65-char payload must be rejected");
+        assert_eq!(err.reason, "hex payload must be exactly 64 chars");
+    }
+
+    #[test]
+    fn blake_hash_new_rejects_non_hex_chars() {
+        // 'g' is not a hex digit; everything else is.
+        let mut payload = "a".repeat(63);
+        payload.push('g');
+        let err =
+            BlakeHash::new(format!("blake3:{payload}")).expect_err("non-hex char must be rejected");
+        assert_eq!(err.reason, "hex payload must be ASCII hex digits");
+    }
+
+    #[test]
+    fn blake_hash_serializes_as_plain_string() {
+        let h = BlakeHash::placeholder();
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, format!("\"{}\"", h.as_str()));
+    }
+
+    #[test]
+    fn blake_hash_deserialize_routes_through_new() {
+        // A legacy tracking file with `"source_hash": ""` must fail to load
+        // rather than being silently accepted as a sentinel — that was the
+        // I-1 finding under PR #100/#101 review.
+        let err = serde_json::from_str::<BlakeHash>("\"\"")
+            .expect_err("empty string must fail deserialize");
+        assert!(
+            err.to_string().contains("missing `blake3:` prefix"),
+            "deserialize error must surface the validation reason; got: {err}"
+        );
+    }
+
+    #[test]
+    fn blake_hash_deserialize_accepts_canonical_form() {
+        let canonical = format!("blake3:{}", "f".repeat(64));
+        let json = format!("\"{canonical}\"");
+        let h: BlakeHash = serde_json::from_str(&json).unwrap();
+        assert_eq!(h.as_str(), canonical);
+    }
+
+    #[test]
+    fn hash_artifact_returns_blake_hash_round_trips_through_serde() {
+        // hash_artifact's BlakeHash output must satisfy BlakeHash's own
+        // validation invariant. Belt-and-braces check that the
+        // `from_blake3_digest` constructor stays in sync with `validate_blake_hash`.
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        fs::write(base.join("a.txt"), b"hello").unwrap();
+
+        let h = hash_artifact(base, &[PathBuf::from("a.txt")]).unwrap();
+        let json = serde_json::to_string(&h).unwrap();
+        let h2: BlakeHash = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, h2);
     }
 }

--- a/crates/kiro-market-core/src/hash.rs
+++ b/crates/kiro-market-core/src/hash.rs
@@ -22,19 +22,26 @@ use thiserror::Error;
 /// to construct one are (a) `BlakeHash::new` (validates the format),
 /// (b) the artifact-hash producers in this module ([`hash_artifact`]
 /// / [`hash_dir_tree`], which build the canonical form by
-/// construction), or (c) the [`BlakeHash::placeholder`] constructor used
-/// during install scaffolding (and in test fixtures that don't care about
-/// the actual content).
+/// construction), or (c) the `placeholder` constructor used during
+/// install scaffolding (and in test fixtures that don't care about the
+/// actual content).
 ///
 /// The `Deserialize` impl routes through `new`, so a tracking file
 /// containing `"source_hash": ""` (or any other malformed value) fails
 /// to load instead of being silently accepted as a sentinel.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(transparent)]
 pub struct BlakeHash(String);
 
 const BLAKE_HASH_PREFIX: &str = "blake3:";
 const BLAKE_HASH_HEX_LEN: usize = 64;
+/// Inner string for [`BlakeHash::placeholder`]. Centralised so a future
+/// change to `BLAKE_HASH_PREFIX` / `BLAKE_HASH_HEX_LEN` can't desync the
+/// placeholder from `validate_blake_hash` — the
+/// `placeholder_satisfies_blake_hash_validation` test pins this.
+const BLAKE_HASH_PLACEHOLDER_HEX: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
 
 impl BlakeHash {
     /// Construct a `BlakeHash` from a string, validating the canonical
@@ -45,7 +52,8 @@ impl BlakeHash {
     /// Returns [`BlakeHashParseError`] if `value` doesn't start with
     /// `"blake3:"`, isn't exactly 64 hex chars after the prefix, or
     /// contains non-ASCII-hex characters.
-    pub fn new(value: String) -> Result<Self, BlakeHashParseError> {
+    pub fn new(value: impl Into<String>) -> Result<Self, BlakeHashParseError> {
+        let value = value.into();
         validate_blake_hash(&value)?;
         Ok(Self(value))
     }
@@ -83,9 +91,31 @@ impl<'de> Deserialize<'de> for BlakeHash {
     }
 }
 
+/// Production visibility for [`BlakeHash::placeholder`]. In-crate scaffolding
+/// sites (skill/agent/companion install paths) construct the meta value
+/// before the real hash is known, then overwrite both hash fields against
+/// the staged content before committing to tracking. Keeping this
+/// `pub(crate)` in production builds prevents external crates from
+/// minting a content-meaningless hash that could later reach disk.
+#[cfg(not(any(test, feature = "test-support")))]
 impl BlakeHash {
-    /// A canonical-but-content-meaningless `BlakeHash`, used for two
-    /// patterns:
+    pub(crate) fn placeholder() -> Self {
+        Self(format!("{BLAKE_HASH_PREFIX}{BLAKE_HASH_PLACEHOLDER_HEX}"))
+    }
+}
+
+/// Test-build visibility for [`BlakeHash::placeholder`]. The Tauri crate's
+/// dev-dependencies activate `test-support`, so test fixtures across
+/// crates can build meta values without rigging up a real source file.
+/// The placeholder value is well-formed under the `BlakeHash` invariant
+/// (it round-trips through `Deserialize`), so leaking one into a
+/// production tracking file would cause loud content-drift on the next
+/// install rather than silent corruption — but production code should
+/// still go through the in-crate scaffolding sites that overwrite
+/// before persistence.
+#[cfg(any(test, feature = "test-support"))]
+impl BlakeHash {
+    /// A canonical-but-content-meaningless `BlakeHash` for two patterns:
     ///
     /// 1. **Install scaffolding**: an `InstalledSkillMeta` /
     ///    `InstalledAgentMeta` / `InstalledNativeCompanionsMeta` is
@@ -94,17 +124,16 @@ impl BlakeHash {
     ///    the entry is committed to tracking. The placeholder is
     ///    well-formed (it will round-trip through `Deserialize`) but
     ///    must never reach disk — the install-finalisation step is
-    ///    responsible for the overwrite.
-    /// 2. **Test fixtures** that synthesise a meta value from thin
-    ///    air and don't exercise drift detection. Tests asserting
-    ///    drift behaviour should compute a real hash via
-    ///    [`hash_artifact`] instead.
+    ///    responsible for the overwrite. **Do not branch on equality
+    ///    with `placeholder()` to detect "unset"** — the all-zeros
+    ///    value is computationally indistinguishable from a real hash.
+    /// 2. **Test fixtures** that synthesise a meta value from thin air
+    ///    and don't exercise drift detection. Tests asserting drift
+    ///    behaviour should compute a real hash via [`hash_artifact`]
+    ///    instead.
     #[must_use]
     pub fn placeholder() -> Self {
-        Self(format!(
-            "{BLAKE_HASH_PREFIX}{}",
-            "0".repeat(BLAKE_HASH_HEX_LEN)
-        ))
+        Self(format!("{BLAKE_HASH_PREFIX}{BLAKE_HASH_PLACEHOLDER_HEX}"))
     }
 }
 
@@ -519,9 +548,8 @@ mod tests {
 
     #[test]
     fn blake_hash_deserialize_routes_through_new() {
-        // A legacy tracking file with `"source_hash": ""` must fail to load
-        // rather than being silently accepted as a sentinel — that was the
-        // I-1 finding under PR #100/#101 review.
+        // A tracking file with `"source_hash": ""` must fail to load
+        // rather than being silently accepted as a sentinel.
         let err = serde_json::from_str::<BlakeHash>("\"\"")
             .expect_err("empty string must fail deserialize");
         assert!(
@@ -536,6 +564,18 @@ mod tests {
         let json = format!("\"{canonical}\"");
         let h: BlakeHash = serde_json::from_str(&json).unwrap();
         assert_eq!(h.as_str(), canonical);
+    }
+
+    /// `placeholder()` and `validate_blake_hash` must agree on the format —
+    /// otherwise a future change to `BLAKE_HASH_PREFIX` /
+    /// `BLAKE_HASH_HEX_LEN` could desync the placeholder constant from the
+    /// validator without any caller noticing (until a `Deserialize`
+    /// round-trip on a placeholder-bearing tracking file blew up at load
+    /// time).
+    #[test]
+    fn placeholder_satisfies_blake_hash_validation() {
+        let p = BlakeHash::placeholder();
+        BlakeHash::new(p.as_str().to_owned()).expect("placeholder must satisfy validation");
     }
 
     #[test]

--- a/crates/kiro-market-core/src/hash.rs
+++ b/crates/kiro-market-core/src/hash.rs
@@ -45,7 +45,12 @@ const BLAKE_HASH_PLACEHOLDER_HEX: &str =
 
 impl BlakeHash {
     /// Construct a `BlakeHash` from a string, validating the canonical
-    /// `"blake3:" + 64 hex` format.
+    /// `"blake3:" + 64 hex` format. The hex payload is normalised to
+    /// lowercase so two `BlakeHash` values that represent the same
+    /// content always compare equal, even if one was authored in
+    /// uppercase (e.g. by a hand-edited tracking file or an external
+    /// producer). Lowercase is canonical because `blake3::Hash::Display`
+    /// and `from_blake3_digest` both emit lowercase.
     ///
     /// # Errors
     ///
@@ -53,8 +58,12 @@ impl BlakeHash {
     /// `"blake3:"`, isn't exactly 64 hex chars after the prefix, or
     /// contains non-ASCII-hex characters.
     pub fn new(value: impl Into<String>) -> Result<Self, BlakeHashParseError> {
-        let value = value.into();
+        let mut value = value.into();
         validate_blake_hash(&value)?;
+        // Validation accepts mixed case; equality is case-sensitive on
+        // the inner String. Normalise post-validation so the canonical
+        // form is the only representation that ever lands in `Self`.
+        value.make_ascii_lowercase();
         Ok(Self(value))
     }
 
@@ -66,12 +75,11 @@ impl BlakeHash {
     /// Build a `BlakeHash` directly from a finalized blake3 digest.
     /// Crate-internal because the caller holds the raw digest bytes —
     /// no string parsing involved, format invariant holds by
-    /// construction.
+    /// construction. Uses `blake3::Hash`'s `Display` impl (lowercase
+    /// hex) so the produced value is in canonical form and round-trips
+    /// through `Deserialize` without re-normalisation.
     pub(crate) fn from_blake3_digest(digest: &blake3::Hash) -> Self {
-        Self(format!(
-            "{BLAKE_HASH_PREFIX}{}",
-            hex::encode(digest.as_bytes())
-        ))
+        Self(format!("{BLAKE_HASH_PREFIX}{digest}"))
     }
 }
 
@@ -564,6 +572,24 @@ mod tests {
         let json = format!("\"{canonical}\"");
         let h: BlakeHash = serde_json::from_str(&json).unwrap();
         assert_eq!(h.as_str(), canonical);
+    }
+
+    /// Two `BlakeHash` values authored in different cases but representing
+    /// the same content must compare equal. `validate_blake_hash` accepts
+    /// mixed case, so without lowercase normalisation in `new` an
+    /// uppercase-authored entry from a hand-edited tracking file would
+    /// fail to match the lowercase output of `from_blake3_digest`,
+    /// producing spurious drift on every detection pass.
+    #[test]
+    fn blake_hash_normalises_case_so_equality_is_canonical() {
+        let upper = BlakeHash::new(format!("blake3:{}", "ABCDEF1234567890".repeat(4))).unwrap();
+        let lower = BlakeHash::new(format!("blake3:{}", "abcdef1234567890".repeat(4))).unwrap();
+        assert_eq!(upper, lower, "case-different inputs must compare equal");
+        assert_eq!(
+            upper.as_str(),
+            format!("blake3:{}", "abcdef1234567890".repeat(4)),
+            "stored form must be lowercase canonical"
+        );
     }
 
     /// `placeholder()` and `validate_blake_hash` must agree on the format —

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -395,12 +395,11 @@ const SKILL_MD: &str = "SKILL.md";
 /// install path uses `skill_dir.strip_prefix(scan_root)` to derive the
 /// install-time relative name; a mismatched pair would produce a
 /// nonsense `RelativePath`. Construction goes through
-/// [`Self::new_unchecked`] (in-crate only — the discover sites
+/// [`Self::new_internal`] (in-crate only — the discover sites
 /// guarantee the invariant by construction) which `debug_assert!`s the
 /// prefix relationship; fields are `pub(crate)` so external crates
 /// must read through the [`Self::scan_root`] / [`Self::skill_dir`]
 /// accessors and cannot bypass the invariant with a struct literal.
-/// Per PR #100 review S4.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSkill {
     /// Absolute path to the scan root that contains `skill_dir`,
@@ -422,7 +421,13 @@ impl DiscoveredSkill {
     /// construction. The `debug_assert!` catches contract violations in
     /// tests rather than allowing a silent wrong-prefix that would
     /// later derail `strip_prefix(...)` at the install boundary.
-    pub(crate) fn new_unchecked(scan_root: PathBuf, skill_dir: PathBuf) -> Self {
+    ///
+    /// Named `new_internal` rather than `new_unchecked` because there's
+    /// no `new() -> Result` sibling for the suffix to contrast with:
+    /// the only callers are in-crate construction sites, not external
+    /// validation paths. `unchecked` would falsely imply a checked
+    /// alternative exists.
+    pub(crate) fn new_internal(scan_root: PathBuf, skill_dir: PathBuf) -> Self {
         debug_assert!(
             skill_dir.starts_with(&scan_root),
             "DiscoveredSkill invariant violated: skill_dir `{}` is not under scan_root `{}`",
@@ -496,10 +501,8 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
                         };
                         let entry_path = entry.path();
                         if entry_path.is_dir() && entry_path.join(SKILL_MD).exists() {
-                            found.push(DiscoveredSkill::new_unchecked(
-                                candidate.clone(),
-                                entry_path,
-                            ));
+                            found
+                                .push(DiscoveredSkill::new_internal(candidate.clone(), entry_path));
                         }
                     }
                 }
@@ -518,7 +521,7 @@ pub fn discover_skill_dirs(plugin_root: &Path, skill_paths: &[&str]) -> Vec<Disc
             let scan_root = candidate
                 .parent()
                 .map_or_else(|| plugin_root.to_path_buf(), Path::to_path_buf);
-            found.push(DiscoveredSkill::new_unchecked(scan_root, candidate));
+            found.push(DiscoveredSkill::new_internal(scan_root, candidate));
         } else {
             debug!(
                 path = %candidate.display(),

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -2171,11 +2171,9 @@ impl KiroProject {
     /// function under the line cap.
     ///
     /// `Option<&Path>` is preserved on the public install signature so
-    /// the ~20 in-tree synthetic-agent tests don't all need a real
-    /// source file. The `BlakeHash` field invariant (well-formed
-    /// `"blake3:" + 64-hex`) holds either way — replacing the prior
-    /// `String::new()` empty-string sentinel that could not survive
-    /// the post-PR #101 `BlakeHash::Deserialize` boundary.
+    /// the synthetic-agent tests don't all need a real source file; the
+    /// `BlakeHash` field invariant (well-formed `"blake3:" + 64-hex`)
+    /// holds either way.
     fn hash_translated_source(
         source_path: Option<&Path>,
     ) -> crate::error::Result<crate::hash::BlakeHash> {

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -46,11 +46,11 @@ pub struct InstalledSkillMeta {
     /// in `scan_plugin_for_content_drift` was unreachable in practice
     /// once `source_scan_root` became required (no entry could have
     /// `scan_root` without `source_hash`) and is gone.
-    pub source_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
 
     /// Tree-hash of the skill as it was copied into the project.
     /// Required after PR #100 review I2; see [`Self::source_hash`].
-    pub installed_hash: String,
+    pub installed_hash: crate::hash::BlakeHash,
 
     /// Scan root (relative to `plugin_dir`) that this skill was
     /// installed from. Required at install time; populated from the
@@ -115,11 +115,11 @@ pub struct InstalledAgentMeta {
     /// path computes it, and the post-symmetry-pass schema makes a
     /// missing-source_hash entry impossible (the matching
     /// `source_path` and `dialect` fields are also required).
-    pub source_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
 
     /// Tree-hash of the agent as it was copied into the project.
     /// Required after PR #100 review I2; see [`Self::source_hash`].
-    pub installed_hash: String,
+    pub installed_hash: crate::hash::BlakeHash,
 }
 
 /// Tracking entry for a plugin's companion file bundle that lives under
@@ -151,8 +151,8 @@ pub struct InstalledNativeCompanionsMeta {
     /// by this plugin. Used for collision detection (cross-plugin path
     /// overlap) and for uninstall.
     pub files: Vec<PathBuf>,
-    pub source_hash: String,
-    pub installed_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
+    pub installed_hash: crate::hash::BlakeHash,
     /// Scan root (relative to `plugin_dir`) that this companion bundle
     /// was installed from. Required at install time. The
     /// single-scan-root invariant is enforced upstream by
@@ -192,8 +192,8 @@ pub struct InstalledSteeringMeta {
     pub plugin: PluginName,
     pub version: Option<String>,
     pub installed_at: DateTime<Utc>,
-    pub source_hash: String,
-    pub installed_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
+    pub installed_hash: crate::hash::BlakeHash,
     /// Scan root (relative to `plugin_dir`) that this steering file
     /// was installed from. Required at install time; populated from
     /// `DiscoveredNativeFile.scan_root` (which steering shares with
@@ -273,8 +273,8 @@ pub struct InstalledNativeAgentOutcome {
     pub name: String,
     pub json_path: PathBuf,
     pub kind: InstallOutcomeKind,
-    pub source_hash: String,
-    pub installed_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
+    pub installed_hash: crate::hash::BlakeHash,
 }
 
 /// Output of any classifier that decides between "early-return idempotent
@@ -307,7 +307,7 @@ enum CollisionDecision<T> {
 /// reinstalls — visible to Tauri callers via the
 /// `#[derive(specta::Type)]` on `InstalledSteeringOutcome`.
 struct SteeringIdempotentEcho {
-    prior_installed_hash: String,
+    prior_installed_hash: crate::hash::BlakeHash,
 }
 
 /// Input bundle for [`KiroProject::install_native_companions`]. Groups the
@@ -329,7 +329,7 @@ pub struct NativeCompanionsInput<'a> {
     pub marketplace: &'a MarketplaceName,
     pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
-    pub source_hash: &'a str,
+    pub source_hash: &'a crate::hash::BlakeHash,
     pub mode: crate::service::InstallMode,
     /// Plugin root directory; used to compute
     /// [`InstalledNativeCompanionsMeta::source_scan_root`] from
@@ -350,7 +350,7 @@ pub struct NativeAgentInstallInput<'a> {
     pub marketplace: &'a MarketplaceName,
     pub plugin: &'a PluginName,
     pub version: Option<&'a str>,
-    pub source_hash: &'a str,
+    pub source_hash: &'a crate::hash::BlakeHash,
     pub source_path: &'a crate::validation::RelativePath,
     pub mode: crate::service::InstallMode,
 }
@@ -375,8 +375,8 @@ pub struct InstalledNativeCompanionsOutcome {
     pub plugin: String,
     pub files: Vec<PathBuf>,
     pub kind: InstallOutcomeKind,
-    pub source_hash: String,
-    pub installed_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
+    pub installed_hash: crate::hash::BlakeHash,
 }
 
 /// Aggregated view of a single installed plugin — the union of
@@ -1742,7 +1742,7 @@ impl KiroProject {
         &self,
         source: &Path,
         rel_path: &Path,
-    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, String)> {
+    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, crate::hash::BlakeHash)> {
         let kiro_dir = self.kiro_dir();
         fs::create_dir_all(&kiro_dir).map_err(|src| {
             crate::steering::SteeringError::DestinationDirFailed {
@@ -1839,13 +1839,13 @@ impl KiroProject {
         installed: &InstalledSteering,
         rel_path: &Path,
         plugin: &PluginName,
-        source_hash: &str,
+        source_hash: &crate::hash::BlakeHash,
         dest: &Path,
         mode: crate::service::InstallMode,
     ) -> Result<CollisionDecision<SteeringIdempotentEcho>, crate::steering::SteeringError> {
         match installed.files.get(rel_path) {
             Some(existing) if existing.plugin == *plugin => {
-                if existing.source_hash == source_hash {
+                if existing.source_hash == *source_hash {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         SteeringIdempotentEcho {
                             prior_installed_hash: existing.installed_hash.clone(),
@@ -1939,7 +1939,7 @@ impl KiroProject {
     pub fn install_steering_file(
         &self,
         source: &crate::agent::DiscoveredNativeFile,
-        source_hash: &str,
+        source_hash: &crate::hash::BlakeHash,
         ctx: crate::steering::SteeringInstallContext<'_>,
     ) -> Result<crate::steering::InstalledSteeringOutcome, crate::steering::SteeringError> {
         let rel_path = match source.source.strip_prefix(&source.scan_root) {
@@ -1986,7 +1986,7 @@ impl KiroProject {
         source: &crate::agent::DiscoveredNativeFile,
         rel_path: &Path,
         dest: &Path,
-        source_hash: &str,
+        source_hash: &crate::hash::BlakeHash,
         ctx: crate::steering::SteeringInstallContext<'_>,
     ) -> crate::error::Result<crate::steering::InstalledSteeringOutcome> {
         let tracking_path = self.steering_tracking_path();
@@ -2163,21 +2163,24 @@ impl KiroProject {
     }
 
     /// Hash a translated-agent source file against its parent
-    /// directory + filename. Returns `Ok(None)` for `None` input
-    /// (test fixtures sometimes synthesize an `AgentDefinition` from
-    /// thin air); otherwise delegates to [`crate::hash::hash_artifact`]
-    /// for the canonical hash format. Lifted out of `install_agent_inner`
-    /// to keep that function under the line cap.
-    fn hash_translated_source(source_path: Option<&Path>) -> crate::error::Result<String> {
-        // PR #100 review I2 tightened `InstalledAgentMeta::source_hash`
-        // to required `String` (was `Option<String>`). Production
-        // callers always pass `Some(path)` — the only `None` callers
-        // are test fixtures that synthesise an `AgentDefinition` from
-        // thin air and don't care about drift detection. For those the
-        // empty-string sentinel is the deliberate "no source-side
-        // hash recorded" marker; in production it's never observed.
+    /// directory + filename. For `Some(path)` (the production case)
+    /// delegates to [`crate::hash::hash_artifact`] for the canonical
+    /// hash format; for `None` (synthetic test agents only) returns
+    /// [`BlakeHash::placeholder`] so the meta's hash field stays
+    /// well-formed. Lifted out of `install_agent_inner` to keep that
+    /// function under the line cap.
+    ///
+    /// `Option<&Path>` is preserved on the public install signature so
+    /// the ~20 in-tree synthetic-agent tests don't all need a real
+    /// source file. The `BlakeHash` field invariant (well-formed
+    /// `"blake3:" + 64-hex`) holds either way — replacing the prior
+    /// `String::new()` empty-string sentinel that could not survive
+    /// the post-PR #101 `BlakeHash::Deserialize` boundary.
+    fn hash_translated_source(
+        source_path: Option<&Path>,
+    ) -> crate::error::Result<crate::hash::BlakeHash> {
         let Some(p) = source_path else {
-            return Ok(String::new());
+            return Ok(crate::hash::BlakeHash::placeholder());
         };
         // Production callers always pass a fully-qualified file path so
         // both `parent()` and `file_name()` are guaranteed `Some`. The
@@ -2456,7 +2459,7 @@ impl KiroProject {
         name: &str,
         json_bytes: &[u8],
         prompt_bytes: &[u8],
-    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, PathBuf, String)> {
+    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, PathBuf, crate::hash::BlakeHash)> {
         // TempDir RAII: any `?` propagation below cleans up the staging
         // dir on Drop, so error branches don't need explicit cleanup.
         let staging = tempfile::Builder::new()
@@ -2531,8 +2534,8 @@ impl KiroProject {
                 version: input.version.map(str::to_owned),
                 installed_at: chrono::Utc::now(),
                 files: Vec::new(),
-                source_hash: String::new(),
-                installed_hash: String::new(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
                 source_scan_root: input.source_scan_root.clone(),
             });
         // Refresh marketplace/version/timestamp + source_scan_root on
@@ -2581,13 +2584,13 @@ impl KiroProject {
         installed: &InstalledAgents,
         agent_name: &str,
         plugin: &PluginName,
-        source_hash: &str,
+        source_hash: &crate::hash::BlakeHash,
         json_target: &Path,
         mode: crate::service::InstallMode,
     ) -> crate::error::Result<CollisionDecision<InstalledNativeAgentOutcome>> {
         match installed.agents.get(agent_name) {
             Some(existing) if existing.plugin == *plugin => {
-                if existing.source_hash == source_hash {
+                if existing.source_hash == *source_hash {
                     return Ok(CollisionDecision::Idempotent(Box::new(
                         InstalledNativeAgentOutcome {
                             name: agent_name.to_owned(),
@@ -2736,7 +2739,7 @@ impl KiroProject {
                         installed_at: chrono::Utc::now(),
                         dialect: AgentDialect::Native,
                         source_path: input.source_path.clone(),
-                        source_hash: input.source_hash.to_string(),
+                        source_hash: input.source_hash.clone(),
                         installed_hash: installed_hash.clone(),
                     },
                 );
@@ -2793,7 +2796,7 @@ impl KiroProject {
                     } else {
                         InstallOutcomeKind::Installed
                     },
-                    source_hash: input.source_hash.to_string(),
+                    source_hash: input.source_hash.clone(),
                     installed_hash,
                 })
             });
@@ -2818,7 +2821,7 @@ impl KiroProject {
         &self,
         name: &str,
         raw_bytes: &[u8],
-    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, String)> {
+    ) -> crate::error::Result<(tempfile::TempDir, PathBuf, crate::hash::BlakeHash)> {
         let staging = tempfile::Builder::new()
             .prefix(&format!("_installing-agent-{name}-"))
             .tempdir_in(self.kiro_dir())?;
@@ -2938,8 +2941,8 @@ impl KiroProject {
                 plugin: input.plugin.to_string(),
                 files: Vec::new(),
                 kind: InstallOutcomeKind::Idempotent,
-                source_hash: input.source_hash.to_string(),
-                installed_hash: input.source_hash.to_string(),
+                source_hash: input.source_hash.clone(),
+                installed_hash: input.source_hash.clone(),
             });
         }
 
@@ -3044,7 +3047,7 @@ impl KiroProject {
                 version: input.version.map(String::from),
                 installed_at: chrono::Utc::now(),
                 files: input.rel_paths.to_vec(),
-                source_hash: input.source_hash.to_string(),
+                source_hash: input.source_hash.clone(),
                 installed_hash: installed_hash.clone(),
                 source_scan_root,
             },
@@ -3095,7 +3098,7 @@ impl KiroProject {
             } else {
                 InstallOutcomeKind::Installed
             },
-            source_hash: input.source_hash.to_string(),
+            source_hash: input.source_hash.clone(),
             installed_hash,
         })
     }
@@ -3114,13 +3117,13 @@ impl KiroProject {
         // The HashMap key is still `String` (out of scope), so look up
         // by string view; equality below uses the same shape.
         if let Some(existing) = installed.native_companions.get(input.plugin.as_str()) {
-            if existing.source_hash == input.source_hash {
+            if existing.source_hash == *input.source_hash {
                 return Ok(CollisionDecision::Idempotent(Box::new(
                     InstalledNativeCompanionsOutcome {
                         plugin: input.plugin.to_string(),
                         files: existing.files.iter().map(|p| agents_dir.join(p)).collect(),
                         kind: InstallOutcomeKind::Idempotent,
-                        source_hash: input.source_hash.to_string(),
+                        source_hash: input.source_hash.clone(),
                         installed_hash: existing.installed_hash.clone(),
                     },
                 )));
@@ -3181,7 +3184,7 @@ impl KiroProject {
         plugin: &PluginName,
         scan_root: &Path,
         rel_paths: &[PathBuf],
-    ) -> crate::error::Result<(tempfile::TempDir, String)> {
+    ) -> crate::error::Result<(tempfile::TempDir, crate::hash::BlakeHash)> {
         let staging = tempfile::Builder::new()
             .prefix(&format!("_installing-companions-{}-", plugin.as_str()))
             .tempdir_in(self.kiro_dir())?;
@@ -3510,7 +3513,7 @@ impl KiroProject {
         source_dir: &Path,
         mut meta: InstalledSkillMeta,
         force: bool,
-        source_hash: String,
+        source_hash: crate::hash::BlakeHash,
     ) -> crate::error::Result<()> {
         crate::file_lock::with_file_lock(&self.tracking_path(), || -> crate::error::Result<()> {
             let dir = self.skill_dir(name);
@@ -3634,8 +3637,8 @@ mod tests {
             // both with real hashes during the install path. Tests that
             // pre-stamp tracking entries (no install call) and assert
             // on the field carry their own real hash.
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         }
     }
@@ -3649,8 +3652,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: InstalledAgentMeta = serde_json::from_str(&json).unwrap();
@@ -3672,8 +3675,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Copilot,
             source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid"),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(json.contains("\"dialect\":\"copilot\""));
@@ -3705,8 +3708,8 @@ mod tests {
                 plugin: pn("p"),
                 version: Some("0.1.0".into()),
                 installed_at: chrono::Utc::now(),
-                source_hash: "blake3:abc".into(),
-                installed_hash: "blake3:abc".into(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
                 source_scan_root: RelativePath::new("steering").expect("valid"),
             },
         );
@@ -3759,8 +3762,8 @@ mod tests {
                     "plugin": "p",
                     "version": null,
                     "installed_at": chrono::Utc::now(),
-                    "source_hash": "blake3:abc",
-                    "installed_hash": "blake3:abc",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "steering",
                 }
             }
@@ -3801,8 +3804,8 @@ mod tests {
                     "plugin": "p",
                     "version": null,
                     "installed_at": chrono::Utc::now(),
-                    "source_hash": "blake3:abc",
-                    "installed_hash": "blake3:abc",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "skills",
                 }
             }
@@ -3845,8 +3848,8 @@ mod tests {
                     "installed_at": chrono::Utc::now(),
                     "dialect": "claude",
                     "source_path": "agents/etc.md",
-                    "source_hash": "x",
-                    "installed_hash": "x",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                 }
             }
         });
@@ -3887,8 +3890,8 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "files": [],
-                    "source_hash": "blake3:abc",
-                    "installed_hash": "blake3:abc",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "agents",
                 }
             }
@@ -3931,8 +3934,8 @@ mod tests {
                     "version": null,
                     "installed_at": chrono::Utc::now(),
                     "files": ["../../etc/passwd"],
-                    "source_hash": "blake3:abc",
-                    "installed_hash": "blake3:abc",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "agents",
                 }
             }
@@ -4009,8 +4012,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("subdir/agent.md").expect("valid rel path"),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(
@@ -4137,8 +4140,8 @@ mod tests {
                 plugin: pn("p"),
                 version: None,
                 installed_at: chrono::Utc::now(),
-                source_hash: "blake3:abc".into(),
-                installed_hash: "blake3:abc".into(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
                 source_scan_root: RelativePath::new("steering").expect("valid"),
             },
         );
@@ -4164,8 +4167,8 @@ mod tests {
                     "plugin": "plug-a",
                     "version": "1.0.0",
                     "installed_at": now,
-                    "source_hash": "deadbeef",
-                    "installed_hash": "deadbeef",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "skills"
                 }
             }
@@ -4183,8 +4186,8 @@ mod tests {
                     "plugin": "plug-a",
                     "version": "1.0.0",
                     "installed_at": now,
-                    "source_hash": "cafebabe",
-                    "installed_hash": "cafebabe",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "steering"
                 },
                 "review.md": {
@@ -4192,8 +4195,8 @@ mod tests {
                     "plugin": "plug-b",
                     "version": "0.5.0",
                     "installed_at": now,
-                    "source_hash": "feedface",
-                    "installed_hash": "feedface",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "steering"
                 }
             }
@@ -4248,8 +4251,8 @@ mod tests {
                 "alpha": {
                     "marketplace": "mp", "plugin": "p",
                     "version": "1.0.0", "installed_at": same_time,
-                    "source_hash": "deadbeef",
-                    "installed_hash": "deadbeef",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "skills"
                 }
             }
@@ -4265,7 +4268,7 @@ mod tests {
                 "guide.md": {
                     "marketplace": "mp", "plugin": "p",
                     "version": "2.0.0", "installed_at": same_time,
-                    "source_hash": "cafebabe", "installed_hash": "cafebabe",
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     "source_scan_root": "steering"
                 }
             }
@@ -4320,8 +4323,8 @@ mod tests {
             serde_json::json!({
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
-                "source_hash": "x",
-                "installed_hash": "x",
+                "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                 "source_scan_root": "skills"
             })
         };
@@ -4329,7 +4332,7 @@ mod tests {
             serde_json::json!({
                 "marketplace": "mp", "plugin": "p",
                 "version": "1.0.0", "installed_at": now,
-                "source_hash": "x", "installed_hash": "x",
+                "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                 "source_scan_root": "steering"
             })
         };
@@ -4339,8 +4342,8 @@ mod tests {
                 "version": "1.0.0", "installed_at": now,
                 "dialect": "claude",
                 "source_path": "agents/x.md",
-                "source_hash": "x",
-                "installed_hash": "x"
+                "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
             })
         };
 
@@ -4437,7 +4440,7 @@ mod tests {
                     "guide.md": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "x", "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -4495,7 +4498,7 @@ mod tests {
         project: KiroProject,
         scan_root: PathBuf,
         rel_path: PathBuf,
-        source_hash: String,
+        source_hash: crate::hash::BlakeHash,
     }
 
     impl SteeringFile {
@@ -4807,7 +4810,7 @@ mod tests {
         assert!(dest.exists(), "destination file must exist on disk");
         assert_eq!(fs::read(&dest).unwrap(), b"# Steering Guide\n\nbody");
         assert_eq!(outcome.source_hash, source_hash);
-        assert!(outcome.installed_hash.starts_with("blake3:"));
+        assert!(outcome.installed_hash.as_str().starts_with("blake3:"));
         assert_eq!(outcome.kind, InstallOutcomeKind::Installed);
 
         // Tracking entry must be present.
@@ -4845,8 +4848,8 @@ mod tests {
             installed_at: Utc::now(),
             dialect: AgentDialect::Claude,
             source_path: RelativePath::new("agents/reviewer.md").expect("valid"),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
         }
     }
 
@@ -5585,8 +5588,8 @@ mod tests {
                     "orphan": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "deadbeef",
-                        "installed_hash": "deadbeef",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "skills",
                     }
                 }
@@ -5625,8 +5628,8 @@ mod tests {
                         "plugin": "p",
                         "version": "1.0.0",
                         "installed_at": now,
-                        "source_hash": "feedface",
-                        "installed_hash": "feedface",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -5689,8 +5692,8 @@ mod tests {
                         "plugin": "p",
                         "version": "1.0.0",
                         "installed_at": now,
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -5734,8 +5737,8 @@ mod tests {
                         "plugin": "p",
                         "version": "1.0.0",
                         "installed_at": now,
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -5807,8 +5810,8 @@ mod tests {
                         "installed_at": now,
                         "dialect": "native",
                         "source_path": "agents/reviewer.json",
-                        "source_hash": "deadbeef",
-                        "installed_hash": "deadbeef",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     }
                 }
             }))
@@ -5875,8 +5878,8 @@ mod tests {
                         "installed_at": now,
                         "dialect": "native",
                         "source_path": "agents/ghost.json",
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     }
                 }
             }))
@@ -5929,8 +5932,8 @@ mod tests {
                         "installed_at": now,
                         "dialect": "native",
                         "source_path": "agents/reviewer.json",
-                        "source_hash": "deadbeef",
-                        "installed_hash": "deadbeef",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                     }
                 }
             }))
@@ -5978,8 +5981,8 @@ mod tests {
                         "version": null,
                         "installed_at": now,
                         "files": [],
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "agents",
                     }
                 }
@@ -6028,8 +6031,8 @@ mod tests {
                         "version": null,
                         "installed_at": now,
                         "files": ["prompts/helper.md"],
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "agents",
                     }
                 }
@@ -6083,8 +6086,8 @@ mod tests {
                     "alpha": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "deadbeef",
-                        "installed_hash": "deadbeef",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6100,7 +6103,7 @@ mod tests {
                     "guide.md": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "feedface", "installed_hash": "feedface",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -6154,13 +6157,13 @@ mod tests {
                     "a.md": {
                         "marketplace": "mp-a", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "1", "installed_hash": "1",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     },
                     "b.md": {
                         "marketplace": "mp-b", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "2", "installed_hash": "2",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -6214,8 +6217,8 @@ mod tests {
                     "orphan": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "deadbeef",
-                        "installed_hash": "deadbeef",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "skills",
                     }
                 }
@@ -6288,8 +6291,8 @@ mod tests {
                     plugin: pn("p"),
                     version: Some("1.0.0".into()),
                     installed_at: Utc::now(),
-                    source_hash: "deadbeef".into(),
-                    installed_hash: "deadbeef".into(),
+                    source_hash: crate::hash::BlakeHash::placeholder(),
+                    installed_hash: crate::hash::BlakeHash::placeholder(),
                     source_scan_root: RelativePath::new("skills").expect("valid"),
                 },
             )
@@ -6309,8 +6312,8 @@ mod tests {
                         "plugin": "p",
                         "version": "1.0.0",
                         "installed_at": now,
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -6402,7 +6405,7 @@ mod tests {
                     "../../etc/passwd": {
                         "marketplace": "mp", "plugin": "p",
                         "version": "1.0.0", "installed_at": now,
-                        "source_hash": "x", "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000", "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "steering",
                     }
                 }
@@ -6445,8 +6448,8 @@ mod tests {
                         "version": null,
                         "installed_at": now,
                         "files": [],
-                        "source_hash": "x",
-                        "installed_hash": "x",
+                        "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                        "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
                         "source_scan_root": "agents",
                     }
                 }
@@ -6949,8 +6952,8 @@ mod tests {
                 std::path::PathBuf::from("prompts/a.md"),
                 std::path::PathBuf::from("prompts/b.md"),
             ],
-            source_hash: "blake3:abc".into(),
-            installed_hash: "blake3:abc".into(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
             source_scan_root: RelativePath::new("agents").expect("valid"),
         };
         let bytes = serde_json::to_vec(&meta).unwrap();
@@ -7052,8 +7055,8 @@ mod tests {
                     "plugin": "p",
                     "version": "1.0",
                     "installed_at": "2026-01-01T00:00:00Z",
-                    "source_hash": "blake3:0000",
-                    "installed_hash": "blake3:0000"
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
                 }
             }
         }"#;
@@ -7188,8 +7191,8 @@ mod tests {
                     "version": "1.0",
                     "installed_at": "2026-01-01T00:00:00Z",
                     "files": ["prompts/reviewer.md"],
-                    "source_hash": "blake3:0000",
-                    "installed_hash": "blake3:0000"
+                    "source_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+                    "installed_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
                 }
             }
         }"#;
@@ -7237,8 +7240,8 @@ mod tests {
             plugin: pn("p"),
             version: Some("1.0.0".into()),
             installed_at: chrono::Utc::now(),
-            source_hash: String::new(),
-            installed_hash: String::new(),
+            source_hash: crate::hash::BlakeHash::placeholder(),
+            installed_hash: crate::hash::BlakeHash::placeholder(),
             source_scan_root: RelativePath::new("skills").expect("valid"),
         };
 
@@ -7252,8 +7255,8 @@ mod tests {
         let src_hash = &entry.source_hash;
         let inst_hash = &entry.installed_hash;
 
-        assert!(src_hash.starts_with("blake3:"));
-        assert!(inst_hash.starts_with("blake3:"));
+        assert!(src_hash.as_str().starts_with("blake3:"));
+        assert!(inst_hash.as_str().starts_with("blake3:"));
         // Source and installed contents are identical (we just copied), so the
         // hashes match.
         assert_eq!(src_hash, inst_hash);
@@ -7276,8 +7279,8 @@ mod tests {
         };
         let mapped: Vec<crate::agent::tools::MappedTool> = vec![];
         let mut meta = sample_agent_meta();
-        meta.source_hash = String::new();
-        meta.installed_hash = String::new();
+        meta.source_hash = crate::hash::BlakeHash::placeholder();
+        meta.installed_hash = crate::hash::BlakeHash::placeholder();
         let plugin_name = meta.plugin.clone();
 
         project
@@ -7289,8 +7292,8 @@ mod tests {
 
         let src = &entry.source_hash;
         let inst = &entry.installed_hash;
-        assert!(src.starts_with("blake3:"));
-        assert!(inst.starts_with("blake3:"));
+        assert!(src.as_str().starts_with("blake3:"));
+        assert!(inst.as_str().starts_with("blake3:"));
         // Translated path: source bytes (raw .md) differ from installed bytes
         // (emitted .json + prompt body), so the two hashes ARE different here.
         assert_ne!(src, inst);
@@ -7317,7 +7320,7 @@ mod tests {
             "prompt file must be tracked under native_companions: {:?}",
             companion.files
         );
-        assert!(companion.source_hash.starts_with("blake3:"));
+        assert!(companion.source_hash.as_str().starts_with("blake3:"));
         assert_eq!(companion.source_hash, companion.installed_hash);
     }
 
@@ -7341,8 +7344,8 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Claude,
             };
             let mut meta = sample_agent_meta();
-            meta.source_hash = String::new();
-            meta.installed_hash = String::new();
+            meta.source_hash = crate::hash::BlakeHash::placeholder();
+            meta.installed_hash = crate::hash::BlakeHash::placeholder();
             project
                 .install_agent(&def, &[], meta, Some(&source_md))
                 .expect("install succeeds");
@@ -7395,8 +7398,8 @@ mod tests {
         };
         let mut meta_alpha = sample_agent_meta();
         meta_alpha.source_path = RelativePath::new("agents/alpha.md").expect("valid");
-        meta_alpha.source_hash = String::new();
-        meta_alpha.installed_hash = String::new();
+        meta_alpha.source_hash = crate::hash::BlakeHash::placeholder();
+        meta_alpha.installed_hash = crate::hash::BlakeHash::placeholder();
         project
             .install_agent(&alpha_def, &[], meta_alpha, Some(&alpha_md))
             .expect("install alpha");
@@ -7429,8 +7432,8 @@ mod tests {
         };
         let mut meta_beta = sample_agent_meta();
         meta_beta.source_path = RelativePath::new("prompts/beta.md").expect("valid");
-        meta_beta.source_hash = String::new();
-        meta_beta.installed_hash = String::new();
+        meta_beta.source_hash = crate::hash::BlakeHash::placeholder();
+        meta_beta.installed_hash = crate::hash::BlakeHash::placeholder();
         project
             .install_agent(&beta_def, &[], meta_beta, Some(&beta_md))
             .expect("install beta");
@@ -7469,7 +7472,7 @@ mod tests {
         bundle: crate::agent::NativeAgentBundle,
         src_dir: std::path::PathBuf,
         src_json: std::path::PathBuf,
-        source_hash: String,
+        source_hash: crate::hash::BlakeHash,
     }
 
     impl NativeRev {
@@ -7584,7 +7587,7 @@ mod tests {
         assert!(outcome.json_path.ends_with("rev.json"));
         assert_eq!(outcome.kind, InstallOutcomeKind::Installed);
         assert_eq!(outcome.source_hash, source_hash);
-        assert!(outcome.installed_hash.starts_with("blake3:"));
+        assert!(outcome.installed_hash.as_str().starts_with("blake3:"));
         assert!(outcome.json_path.exists());
 
         let tracking = project.load_installed_agents().expect("load tracking");
@@ -7925,7 +7928,7 @@ mod tests {
     fn stage_companion_source(
         scratch: &Path,
         bodies: &[(&str, &[u8])],
-    ) -> (PathBuf, Vec<PathBuf>, String) {
+    ) -> (PathBuf, Vec<PathBuf>, crate::hash::BlakeHash) {
         let scan_root = scratch.join("companions-src");
         let prompts = scan_root.join("prompts");
         fs::create_dir_all(&prompts).expect("create prompts dir");
@@ -7965,7 +7968,7 @@ mod tests {
         assert_eq!(outcome.files.len(), 2);
         assert_eq!(outcome.kind, InstallOutcomeKind::Installed);
         assert_eq!(outcome.source_hash, source_hash);
-        assert!(outcome.installed_hash.starts_with("blake3:"));
+        assert!(outcome.installed_hash.as_str().starts_with("blake3:"));
 
         // Files landed at the right destinations with original content.
         let dest_a = project.kiro_dir().join("agents/prompts/a.md");
@@ -8004,7 +8007,7 @@ mod tests {
                 marketplace: &mp("m"),
                 plugin: &pn("p"),
                 version: None,
-                source_hash: "blake3:empty",
+                source_hash: &crate::hash::BlakeHash::placeholder(),
                 mode: crate::service::InstallMode::New,
                 plugin_dir: std::path::Path::new("/tmp"),
             })
@@ -8217,7 +8220,7 @@ mod tests {
         project: KiroProject,
         scan_root: PathBuf,
         rel_paths: Vec<PathBuf>,
-        source_hash: String,
+        source_hash: crate::hash::BlakeHash,
     }
 
     impl CompanionBundle {

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1858,8 +1858,8 @@ mod tests {
                 plugin: pn(plugin),
                 version: None,
                 installed_at: Utc::now(),
-                source_hash: String::new(),
-                installed_hash: String::new(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
                 source_scan_root: crate::validation::RelativePath::new("skills").expect("valid"),
             },
         );

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -1302,8 +1302,8 @@ impl MarketplaceService {
                 // `install_skill_from_dir` overwrites both with the
                 // staging-time + post-rename hashes before the entry
                 // is committed to tracking.
-                source_hash: String::new(),
-                installed_hash: String::new(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
                 source_scan_root,
             };
 
@@ -1705,8 +1705,8 @@ impl MarketplaceService {
                 // `install_agent_inner` overwrites both with the
                 // hash_translated_source / staging-time hashes before
                 // the entry is committed to tracking.
-                source_hash: String::new(),
-                installed_hash: String::new(),
+                source_hash: crate::hash::BlakeHash::placeholder(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
             };
             let install_result = if ctx.mode.is_force() {
                 project.install_agent_force(&def, &mapped, meta, Some(&path))
@@ -2704,7 +2704,6 @@ fn read_and_parse_skill_md(
     }
 }
 
-/// Compute the install-time `source_scan_root` for a discovered skill
 /// Build a synthetic `io::Error` describing a structural validation
 /// failure on a path that should have been expressible as a
 /// [`crate::validation::RelativePath`] under `plugin_dir`.
@@ -2737,6 +2736,7 @@ fn scan_root_invalid_io_err(
     )
 }
 
+/// Compute the install-time `source_scan_root` for a discovered skill,
 /// or build a [`FailedSkill`] entry if the discovered `scan_root`
 /// can't be expressed as a `RelativePath` under `plugin_dir`.
 /// Discovery yields paths under `plugin_dir` in practice, so the
@@ -6094,8 +6094,8 @@ mod tests {
                     plugin: pn("structured-p"),
                     version: Some("1.0".into()),
                     installed_at: chrono::Utc::now(),
-                    source_hash: String::new(),
-                    installed_hash: String::new(),
+                    source_hash: crate::hash::BlakeHash::placeholder(),
+                    installed_hash: crate::hash::BlakeHash::placeholder(),
                     source_scan_root: crate::validation::RelativePath::new("skills")
                         .expect("valid"),
                 },
@@ -6390,12 +6390,16 @@ mod tests {
         );
     }
 
-    /// P2a-4 finding: agents have the same `Option<String>` `source_hash` shape
-    /// as skills and must follow the same legacy fallback path. Uses a
-    /// native-format agent to avoid the translated-agent companion-files
+    /// A version bump on a plugin whose tracked agent has a content-mismatched
+    /// `source_hash` must surface as an update. The original test simulated
+    /// the legacy `Option<String>` "no hash recorded" case via empty-string;
+    /// post-`BlakeHash` newtype that shape is structurally impossible, so this
+    /// substitutes [`BlakeHash::placeholder`] which round-trips through
+    /// `Deserialize` but won't match any real content hash. Uses a native-
+    /// format agent to avoid the translated-agent companion-files
     /// path-reconstruction complexity (C7).
     #[test]
-    fn detect_plugin_updates_agent_legacy_fallback_source_hash_none() {
+    fn detect_plugin_updates_agent_version_bump_with_mismatched_hash_surfaces_update() {
         use crate::project::KiroProject;
         use crate::service::test_support::{
             make_plugin_with_skills, relative_path_entry, seed_marketplace_with_registry,
@@ -6433,10 +6437,13 @@ mod tests {
             "agent must be installed before test mutation"
         );
 
-        // Set agent source_hash: None in tracking file
+        // Replace the recorded source_hash with a deliberate placeholder
+        // that won't match the on-disk content. Combined with the version
+        // bump below, this exercises the drift-detection path that
+        // surfaces an update.
         let mut tracking = project.load_installed_agents().unwrap();
         for meta in tracking.agents.values_mut() {
-            meta.source_hash = String::new();
+            meta.source_hash = crate::hash::BlakeHash::placeholder();
         }
         let tracking_path = project_tmp.path().join(".kiro/installed-agents.json");
         fs::write(
@@ -6974,7 +6981,7 @@ mod tests {
                 dialect: crate::agent::AgentDialect::Copilot,
                 source_path: RelativePath::new("agents/reviewer.agent.md").expect("valid rel"),
                 source_hash: expected_hash,
-                installed_hash: String::new(),
+                installed_hash: crate::hash::BlakeHash::placeholder(),
             },
         );
         let installed = InstalledAgents {

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2778,18 +2778,21 @@ fn required_source_path(
     plugin_dir: &Path,
     agent_name: String,
 ) -> Result<crate::validation::RelativePath, FailedAgent> {
-    crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| FailedAgent {
-        name: Some(agent_name),
-        source_path: path.to_path_buf(),
-        error: crate::error::AgentError::InstallFailed {
-            path: path.to_path_buf(),
-            source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
-                "discovered agent path",
-                path,
-                plugin_dir,
-                &e,
-            ))),
-        },
+    crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| {
+        let path_buf = path.to_path_buf();
+        FailedAgent {
+            name: Some(agent_name),
+            source_path: path_buf.clone(),
+            error: crate::error::AgentError::InstallFailed {
+                path: path_buf,
+                source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
+                    "discovered agent path",
+                    path,
+                    plugin_dir,
+                    &e,
+                ))),
+            },
+        }
     })
 }
 

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -6391,13 +6391,10 @@ mod tests {
     }
 
     /// A version bump on a plugin whose tracked agent has a content-mismatched
-    /// `source_hash` must surface as an update. The original test simulated
-    /// the legacy `Option<String>` "no hash recorded" case via empty-string;
-    /// post-`BlakeHash` newtype that shape is structurally impossible, so this
-    /// substitutes [`BlakeHash::placeholder`] which round-trips through
-    /// `Deserialize` but won't match any real content hash. Uses a native-
-    /// format agent to avoid the translated-agent companion-files
-    /// path-reconstruction complexity (C7).
+    /// `source_hash` must surface as an update. Uses [`BlakeHash::placeholder`]
+    /// to deliberately mismatch any real content hash without needing a
+    /// real fixture file. Native-format agent avoids the translated-agent
+    /// companion-files path-reconstruction complexity (C7).
     #[test]
     fn detect_plugin_updates_agent_version_bump_with_mismatched_hash_surfaces_update() {
         use crate::project::KiroProject;
@@ -6437,9 +6434,10 @@ mod tests {
             "agent must be installed before test mutation"
         );
 
-        // Replace the recorded source_hash with a deliberate placeholder
-        // that won't match the on-disk content. Combined with the version
-        // bump below, this exercises the drift-detection path that
+        // The placeholder hash is content-meaningless and will not equal
+        // the recomputed source hash, so it stands in for a drifted entry
+        // without needing to mutate the on-disk source file. Combined
+        // with the version bump below this exercises the drift path that
         // surfaces an update.
         let mut tracking = project.load_installed_agents().unwrap();
         for meta in tracking.agents.values_mut() {
@@ -6463,7 +6461,7 @@ mod tests {
         assert_eq!(
             result.updates.len(),
             1,
-            "agent with source_hash: None and version bump must surface as update, got: {result:?}"
+            "agent with placeholder source_hash and version bump must surface as update, got: {result:?}"
         );
         assert_eq!(result.updates[0].plugin.as_str(), "p");
         assert!(matches!(

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -181,8 +181,8 @@ pub struct InstalledSteeringOutcome {
     pub source: PathBuf,
     pub destination: PathBuf,
     pub kind: InstallOutcomeKind,
-    pub source_hash: String,
-    pub installed_hash: String,
+    pub source_hash: crate::hash::BlakeHash,
+    pub installed_hash: crate::hash::BlakeHash,
 }
 
 /// Per-file failure entry in a steering install batch.

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -122,18 +122,42 @@ impl RelativePath {
         // hashing later misses with `NotFound` and the user sees a
         // misleading "missing file" error. Failing the construction
         // here surfaces the real cause at the parse boundary.
+        // Match each component explicitly rather than `_ => None`. Only
+        // `CurDir` (`.`) is silently discarded; `ParentDir` (`..`),
+        // `Prefix` (Windows drive letters), and `RootDir` (a leading
+        // separator) are structurally illegal under a relative-path
+        // contract and must error rather than silently disappear into the
+        // filter. Without this gate a hand-built path lexically containing
+        // `..` after `strip_prefix` would round-trip as a "clean"
+        // `RelativePath` that doesn't represent the input.
         let parts: Vec<&str> = rel
             .components()
             .filter_map(|c| match c {
-                std::path::Component::Normal(s) => Some(s),
-                _ => None,
-            })
-            .map(|s| {
-                s.to_str()
-                    .ok_or_else(|| ValidationError::InvalidRelativePath {
+                std::path::Component::Normal(s) => Some(Ok(s)),
+                std::path::Component::CurDir => None,
+                std::path::Component::ParentDir => {
+                    Some(Err(ValidationError::InvalidRelativePath {
                         path: path.display().to_string(),
-                        reason: "path contains a non-UTF-8 component".to_owned(),
-                    })
+                        reason: "path contains a `..` component".to_owned(),
+                    }))
+                }
+                std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                    Some(Err(ValidationError::InvalidRelativePath {
+                        path: path.display().to_string(),
+                        reason: "path contains an absolute or prefix component after \
+                                 strip_prefix"
+                            .to_owned(),
+                    }))
+                }
+            })
+            .map(|c| {
+                c.and_then(|s| {
+                    s.to_str()
+                        .ok_or_else(|| ValidationError::InvalidRelativePath {
+                            path: path.display().to_string(),
+                            reason: "path contains a non-UTF-8 component".to_owned(),
+                        })
+                })
             })
             .collect::<Result<_, _>>()?;
         let rel_str = parts.join("/").replace('\\', "/");
@@ -1330,6 +1354,32 @@ mod tests {
                 assert!(
                     reason.contains("non-UTF-8"),
                     "reason should call out non-UTF-8, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidRelativePath, got {other:?}"),
+        }
+    }
+
+    /// `..` component in the post-`strip_prefix` path must error rather
+    /// than silently disappear into the component filter. Without this
+    /// gate a hand-built path lexically containing `..` would round-trip
+    /// as a "clean" `RelativePath` that doesn't represent the input —
+    /// the precondition for a path-traversal smuggling bug.
+    ///
+    /// Constructs the relative path directly via `Path::new("..")` and
+    /// passes a base of `""` so `strip_prefix` is a no-op and the `..`
+    /// reaches the component-classification arm.
+    #[test]
+    fn from_path_under_rejects_parent_dir_component() {
+        use std::path::Path;
+
+        let err = RelativePath::from_path_under(Path::new("../etc/passwd"), Path::new(""))
+            .expect_err("ParentDir component must error, not silently disappear");
+        match err {
+            crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
+                assert!(
+                    reason.contains(".."),
+                    "reason should call out the `..` component, got: {reason}"
                 );
             }
             other => panic!("expected InvalidRelativePath, got {other:?}"),

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -1385,4 +1385,28 @@ mod tests {
             other => panic!("expected InvalidRelativePath, got {other:?}"),
         }
     }
+
+    /// `RootDir` (a leading separator) is structurally illegal under a
+    /// relative-path contract. Pre-S-4 the `_ => None` filter silently
+    /// dropped it; this test pins the explicit error so a future
+    /// refactor can't collapse the arm back into a silent discard.
+    /// `Prefix` (Windows drive letters) shares the same arm and is
+    /// covered by the same regression by construction.
+    #[cfg(unix)]
+    #[test]
+    fn from_path_under_rejects_absolute_path() {
+        use std::path::Path;
+
+        let err = RelativePath::from_path_under(Path::new("/etc/passwd"), Path::new(""))
+            .expect_err("absolute path must error, not silently disappear");
+        match err {
+            crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
+                assert!(
+                    reason.contains("absolute") || reason.contains("prefix"),
+                    "reason should call out the absolute/prefix component, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidRelativePath, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Standalone follow-up to merged PR #101 (the merge happened mid-review). Lands the `BlakeHash` newtype that closes the I-1 finding from the wave-3 multi-agent review, plus the small polish items the same review surfaced.

Stacked on PR #100 (same `fix/install-detect-symmetry` base PR #101 used).

**Two commits:**

### Wave 3 — `4491955`
- **I-1** — `BlakeHash` newtype with private inner field, `"blake3:" + 64 ASCII hex` invariant, custom `Deserialize` routes through `new`. Replaces `String` on every persisted-hash field across 5 meta types and 3 Tauri-facing outcome types. The `String::new()` empty-string sentinel that survived I2 (and that the multi-agent review of merged #101 flagged as a still-silent failure) is gone — a tracking file with `"source_hash": ""` now fails to load instead of silently feeding the comparison-as-equal bug. `hash_artifact` / `hash_dir_tree` produce `BlakeHash` directly via a `pub(crate)` constructor that takes the `blake3::Hash` digest bytes — no `expect`, no plan-lint allowlist addition. Production scaffolding sites and test fixtures use a documented `BlakeHash::placeholder()` for the well-formed-but-content-meaningless case.
- **I-3** — fixed doc-comment paste error at `service/mod.rs:2707` (orphaned "or build" fragment after the `scan_root_invalid_io_err` extraction).
- **I-4** — `hash_translated_source` doc no longer claims `Ok(None)`; `Option<&Path>` preserved on the public install signature so the synthetic-agent tests don't all need a real source file.
- **I-5** — renamed `detect_plugin_updates_agent_legacy_fallback_source_hash_none` to `detect_plugin_updates_agent_version_bump_with_mismatched_hash_surfaces_update`; rewrote body to use `BlakeHash::placeholder()` since the empty-string "no hash recorded" shape is structurally impossible post-I-1.
- **S-2** — `DiscoveredSkill::new_unchecked` → `new_internal`. No `new() -> Result` sibling exists, so `unchecked` was misleading.
- **S-4** — `RelativePath::from_path_under` now matches every `Component` variant explicitly. `ParentDir` and `RootDir`/`Prefix` produce `InvalidRelativePath` errors instead of silently disappearing into the `_ => None` filter.

### Wave 4 — `568b505`
Polish from the multi-agent review of wave 3:
- **W3-I-1** — `BlakeHash::placeholder()` is now `pub(crate)` in production builds, `pub` only under `cfg(any(test, feature = "test-support"))`. Closes the silent-failure surface where an external crate could mint a content-meaningless hash.
- **W3-I-3** — `#[serde(transparent)]` on `BlakeHash` for parity with sibling validation newtypes (`RelativePath`, `AgentName`).
- **W3-I-4** — stripped 3 PR-anchor trailing clauses from new comments (`hash.rs`, `project.rs`, `service/mod.rs`) to keep issue #103 from growing.
- **W3-I-5** — `BlakeHash::new(value: impl Into<String>)` matches sibling newtype API.
- **W3-S-1** — new `placeholder_satisfies_blake_hash_validation` test catches a future `BLAKE_HASH_PREFIX` / `BLAKE_HASH_HEX_LEN` constant drift; constant extracted to `BLAKE_HASH_PLACEHOLDER_HEX`.
- **W3-S-2** — fixed stale "agent with source_hash: None" assertion message (the `None` shape is impossible post-I-1).
- **W3-S-3** — new `from_path_under_rejects_absolute_path` test pins the `Component::Prefix` / `RootDir` arms.

## Follow-ups (deferred to issues)

Surfaced by the multi-agent review of merged PR #101; intentionally out of scope here:
- #102 — companion install accumulates files but overwrites `source_scan_root` (structural)
- #103 — comment hygiene (~20 PR-number anchor sites + deleted-test gravestone)
- #104 — `#[non_exhaustive]` on wire-format types (`InstalledSkillMeta`, `InstalledAgentMeta`)
- #105 — small test gaps (`new_internal` `#[should_panic]`, `agents_root()` direct test, `scan_root_invalid_io_err` defensive arm)

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (810 core, all crates green)
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo xtask plan-lint` (all 6 gates)
- [x] `cargo test -p kiro-control-center --lib -- --ignored` (bindings.ts regen — adds `BlakeHash` type alias + 6 outcome-field type tightenings)
- [x] `npm run check` (svelte-check 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)