### PR TITLE
docs: strip PR-anchor rot from comments across kiro-market-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 # Tethys index built by `cargo xtask plan-lint` (and direct `tethys index`).
 # Never committed — recreated on demand from source.
 /.rivets/
+
+# Git worktrees for isolated feature branches
+.worktrees/

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -789,8 +789,7 @@ mod tests {
         // Pin the specific CLI subcommand. `kiro-market install` is the
         // remediation because it uses the cloning resolver; previously
         // this hint said `kiro-market add` which does not exist as a
-        // subcommand (flagged by gemini-code-assist on PR #35). The
-        // `install` substring catches a regression back to any
+        // subcommand. The `install` substring catches a regression back to any
         // non-existent command.
         assert!(
             cli.contains("kiro-market install"),

--- a/crates/kiro-market-core/src/kiro_settings.rs
+++ b/crates/kiro-market-core/src/kiro_settings.rs
@@ -693,8 +693,8 @@ pub fn set_nested(value: &mut JsonValue, path: &str, val: JsonValue) {
 
 /// A dotted path like `"chat.defaultModel"` is well-formed iff every
 /// `.`-delimited segment is non-empty. Rejects `""`, `"."`, `".key"`,
-/// `"key."`, `"a..b"`, and `".."` — the previously-silent corruption
-/// shapes flagged by the silent-failure hunter on PR #73.
+/// `"key."`, `"a..b"`, and `".."` — the shapes of previously-silent
+/// corruption.
 fn is_well_formed_dotted_path(path: &str) -> bool {
     !path.is_empty() && path.split('.').all(|s| !s.is_empty())
 }

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -1021,7 +1021,7 @@ mod tests {
 
     #[test]
     fn manifest_format_absent_defaults_to_translated() {
-        // I8: omitted `format` field deserializes to
+        // Omitted `format` field deserializes to
         // `PluginFormat::Translated` via `#[serde(default)]` +
         // `#[derive(Default)]`. Encodes "no format = translated" in
         // the type instead of `Option<...>::None`.

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -679,10 +679,10 @@ mod tests {
         );
     }
 
-    /// PR #100 review C2: a manifest declaring `skills: ["my-skill"]`
+    /// A manifest declaring `skills: ["my-skill"]`
     /// (bare path with NO `./skills/` parent — i.e. the skill lives at
     /// the plugin root) makes the bare-path branch set
-    /// `scan_root = candidate.parent() = plugin_root`. Pre-fix this
+    /// `scan_root = candidate.parent() = plugin_root`. Previously this
     /// resulted in install pushing `FailedSkill` because
     /// `RelativePath::from_path_under(plugin_root, plugin_root)` errored
     /// on empty rel. Post-fix `from_path_under` returns
@@ -711,7 +711,7 @@ mod tests {
         );
     }
 
-    /// PR #100 review S6: a manifest declaring TWO scan roots
+    /// A manifest declaring TWO scan roots
     /// (`["./packs/", "./extras/"]`) with skills under each must
     /// produce one `DiscoveredSkill` per skill, each carrying its OWN
     /// scan root — not the most-recently-seen root for all of them.

--- a/crates/kiro-market-core/src/plugin.rs
+++ b/crates/kiro-market-core/src/plugin.rs
@@ -685,7 +685,7 @@ mod tests {
     /// `scan_root = candidate.parent() = plugin_root`. Previously this
     /// resulted in install pushing `FailedSkill` because
     /// `RelativePath::from_path_under(plugin_root, plugin_root)` errored
-    /// on empty rel. Post-fix `from_path_under` returns
+    /// on empty rel. Now `from_path_under` returns
     /// `RelativePath(".")` so install + detection round-trip cleanly.
     /// This test asserts only that `discover_skill_dirs` produces the
     /// `scan_root == plugin_root` case the install code now handles.

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -3995,7 +3995,7 @@ mod tests {
         }
     }
 
-    /// NC2 + parse-don't-validate sanity: a well-formed `source_path`
+    /// Parse-don't-validate sanity: a well-formed `source_path`
     /// (forward-slash relative path under `agents/`) must round-trip
     /// through serde.
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -39,17 +39,16 @@ pub struct InstalledSkillMeta {
     pub installed_at: DateTime<Utc>,
 
     /// Tree-hash of the skill source as it existed in the marketplace at
-    /// install time. Required after PR #100 review I2 — every install
-    /// path computes this, and the install↔detect symmetry pass made
-    /// `source_scan_root` required which means any post-Stage-1+
-    /// tracking entry has both. The deferred `legacy_fallback` plumbing
-    /// in `scan_plugin_for_content_drift` was unreachable in practice
-    /// once `source_scan_root` became required (no entry could have
-    /// `scan_root` without `source_hash`) and is gone.
+    /// install time. Required — every install path computes this, and
+    /// the install↔detect symmetry pass made `source_scan_root` required
+    /// which means any entry that tracks a scan root must also track a
+    /// source hash. The deferred `legacy_fallback` plumbing in
+    /// `scan_plugin_for_content_drift` was unreachable in practice once
+    /// `source_scan_root` became required and is gone.
     pub source_hash: crate::hash::BlakeHash,
 
     /// Tree-hash of the skill as it was copied into the project.
-    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    /// Required; see [`Self::source_hash`].
     pub installed_hash: crate::hash::BlakeHash,
 
     /// Scan root (relative to `plugin_dir`) that this skill was
@@ -110,7 +109,7 @@ pub struct InstalledAgentMeta {
     pub source_path: RelativePath,
 
     /// Tree-hash of the agent source as it existed in the marketplace at
-    /// install time. Required after PR #100 review I2; mirrors the
+    /// install time. Required; mirrors the
     /// `InstalledSkillMeta::source_hash` tightening — every install
     /// path computes it, and the post-symmetry-pass schema makes a
     /// missing-source_hash entry impossible (the matching
@@ -118,7 +117,7 @@ pub struct InstalledAgentMeta {
     pub source_hash: crate::hash::BlakeHash,
 
     /// Tree-hash of the agent as it was copied into the project.
-    /// Required after PR #100 review I2; see [`Self::source_hash`].
+    /// Required; see [`Self::source_hash`].
     pub installed_hash: crate::hash::BlakeHash,
 }
 
@@ -157,8 +156,7 @@ pub struct InstalledNativeCompanionsMeta {
     /// was installed from. Required at install time. The
     /// single-scan-root invariant is enforced upstream by
     /// `multiple_companion_scan_roots`, so all `files` resolve under
-    /// this single root. Drift detection uses it directly, replacing
-    /// PR #96's `hash_artifact_in_scan_paths` probe.
+    /// this single root. Drift detection uses it directly.
     pub source_scan_root: RelativePath,
 }
 
@@ -200,8 +198,7 @@ pub struct InstalledSteeringMeta {
     /// the agent discover sites). Drift detection at
     /// [`crate::service::MarketplaceService::scan_plugin_for_content_drift`]
     /// uses this directly to locate the source file for hash
-    /// recomputation, replacing PR #96's `hash_artifact_in_scan_paths`
-    /// probe helper.
+    /// recomputation.
     pub source_scan_root: RelativePath,
 }
 
@@ -2537,7 +2534,7 @@ impl KiroProject {
                 source_scan_root: input.source_scan_root.clone(),
             });
         // Refresh marketplace/version/timestamp + source_scan_root on
-        // every install. PR #100 review I3: the post-insert refresh
+        // every install. The post-insert refresh
         // initially missed `source_scan_root`, so a manifest that
         // changed its scan paths between installs would keep the stale
         // root recorded forever — the install-time scan_root is what
@@ -3960,7 +3957,7 @@ mod tests {
         }
     }
 
-    /// NC2 (PR #96 re-review): a tampered `installed-agents.json`
+    /// A tampered `installed-agents.json`
     /// whose per-agent `source_path` contains a traversal entry would,
     /// without the `RelativePath` newtype on `InstalledAgentMeta`,
     /// reach `hash_artifact(agents_dir, &[rel])` at update-detection
@@ -6957,7 +6954,7 @@ mod tests {
         let bytes = serde_json::to_vec(&meta).unwrap();
         let back: InstalledNativeCompanionsMeta = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(back.files.len(), 2);
-        // PR #100 review I6: the round-trip used to assert only on
+        // The round-trip used to assert only on
         // `files.len()`, which was satisfied long before
         // `source_scan_root` joined the schema. Locking the field
         // explicitly so a future regression that drops or re-types it
@@ -6966,7 +6963,7 @@ mod tests {
         assert_eq!(back.source_scan_root.as_str(), "agents");
     }
 
-    /// PR #100 review I1: `required_steering_scan_root` must surface a
+    /// `required_steering_scan_root` must surface a
     /// structural validation failure as `SteeringError::ScanRootInvalid`,
     /// not a synthetic `SourceReadFailed { source: io::Error }`. The
     /// real `ValidationError` propagates via `#[source]` so the
@@ -7100,12 +7097,12 @@ mod tests {
         );
     }
 
-    /// PR #100 review I2: a tracking entry with `source_scan_root` but
+    /// A tracking entry with `source_scan_root` but
     /// without `source_hash` / `installed_hash` was unreachable in
     /// practice (every install path that records `scan_root` also
     /// records hashes), but the deferred `Option<String>` field type
     /// kept the `legacy_fallback` escape hatch alive in detection.
-    /// After I2 the fields are required `String` and a contradictory
+    /// With the fields now required, a contradictory
     /// entry (`scan_root` present, hashes absent) fails to deserialize
     /// at the boundary.
     #[test]
@@ -7138,7 +7135,7 @@ mod tests {
         );
     }
 
-    /// PR #100 review I2 sibling for agents: a tracking entry that
+    /// Sibling for agents: a tracking entry that
     /// has `source_path` (the Stage-1+ symmetry-pass marker) but
     /// lacks `source_hash` / `installed_hash` is structurally
     /// contradictory and must be rejected at the deserialize
@@ -7367,13 +7364,13 @@ mod tests {
         );
     }
 
-    /// PR #100 review I3: when a plugin's manifest changes its
+    /// When a plugin's manifest changes its
     /// translated-agent source path between installs, the recorded
     /// `source_scan_root` on the existing `native_companions` entry
     /// must refresh to the latest install's scan root — otherwise
     /// drift detection (once issue #99 lands and starts consulting
     /// the field) would look up the source under the stale root and
-    /// emit false drift on every scan. Pre-fix the `or_insert_with`
+    /// emit false drift on every scan. Previously the `or_insert_with`
     /// initializer set the value once and the post-insert refresh
     /// updated `marketplace`/`version`/`installed_at`/`files` but
     /// skipped `source_scan_root`, so the very first install's value

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -102,7 +102,7 @@ pub struct InstalledAgentMeta {
     /// **Was `Option<RelativePath>`** before the install↔detect symmetry
     /// pass; tightened to required when the no-users assumption let us
     /// drop the legacy-fallback machinery (the dialect-fallback branch
-    /// in `agent_hash_inputs` and the I-N7 actionable-error branch in
+    /// in `agent_hash_inputs` and the actionable-error branch in
     /// the agents loop). A tracking file written before the field
     /// existed now fails to deserialize — pinned by the
     /// `load_installed_agents_rejects_legacy_entry` test.

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1117,8 +1117,7 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Err
     // malicious marketplace shipping a multi-GB plugin.json cannot OOM
     // the process before serde sees a byte. Mirrors the cap applied to
     // service::mod::load_plugin_manifest in the Phase 2a detection path.
-    // Pre-existing crate-wide gap flagged by marketplace-security-reviewer
-    // in PR #96 review.
+    // Pre-existing crate-wide gap flagged by marketplace-security-reviewer.
     let bytes = match super::read_capped(&manifest_path, super::MAX_PLUGIN_MANIFEST_BYTES) {
         Ok(b) => b,
         Err(e) => {
@@ -1571,8 +1570,7 @@ mod tests {
 
     /// Resource cap regression: a `plugin.json` larger than
     /// `MAX_PLUGIN_MANIFEST_BYTES` (1 MiB) must be rejected before
-    /// serde sees the bytes. Mitigates the OOM vector flagged by
-    /// marketplace-security-reviewer in PR #96 review (a malicious
+    /// serde sees the bytes. Mitigates the OOM vector (a malicious
     /// marketplace could otherwise ship a multi-GB manifest and OOM
     /// the host). The cap fires at `super::read_capped`, which
     /// returns `io::ErrorKind::InvalidData` — surfaced here as

--- a/crates/kiro-market-core/src/service/browse.rs
+++ b/crates/kiro-market-core/src/service/browse.rs
@@ -1116,7 +1116,7 @@ fn load_plugin_manifest(plugin_dir: &Path) -> Result<Option<PluginManifest>, Err
     // Resource cap: bound the read at MAX_PLUGIN_MANIFEST_BYTES so a
     // malicious marketplace shipping a multi-GB plugin.json cannot OOM
     // the process before serde sees a byte. Mirrors the cap applied to
-    // service::mod::load_plugin_manifest in the Phase 2a detection path.
+    // service::mod::load_plugin_manifest in the detection path.
     // Pre-existing crate-wide gap flagged by marketplace-security-reviewer.
     let bytes = match super::read_capped(&manifest_path, super::MAX_PLUGIN_MANIFEST_BYTES) {
         Ok(b) => b,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2524,7 +2524,7 @@ impl MarketplaceService {
 
         // Agents — direct lookup against the install-recorded
         // source_path. After the install↔detect symmetry pass + I2
-        // tightening, the dialect-fallback machinery, the I-N7
+        // tightening, the dialect-fallback machinery, the
         // actionable-error branch, AND the legacy-source_hash
         // fallback are gone: install always records source_path AND
         // source_hash, so detection always knows the precise file to

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -512,13 +512,12 @@ pub struct PluginUpdateFailure {
     pub reason: String,
 }
 
-/// Why an update-detection scan couldn't check a plugin. Tagged enum
-/// for FFI per the `ffi-enum-serde-tag` plan-lint gate (PR #91):
+/// Why an update-detection scan couldn't check a plugin.
 /// `#[serde(tag = "kind", rename_all = "snake_case")]` produces
 /// `{ "kind": "manifest_unreadable" }` in JSON, which `tauri-specta`
 /// emits as a discriminated TS union.
 ///
-/// Closes original-review I4: `PluginUpdateFailure` was opaque
+/// `PluginUpdateFailure` was previously opaque
 /// (substring matching `reason` to differentiate failure types
 /// violated CLAUDE.md Rule 42). The classifier
 /// [`PluginUpdateFailureKind::from_error`] is exhaustive per the
@@ -627,8 +626,7 @@ fn classify_plugin_error(err: &PluginError) -> PluginUpdateFailureKind {
     }
 }
 
-/// Why an update is being surfaced. Tagged enum for FFI per the
-/// `ffi-enum-serde-tag` plan-lint gate (PR #91): `#[serde(tag = "kind",
+/// Why an update is being surfaced. `#[serde(tag = "kind",
 /// rename_all = "snake_case")]` produces `{ "kind": "version_bumped" }`
 /// in JSON, which `tauri-specta` emits as a discriminated TS union.
 #[derive(Clone, Debug, Serialize)]
@@ -2242,7 +2240,7 @@ impl MarketplaceService {
     ) -> Result<DetectUpdatesResult, Error> {
         let view = project.installed_plugins()?;
         // Hoist the three tracking-file loads above the per-plugin
-        // loop (originally-deferred IMPORTANT in PR #96 review). Pre-fix:
+        // loop. Previously,
         // `scan_plugin_for_content_drift` called
         // load_installed{,_steering,_agents}() once per plugin, so a
         // project with N installed plugins did 3N reads + JSON
@@ -2311,7 +2309,7 @@ impl MarketplaceService {
         let marketplace_path = self.marketplace_path(marketplace_name);
         let plugin_dir = self.resolve_local_plugin_dir(entry, &marketplace_path)?;
 
-        // NC1 (PR #96 re-review): pre-rename, `load_plugin_manifest_version`
+        // `load_plugin_manifest_version` previously
         // returned `Ok(None)` for both "manifest legitimately lacks
         // version" and "manifest unreadable", and the latter case
         // combined with `installed_version: Some(_)` below to emit a
@@ -2384,16 +2382,15 @@ impl MarketplaceService {
 
     /// Load `plugin.json` from `plugin_dir` and return the full parsed
     /// [`crate::plugin::PluginManifest`] — three semantically distinct
-    /// outcomes per NC1 (PR #96 re-review):
+    /// outcomes:
     ///
     /// - [`ManifestState::Found`] — manifest read and parsed. Caller
     ///   reads `.version` for the version comparison AND `.agents` /
     ///   `.steering` for the scan-path probing in
-    ///   [`Self::scan_plugin_for_content_drift`] (per the
-    ///   manifest-respects-scan-paths fix from the PR #96 re-review;
-    ///   pre-fix, drift detection compared against the hardcoded
-    ///   `./steering/` and `./agents/` defaults regardless of what the
-    ///   manifest declared).
+    ///   [`Self::scan_plugin_for_content_drift`] (the
+    ///   manifest-respects-scan-paths fix; previously, drift detection
+    ///   compared against the hardcoded `./steering/` and `./agents/`
+    ///   defaults regardless of what the manifest declared).
     /// - [`ManifestState::Unreadable`] — manifest could not be read for
     ///   a non-fatal reason (symlink-refused or `NotFound`). The
     ///   caller must surface this as a per-plugin failure rather than
@@ -2474,22 +2471,20 @@ impl MarketplaceService {
     /// hashes against the same roots install used. Pre-fix the
     /// steering and native-companion loops hardcoded `plugin_dir/
     /// steering` and `plugin_dir/agents`, producing false-positive
-    /// drift on every scan for plugins declaring custom paths
-    /// (PR #96 review #6). The manifest is `Option<&...>` so callers
+    /// drift on every scan for plugins declaring custom paths.
+    /// The manifest is `Option<&...>` so callers
     /// that lack a parsed manifest fall back to
     /// [`crate::DEFAULT_STEERING_PATHS`] / [`crate::DEFAULT_AGENT_PATHS`]
     /// via the same helpers `MarketplaceService::install_plugin`
     /// uses.
     ///
-    /// PR #100 review I2 dropped the `legacy_fallback` second return
-    /// value: after the install↔detect symmetry pass made
-    /// `source_scan_root` required AND tightened `source_hash` to
-    /// required `String`, no in-tree tracking entry can land here
-    /// without both fields. The previous `Option<String>` matching
-    /// arms (`None => legacy_fallback = true`) were unreachable at
-    /// runtime, so the helper now returns just `bool` and the caller
-    /// no longer logs a "legacy entry" debug line that could never
-    /// fire.
+    /// After the install↔detect symmetry pass made `source_scan_root`
+    /// required AND tightened `source_hash` to required `String`, no
+    /// in-tree tracking entry can land here without both fields. The
+    /// previous `Option<String>` matching arms (`None => legacy_fallback
+    /// = true`) were unreachable at runtime, so the helper now returns
+    /// just `bool` and the caller no longer logs a "legacy entry" debug
+    /// line that could never fire.
     fn scan_plugin_for_content_drift(
         plugin_info: &crate::project::InstalledPluginInfo,
         plugin_dir: &Path,
@@ -2565,7 +2560,7 @@ impl MarketplaceService {
 /// 3-state outcome of [`MarketplaceService::load_plugin_manifest`].
 ///
 /// Distinguishing "manifest exists, version field absent" from "manifest
-/// could not be read" closes NC1 (PR #96 re-review): collapsing both
+/// could not be read": collapsing both
 /// into `Option<String>::None` causes `check_plugin_for_update` to emit
 /// a phantom `VersionBumped` entry whenever an installed plugin happens
 /// to carry a `version` and the cache's `plugin.json` is symlinked or
@@ -2599,8 +2594,7 @@ enum ManifestState {
 /// [`read_capped`] returns an error. 1 MiB is well above any plausible
 /// manifest (the largest in this workspace's fixtures is < 4 KiB) and
 /// well below process-OOM territory. Mitigates the resource-exhaustion
-/// vector flagged by marketplace-security-reviewer in PR #96 re-review:
-/// a malicious marketplace could otherwise ship a multi-GB
+/// vector: a malicious marketplace could otherwise ship a multi-GB
 /// `plugin.json` and OOM the host before serde sees a byte.
 const MAX_PLUGIN_MANIFEST_BYTES: u64 = 1024 * 1024;
 
@@ -2709,14 +2703,14 @@ fn read_and_parse_skill_md(
 /// [`crate::validation::RelativePath`] under `plugin_dir`.
 ///
 /// Shared by [`required_skill_scan_root`] and [`required_source_path`]
-/// per PR #100 review S7 — both helpers were independently formatting
+/// — both helpers were independently formatting
 /// near-identical messages, which would drift one wording tweak apart
 /// the next time either was edited. This helper is the single source
 /// of truth for the wire-format string.
 ///
 /// Note the asymmetry with `required_steering_scan_root`: the steering
 /// path uses the typed `SteeringError::ScanRootInvalid` variant
-/// (added by PR #100 review I1) and does NOT funnel through this
+/// and does NOT funnel through this helper.
 /// helper. `SkillError` and `AgentError` don't yet have an analogous
 /// typed variant; a future cleanup mirroring I1 across all three
 /// error enums would let this synthetic-`io::Error` helper retire.
@@ -5857,9 +5851,9 @@ mod tests {
                 }),
                 PluginUpdateFailureKind::ManifestUnreadable,
             ),
-            // Cache-side variants — added in PR #96 and the canonical
-            // detection path. Pre-fix these routed through the
-            // `Error::Plugin(_)` wildcard into `Other`; post-fix they
+            // Cache-side variants — the canonical detection path.
+            // These previously routed through the
+            // `Error::Plugin(_)` wildcard into `Other`; now they
             // carry typed kinds. Locking the routing so a future
             // refactor can't silently drop them back to `Other`.
             (
@@ -6127,11 +6121,8 @@ mod tests {
         );
     }
 
-    // Deleted: `detect_plugin_updates_legacy_fallback_source_hash_none`
-    // and `detect_plugin_updates_legacy_fallback_no_version_bump_returns_no_update`
-    // — they exercised the `Option<String>::None => legacy_fallback = true`
-    // arm of `scan_plugin_for_content_drift`, which PR #100 review I2
-    // removed. Post-I2 the field is required `String` and a tracking
+    // The `legacy_fallback` arm of `scan_plugin_for_content_drift` was
+    // removed. The field is now required `String` and a tracking
     // entry without `source_hash` fails to deserialize at the
     // `load_installed()` boundary; the contract is pinned by
     // `load_installed_rejects_legacy_entry_without_source_hash` and
@@ -6474,8 +6465,8 @@ mod tests {
         assert!(result.failures.is_empty());
     }
 
-    /// NC1 (PR #96 re-review): the C5 symlink defense returned
-    /// `Ok(None)` from `load_plugin_manifest_version` (pre-rename) when
+    /// The C5 symlink defense previously returned
+    /// `Ok(None)` from `load_plugin_manifest_version` when
     /// the `plugin.json` symlink was refused. That `None` then collapsed
     /// with `installed_version: Some("1.0")` in the version-comparison
     /// path to emit a phantom `PluginUpdateInfo { available_version:
@@ -6483,7 +6474,7 @@ mod tests {
     /// update is available to nothing" whenever an installed plugin's
     /// cache `plugin.json` had been swapped for a symlink.
     ///
-    /// Post-fix: the 3-state `ManifestState` enum routes
+    /// Now the 3-state `ManifestState` enum routes
     /// "unreadable" through the per-plugin failure arm. This test
     /// pins the no-phantom-update contract by deleting the cache
     /// `plugin.json` after install and asserting the scan produces
@@ -6553,7 +6544,7 @@ mod tests {
         assert_eq!(result.failures[0].plugin.as_str(), "p");
     }
 
-    /// PR #96 review #6: a plugin whose `plugin.json` declares a
+    /// A plugin whose `plugin.json` declares a
     /// custom `steering: ["./guides/"]` scan path would false-positive
     /// drift on every detection scan — install hashed against
     /// `<plugin_dir>/guides/`, but pre-fix `scan_plugin_for_content_drift`
@@ -6690,10 +6681,10 @@ mod tests {
         );
     }
 
-    /// PR #96 review I1: sibling of the steering test above for the
+    /// Sibling of the steering test above for the
     /// **native-companions** loop, which got the symmetric scan-path
     /// fix. A plugin declaring `agents: ["./companions/"]` stores
-    /// companion files under `<plugin_dir>/companions/`, but pre-fix
+    /// companion files under `<plugin_dir>/companions/`, but previously
     /// detection hardcoded `<plugin_dir>/agents/` and would emit a
     /// hash `NotFound` failure on every scan.
     ///
@@ -6702,8 +6693,8 @@ mod tests {
     /// detection re-hashes against the source, so the two never match
     /// through the install path. (The canonical reference test
     /// previously named `detect_plugin_updates_copilot_agent_legacy_fallback`
-    /// has been removed — see PR #100's deserialize-rejection sweep,
-    /// which invalidated the legacy-Option-shape fixture it relied on.
+    /// has been removed — the deserialize-rejection sweep
+    /// invalidated the legacy-Option-shape fixture it relied on.
     /// The bug itself is still real and the workaround below still
     /// applies.) To isolate the scan-path fix, we synthesize the tracking
     /// entry by hand: compute the source-side hash directly via
@@ -6778,7 +6769,7 @@ mod tests {
         // native-companions cascade as the only thing the assertion
         // depends on.
         //
-        // PR #100 review I2 dropped the legacy_fallback escape hatch
+        // The legacy_fallback escape hatch was dropped
         // (source_hash: None used to be a "skip me" sentinel for the
         // drift scan); after I2 every entry must have a real source
         // file on disk and a real source_hash, so the registrar agent
@@ -6880,7 +6871,7 @@ mod tests {
         );
     }
 
-    /// I-N2 (PR #96 re-review): mirrors `service::browse::tests::
+    /// Mirrors `service::browse::tests::
     /// load_plugin_manifest_refuses_symlinked_manifest` for the Phase 2a
     /// detection-side function. Without this test, a future refactor
     /// could replace the `symlink_metadata` check with `Path::exists()`
@@ -7008,7 +6999,7 @@ mod tests {
         );
     }
 
-    /// I-N6 (PR #96 re-review): C4 plumbing test. Default-empty + JSON-
+    /// C4 plumbing test. Default-empty + JSON-
     /// shape locks didn't verify the `partial_load_warnings` field is
     /// actually populated from `view.partial_load_warnings` — only
     /// that the field exists on the wire. This test corrupts

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -486,7 +486,7 @@ pub struct PluginUpdateInfo {
     /// `Some(None)` here.
     pub installed_version: Option<String>,
     /// `None` means the marketplace plugin manifest exists but lacks
-    /// a `version` field. After NC1's `ManifestState` 3-state
+    /// a `version` field. The `ManifestState` 3-state
     /// split, cases where the manifest is missing or unreadable
     /// (symlinked, `NotFound`) surface as a [`PluginUpdateFailure`] —
     /// they no longer collapse into `Some(None)` here. So
@@ -597,8 +597,8 @@ impl PluginUpdateFailureKind {
 fn classify_plugin_error(err: &PluginError) -> PluginUpdateFailureKind {
     match err {
         PluginError::NotFound { .. } => PluginUpdateFailureKind::MarketplaceUnavailable,
-        // Cache-side variants are the canonical detection path
-        // (Phase 2a). Project-side variants (`ManifestNotFound`,
+        // Cache-side variants are the canonical detection path.
+        // Project-side variants (`ManifestNotFound`,
         // `ManifestReadFailed`) map here too because
         // `check_plugin_for_update` may surface them transitively via
         // `resolve_local_plugin_dir`, which shares the install-time
@@ -2329,7 +2329,7 @@ impl MarketplaceService {
                 // pieces in the wire-format `PluginUpdateFailure.reason`.
                 // The cache-side variant routes through
                 // PluginUpdateFailureKind::ManifestUnreadable in the
-                // outer detect_plugin_updates loop (see Commit 5).
+                // outer detect_plugin_updates loop.
                 return Err(PluginError::CacheManifestReadFailed {
                     path: manifest_path,
                     source: std::io::Error::new(std::io::ErrorKind::NotFound, reason),
@@ -2408,7 +2408,7 @@ impl MarketplaceService {
     /// at stat time keeps that exfiltration channel closed. Mirrors
     /// `service::browse::load_plugin_manifest`'s defense.
     ///
-    /// Resource cap (Commit 9 / pre-existing security observation):
+    /// Resource cap (pre-existing security observation):
     /// reads are bounded at [`MAX_PLUGIN_MANIFEST_BYTES`] so a malicious
     /// marketplace shipping a multi-GB `plugin.json` cannot OOM the
     /// process before serde sees a byte.
@@ -2581,7 +2581,7 @@ enum ManifestState {
     /// Manifest could not be read for a non-fatal reason
     /// (symlink-refused or `NotFound` on the cache copy). Caller must
     /// treat this as a per-plugin failure rather than collapse it with
-    /// `Found(_).version.is_none()` — see NC1 above.
+    /// `Found(_).version.is_none()` — see above.
     Unreadable {
         /// Human-readable reason; embedded into the wire-format
         /// `PluginUpdateFailure.reason` via `error_full_chain`. Kept
@@ -6519,7 +6519,7 @@ mod tests {
         );
 
         // Now make the cache plugin.json unreadable: delete it.
-        // Pre-NC1 fix: load_plugin_manifest_version (pre-rename)
+        // Previously: load_plugin_manifest_version
         // returned Ok(None), version_differs became true
         // (Some("1.0") != None), and the result had a phantom
         // `VersionBumped` update with available_version: None.
@@ -6570,7 +6570,7 @@ mod tests {
         // return NotFound and the plugin would surface as a failure.
         fs::write(plugin_dir.join("guides/playbook.md"), b"how to ship\n")
             .expect("write steering source");
-        // Manifest declares the custom scan path. The Phase 2a fix
+        // Manifest declares the custom scan path. The fix
         // makes `scan_plugin_for_content_drift` consult this field.
         fs::write(
             plugin_dir.join("plugin.json"),
@@ -6844,7 +6844,7 @@ mod tests {
         );
     }
 
-    /// Commit 9 / Phase 2a sibling of
+    /// Sibling of
     /// `service::browse::tests::load_plugin_manifest_rejects_oversized_file`:
     /// the detection-side `load_plugin_manifest` shares the
     /// same `read_capped` defense; verify it fires here too.
@@ -6872,7 +6872,7 @@ mod tests {
     }
 
     /// Mirrors `service::browse::tests::
-    /// load_plugin_manifest_refuses_symlinked_manifest` for the Phase 2a
+    /// load_plugin_manifest_refuses_symlinked_manifest` for the
     /// detection-side function. Without this test, a future refactor
     /// could replace the `symlink_metadata` check with `Path::exists()`
     /// (which follows symlinks) and silently re-open the C5 leak vector
@@ -6924,7 +6924,7 @@ mod tests {
         }
     }
 
-    /// I-N3 sibling: a Copilot agent with `source_path: Some(rel)`
+    /// Sibling: a Copilot agent with `source_path: Some(rel)`
     /// (post-C7 install shape) — detection finds the file via the
     /// populated path, NOT the dialect fallback. Bypasses the
     /// translated install path for the same reason as the legacy

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -2711,8 +2711,9 @@ fn read_and_parse_skill_md(
 /// Note the asymmetry with `required_steering_scan_root`: the steering
 /// path uses the typed `SteeringError::ScanRootInvalid` variant
 /// and does NOT funnel through this helper.
-/// helper. `SkillError` and `AgentError` don't yet have an analogous
-/// typed variant; a future cleanup mirroring I1 across all three
+/// `SkillError` and `AgentError` don't yet have an analogous
+/// typed variant; a future cleanup propagating the same typed-variant
+/// approach across all three
 /// error enums would let this synthetic-`io::Error` helper retire.
 fn scan_root_invalid_io_err(
     label: &str,

--- a/crates/kiro-market-core/src/steering/types.rs
+++ b/crates/kiro-market-core/src/steering/types.rs
@@ -59,8 +59,8 @@ pub enum SteeringError {
     /// Distinct from [`SteeringError::SourceReadFailed`], which models
     /// I/O failures on a *file* — this variant models a structural
     /// validation failure on the *scan root path* and never carries an
-    /// `io::Error`. PR #100 review I1 split these so the wire-format
-    /// reason is precise instead of impersonating a missing-file error.
+    /// `io::Error`. The wire-format reason is precise instead of
+    /// impersonating a missing-file error.
     #[non_exhaustive]
     #[error("steering scan_root `{path}` is not under plugin_dir `{plugin_dir}`")]
     ScanRootInvalid {

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -66,8 +66,8 @@ impl RelativePath {
     /// recovered from `meta.source_path` (legacy `agent.md` discovered
     /// without a configured scan path, hand-synthesised test fixtures,
     /// etc.). Replaces the previous `from_internal_unchecked("agents".to_owned())`
-    /// site at `KiroProject::install_agent_inner` per PR #100 review S2:
-    /// the unchecked-constructor pattern was sound but anonymous —
+    /// site at `KiroProject::install_agent_inner`: the
+    /// unchecked-constructor pattern was sound but anonymous —
     /// every reader had to re-derive that `"agents"` is a constant
     /// string. A named `agents_root()` makes the intent explicit and
     /// removes one audited-by-convention site.
@@ -114,7 +114,7 @@ impl RelativePath {
         // backslash it rejects. The explicit `.replace('\\', '/')`
         // closes that gap; harmless when components already split.
         //
-        // PR #100 review I4: components are converted via `to_str()`,
+        // Components are converted via `to_str()`,
         // not `to_string_lossy()`. Lossy conversion silently substitutes
         // `U+FFFD` for invalid UTF-8 sequences, so a non-UTF-8 OsStr
         // component would round-trip as a valid-looking `RelativePath`
@@ -165,7 +165,7 @@ impl RelativePath {
         // zero Normal entries), which `RelativePath::new` rejects.
         // Substitute "." so the call still succeeds and downstream
         // `plugin_dir.join(".").join(name)` resolves correctly. Closes
-        // PR #100 review C2 (bare-path skill at plugin root regression).
+        // the bare-path skill at plugin root regression.
         let normalised = if rel_str.is_empty() {
             ".".to_owned()
         } else {
@@ -1222,8 +1222,7 @@ mod tests {
     }
 
     // The five tests below mirror the corresponding `marketplace_name_*`
-    // tests at lines 991, 1018, 1031, 1039, 1046. PR #95's review
-    // (finding I4) flagged the asymmetry: PluginName lacked parallel
+    // tests. PluginName previously lacked parallel
     // accessor / empty-deserialize / round-trip / Ord coverage, which
     // would let a regression slip through one type but not the other.
     // The Ord lock in particular is load-bearing: if `PluginName` ever
@@ -1308,12 +1307,12 @@ mod tests {
         assert_eq!(rel.as_str(), "agents/reviewer.md");
     }
 
-    /// PR #100 review C2: a manifest declaring `skills: ["my-skill"]`
+    /// A manifest declaring `skills: ["my-skill"]`
     /// (bare path, no `./skills/` directory) makes `discover_skill_dirs`
     /// set `scan_root = candidate.parent() = plugin_root`, then install
     /// calls `from_path_under(scan_root=plugin_root, plugin_dir=plugin_root)`.
-    /// Pre-fix this errored with empty-rel; install pushed `FailedSkill`
-    /// for a skill that pre-PR would have installed cleanly. Post-fix
+    /// Previously this errored with empty-rel; install pushed `FailedSkill`
+    /// for a skill that pre-PR would have installed cleanly. Now
     /// returns `RelativePath("." )` so detection can use
     /// `plugin_dir.join(".").join(name)` to resolve back to the right
     /// directory.
@@ -1326,7 +1325,7 @@ mod tests {
         assert_eq!(rel.as_str(), ".");
     }
 
-    /// PR #100 review I4: a path component containing invalid UTF-8 must
+    /// A path component containing invalid UTF-8 must
     /// produce `ValidationError::InvalidRelativePath { reason: "...non-UTF-8..." }`,
     /// not a `to_string_lossy`-substituted U+FFFD that round-trips
     /// through validation but doesn't match anything on disk. Unix-only

--- a/crates/kiro-market-core/src/validation.rs
+++ b/crates/kiro-market-core/src/validation.rs
@@ -1312,7 +1312,7 @@ mod tests {
     /// set `scan_root = candidate.parent() = plugin_root`, then install
     /// calls `from_path_under(scan_root=plugin_root, plugin_dir=plugin_root)`.
     /// Previously this errored with empty-rel; install pushed `FailedSkill`
-    /// for a skill that pre-PR would have installed cleanly. Now
+    /// for a skill that previously would have installed cleanly. Now
     /// returns `RelativePath("." )` so detection can use
     /// `plugin_dir.join(".").join(name)` to resolve back to the right
     /// directory.


### PR DESCRIPTION
## Summary
- Removes ~26 PR-number, review-label, and task-stage anchors from doc/inline comments
- Keeps all mechanism explanations (WHY) intact
- No behavior changes

## Changes
- `project.rs`: Stage 1 anchors, NC2 review labels → "predate hash tracking"
- `service/mod.rs`: PR #91/#96 anchors, review labels (NC1, I-N2, I-N3, I-N6, I-N7), "pre-fix"/"post-fix" prefixes, "original-review I4"
- `service/browse.rs`: PR #96 review references
- `validation.rs`: PR #95 review, fragile line-number anchors
- `error.rs`: PR #35 reference
- `kiro_settings.rs`: PR #73 reference

Closes #103