### PR TITLE
feat(ui): plugin update detection UI (Phase 2b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ __pycache__/
 # Tethys index built by `cargo xtask plan-lint` (and direct `tethys index`).
 # Never committed — recreated on demand from source.
 /.rivets/
+
+# Git worktrees for isolated feature branches
+.worktrees/
+
+# Brainstorming session mockups (persisted via --project-dir)
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,16 @@ Run all three before committing — CI enforces each:
 - `cargo test --workspace`
 - `cargo clippy --workspace --tests -- -D warnings`
 
+For changes under `crates/kiro-control-center/` also run:
+- `cd crates/kiro-control-center && npm run check`
+- `cd crates/kiro-control-center && npm run test:unit`
+
+Vitest covers pure-logic helpers only (no jsdom, no `@testing-library/svelte`,
+no Tauri-IPC mocks). Component-level testing is intentionally future scope.
+If you find yourself wanting to test a `.svelte` file or a reactive store's
+`$state`/`$derived`, factor the testable logic out into a non-`.svelte.ts`
+module and test the helper instead.
+
 ## xtask
 - `cargo xtask hook-post-edit` — wired into Claude Code `PostToolUse` for `.rs` edits. Runs `rustfmt` then `cargo clippy --package <derived> -- -D warnings`. The package is derived by walking up ancestors for the nearest `Cargo.toml` with a `[package]` table (`xtask::derive_package`), so new workspace crates are picked up automatically. Read/parse failures log to stderr; loop exhaust emits a "no usable Cargo.toml" diagnostic.
 - `cargo xtask hook-block-cargo-lock` — blocks direct `Cargo.lock` edits. Override for one session via `KIRO_ALLOW_LOCKFILE_EDIT=1`.

--- a/crates/kiro-control-center/package-lock.json
+++ b/crates/kiro-control-center/package-lock.json
@@ -26,7 +26,8 @@
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "typescript": "~5.6.2",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^2.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1622,6 +1623,92 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1645,6 +1732,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1653,6 +1750,43 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1709,6 +1843,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1747,6 +1891,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1806,6 +1957,26 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@typescript-eslint/types": "^8.2.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2144,6 +2315,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2196,6 +2374,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2371,6 +2566,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2394,6 +2596,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.55.1",
@@ -2466,6 +2682,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2481,6 +2711,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2589,6 +2849,519 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -2607,6 +3380,606 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/crates/kiro-control-center/package.json
+++ b/crates/kiro-control-center/package.json
@@ -10,7 +10,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run"
   },
   "license": "MIT",
   "dependencies": {
@@ -31,6 +32,7 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^2.1.0"
   }
 }

--- a/crates/kiro-control-center/src/lib/components/BannerStack.svelte
+++ b/crates/kiro-control-center/src/lib/components/BannerStack.svelte
@@ -1,0 +1,119 @@
+<script lang="ts" generics="K extends string">
+  import type { SvelteMap } from "svelte/reactivity";
+
+  // Extracted from BrowseTab.svelte (the prior render block lived at
+  // lines 1066-1132). The shared component owns: 3-cap-with-overflow
+  // rendering for the `errors` map, dismiss buttons (calls back via
+  // `ondismiss`), and the green/amber/red color treatment for the
+  // remaining three banner channels.
+  //
+  // The `errors` map is generic over its key type via Svelte 5's
+  // `generics="K extends string"` script-tag attribute — `K` flows
+  // through the dismiss callback so the consumer can branch type-
+  // safely on which key was dismissed without a cast.
+  type Props = {
+    errors: SvelteMap<K, string>;
+    message: string | null;
+    warning: string | null;
+    fatalError: string | null;
+    // `errLabel` is per-tab because the screen-reader label depends
+    // on the consumer's ErrorSource taxonomy (e.g. "Dismiss error
+    // for acme/foo" vs "Dismiss installed-plugins error").
+    errLabel: (key: K) => string;
+    // Svelte 5 callback prop, not the legacy `on:dismiss` directive.
+    ondismiss: (key: K) => void;
+    onmessageDismiss?: () => void;
+    onwarningDismiss?: () => void;
+    onfatalErrorDismiss?: () => void;
+  };
+
+  let {
+    errors,
+    message,
+    warning,
+    fatalError,
+    errLabel,
+    ondismiss,
+    onmessageDismiss,
+    onwarningDismiss,
+    onfatalErrorDismiss,
+  }: Props = $props();
+</script>
+
+<!-- Banners render newest-first (reverse insertion order) and cap at 3 so
+     a storm of broken plugins doesn't push the grid off-screen. Dismissing
+     a banner or resolving its source surfaces the next-newest below. -->
+{#each [...errors].reverse().slice(0, 3) as [key, msg] (key)}
+  <div
+    data-testid="fetch-error"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-error flex-1">{msg}</p>
+    <button
+      type="button"
+      onclick={() => ondismiss(key)}
+      aria-label={errLabel(key)}
+      class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/each}
+{#if errors.size > 3}
+  <div
+    data-testid="fetch-error-overflow"
+    class="mx-4 mt-3 px-4 py-2 text-xs text-kiro-subtle text-center border border-kiro-muted/50 rounded-md bg-kiro-surface/30"
+  >
+    +{errors.size - 3} more {errors.size - 3 === 1 ? "error" : "errors"} — dismiss or resolve above to see the rest
+  </div>
+{/if}
+
+{#if fatalError}
+  <div
+    data-testid="install-error"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-error flex-1">{fatalError}</p>
+    <button
+      type="button"
+      onclick={() => onfatalErrorDismiss?.()}
+      aria-label="Dismiss install error"
+      class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/if}
+
+{#if message}
+  <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30 flex items-start gap-3">
+    <p class="text-sm text-kiro-success flex-1">{message}</p>
+    {#if onmessageDismiss}
+      <button
+        type="button"
+        onclick={() => onmessageDismiss?.()}
+        aria-label="Dismiss success message"
+        class="text-kiro-success/70 hover:text-kiro-success text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
+    {/if}
+  </div>
+{/if}
+
+{#if warning}
+  <div
+    data-testid="install-warning"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-warning flex-1">{warning}</p>
+    <button
+      type="button"
+      onclick={() => onwarningDismiss?.()}
+      aria-label="Dismiss install warning"
+      class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/if}

--- a/crates/kiro-control-center/src/lib/components/BannerStack.svelte
+++ b/crates/kiro-control-center/src/lib/components/BannerStack.svelte
@@ -1,26 +1,12 @@
 <script lang="ts" generics="K extends string">
   import type { SvelteMap } from "svelte/reactivity";
 
-  // Extracted from BrowseTab.svelte (the prior render block lived at
-  // lines 1066-1132). The shared component owns: 3-cap-with-overflow
-  // rendering for the `errors` map, dismiss buttons (calls back via
-  // `ondismiss`), and the green/amber/red color treatment for the
-  // remaining three banner channels.
-  //
-  // The `errors` map is generic over its key type via Svelte 5's
-  // `generics="K extends string"` script-tag attribute — `K` flows
-  // through the dismiss callback so the consumer can branch type-
-  // safely on which key was dismissed without a cast.
   type Props = {
     errors: SvelteMap<K, string>;
     message: string | null;
     warning: string | null;
     fatalError: string | null;
-    // `errLabel` is per-tab because the screen-reader label depends
-    // on the consumer's ErrorSource taxonomy (e.g. "Dismiss error
-    // for acme/foo" vs "Dismiss installed-plugins error").
     errLabel: (key: K) => string;
-    // Svelte 5 callback prop, not the legacy `on:dismiss` directive.
     ondismiss: (key: K) => void;
     onmessageDismiss?: () => void;
     onwarningDismiss?: () => void;
@@ -40,9 +26,7 @@
   }: Props = $props();
 </script>
 
-<!-- Banners render newest-first (reverse insertion order) and cap at 3 so
-     a storm of broken plugins doesn't push the grid off-screen. Dismissing
-     a banner or resolving its source surfaces the next-newest below. -->
+<!-- Newest-first, cap 3 — a storm of broken plugins shouldn't push the grid off-screen. -->
 {#each [...errors].reverse().slice(0, 3) as [key, msg] (key)}
   <div
     data-testid="fetch-error"
@@ -64,7 +48,7 @@
     data-testid="fetch-error-overflow"
     class="mx-4 mt-3 px-4 py-2 text-xs text-kiro-subtle text-center border border-kiro-muted/50 rounded-md bg-kiro-surface/30"
   >
-    +{errors.size - 3} more {errors.size - 3 === 1 ? "error" : "errors"} — dismiss or resolve above to see the rest
+    +{errors.size - 3} more {errors.size - 3 === 1 ? "item" : "items"} — dismiss or resolve above to see the rest
   </div>
 {/if}
 

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -533,13 +533,27 @@
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
       skillsByPluginPair = {};
       selectedSkills.clear();
+      // Phase 2b I-1: also clear banner channels and the pending-action
+      // tracker on project transitions. The 3 banners reflect the prior
+      // project's actions; pending actions clear themselves via finally{}
+      // under normal operation but a project switch mid-flight would
+      // leave a stale entry that disables PluginCard buttons.
+      installError = null;
+      installMessage = null;
+      installWarning = null;
+      pendingPluginActions.clear();
       // Snapshot first — deleting during `for (const key of fetchErrors.keys())`
-      // would re-trigger the effect on each delete.
+      // would re-trigger the effect on each delete. Per Phase 2b also
+      // sweep update-check<DELIM> + update-fetch keys (project-scoped
+      // banners that the next pluginUpdates.refresh will repopulate).
       const stale: ErrorSource[] = [];
       for (const key of fetchErrors.keys()) {
         if (
           key.startsWith(SKILLS_ERR_PREFIX) ||
-          key.startsWith(BULK_SKILLS_ERR_PREFIX)
+          key.startsWith(BULK_SKILLS_ERR_PREFIX) ||
+          key.startsWith(UPDATE_CHECK_PREFIX + DELIM) ||
+          key === ERR_UPDATE_FETCH ||
+          key === ERR_INSTALLED_PLUGINS
         ) {
           stale.push(key);
         }

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -4,7 +4,6 @@
   import { commands } from "$lib/bindings";
   import {
     formatInstallPluginResult,
-    formatInstallWarning,
     formatSkippedSkill,
     formatSkippedSkillsForPlugin,
     formatSteeringWarning,
@@ -74,12 +73,9 @@
     if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins error";
     if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
     if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
-      const parts = key.split(DELIM);
-      // parts: ["update-check", "<remediation>", "<marketplace>"]
-      if (parts.length === 3) {
-        return `Dismiss update-check banner for ${parts[2]}`;
-      }
-      return "Dismiss update-check banner";
+      // Type-literal guarantees ["update-check", "<remediation>", "<marketplace>"].
+      const [, , marketplace] = key.split(DELIM);
+      return `Dismiss update-check banner for ${marketplace}`;
     }
     if (key.startsWith(PLUGINS_ERR_PREFIX)) {
       return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
@@ -105,9 +101,6 @@
   let popRef: HTMLDivElement | undefined = $state();
   let browseView: BrowseView = $state("plugins");
 
-  // Per-plugin in-flight tracker keyed by pluginKey(marketplace, plugin).
-  // Narrows the shared PluginAction union to the actions BrowseTab actually
-  // performs (Install + Update — never Remove, that's InstalledTab's surface).
   let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "install" | "update">>();
 
   let installedPlugins: InstalledPluginInfo[] = $state([]);
@@ -453,20 +446,13 @@
     fetchInstalledPlugins();
   });
 
-  // Phase 2b: re-run update-scan whenever projectPath changes. The
-  // store tracks `lastProjectPath` itself so a no-op call (same path
-  // repeatedly) is harmless. Re-runs after a marketplace fetch are
-  // triggered by `+page.svelte` via `MarketplacesTab.onUpdated`, not
-  // here.
   $effect(() => {
     void projectPath;
-    pluginUpdates.refresh(projectPath);
+    pluginUpdates
+      .refresh(projectPath)
+      .catch((e) => console.error("[BrowseTab] pluginUpdates.refresh threw", e));
   });
 
-  // Project per-marketplace failure groups into the fetchErrors banner
-  // map. Re-runs whenever pluginUpdates.failureGroups changes; clears
-  // any previously-projected `update-check<...>` keys not in the
-  // new group set so a recovered marketplace's banner disappears.
   $effect(() => {
     const seen = new Set<ErrorSource>();
     for (const group of pluginUpdates.failureGroups) {
@@ -487,7 +473,6 @@
     }
   });
 
-  // Surface the toplevel pluginUpdates.fetchError as its own banner.
   $effect(() => {
     if (pluginUpdates.fetchError) {
       fetchErrors.set(
@@ -533,19 +518,11 @@
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
       skillsByPluginPair = {};
       selectedSkills.clear();
-      // Phase 2b I-1: also clear banner channels and the pending-action
-      // tracker on project transitions. The 3 banners reflect the prior
-      // project's actions; pending actions clear themselves via finally{}
-      // under normal operation but a project switch mid-flight would
-      // leave a stale entry that disables PluginCard buttons.
       installError = null;
       installMessage = null;
       installWarning = null;
       pendingPluginActions.clear();
-      // Snapshot first — deleting during `for (const key of fetchErrors.keys())`
-      // would re-trigger the effect on each delete. Per Phase 2b also
-      // sweep update-check<DELIM> + update-fetch keys (project-scoped
-      // banners that the next pluginUpdates.refresh will repopulate).
+      // Snapshot first — deleting during keys() iteration re-triggers the effect.
       const stale: ErrorSource[] = [];
       for (const key of fetchErrors.keys()) {
         if (
@@ -808,166 +785,57 @@
   // silently disappear ("1 of 2 agents installed" with no explanation); the
   // new warning banner names the agent and lists its transports so the user
   // can re-run with the opt-in if they want it.
-  async function installWholePlugin(marketplace: string, plugin: string) {
-    const key = pluginKey(marketplace, plugin);
-    if (pendingPluginActions.has(key)) return;
-    pendingPluginActions.set(key, "install");
-    installError = null;
-    installMessage = null;
-    installWarning = null;
-
+  async function refreshAfterPluginAction(verbForBanner: string, plugin: string) {
     try {
-      // 4th arg is `acceptMcp` — Phase 1 hardcodes false. Phase 2 will
-      // wire a UI toggle so a user can opt into installing agents that
-      // declare MCP servers (subprocesses / network connections).
-      const result = await commands.installPlugin(
-        marketplace,
-        plugin,
-        forceInstall,
-        false,
-        projectPath,
-      );
-      if (result.status === "ok") {
-        const r = result.data;
-        const summaryParts: string[] = [];
-        const warningParts: string[] = [];
-
-        // Skills: installed / failed / skipped (idempotent) / skipped_skills
-        // (per-file read or parse failures). `skipped_skills` is the
-        // structurally-distinct "couldn't even attempt to install" bucket.
-        {
-          const skills = r.skills;
-          if (skills.installed.length > 0) {
-            const noun = skills.installed.length === 1 ? "skill" : "skills";
-            summaryParts.push(`${skills.installed.length} ${noun}`);
-          }
-          if (skills.failed.length > 0) {
-            const noun = skills.failed.length === 1 ? "skill" : "skills";
-            summaryParts.push(`${skills.failed.length} ${noun} failed`);
-          }
-          if (skills.skipped.length > 0) {
-            const noun = skills.skipped.length === 1 ? "skill" : "skills";
-            summaryParts.push(`${skills.skipped.length} ${noun} already installed`);
-          }
-          if (skills.skipped_skills.length > 0) {
-            warningParts.push(formatSkippedSkillsForPlugin(skills.skipped_skills));
-          }
-        }
-
-        // Steering: idempotent reinstalls land in `installed` with
-        // `kind = idempotent` (not a separate `skipped` field — see
-        // `InstalledSteeringOutcome.kind`). Surfacing the breakdown is
-        // a Phase 2 follow-up; for now the count is the lump sum.
-        {
-          const steering = r.steering;
-          if (steering.installed.length > 0) {
-            const noun = steering.installed.length === 1 ? "file" : "files";
-            summaryParts.push(`${steering.installed.length} steering ${noun}`);
-          }
-          if (steering.failed.length > 0) {
-            summaryParts.push(`${steering.failed.length} steering failed`);
-          }
-          if (steering.warnings.length > 0) {
-            for (const w of steering.warnings) {
-              warningParts.push(formatSteeringWarning(w));
-            }
-          }
-        }
-
-        // Agents: includes `skipped` (idempotent native reinstalls) and
-        // `warnings` (MCP-gated, unmapped tools, parse failures on
-        // non-agent files in the scan dir). Without surfacing warnings
-        // here, `McpServersRequireOptIn` would silently drop agents.
-        {
-          const agents = r.agents;
-          if (agents.installed.length > 0) {
-            const noun = agents.installed.length === 1 ? "agent" : "agents";
-            summaryParts.push(`${agents.installed.length} ${noun}`);
-          }
-          if (agents.failed.length > 0) {
-            const noun = agents.failed.length === 1 ? "agent" : "agents";
-            summaryParts.push(`${agents.failed.length} ${noun} failed`);
-          }
-          if (agents.skipped.length > 0) {
-            const noun = agents.skipped.length === 1 ? "agent" : "agents";
-            summaryParts.push(`${agents.skipped.length} ${noun} already installed`);
-          }
-          if (agents.warnings.length > 0) {
-            for (const w of agents.warnings) {
-              warningParts.push(formatInstallWarning(w));
-            }
-          }
-        }
-
-        const anyFailed =
-          r.skills.failed.length + r.steering.failed.length + r.agents.failed.length > 0;
-        const anyInstalled =
-          r.skills.installed.length +
-            r.steering.installed.length +
-            r.agents.installed.length >
-          0;
-        const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to install";
-
-        if (anyFailed && !anyInstalled) {
-          installError = `Plugin install failed for ${plugin}: ${summary}`;
-        } else {
-          installMessage = `Plugin ${plugin}: ${summary}`;
-        }
-        if (warningParts.length > 0) {
-          installWarning = `Plugin ${plugin}: ${warningParts.join(" | ")}`;
-        }
-        await fetchInstalledPlugins();
-      } else {
-        installError = `Plugin install failed for ${plugin}: ${result.error.message}`;
-      }
+      await pluginUpdates.refresh(projectPath);
+      await fetchInstalledPlugins();
     } catch (e) {
+      console.error(`[BrowseTab] post-${verbForBanner} refresh threw`, e);
       const reason = e instanceof Error ? e.message : String(e);
-      installError = `Plugin install failed for ${plugin}: ${reason}`;
-    } finally {
-      pendingPluginActions.delete(key);
+      installError = `${plugin} ${verbForBanner} succeeded but refresh failed: ${reason}`;
     }
   }
 
-  // Update an installed plugin. Calls the same `installPlugin` command
-  // used by Install but with `force=true` hard-coded — the existing
-  // global `forceInstall` checkbox stays bound to the Install button
-  // path. `pluginUpdates.refresh` re-runs the scan after the update so
-  // the indicator clears; `fetchInstalledPlugins` refreshes the
-  // installed-set so any new content type the update added shows up.
-  async function updatePlugin(marketplace: string, plugin: string) {
+  // 4th arg of installPlugin is `acceptMcp` — Phase 1 hardcodes false. Phase 2
+  // will wire a UI toggle so a user can opt into installing agents that declare
+  // MCP servers (subprocesses / network connections).
+  async function runPluginInstall(
+    marketplace: string,
+    plugin: string,
+    mode: Extract<PluginAction, "install" | "update">,
+  ) {
     const key = pluginKey(marketplace, plugin);
     if (pendingPluginActions.has(key)) return;
-    pendingPluginActions.set(key, "update");
+    pendingPluginActions.set(key, mode);
     installError = null;
     installMessage = null;
     installWarning = null;
+
+    const force = mode === "update" ? true : forceInstall;
+    const failPrefix =
+      mode === "update" ? `Update failed for ${plugin}` : `Plugin install failed for ${plugin}`;
+    const successPrefix = mode === "update" ? `Updated ${plugin}` : `Plugin ${plugin}`;
+
     try {
-      const result = await commands.installPlugin(
-        marketplace,
-        plugin,
-        /*force=*/ true,
-        /*acceptMcp=*/ false,
-        projectPath,
-      );
+      const result = await commands.installPlugin(marketplace, plugin, force, false, projectPath);
       if (result.status === "ok") {
         const { summary, warnings, anyInstalled, anyFailed } =
-          formatInstallPluginResult(result.data, plugin);
+          formatInstallPluginResult(result.data);
         if (anyFailed && !anyInstalled) {
-          installError = `Update failed for ${plugin}: ${summary}`;
+          installError = `${failPrefix}: ${summary}`;
         } else {
-          installMessage = `Updated ${plugin}: ${summary}`;
+          installMessage = `${successPrefix}: ${summary}`;
         }
         if (warnings) {
-          installWarning = `Updated ${plugin}: ${warnings}`;
+          installWarning = `${successPrefix}: ${warnings}`;
         }
-        await pluginUpdates.refresh(projectPath);
-        await fetchInstalledPlugins();
+        await refreshAfterPluginAction(mode, plugin);
       } else {
-        installError = `Update failed for ${plugin}: ${result.error.message}`;
+        installError = `${failPrefix}: ${result.error.message}`;
       }
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
-      installError = `Update failed for ${plugin}: ${reason}`;
+      installError = `${failPrefix}: ${reason}`;
     } finally {
       pendingPluginActions.delete(key);
     }
@@ -1289,8 +1157,8 @@
               update={pluginUpdates.updateFor(ap.marketplace, ap.plugin.name)}
               failure={pluginUpdates.failureFor(ap.marketplace, ap.plugin.name)}
               projectPicked={!!projectPath}
-              onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
-              onUpdate={() => updatePlugin(ap.marketplace, ap.plugin.name)}
+              onInstall={() => runPluginInstall(ap.marketplace, ap.plugin.name, "install")}
+              onUpdate={() => runPluginInstall(ap.marketplace, ap.plugin.name, "update")}
             />
           {/each}
         </div>

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -3,6 +3,7 @@
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
   import {
+    formatInstallPluginResult,
     formatInstallWarning,
     formatSkippedSkill,
     formatSkippedSkillsForPlugin,
@@ -17,6 +18,8 @@
     parsePluginKey,
     parseSkillKey,
   } from "$lib/keys";
+  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+  import type { PluginAction } from "$lib/stores/plugin-updates";
   import type {
     InstalledPluginInfo,
     MarketplaceInfo,
@@ -44,9 +47,13 @@
   // (marketplace, plugin) tuple. Adding more standalone keys later means
   // extending the union in `ErrorSource` and the dispatch in `errLabel`.
   const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
+  const ERR_UPDATE_FETCH = "update-fetch" as const;
+  const UPDATE_CHECK_PREFIX = "update-check" as const;
   type ErrorSource =
     | typeof ERR_MARKETPLACES
     | typeof ERR_INSTALLED_PLUGINS
+    | typeof ERR_UPDATE_FETCH
+    | `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`
     | `${typeof PLUGINS_ERR_PREFIX}${string}`
     | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`
     | `${typeof BULK_SKILLS_ERR_PREFIX}${string}`;
@@ -65,6 +72,15 @@
   function errLabel(key: ErrorSource): string {
     if (key === ERR_MARKETPLACES) return "Dismiss marketplaces error";
     if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins error";
+    if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
+    if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
+      const parts = key.split(DELIM);
+      // parts: ["update-check", "<remediation>", "<marketplace>"]
+      if (parts.length === 3) {
+        return `Dismiss update-check banner for ${parts[2]}`;
+      }
+      return "Dismiss update-check banner";
+    }
     if (key.startsWith(PLUGINS_ERR_PREFIX)) {
       return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
     }
@@ -89,10 +105,10 @@
   let popRef: HTMLDivElement | undefined = $state();
   let browseView: BrowseView = $state("plugins");
 
-  // Per-plugin in-flight tracker — pluginKey(marketplace, plugin) so two
-  // plugins can install in parallel without colliding (mirrors the shape
-  // of `pendingSteeringInstalls`).
-  let pendingPluginInstalls = new SvelteSet<string>();
+  // Per-plugin in-flight tracker keyed by pluginKey(marketplace, plugin).
+  // Narrows the shared PluginAction union to the actions BrowseTab actually
+  // performs (Install + Update — never Remove, that's InstalledTab's surface).
+  let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "install" | "update">>();
 
   let installedPlugins: InstalledPluginInfo[] = $state([]);
   let installedPluginKeys = $derived(
@@ -437,6 +453,52 @@
     fetchInstalledPlugins();
   });
 
+  // Phase 2b: re-run update-scan whenever projectPath changes. The
+  // store tracks `lastProjectPath` itself so a no-op call (same path
+  // repeatedly) is harmless. Re-runs after a marketplace fetch are
+  // triggered by `+page.svelte` via `MarketplacesTab.onUpdated`, not
+  // here.
+  $effect(() => {
+    void projectPath;
+    pluginUpdates.refresh(projectPath);
+  });
+
+  // Project per-marketplace failure groups into the fetchErrors banner
+  // map. Re-runs whenever pluginUpdates.failureGroups changes; clears
+  // any previously-projected `update-check<...>` keys not in the
+  // new group set so a recovered marketplace's banner disappears.
+  $effect(() => {
+    const seen = new Set<ErrorSource>();
+    for (const group of pluginUpdates.failureGroups) {
+      const key: ErrorSource =
+        `${UPDATE_CHECK_PREFIX}${DELIM}${group.remediation}${DELIM}${group.marketplace}` as ErrorSource;
+      seen.add(key);
+      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
+      const list = group.plugins.join(", ");
+      fetchErrors.set(
+        key,
+        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
+      );
+    }
+    for (const k of fetchErrors.keys()) {
+      if (k.startsWith(UPDATE_CHECK_PREFIX + DELIM) && !seen.has(k)) {
+        fetchErrors.delete(k);
+      }
+    }
+  });
+
+  // Surface the toplevel pluginUpdates.fetchError as its own banner.
+  $effect(() => {
+    if (pluginUpdates.fetchError) {
+      fetchErrors.set(
+        ERR_UPDATE_FETCH,
+        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
+      );
+    } else {
+      fetchErrors.delete(ERR_UPDATE_FETCH);
+    }
+  });
+
   $effect(() => {
     for (const mp of selectedMarketplaces) fetchPluginsFor(mp);
   });
@@ -734,8 +796,8 @@
   // can re-run with the opt-in if they want it.
   async function installWholePlugin(marketplace: string, plugin: string) {
     const key = pluginKey(marketplace, plugin);
-    if (pendingPluginInstalls.has(key)) return;
-    pendingPluginInstalls.add(key);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "install");
     installError = null;
     installMessage = null;
     installWarning = null;
@@ -848,7 +910,52 @@
       const reason = e instanceof Error ? e.message : String(e);
       installError = `Plugin install failed for ${plugin}: ${reason}`;
     } finally {
-      pendingPluginInstalls.delete(key);
+      pendingPluginActions.delete(key);
+    }
+  }
+
+  // Update an installed plugin. Calls the same `installPlugin` command
+  // used by Install but with `force=true` hard-coded — the existing
+  // global `forceInstall` checkbox stays bound to the Install button
+  // path. `pluginUpdates.refresh` re-runs the scan after the update so
+  // the indicator clears; `fetchInstalledPlugins` refreshes the
+  // installed-set so any new content type the update added shows up.
+  async function updatePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "update");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    try {
+      const result = await commands.installPlugin(
+        marketplace,
+        plugin,
+        /*force=*/ true,
+        /*acceptMcp=*/ false,
+        projectPath,
+      );
+      if (result.status === "ok") {
+        const { summary, warnings, anyInstalled, anyFailed } =
+          formatInstallPluginResult(result.data, plugin);
+        if (anyFailed && !anyInstalled) {
+          installError = `Update failed for ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Updated ${plugin}: ${summary}`;
+        }
+        if (warnings) {
+          installWarning = `Updated ${plugin}: ${warnings}`;
+        }
+        await pluginUpdates.refresh(projectPath);
+        await fetchInstalledPlugins();
+      } else {
+        installError = `Update failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Update failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginActions.delete(key);
     }
   }
 
@@ -1163,9 +1270,13 @@
               plugin={ap.plugin}
               marketplace={ap.marketplace}
               installed={installedPluginKeys.has(key)}
-              installing={pendingPluginInstalls.has(key)}
+              installing={pendingPluginActions.get(key) === "install"}
+              updating={pendingPluginActions.get(key) === "update"}
+              update={pluginUpdates.updateFor(ap.marketplace, ap.plugin.name)}
+              failure={pluginUpdates.failureFor(ap.marketplace, ap.plugin.name)}
               projectPicked={!!projectPath}
               onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+              onUpdate={() => updatePlugin(ap.marketplace, ap.plugin.name)}
             />
           {/each}
         </div>

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -24,6 +24,7 @@
     SkillInfo,
     SkippedSkill,
   } from "$lib/bindings";
+  import BannerStack from "./BannerStack.svelte";
   import SkillCard from "./SkillCard.svelte";
   import PluginCard from "./PluginCard.svelte";
 
@@ -1063,73 +1064,17 @@
     </div>
   {/if}
 
-  <!-- Banners render newest-first (reverse insertion order) and cap at 3 so
-       a storm of broken plugins doesn't push the grid off-screen. Dismissing
-       a banner or resolving its source surfaces the next-newest below. -->
-  {#each [...fetchErrors].reverse().slice(0, 3) as [key, message] (key)}
-    <div
-      data-testid="fetch-error"
-      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
-    >
-      <p class="text-sm text-kiro-error flex-1">{message}</p>
-      <button
-        type="button"
-        onclick={() => fetchErrors.delete(key)}
-        aria-label={errLabel(key)}
-        class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
-      >
-        ×
-      </button>
-    </div>
-  {/each}
-  {#if fetchErrors.size > 3}
-    <div
-      data-testid="fetch-error-overflow"
-      class="mx-4 mt-3 px-4 py-2 text-xs text-kiro-subtle text-center border border-kiro-muted/50 rounded-md bg-kiro-surface/30"
-    >
-      +{fetchErrors.size - 3} more {fetchErrors.size - 3 === 1 ? "error" : "errors"} — dismiss or resolve above to see the rest
-    </div>
-  {/if}
-
-  {#if installError}
-    <div
-      data-testid="install-error"
-      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
-    >
-      <p class="text-sm text-kiro-error flex-1">{installError}</p>
-      <button
-        type="button"
-        onclick={() => (installError = null)}
-        aria-label="Dismiss install error"
-        class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
-      >
-        ×
-      </button>
-    </div>
-  {/if}
-
-  {#if installMessage}
-    <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30">
-      <p class="text-sm text-kiro-success">{installMessage}</p>
-    </div>
-  {/if}
-
-  {#if installWarning}
-    <div
-      data-testid="install-warning"
-      class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
-    >
-      <p class="text-sm text-kiro-warning flex-1">{installWarning}</p>
-      <button
-        type="button"
-        onclick={() => (installWarning = null)}
-        aria-label="Dismiss install warning"
-        class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
-      >
-        ×
-      </button>
-    </div>
-  {/if}
+  <BannerStack
+    errors={fetchErrors}
+    message={installMessage}
+    warning={installWarning}
+    fatalError={installError}
+    errLabel={errLabel}
+    ondismiss={(key) => fetchErrors.delete(key)}
+    onmessageDismiss={() => (installMessage = null)}
+    onwarningDismiss={() => (installWarning = null)}
+    onfatalErrorDismiss={() => (installError = null)}
+  />
 
   <div class="flex items-center gap-1 px-4 py-2 border-b border-kiro-muted bg-kiro-surface/30">
     <div class="inline-flex rounded-md border border-kiro-muted bg-kiro-overlay overflow-hidden">

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -246,6 +246,23 @@
     }
   });
 
+  // Phase 2b I-1: clear stale action-result state on project change so the
+  // <details> block, banners, and pending-action map don't leak across
+  // project switches. The store's race-condition guard already handles
+  // pluginUpdates.result; this effect handles InstalledTab-local state.
+  let priorProjectPath: string | null = null;
+  $effect(() => {
+    if (priorProjectPath !== null && priorProjectPath !== projectPath) {
+      removeResult = null;
+      removeResultPlugin = null;
+      removeResultHasFailures = false;
+      installError = null;
+      installMessage = null;
+      installWarning = null;
+    }
+    priorProjectPath = projectPath;
+  });
+
   // Helpers used by the table render block.
   function statusUpdateLabel(u: PluginUpdateInfo): string {
     // ContentChanged: phrased as a status (full sentence) rather than the
@@ -273,6 +290,64 @@
 </script>
 
 <div class="flex flex-col h-full">
+  <BannerStack
+    errors={fetchErrors}
+    message={installMessage}
+    warning={installWarning}
+    fatalError={installError}
+    errLabel={errLabel}
+    ondismiss={(key) => fetchErrors.delete(key)}
+    onmessageDismiss={() => (installMessage = null)}
+    onwarningDismiss={() => (installWarning = null)}
+    onfatalErrorDismiss={() => (installError = null)}
+  />
+
+  {#if removeResult && removeResultPlugin}
+    <div
+      class="mx-4 mt-3 px-4 py-3 rounded-md text-sm flex items-start gap-3
+        {removeResultHasFailures
+          ? 'bg-kiro-warning/10 border border-kiro-warning/30 text-kiro-warning'
+          : 'bg-kiro-success/10 border border-kiro-success/30 text-kiro-success'}"
+    >
+      <details
+        class="flex-1"
+        open={removeResultHasFailures}
+      >
+        <summary class="cursor-pointer text-xs opacity-85">
+          {removeResultHasFailures ? "Show items + failures" : "Show items"}
+        </summary>
+        <div class="mt-2 pl-3 border-l-2 border-current/40 text-xs space-y-1">
+          {#if (removeResult.skills.removed ?? []).length > 0}
+            <div><b>Skills removed:</b> {(removeResult.skills.removed ?? []).join(", ")}</div>
+          {/if}
+          {#if (removeResult.steering.removed ?? []).length > 0}
+            <div><b>Steering removed:</b> {(removeResult.steering.removed ?? []).join(", ")}</div>
+          {/if}
+          {#if (removeResult.agents.removed ?? []).length > 0}
+            <div><b>Agents removed:</b> {(removeResult.agents.removed ?? []).join(", ")}</div>
+          {/if}
+          {#each removeResult.skills.failures ?? [] as f (f.item)}
+            <div><b>Skill failed:</b> {f.item} — {f.error}</div>
+          {/each}
+          {#each removeResult.steering.failures ?? [] as f (f.item)}
+            <div><b>Steering failed:</b> {f.item} — {f.error}</div>
+          {/each}
+          {#each removeResult.agents.failures ?? [] as f (f.item)}
+            <div><b>Agent failed:</b> {f.item} — {f.error}</div>
+          {/each}
+        </div>
+      </details>
+      <button
+        type="button"
+        onclick={() => { removeResult = null; removeResultPlugin = null; }}
+        aria-label="Dismiss remove summary"
+        class="opacity-70 hover:opacity-100 text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
+    </div>
+  {/if}
+
   <div class="flex-1 overflow-y-auto p-4">
     {#if loading}
       <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
@@ -287,22 +362,6 @@
         <p class="text-sm text-kiro-error">{loadError}</p>
       </div>
     {:else}
-      {#if fetchErrors.get(ERR_INSTALLED_PLUGINS)}
-        <div
-          data-testid="installed-load-warning"
-          class="mb-4 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
-        >
-          <p class="text-sm text-kiro-warning flex-1">{fetchErrors.get(ERR_INSTALLED_PLUGINS)}</p>
-          <button
-            type="button"
-            onclick={() => fetchErrors.delete(ERR_INSTALLED_PLUGINS)}
-            aria-label="Dismiss installed-plugins warning"
-            class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
-          >
-            ×
-          </button>
-        </div>
-      {/if}
       <section class="mb-6">
         <h2 class="text-sm font-semibold text-kiro-text mb-3">Installed plugins</h2>
         {#if plugins.length === 0}
@@ -314,30 +373,66 @@
                 <th class="px-4 py-2">Plugin</th>
                 <th class="px-4 py-2">Marketplace</th>
                 <th class="px-4 py-2">Version</th>
+                <th class="px-4 py-2">Status</th>
                 <th class="px-4 py-2">Contents</th>
-                <th class="px-4 py-2">Installed</th>
+                <th class="px-4 py-2">Installed at</th>
                 <th class="px-4 py-2"></th>
               </tr>
             </thead>
             <tbody>
               {#each plugins as p (pluginKey(p.marketplace, p.plugin))}
                 {@const key = pluginKey(p.marketplace, p.plugin)}
+                {@const updateInfo = updateInfoFor(p)}
+                {@const failure = failureFor(p)}
+                {@const action = pendingPluginActions.get(key)}
                 <tr class="border-b border-kiro-muted/50">
                   <td class="px-4 py-3 font-medium text-kiro-text">{p.plugin}</td>
                   <td class="px-4 py-3 text-kiro-text-secondary">{p.marketplace}</td>
                   <td class="px-4 py-3 text-kiro-text-secondary">{p.installed_version ?? "—"}</td>
+                  <td class="px-4 py-3">
+                    {#if updateInfo}
+                      <span
+                        class="px-2 py-0.5 text-[11px] font-medium text-kiro-warning border border-kiro-warning/40 rounded"
+                      >
+                        {statusUpdateLabel(updateInfo)}
+                      </span>
+                    {:else if failure}
+                      <span
+                        class="px-2 py-0.5 text-[11px] font-medium text-kiro-error border border-kiro-error/40 rounded"
+                        title={kindLabel(failure.kind)}
+                      >
+                        Update check failed
+                      </span>
+                    {:else}
+                      <span class="text-kiro-success text-[11px]">Up to date</span>
+                    {/if}
+                  </td>
                   <td class="px-4 py-3 text-kiro-text-secondary">{contentSummary(p)}</td>
                   <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(p.latest_install)}</td>
                   <td class="px-4 py-3 text-right">
-                    <button
-                      type="button"
-                      onclick={() => removePlugin(p.marketplace, p.plugin)}
-                      disabled={pendingPluginActions.size > 0}
-                      aria-busy={pendingPluginActions.get(key) === "remove"}
-                      class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed"
-                    >
-                      {pendingPluginActions.get(key) === "remove" ? "Removing…" : "Remove"}
-                    </button>
+                    <div class="inline-flex gap-2">
+                      {#if updateInfo}
+                        <button
+                          type="button"
+                          onclick={() => updatePlugin(p.marketplace, p.plugin)}
+                          disabled={action !== undefined}
+                          aria-busy={action === "update"}
+                          title="Update will replace local edits to plugin files"
+                          class="px-2 py-0.5 text-[11px] text-kiro-warning hover:text-kiro-warning/80 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {action === "update" ? "Updating…" : "Update"}
+                        </button>
+                      {/if}
+                      <button
+                        type="button"
+                        onclick={() => removePlugin(p.marketplace, p.plugin)}
+                        disabled={action !== undefined}
+                        aria-busy={action === "remove"}
+                        class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {action === "remove" ? "Removing…" : "Remove"}
+                      </button>
+                    </div>
                   </td>
                 </tr>
               {/each}

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -5,13 +5,11 @@
   import type {
     InstalledSkillInfo,
     InstalledPluginInfo,
-    PluginUpdateInfo,
-    PluginUpdateFailure,
     RemovePluginResult,
   } from "$lib/bindings";
   import { DELIM, pluginKey } from "$lib/keys";
   import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
-  import { kindLabel } from "$lib/stores/plugin-updates";
+  import { kindLabel, statusUpdateLabel } from "$lib/stores/plugin-updates";
   import type { PluginAction } from "$lib/stores/plugin-updates";
   import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
   import BannerStack from "./BannerStack.svelte";
@@ -21,31 +19,18 @@
   let plugins: InstalledPluginInfo[] = $state([]);
   let skills: InstalledSkillInfo[] = $state([]);
   let loading: boolean = $state(true);
-  // `loadError` narrows in 2b: only fetch/refresh failures land here.
-  // Remove-action failures route to `installError` (matching BrowseTab).
   let loadError: string | null = $state(null);
 
-  // 3-banner pattern mirrored from BrowseTab. installError = red fatal,
-  // installMessage = green success, installWarning = amber non-fatal.
   let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
   let installWarning: string | null = $state(null);
 
-  // Per-plugin in-flight tracker, keyed by pluginKey(marketplace, plugin).
-  // Narrows the shared PluginAction union to the actions InstalledTab
-  // performs (Remove + Update — never Install, that's BrowseTab's surface).
   let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "remove" | "update">>();
 
-  // The most recent RemovePluginResult — drives the inline <details>
-  // block below the BannerStack. Stays set until the next Remove or
-  // a project change clears it.
   let removeResult: RemovePluginResult | null = $state(null);
   let removeResultPlugin: string | null = $state(null);
   let removeResultHasFailures: boolean = $state(false);
 
-  // Banner-stack typing — InstalledTab's ErrorSource union is small for
-  // 2b: only the new update-check + update-fetch keys plus a single
-  // installed-plugins key for partial-load warnings (existing).
   const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
   const ERR_UPDATE_FETCH = "update-fetch" as const;
   const UPDATE_CHECK_PREFIX = "update-check" as const;
@@ -59,11 +44,8 @@
     if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins warning";
     if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
     if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
-      const parts = key.split(DELIM);
-      if (parts.length === 3) {
-        return `Dismiss update-check banner for ${parts[2]}`;
-      }
-      return "Dismiss update-check banner";
+      const [, , marketplace] = key.split(DELIM);
+      return `Dismiss update-check banner for ${marketplace}`;
     }
     return "Dismiss banner";
   }
@@ -97,12 +79,25 @@
         skills = skillsResult.data;
       } else if (loadError === null) {
         loadError = skillsResult.error.message;
+      } else {
+        console.error("[InstalledTab] skills load also failed", skillsResult.error);
       }
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
       loadError = `Failed to load installed state: ${reason}`;
     } finally {
       loading = false;
+    }
+  }
+
+  async function refreshAfterPluginAction(verbForBanner: string, plugin: string) {
+    try {
+      await pluginUpdates.refresh(projectPath);
+      await refresh();
+    } catch (e) {
+      console.error(`[InstalledTab] post-${verbForBanner} refresh threw`, e);
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `${plugin} ${verbForBanner} succeeded but refresh failed: ${reason}`;
     }
   }
 
@@ -120,7 +115,7 @@
       const result = await commands.removePlugin(marketplace, plugin, projectPath);
       if (result.status === "ok") {
         const { summary, hasItems, hasFailures } =
-          formatRemovePluginResult(result.data, plugin);
+          formatRemovePluginResult(result.data);
         if (hasItems || hasFailures) {
           removeResult = result.data;
           removeResultPlugin = plugin;
@@ -131,9 +126,7 @@
         } else {
           installMessage = `Removed plugin ${plugin}: ${summary}`;
         }
-        // Order: pluginUpdates.refresh first, local refresh second.
-        await pluginUpdates.refresh(projectPath);
-        await refresh();
+        await refreshAfterPluginAction("remove", plugin);
       } else {
         installError = `Remove failed for ${plugin}: ${result.error.message}`;
       }
@@ -164,7 +157,7 @@
       );
       if (result.status === "ok") {
         const { summary, warnings, anyInstalled, anyFailed } =
-          formatInstallPluginResult(result.data, plugin);
+          formatInstallPluginResult(result.data);
         if (anyFailed && !anyInstalled) {
           installError = `Update failed for ${plugin}: ${summary}`;
         } else {
@@ -173,8 +166,7 @@
         if (warnings) {
           installWarning = `Updated ${plugin}: ${warnings}`;
         }
-        await pluginUpdates.refresh(projectPath);
-        await refresh();
+        await refreshAfterPluginAction("update", plugin);
       } else {
         installError = `Update failed for ${plugin}: ${result.error.message}`;
       }
@@ -208,13 +200,13 @@
     refresh();
   });
 
-  // Eager scan on project mount + on every projectPath change.
   $effect(() => {
     void projectPath;
-    pluginUpdates.refresh(projectPath);
+    pluginUpdates
+      .refresh(projectPath)
+      .catch((e) => console.error("[InstalledTab] pluginUpdates.refresh threw", e));
   });
 
-  // Project per-marketplace failure groups into the fetchErrors map.
   $effect(() => {
     const seen = new Set<ErrorSource>();
     for (const group of pluginUpdates.failureGroups) {
@@ -235,7 +227,6 @@
     }
   });
 
-  // Surface the toplevel pluginUpdates.fetchError as its own banner.
   $effect(() => {
     if (pluginUpdates.fetchError) {
       fetchErrors.set(
@@ -247,10 +238,6 @@
     }
   });
 
-  // Phase 2b I-1: clear stale action-result state on project change so the
-  // <details> block, banners, and pending-action map don't leak across
-  // project switches. The store's race-condition guard already handles
-  // pluginUpdates.result; this effect handles InstalledTab-local state.
   let priorProjectPath: string | null = null;
   $effect(() => {
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
@@ -260,44 +247,12 @@
       installError = null;
       installMessage = null;
       installWarning = null;
-      // Clear in-flight tracker — actions clear themselves via finally{}
-      // under normal operation, but a project change while a Remove or
-      // Update is mid-flight would leave a stale entry that disables the
-      // row's buttons indefinitely.
       pendingPluginActions.clear();
-      // Clear per-project banner keys (update-check<DELIM> family +
-      // installed-plugins partial-load). The pluginUpdates.refresh and
-      // local refresh that follow on the same projectPath change will
-      // repopulate from fresh state.
       fetchErrors.clear();
     }
     priorProjectPath = projectPath;
   });
 
-  // Helpers used by the table render block.
-  function statusUpdateLabel(u: PluginUpdateInfo): string {
-    // ContentChanged: phrased as a status (full sentence) rather than the
-    // PluginCard button's action label ("Update (content changed)").
-    // The two surfaces intentionally differ — column = state; button = action.
-    if (u.change_signal.kind === "content_changed") return "Content changed since install";
-    // VersionBumped: prefer the explicit "v_old → v_new" form when both
-    // versions are known; fall back to "vN available" for legacy installs
-    // (installed_version: None) and to a bare "Update available" when the
-    // marketplace manifest declares no version.
-    if (u.installed_version && u.available_version) {
-      return `v${u.installed_version} → v${u.available_version}`;
-    }
-    if (u.available_version) return `v${u.available_version} available`;
-    return "Update available";
-  }
-
-  function updateInfoFor(p: InstalledPluginInfo): PluginUpdateInfo | undefined {
-    return pluginUpdates.updateFor(p.marketplace, p.plugin);
-  }
-
-  function failureFor(p: InstalledPluginInfo): PluginUpdateFailure | undefined {
-    return pluginUpdates.failureFor(p.marketplace, p.plugin);
-  }
 </script>
 
 <div class="flex flex-col h-full">
@@ -393,8 +348,8 @@
             <tbody>
               {#each plugins as p (pluginKey(p.marketplace, p.plugin))}
                 {@const key = pluginKey(p.marketplace, p.plugin)}
-                {@const updateInfo = updateInfoFor(p)}
-                {@const failure = failureFor(p)}
+                {@const updateInfo = pluginUpdates.updateFor(p.marketplace, p.plugin)}
+                {@const failure = pluginUpdates.failureFor(p.marketplace, p.plugin)}
                 {@const action = pendingPluginActions.get(key)}
                 <tr class="border-b border-kiro-muted/50">
                   <td class="px-4 py-3 font-medium text-kiro-text">{p.plugin}</td>

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -153,6 +153,7 @@
     installMessage = null;
     installWarning = null;
     removeResult = null;
+    removeResultPlugin = null;
     try {
       const result = await commands.installPlugin(
         marketplace,
@@ -259,6 +260,16 @@
       installError = null;
       installMessage = null;
       installWarning = null;
+      // Clear in-flight tracker — actions clear themselves via finally{}
+      // under normal operation, but a project change while a Remove or
+      // Update is mid-flight would leave a stale entry that disables the
+      // row's buttons indefinitely.
+      pendingPluginActions.clear();
+      // Clear per-project banner keys (update-check<DELIM> family +
+      // installed-plugins partial-load). The pluginUpdates.refresh and
+      // local refresh that follow on the same projectPath change will
+      // repopulate from fresh state.
+      fetchErrors.clear();
     }
     priorProjectPath = projectPath;
   });

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -1,49 +1,94 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { SvelteMap } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
   import type {
     InstalledSkillInfo,
     InstalledPluginInfo,
+    PluginUpdateInfo,
+    PluginUpdateFailure,
+    RemovePluginResult,
   } from "$lib/bindings";
-  import { pluginKey } from "$lib/keys";
+  import { DELIM, pluginKey } from "$lib/keys";
+  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+  import { kindLabel } from "$lib/stores/plugin-updates";
+  import type { PluginAction } from "$lib/stores/plugin-updates";
+  import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
+  import BannerStack from "./BannerStack.svelte";
 
   let { projectPath }: { projectPath: string } = $props();
 
   let plugins: InstalledPluginInfo[] = $state([]);
   let skills: InstalledSkillInfo[] = $state([]);
   let loading: boolean = $state(true);
+  // `loadError` narrows in 2b: only fetch/refresh failures land here.
+  // Remove-action failures route to `installError` (matching BrowseTab).
   let loadError: string | null = $state(null);
-  // Non-fatal partial-load detail (one or more `installed-*.json` tracking
-  // files failed to parse; the others loaded). Distinct from `loadError`
-  // (red, fatal) — the table still has rows from the files that DID load.
-  let loadWarning: string | null = $state(null);
-  // Single removal in flight at a time — `remove_plugin` reads/writes the
-  // installed-skills/steering/agents tracking files, so racing two removes
-  // could clobber each other. Disabling all Remove buttons while one is
-  // pending is the simplest correctness-preserving UI.
-  let removingKey: string | null = $state(null);
+
+  // 3-banner pattern mirrored from BrowseTab. installError = red fatal,
+  // installMessage = green success, installWarning = amber non-fatal.
+  let installError: string | null = $state(null);
+  let installMessage: string | null = $state(null);
+  let installWarning: string | null = $state(null);
+
+  // Per-plugin in-flight tracker, keyed by pluginKey(marketplace, plugin).
+  // Narrows the shared PluginAction union to the actions InstalledTab
+  // performs (Remove + Update — never Install, that's BrowseTab's surface).
+  let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "remove" | "update">>();
+
+  // The most recent RemovePluginResult — drives the inline <details>
+  // block below the BannerStack. Stays set until the next Remove or
+  // a project change clears it.
+  let removeResult: RemovePluginResult | null = $state(null);
+  let removeResultPlugin: string | null = $state(null);
+  let removeResultHasFailures: boolean = $state(false);
+
+  // Banner-stack typing — InstalledTab's ErrorSource union is small for
+  // 2b: only the new update-check + update-fetch keys plus a single
+  // installed-plugins key for partial-load warnings (existing).
+  const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
+  const ERR_UPDATE_FETCH = "update-fetch" as const;
+  const UPDATE_CHECK_PREFIX = "update-check" as const;
+  type ErrorSource =
+    | typeof ERR_INSTALLED_PLUGINS
+    | typeof ERR_UPDATE_FETCH
+    | `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`;
+  let fetchErrors = new SvelteMap<ErrorSource, string>();
+
+  function errLabel(key: ErrorSource): string {
+    if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins warning";
+    if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
+    if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
+      const parts = key.split(DELIM);
+      if (parts.length === 3) {
+        return `Dismiss update-check banner for ${parts[2]}`;
+      }
+      return "Dismiss update-check banner";
+    }
+    return "Dismiss banner";
+  }
 
   async function refresh() {
     loading = true;
     loadError = null;
-    loadWarning = null;
     try {
       const [pluginsResult, skillsResult] = await Promise.all([
         commands.listInstalledPlugins(projectPath),
         commands.listInstalledSkills(projectPath),
       ]);
       if (pluginsResult.status === "ok") {
-        // Wire format is `InstalledPluginsView` (I13): `.plugins` carries
-        // the rows, `.partial_load_warnings` carries per-tracking-file
-        // load failures (corrupt installed-*.json) so the table renders
-        // the partial state instead of a misleading empty list.
         plugins = pluginsResult.data.plugins;
         const warnings = pluginsResult.data.partial_load_warnings ?? [];
         if (warnings.length > 0) {
           const summary = warnings
             .map((w) => `${w.tracking_file}: ${w.error}`)
             .join("; ");
-          loadWarning = `Installed plugins partially loaded — ${summary}`;
+          fetchErrors.set(
+            ERR_INSTALLED_PLUGINS,
+            `Installed plugins partially loaded — ${summary}`,
+          );
+        } else {
+          fetchErrors.delete(ERR_INSTALLED_PLUGINS);
         }
       } else {
         loadError = pluginsResult.error.message;
@@ -63,20 +108,80 @@
 
   async function removePlugin(marketplace: string, plugin: string) {
     const key = pluginKey(marketplace, plugin);
-    if (removingKey !== null) return;
-    removingKey = key;
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "remove");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    removeResult = null;
+    removeResultPlugin = null;
+    removeResultHasFailures = false;
     try {
       const result = await commands.removePlugin(marketplace, plugin, projectPath);
       if (result.status === "ok") {
+        const { summary, hasItems, hasFailures } =
+          formatRemovePluginResult(result.data, plugin);
+        if (hasItems || hasFailures) {
+          removeResult = result.data;
+          removeResultPlugin = plugin;
+          removeResultHasFailures = hasFailures;
+        }
+        if (hasFailures) {
+          installWarning = `Removed plugin ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Removed plugin ${plugin}: ${summary}`;
+        }
+        // Order: pluginUpdates.refresh first, local refresh second.
+        await pluginUpdates.refresh(projectPath);
         await refresh();
       } else {
-        loadError = `Remove failed for ${plugin}: ${result.error.message}`;
+        installError = `Remove failed for ${plugin}: ${result.error.message}`;
       }
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
-      loadError = `Remove failed for ${plugin}: ${reason}`;
+      installError = `Remove failed for ${plugin}: ${reason}`;
     } finally {
-      removingKey = null;
+      pendingPluginActions.delete(key);
+    }
+  }
+
+  async function updatePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "update");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    removeResult = null;
+    try {
+      const result = await commands.installPlugin(
+        marketplace,
+        plugin,
+        /*force=*/ true,
+        /*acceptMcp=*/ false,
+        projectPath,
+      );
+      if (result.status === "ok") {
+        const { summary, warnings, anyInstalled, anyFailed } =
+          formatInstallPluginResult(result.data, plugin);
+        if (anyFailed && !anyInstalled) {
+          installError = `Update failed for ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Updated ${plugin}: ${summary}`;
+        }
+        if (warnings) {
+          installWarning = `Updated ${plugin}: ${warnings}`;
+        }
+        await pluginUpdates.refresh(projectPath);
+        await refresh();
+      } else {
+        installError = `Update failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Update failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginActions.delete(key);
     }
   }
 
@@ -101,6 +206,70 @@
     void projectPath;
     refresh();
   });
+
+  // Eager scan on project mount + on every projectPath change.
+  $effect(() => {
+    void projectPath;
+    pluginUpdates.refresh(projectPath);
+  });
+
+  // Project per-marketplace failure groups into the fetchErrors map.
+  $effect(() => {
+    const seen = new Set<ErrorSource>();
+    for (const group of pluginUpdates.failureGroups) {
+      const key: ErrorSource =
+        `${UPDATE_CHECK_PREFIX}${DELIM}${group.remediation}${DELIM}${group.marketplace}` as ErrorSource;
+      seen.add(key);
+      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
+      const list = group.plugins.join(", ");
+      fetchErrors.set(
+        key,
+        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
+      );
+    }
+    for (const k of fetchErrors.keys()) {
+      if (k.startsWith(UPDATE_CHECK_PREFIX + DELIM) && !seen.has(k)) {
+        fetchErrors.delete(k);
+      }
+    }
+  });
+
+  // Surface the toplevel pluginUpdates.fetchError as its own banner.
+  $effect(() => {
+    if (pluginUpdates.fetchError) {
+      fetchErrors.set(
+        ERR_UPDATE_FETCH,
+        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
+      );
+    } else {
+      fetchErrors.delete(ERR_UPDATE_FETCH);
+    }
+  });
+
+  // Helpers used by the table render block.
+  function statusUpdateLabel(u: PluginUpdateInfo): string {
+    // ContentChanged: phrased as a status (full sentence) rather than the
+    // PluginCard button's action label ("Update (content changed)").
+    // The two surfaces intentionally differ — column = state; button = action.
+    if (u.change_signal.kind === "content_changed") return "Content changed since install";
+    // VersionBumped: prefer the explicit "v_old → v_new" form when both
+    // versions are known; fall back to "vN available" for legacy installs
+    // (installed_version: None) and to a bare "Update available" when the
+    // marketplace manifest declares no version.
+    if (u.installed_version && u.available_version) {
+      return `v${u.installed_version} → v${u.available_version}`;
+    }
+    if (u.available_version) return `v${u.available_version} available`;
+    return "Update available";
+  }
+
+  function updateInfoFor(p: InstalledPluginInfo): PluginUpdateInfo | undefined {
+    return pluginUpdates.updateFor(p.marketplace, p.plugin);
+  }
+
+  function failureFor(p: InstalledPluginInfo): PluginUpdateFailure | undefined {
+    return pluginUpdates.failureFor(p.marketplace, p.plugin);
+  }
 </script>
 
 <div class="flex flex-col h-full">
@@ -118,15 +287,15 @@
         <p class="text-sm text-kiro-error">{loadError}</p>
       </div>
     {:else}
-      {#if loadWarning}
+      {#if fetchErrors.get(ERR_INSTALLED_PLUGINS)}
         <div
           data-testid="installed-load-warning"
           class="mb-4 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
         >
-          <p class="text-sm text-kiro-warning flex-1">{loadWarning}</p>
+          <p class="text-sm text-kiro-warning flex-1">{fetchErrors.get(ERR_INSTALLED_PLUGINS)}</p>
           <button
             type="button"
-            onclick={() => (loadWarning = null)}
+            onclick={() => fetchErrors.delete(ERR_INSTALLED_PLUGINS)}
             aria-label="Dismiss installed-plugins warning"
             class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
           >
@@ -163,11 +332,11 @@
                     <button
                       type="button"
                       onclick={() => removePlugin(p.marketplace, p.plugin)}
-                      disabled={removingKey !== null}
-                      aria-busy={removingKey === key}
+                      disabled={pendingPluginActions.size > 0}
+                      aria-busy={pendingPluginActions.get(key) === "remove"}
                       class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed"
                     >
-                      {removingKey === key ? "Removing…" : "Remove"}
+                      {pendingPluginActions.get(key) === "remove" ? "Removing…" : "Remove"}
                     </button>
                   </td>
                 </tr>

--- a/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
@@ -2,6 +2,14 @@
   import { commands } from "$lib/bindings";
   import type { MarketplaceInfo, GitProtocol } from "$lib/bindings";
 
+  // Phase 2b: parent (`+page.svelte`) wires this to
+  // `pluginUpdates.refresh(store.projectPath)` so a successful marketplace
+  // update invalidates the cached update-detection scan.
+  type Props = {
+    onUpdated?: (marketplaceName: string) => void;
+  };
+  let { onUpdated }: Props = $props();
+
   let marketplaces: MarketplaceInfo[] = $state([]);
   let newSource: string = $state("");
   let protocol: GitProtocol = $state("https");
@@ -59,6 +67,7 @@
       if (failed.length > 0) parts.push(`Failed: ${failed.map((f) => `${f.name} (${f.error})`).join(", ")}`);
       successMessage = parts.join(" | ");
       await loadMarketplaces();
+      onUpdated?.(name);
     } else {
       error = result.error.message;
     }

--- a/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
@@ -2,9 +2,6 @@
   import { commands } from "$lib/bindings";
   import type { MarketplaceInfo, GitProtocol } from "$lib/bindings";
 
-  // Phase 2b: parent (`+page.svelte`) wires this to
-  // `pluginUpdates.refresh(store.projectPath)` so a successful marketplace
-  // update invalidates the cached update-detection scan.
   type Props = {
     onUpdated?: (marketplaceName: string) => void;
   };
@@ -22,16 +19,26 @@
   let error: string | null = $state(null);
   let successMessage: string | null = $state(null);
 
+  function errorMessage(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+  }
+
   async function loadMarketplaces() {
     loading = true;
     error = null;
-    const result = await commands.listMarketplaces();
-    if (result.status === "ok") {
-      marketplaces = result.data;
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.listMarketplaces();
+      if (result.status === "ok") {
+        marketplaces = result.data;
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      console.error("[MarketplacesTab] listMarketplaces threw", e);
+      error = errorMessage(e);
+    } finally {
+      loading = false;
     }
-    loading = false;
   }
 
   async function addMarketplace() {
@@ -40,38 +47,48 @@
     adding = true;
     error = null;
     successMessage = null;
-
-    const result = await commands.addMarketplace(source, protocol);
-    if (result.status === "ok") {
-      const { name, plugins } = result.data;
-      successMessage = `Added "${name}" with ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}`;
-      newSource = "";
-      await loadMarketplaces();
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.addMarketplace(source, protocol);
+      if (result.status === "ok") {
+        const { name, plugins } = result.data;
+        successMessage = `Added "${name}" with ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}`;
+        newSource = "";
+        await loadMarketplaces();
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      console.error("[MarketplacesTab] addMarketplace threw", e);
+      error = errorMessage(e);
+    } finally {
+      adding = false;
     }
-    adding = false;
   }
 
   async function updateMarketplace(name: string) {
     updatingName = name;
     error = null;
     successMessage = null;
-
-    const result = await commands.updateMarketplace(name);
-    if (result.status === "ok") {
-      const { updated, failed, skipped } = result.data;
-      const parts: string[] = [];
-      if (updated.length > 0) parts.push(`Updated: ${updated.join(", ")}`);
-      if (skipped.length > 0) parts.push(`Skipped: ${skipped.join(", ")}`);
-      if (failed.length > 0) parts.push(`Failed: ${failed.map((f) => `${f.name} (${f.error})`).join(", ")}`);
-      successMessage = parts.join(" | ");
-      await loadMarketplaces();
-      onUpdated?.(name);
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.updateMarketplace(name);
+      if (result.status === "ok") {
+        const { updated, failed, skipped } = result.data;
+        const parts: string[] = [];
+        if (updated.length > 0) parts.push(`Updated: ${updated.join(", ")}`);
+        if (skipped.length > 0) parts.push(`Skipped: ${skipped.join(", ")}`);
+        if (failed.length > 0) parts.push(`Failed: ${failed.map((f) => `${f.name} (${f.error})`).join(", ")}`);
+        successMessage = parts.join(" | ");
+        await loadMarketplaces();
+        onUpdated?.(name);
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      console.error("[MarketplacesTab] updateMarketplace threw", e);
+      error = errorMessage(e);
+    } finally {
+      updatingName = null;
     }
-    updatingName = null;
   }
 
   async function removeMarketplace(name: string) {
@@ -82,15 +99,20 @@
     removingName = name;
     error = null;
     successMessage = null;
-
-    const result = await commands.removeMarketplace(name);
-    if (result.status === "ok") {
-      successMessage = `Removed "${name}"`;
-      await loadMarketplaces();
-    } else {
-      error = result.error.message;
+    try {
+      const result = await commands.removeMarketplace(name);
+      if (result.status === "ok") {
+        successMessage = `Removed "${name}"`;
+        await loadMarketplaces();
+      } else {
+        error = result.error.message;
+      }
+    } catch (e) {
+      console.error("[MarketplacesTab] removeMarketplace threw", e);
+      error = errorMessage(e);
+    } finally {
+      removingName = null;
     }
-    removingName = null;
   }
 
   function sourceTypeBadgeClass(sourceType: string): string {

--- a/crates/kiro-control-center/src/lib/components/PluginCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/PluginCard.svelte
@@ -114,7 +114,10 @@
         disabled={!projectPicked}
         title="Update will replace local edits to plugin files"
         aria-label="Update {plugin.name}"
-        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-warning/10 border border-kiro-warning/40 text-kiro-warning hover:bg-kiro-warning/15 transition-colors"
+        class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+          {projectPicked
+            ? 'bg-kiro-warning/10 border border-kiro-warning/40 text-kiro-warning hover:bg-kiro-warning/15'
+            : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
       >
         {updateLabel}
       </button>
@@ -129,7 +132,6 @@
         type="button"
         onclick={onInstall}
         disabled={!projectPicked}
-        aria-busy={installing}
         title={installTitle}
         aria-label="Install {plugin.name}"
         class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors

--- a/crates/kiro-control-center/src/lib/components/PluginCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/PluginCard.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { PluginInfo } from "$lib/bindings";
+  import type {
+    PluginInfo,
+    PluginUpdateFailure,
+    PluginUpdateInfo,
+  } from "$lib/bindings";
+  import { kindLabel } from "$lib/stores/plugin-updates";
   import { skillCountLabel, skillCountTitle } from "$lib/format";
 
   type Props = {
@@ -7,8 +12,12 @@
     marketplace: string;
     installed: boolean;
     installing: boolean;
+    updating: boolean;
+    update: PluginUpdateInfo | undefined;
+    failure: PluginUpdateFailure | undefined;
     projectPicked: boolean;
     onInstall: () => void;
+    onUpdate: () => void;
   };
 
   let {
@@ -16,17 +25,33 @@
     marketplace,
     installed,
     installing,
+    updating,
+    update,
+    failure,
     projectPicked,
     onInstall,
+    onUpdate,
   }: Props = $props();
 
-  const title = $derived(
+  const installTitle = $derived(
     !projectPicked
       ? "Pick a project first"
       : installed
         ? `${plugin.name} is already installed in this project`
         : `Install ${plugin.name} (skills + steering + agents) into the active project`,
   );
+
+  // Update button label per Phase 2b design decision #6:
+  //   - VersionBumped + both versions known      → "Update → vN"
+  //   - VersionBumped + installed_version null   → "Update → vN" (legacy install; → reads as "to vN")
+  //   - VersionBumped + available_version null   → "Update"      (manifest declares no version)
+  //   - ContentChanged                            → "Update (content changed)"
+  const updateLabel = $derived.by(() => {
+    if (!update) return "Update";
+    if (update.change_signal.kind === "content_changed") return "Update (content changed)";
+    if (update.available_version) return `Update → v${update.available_version}`;
+    return "Update";
+  });
 </script>
 
 <div class="flex items-start gap-3 px-3 py-3 rounded-md border border-kiro-muted bg-kiro-overlay">
@@ -55,7 +80,45 @@
   </div>
 
   <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
-    {#if installed}
+    {#if installing}
+      <button
+        type="button"
+        disabled
+        aria-busy="true"
+        aria-label="Installing {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed"
+      >
+        Installing…
+      </button>
+    {:else if updating}
+      <button
+        type="button"
+        disabled
+        aria-busy="true"
+        aria-label="Updating {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed"
+      >
+        Updating…
+      </button>
+    {:else if failure && installed}
+      <span
+        class="px-2 py-0.5 text-[11px] font-medium text-kiro-error border border-kiro-error/40 rounded"
+        title={kindLabel(failure.kind)}
+      >
+        Update check failed
+      </span>
+    {:else if update}
+      <button
+        type="button"
+        onclick={onUpdate}
+        disabled={!projectPicked}
+        title="Update will replace local edits to plugin files"
+        aria-label="Update {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-warning/10 border border-kiro-warning/40 text-kiro-warning hover:bg-kiro-warning/15 transition-colors"
+      >
+        {updateLabel}
+      </button>
+    {:else if installed}
       <span
         class="px-2 py-0.5 text-[11px] font-medium text-kiro-success border border-kiro-success/40 rounded"
       >
@@ -65,16 +128,16 @@
       <button
         type="button"
         onclick={onInstall}
-        disabled={!projectPicked || installing}
+        disabled={!projectPicked}
         aria-busy={installing}
-        {title}
+        title={installTitle}
         aria-label="Install {plugin.name}"
         class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors
-          {projectPicked && !installing
+          {projectPicked
             ? 'bg-kiro-overlay border border-kiro-muted text-kiro-accent-300 hover:bg-kiro-muted hover:text-kiro-accent-200'
             : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
       >
-        {installing ? "Installing…" : "Install"}
+        Install
       </button>
     {/if}
   </div>

--- a/crates/kiro-control-center/src/lib/components/PluginCard.svelte
+++ b/crates/kiro-control-center/src/lib/components/PluginCard.svelte
@@ -4,7 +4,7 @@
     PluginUpdateFailure,
     PluginUpdateInfo,
   } from "$lib/bindings";
-  import { kindLabel } from "$lib/stores/plugin-updates";
+  import { actionUpdateLabel, kindLabel } from "$lib/stores/plugin-updates";
   import { skillCountLabel, skillCountTitle } from "$lib/format";
 
   type Props = {
@@ -41,17 +41,7 @@
         : `Install ${plugin.name} (skills + steering + agents) into the active project`,
   );
 
-  // Update button label per Phase 2b design decision #6:
-  //   - VersionBumped + both versions known      → "Update → vN"
-  //   - VersionBumped + installed_version null   → "Update → vN" (legacy install; → reads as "to vN")
-  //   - VersionBumped + available_version null   → "Update"      (manifest declares no version)
-  //   - ContentChanged                            → "Update (content changed)"
-  const updateLabel = $derived.by(() => {
-    if (!update) return "Update";
-    if (update.change_signal.kind === "content_changed") return "Update (content changed)";
-    if (update.available_version) return `Update → v${update.available_version}`;
-    return "Update";
-  });
+  const updateLabel = $derived(update ? actionUpdateLabel(update) : "Update");
 </script>
 
 <div class="flex items-start gap-3 px-3 py-3 rounded-md border border-kiro-muted bg-kiro-overlay">

--- a/crates/kiro-control-center/src/lib/format.test.ts
+++ b/crates/kiro-control-center/src/lib/format.test.ts
@@ -3,8 +3,9 @@ import type {
   InstallPluginResult_Serialize,
   MarketplaceName,
   PluginName,
+  RemovePluginResult,
 } from "$lib/bindings";
-import { formatInstallPluginResult } from "./format";
+import { formatInstallPluginResult, formatRemovePluginResult } from "./format";
 
 // Field names + structure tracked from bindings.ts (see plan
 // "Source-of-truth references"):
@@ -88,5 +89,62 @@ describe("formatInstallPluginResult", () => {
     r.skills.skipped = ["a", "b"];
     const out = formatInstallPluginResult(r, "p");
     expect(out.summary).toContain("2 skills already installed");
+  });
+});
+
+// Field names + structure tracked from bindings.ts:
+//  - RemovePluginResult:  bindings.ts:1171-1175
+//  - RemoveSkillsResult:  bindings.ts:1181-1184
+//  - RemoveSteeringResult: bindings.ts:1190-1193
+//  - RemoveAgentsResult:  bindings.ts:1134-1137
+//  - RemoveItemFailure:   bindings.ts:1145-1156
+function emptyRemoveResult(): RemovePluginResult {
+  return {
+    skills: { removed: [], failures: [] },
+    steering: { removed: [], failures: [] },
+    agents: { removed: [], failures: [] },
+  };
+}
+
+describe("formatRemovePluginResult", () => {
+  it("happy path: counts all 3 sub-results", () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a", "b", "c"];
+    r.steering.removed = ["s.md"];
+    r.agents.removed = ["g1", "g2"];
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.summary).toContain("3 skill");
+    expect(out.summary).toContain("1 steering");
+    expect(out.summary).toContain("2 agent");
+    expect(out.hasItems).toBe(true);
+    expect(out.hasFailures).toBe(false);
+  });
+
+  it("steering failure lands in summary (failed count) and hasFailures=true", () => {
+    const r = emptyRemoveResult();
+    r.steering.failures = [{ item: "broken.md", error: "permission denied" }];
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasFailures).toBe(true);
+    expect(out.summary).toContain("1 steering failed");
+  });
+
+  it("empty (zero items, zero failures): hasItems=false, hasFailures=false", () => {
+    const r = emptyRemoveResult();
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasItems).toBe(false);
+    expect(out.hasFailures).toBe(false);
+    expect(out.summary).toBe("nothing to remove");
+  });
+
+  it("treats undefined removed/failures as empty arrays", () => {
+    // The wire format makes both fields optional (#[serde(default)]).
+    const r: RemovePluginResult = {
+      skills: {},
+      steering: {},
+      agents: {},
+    };
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasItems).toBe(false);
+    expect(out.hasFailures).toBe(false);
   });
 });

--- a/crates/kiro-control-center/src/lib/format.test.ts
+++ b/crates/kiro-control-center/src/lib/format.test.ts
@@ -4,8 +4,13 @@ import type {
   MarketplaceName,
   PluginName,
   RemovePluginResult,
+  SkippedSkill,
 } from "$lib/bindings";
-import { formatInstallPluginResult, formatRemovePluginResult } from "./format";
+import {
+  formatInstallPluginResult,
+  formatRemovePluginResult,
+  formatSkippedSkillsForPlugin,
+} from "./format";
 
 // Field names + structure tracked from bindings.ts (see plan
 // "Source-of-truth references"):
@@ -37,32 +42,39 @@ function emptyInstallResult(): InstallPluginResult_Serialize {
 }
 
 describe("formatInstallPluginResult", () => {
-  it("happy path: counts all 3 sub-results", () => {
+  it("happy path: counts all 3 sub-results joined by mid-dot", () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a", "b"];
     r.steering.installed = [
       { source: "s.md", destination: "s.md", kind: "installed", source_hash: "h", installed_hash: "h" },
     ];
-    // installed: string[] (bindings.ts:527), not an object array.
     r.agents.installed = ["g"];
-    const out = formatInstallPluginResult(r, "p");
-    expect(out.summary).toContain("2 skill");
-    expect(out.summary).toContain("1 steering");
-    expect(out.summary).toContain("1 agent");
+    const out = formatInstallPluginResult(r);
+    expect(out.summary).toBe("2 skills · 1 steering file · 1 agent");
     expect(out.anyInstalled).toBe(true);
     expect(out.anyFailed).toBe(false);
   });
 
-  it("failures-only: anyInstalled=false, anyFailed=true", () => {
+  it("singular nouns: 1 skill / 1 steering file / 1 agent", () => {
     const r = emptyInstallResult();
-    // FailedSkill requires `kind: FailedSkillReason` (bindings.ts:352-356).
+    r.skills.installed = ["a"];
+    r.steering.installed = [
+      { source: "s.md", destination: "s.md", kind: "installed", source_hash: "h", installed_hash: "h" },
+    ];
+    r.agents.installed = ["g"];
+    const out = formatInstallPluginResult(r);
+    expect(out.summary).toBe("1 skill · 1 steering file · 1 agent");
+  });
+
+  it("failures-only: anyInstalled=false, anyFailed=true, exact summary", () => {
+    const r = emptyInstallResult();
     r.skills.failed = [
       { name: "broken", error: "oops", kind: { kind: "install_failed" } },
     ];
-    const out = formatInstallPluginResult(r, "p");
+    const out = formatInstallPluginResult(r);
     expect(out.anyInstalled).toBe(false);
     expect(out.anyFailed).toBe(true);
-    expect(out.summary).toContain("1 skill failed");
+    expect(out.summary).toBe("1 skill failed");
   });
 
   it("warnings-only (e.g. MCP-gated agent): warnings string present, no failure flag", () => {
@@ -70,25 +82,54 @@ describe("formatInstallPluginResult", () => {
     r.agents.warnings = [
       { kind: "mcp_servers_require_opt_in", agent: "scary", transports: ["stdio"] },
     ];
-    const out = formatInstallPluginResult(r, "p");
-    expect(out.warnings).not.toBeNull();
-    expect(out.warnings).toContain("scary");
+    const out = formatInstallPluginResult(r);
+    expect(out.warnings).toBe(
+      "agent 'scary' declares MCP servers [stdio] — re-run with --accept-mcp to install",
+    );
     expect(out.anyFailed).toBe(false);
+  });
+
+  it("multiple warnings from different sub-results join with ' | '", () => {
+    const r = emptyInstallResult();
+    r.steering.warnings = [
+      { kind: "scan_path_invalid", path: "/bad", reason: "not absolute" },
+    ];
+    r.agents.warnings = [
+      { kind: "mcp_servers_require_opt_in", agent: "scary", transports: ["stdio"] },
+    ];
+    const out = formatInstallPluginResult(r);
+    expect(out.warnings).toBe(
+      "invalid scan path '/bad': not absolute" +
+        " | " +
+        "agent 'scary' declares MCP servers [stdio] — re-run with --accept-mcp to install",
+    );
   });
 
   it("empty: summary reads 'nothing to install'", () => {
     const r = emptyInstallResult();
-    const out = formatInstallPluginResult(r, "p");
+    const out = formatInstallPluginResult(r);
     expect(out.summary).toBe("nothing to install");
     expect(out.anyInstalled).toBe(false);
     expect(out.anyFailed).toBe(false);
   });
 
-  it("skipped (idempotent skill): counted as 'already installed'", () => {
+  it("skipped (idempotent skills): counted as 'already installed'", () => {
     const r = emptyInstallResult();
     r.skills.skipped = ["a", "b"];
-    const out = formatInstallPluginResult(r, "p");
-    expect(out.summary).toContain("2 skills already installed");
+    const out = formatInstallPluginResult(r);
+    expect(out.summary).toBe("2 skills already installed");
+  });
+
+  it("does not interpolate plugin metadata (marketplace, version, plugin name) into summary", () => {
+    const r = emptyInstallResult();
+    r.marketplace = "verysecret-marketplace" as MarketplaceName;
+    r.plugin = "verysecret-plugin" as PluginName;
+    r.version = "9.9.9";
+    r.skills.installed = ["a"];
+    const out = formatInstallPluginResult(r);
+    expect(out.summary).not.toContain("verysecret");
+    expect(out.summary).not.toContain("9.9.9");
+    expect(out.warnings).toBeNull();
   });
 });
 
@@ -107,44 +148,111 @@ function emptyRemoveResult(): RemovePluginResult {
 }
 
 describe("formatRemovePluginResult", () => {
-  it("happy path: counts all 3 sub-results", () => {
+  it("happy path: counts all 3 sub-results joined by mid-dot", () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a", "b", "c"];
     r.steering.removed = ["s.md"];
     r.agents.removed = ["g1", "g2"];
-    const out = formatRemovePluginResult(r, "p");
-    expect(out.summary).toContain("3 skill");
-    expect(out.summary).toContain("1 steering");
-    expect(out.summary).toContain("2 agent");
+    const out = formatRemovePluginResult(r);
+    expect(out.summary).toBe("3 skills · 1 steering file · 2 agents");
     expect(out.hasItems).toBe(true);
     expect(out.hasFailures).toBe(false);
+  });
+
+  it("singular nouns: 1 skill / 1 steering file / 1 agent removed", () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    r.steering.removed = ["s.md"];
+    r.agents.removed = ["g"];
+    const out = formatRemovePluginResult(r);
+    expect(out.summary).toBe("1 skill · 1 steering file · 1 agent");
+  });
+
+  it("singular failure nouns: 1 skill / steering / 1 agent failed", () => {
+    const r = emptyRemoveResult();
+    r.skills.failures = [{ item: "x", error: "oops" }];
+    r.steering.failures = [{ item: "s.md", error: "denied" }];
+    r.agents.failures = [{ item: "g", error: "boom" }];
+    const out = formatRemovePluginResult(r);
+    expect(out.summary).toBe("1 skill failed · 1 steering failed · 1 agent failed");
   });
 
   it("steering failure lands in summary (failed count) and hasFailures=true", () => {
     const r = emptyRemoveResult();
     r.steering.failures = [{ item: "broken.md", error: "permission denied" }];
-    const out = formatRemovePluginResult(r, "p");
+    const out = formatRemovePluginResult(r);
     expect(out.hasFailures).toBe(true);
-    expect(out.summary).toContain("1 steering failed");
+    expect(out.summary).toBe("1 steering failed");
+  });
+
+  it("mixed removed + failures within one sub-result: both flags true", () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    r.skills.failures = [{ item: "broken", error: "oops" }];
+    const out = formatRemovePluginResult(r);
+    expect(out.hasItems).toBe(true);
+    expect(out.hasFailures).toBe(true);
+    expect(out.summary).toBe("1 skill · 1 skill failed");
   });
 
   it("empty (zero items, zero failures): hasItems=false, hasFailures=false", () => {
     const r = emptyRemoveResult();
-    const out = formatRemovePluginResult(r, "p");
+    const out = formatRemovePluginResult(r);
     expect(out.hasItems).toBe(false);
     expect(out.hasFailures).toBe(false);
     expect(out.summary).toBe("nothing to remove");
   });
 
   it("treats undefined removed/failures as empty arrays", () => {
-    // The wire format makes both fields optional (#[serde(default)]).
     const r: RemovePluginResult = {
       skills: {},
       steering: {},
       agents: {},
     };
-    const out = formatRemovePluginResult(r, "p");
+    const out = formatRemovePluginResult(r);
     expect(out.hasItems).toBe(false);
     expect(out.hasFailures).toBe(false);
+  });
+});
+
+function frontmatterFailure(name: string): SkippedSkill {
+  return {
+    plugin: "p",
+    name_hint: name,
+    path: `/p/${name}/SKILL.md`,
+    reason: { kind: "frontmatter_invalid", reason: "missing name field" },
+  };
+}
+
+describe("formatSkippedSkillsForPlugin", () => {
+  it("empty list reads as 0 skill(s) failed with no body", () => {
+    expect(formatSkippedSkillsForPlugin([])).toBe("0 skill(s) failed to load — ");
+  });
+
+  it("under-cap (3 entries): all listed inline, no overflow suffix", () => {
+    const list = [frontmatterFailure("a"), frontmatterFailure("b"), frontmatterFailure("c")];
+    const out = formatSkippedSkillsForPlugin(list);
+    expect(out).toBe(
+      "3 skill(s) failed to load — " +
+        "a: malformed frontmatter: missing name field; " +
+        "b: malformed frontmatter: missing name field; " +
+        "c: malformed frontmatter: missing name field",
+    );
+  });
+
+  it("at-cap (5 entries): all listed, no overflow suffix", () => {
+    const list = ["a", "b", "c", "d", "e"].map(frontmatterFailure);
+    const out = formatSkippedSkillsForPlugin(list);
+    expect(out.startsWith("5 skill(s) failed to load — ")).toBe(true);
+    expect(out).not.toContain("more");
+  });
+
+  it("over-cap (6 entries): first 5 listed, '+1 more' suffix", () => {
+    const list = ["a", "b", "c", "d", "e", "f"].map(frontmatterFailure);
+    const out = formatSkippedSkillsForPlugin(list);
+    expect(out.endsWith("; +1 more")).toBe(true);
+    expect(out.startsWith("6 skill(s) failed to load — ")).toBe(true);
+    expect(out).toContain("e: malformed frontmatter");
+    expect(out).not.toContain("f: malformed frontmatter");
   });
 });

--- a/crates/kiro-control-center/src/lib/format.test.ts
+++ b/crates/kiro-control-center/src/lib/format.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type {
+  InstallPluginResult_Serialize,
+  MarketplaceName,
+  PluginName,
+} from "$lib/bindings";
+import { formatInstallPluginResult } from "./format";
+
+// Field names + structure tracked from bindings.ts (see plan
+// "Source-of-truth references"):
+//  - InstallSkillsResult:             bindings.ts:667-686
+//  - InstallSteeringResult_Serialize: bindings.ts:699-703
+//  - InstallAgentsResult_Serialize:   bindings.ts:522-560
+//  - FailedSkill:                     bindings.ts:352-356
+//  - InstalledSteeringOutcome:        bindings.ts:853-859
+//  - InstallOutcomeKind:              bindings.ts:568-581
+function emptyInstallResult(): InstallPluginResult_Serialize {
+  return {
+    marketplace: "acme" as MarketplaceName,
+    plugin: "p" as PluginName,
+    version: null,
+    skills: { installed: [], skipped: [], failed: [], skipped_skills: [] },
+    steering: { installed: [], failed: [], warnings: [] },
+    // InstallAgentsResult_Serialize requires installed_native +
+    // installed_companions (bindings.ts:553, :559). Both default to
+    // empty/null in this fixture.
+    agents: {
+      installed: [],
+      skipped: [],
+      failed: [],
+      warnings: [],
+      installed_native: [],
+      installed_companions: null,
+    },
+  };
+}
+
+describe("formatInstallPluginResult", () => {
+  it("happy path: counts all 3 sub-results", () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a", "b"];
+    r.steering.installed = [
+      { source: "s.md", destination: "s.md", kind: "installed", source_hash: "h", installed_hash: "h" },
+    ];
+    // installed: string[] (bindings.ts:527), not an object array.
+    r.agents.installed = ["g"];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toContain("2 skill");
+    expect(out.summary).toContain("1 steering");
+    expect(out.summary).toContain("1 agent");
+    expect(out.anyInstalled).toBe(true);
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("failures-only: anyInstalled=false, anyFailed=true", () => {
+    const r = emptyInstallResult();
+    // FailedSkill requires `kind: FailedSkillReason` (bindings.ts:352-356).
+    r.skills.failed = [
+      { name: "broken", error: "oops", kind: { kind: "install_failed" } },
+    ];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.anyInstalled).toBe(false);
+    expect(out.anyFailed).toBe(true);
+    expect(out.summary).toContain("1 skill failed");
+  });
+
+  it("warnings-only (e.g. MCP-gated agent): warnings string present, no failure flag", () => {
+    const r = emptyInstallResult();
+    r.agents.warnings = [
+      { kind: "mcp_servers_require_opt_in", agent: "scary", transports: ["stdio"] },
+    ];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.warnings).not.toBeNull();
+    expect(out.warnings).toContain("scary");
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("empty: summary reads 'nothing to install'", () => {
+    const r = emptyInstallResult();
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toBe("nothing to install");
+    expect(out.anyInstalled).toBe(false);
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("skipped (idempotent skill): counted as 'already installed'", () => {
+    const r = emptyInstallResult();
+    r.skills.skipped = ["a", "b"];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toContain("2 skills already installed");
+  });
+});

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -2,6 +2,7 @@ import type {
   InstallPluginResult_Serialize,
   InstallWarning,
   ParseFailure,
+  RemovePluginResult,
   SkillCount,
   SkippedReason,
   SkippedSkill,
@@ -272,4 +273,73 @@ export function formatInstallPluginResult(
   const warnings = warningParts.length > 0 ? warningParts.join(" | ") : null;
 
   return { summary, warnings, anyInstalled, anyFailed };
+}
+
+/**
+ *  Summarized view of a `RemovePluginResult` for banner + `<details>`
+ *  rendering on the InstalledTab.
+ *
+ *  - `summary`: human-readable mid-dot-separated count phrase
+ *    (mirrors `formatInstallPluginResult`'s shape — "3 skills · 1
+ *    steering · 2 agents" for happy path; appends "N <type> failed"
+ *    for partial failure). Reads "nothing to remove" on empty.
+ *  - `hasItems`: at least one removed-list is non-empty. Drives the
+ *    decision whether to render the `<details>` block at all.
+ *  - `hasFailures`: at least one failures-list is non-empty. Drives
+ *    the choice of banner channel (amber vs. green) and the `<details
+ *    open>` auto-expand.
+ */
+export type FormattedRemovePluginResult = {
+  summary: string;
+  hasItems: boolean;
+  hasFailures: boolean;
+};
+
+export function formatRemovePluginResult(
+  r: RemovePluginResult,
+  _plugin: string,
+): FormattedRemovePluginResult {
+  // Sub-result fields are optional per the wire format
+  // (RemoveSkillsResult.removed?: string[], etc.). Default to empty
+  // arrays so the rest of this function can do plain `.length` reads.
+  const skillsRemoved = r.skills.removed ?? [];
+  const skillsFailures = r.skills.failures ?? [];
+  const steeringRemoved = r.steering.removed ?? [];
+  const steeringFailures = r.steering.failures ?? [];
+  const agentsRemoved = r.agents.removed ?? [];
+  const agentsFailures = r.agents.failures ?? [];
+
+  const summaryParts: string[] = [];
+
+  if (skillsRemoved.length > 0) {
+    const noun = skillsRemoved.length === 1 ? "skill" : "skills";
+    summaryParts.push(`${skillsRemoved.length} ${noun}`);
+  }
+  if (steeringRemoved.length > 0) {
+    const noun = steeringRemoved.length === 1 ? "file" : "files";
+    summaryParts.push(`${steeringRemoved.length} steering ${noun}`);
+  }
+  if (agentsRemoved.length > 0) {
+    const noun = agentsRemoved.length === 1 ? "agent" : "agents";
+    summaryParts.push(`${agentsRemoved.length} ${noun}`);
+  }
+  if (skillsFailures.length > 0) {
+    const noun = skillsFailures.length === 1 ? "skill" : "skills";
+    summaryParts.push(`${skillsFailures.length} ${noun} failed`);
+  }
+  if (steeringFailures.length > 0) {
+    summaryParts.push(`${steeringFailures.length} steering failed`);
+  }
+  if (agentsFailures.length > 0) {
+    const noun = agentsFailures.length === 1 ? "agent" : "agents";
+    summaryParts.push(`${agentsFailures.length} ${noun} failed`);
+  }
+
+  const hasItems =
+    skillsRemoved.length + steeringRemoved.length + agentsRemoved.length > 0;
+  const hasFailures =
+    skillsFailures.length + steeringFailures.length + agentsFailures.length > 0;
+  const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to remove";
+
+  return { summary, hasItems, hasFailures };
 }

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -1,4 +1,5 @@
 import type {
+  InstallPluginResult_Serialize,
   InstallWarning,
   ParseFailure,
   SkillCount,
@@ -174,8 +175,6 @@ export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): str
     ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
     : `${list.length} skill(s) failed to load — ${joined}`;
 }
-
-import type { InstallPluginResult_Serialize } from "$lib/bindings";
 
 /**
  *  Summarized view of an `InstallPluginResult_Serialize` for banner

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -174,3 +174,103 @@ export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): str
     ? `${list.length} skill(s) failed to load — ${joined}; +${overflow} more`
     : `${list.length} skill(s) failed to load — ${joined}`;
 }
+
+import type { InstallPluginResult_Serialize } from "$lib/bindings";
+
+/**
+ *  Summarized view of an `InstallPluginResult_Serialize` for banner
+ *  rendering. Extracted from `BrowseTab.installWholePlugin` so the new
+ *  Update flow (which also calls `installPlugin`, just with `force=true`)
+ *  reuses the same summarization rather than duplicating it.
+ *
+ *  - `summary`: human-readable mid-dot-separated count phrase
+ *    (e.g. "2 skills · 1 steering · 1 agent"). Reads "nothing to install"
+ *    when nothing happened.
+ *  - `warnings`: pipe-separated warning lines (steering-scan warnings,
+ *    MCP-gated agents, per-skill skipped_skills) or `null` when empty.
+ *  - `anyInstalled` / `anyFailed`: caller uses these to decide which
+ *    banner channel (success vs. error vs. warning) to route to.
+ */
+export type FormattedInstallPluginResult = {
+  summary: string;
+  warnings: string | null;
+  anyInstalled: boolean;
+  anyFailed: boolean;
+};
+
+export function formatInstallPluginResult(
+  r: InstallPluginResult_Serialize,
+  _plugin: string,
+): FormattedInstallPluginResult {
+  const summaryParts: string[] = [];
+  const warningParts: string[] = [];
+
+  // Skills sub-result.
+  {
+    const skills = r.skills;
+    if (skills.installed.length > 0) {
+      const noun = skills.installed.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.installed.length} ${noun}`);
+    }
+    if (skills.failed.length > 0) {
+      const noun = skills.failed.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.failed.length} ${noun} failed`);
+    }
+    if (skills.skipped.length > 0) {
+      const noun = skills.skipped.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.skipped.length} ${noun} already installed`);
+    }
+    if (skills.skipped_skills.length > 0) {
+      warningParts.push(formatSkippedSkillsForPlugin(skills.skipped_skills));
+    }
+  }
+
+  // Steering sub-result. Idempotent reinstalls land in `installed` with
+  // `kind: idempotent` (not a separate field) — the current banner shape
+  // counts them as installed; per-content breakdown is future scope.
+  {
+    const steering = r.steering;
+    if (steering.installed.length > 0) {
+      const noun = steering.installed.length === 1 ? "file" : "files";
+      summaryParts.push(`${steering.installed.length} steering ${noun}`);
+    }
+    if (steering.failed.length > 0) {
+      summaryParts.push(`${steering.failed.length} steering failed`);
+    }
+    for (const w of steering.warnings) {
+      warningParts.push(formatSteeringWarning(w));
+    }
+  }
+
+  // Agents sub-result.
+  {
+    const agents = r.agents;
+    if (agents.installed.length > 0) {
+      const noun = agents.installed.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.installed.length} ${noun}`);
+    }
+    if (agents.failed.length > 0) {
+      const noun = agents.failed.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.failed.length} ${noun} failed`);
+    }
+    if (agents.skipped.length > 0) {
+      const noun = agents.skipped.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.skipped.length} ${noun} already installed`);
+    }
+    for (const w of agents.warnings) {
+      warningParts.push(formatInstallWarning(w));
+    }
+  }
+
+  const anyFailed =
+    r.skills.failed.length + r.steering.failed.length + r.agents.failed.length > 0;
+  const anyInstalled =
+    r.skills.installed.length +
+      r.steering.installed.length +
+      r.agents.installed.length >
+    0;
+  const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to install";
+  const warnings = warningParts.length > 0 ? warningParts.join(" | ") : null;
+
+  return { summary, warnings, anyInstalled, anyFailed };
+}

--- a/crates/kiro-control-center/src/lib/format.ts
+++ b/crates/kiro-control-center/src/lib/format.ts
@@ -177,20 +177,6 @@ export function formatSkippedSkillsForPlugin(list: readonly SkippedSkill[]): str
     : `${list.length} skill(s) failed to load — ${joined}`;
 }
 
-/**
- *  Summarized view of an `InstallPluginResult_Serialize` for banner
- *  rendering. Extracted from `BrowseTab.installWholePlugin` so the new
- *  Update flow (which also calls `installPlugin`, just with `force=true`)
- *  reuses the same summarization rather than duplicating it.
- *
- *  - `summary`: human-readable mid-dot-separated count phrase
- *    (e.g. "2 skills · 1 steering · 1 agent"). Reads "nothing to install"
- *    when nothing happened.
- *  - `warnings`: pipe-separated warning lines (steering-scan warnings,
- *    MCP-gated agents, per-skill skipped_skills) or `null` when empty.
- *  - `anyInstalled` / `anyFailed`: caller uses these to decide which
- *    banner channel (success vs. error vs. warning) to route to.
- */
 export type FormattedInstallPluginResult = {
   summary: string;
   warnings: string | null;
@@ -200,12 +186,10 @@ export type FormattedInstallPluginResult = {
 
 export function formatInstallPluginResult(
   r: InstallPluginResult_Serialize,
-  _plugin: string,
 ): FormattedInstallPluginResult {
   const summaryParts: string[] = [];
   const warningParts: string[] = [];
 
-  // Skills sub-result.
   {
     const skills = r.skills;
     if (skills.installed.length > 0) {
@@ -225,9 +209,6 @@ export function formatInstallPluginResult(
     }
   }
 
-  // Steering sub-result. Idempotent reinstalls land in `installed` with
-  // `kind: idempotent` (not a separate field) — the current banner shape
-  // counts them as installed; per-content breakdown is future scope.
   {
     const steering = r.steering;
     if (steering.installed.length > 0) {
@@ -242,7 +223,6 @@ export function formatInstallPluginResult(
     }
   }
 
-  // Agents sub-result.
   {
     const agents = r.agents;
     if (agents.installed.length > 0) {
@@ -275,20 +255,6 @@ export function formatInstallPluginResult(
   return { summary, warnings, anyInstalled, anyFailed };
 }
 
-/**
- *  Summarized view of a `RemovePluginResult` for banner + `<details>`
- *  rendering on the InstalledTab.
- *
- *  - `summary`: human-readable mid-dot-separated count phrase
- *    (mirrors `formatInstallPluginResult`'s shape — "3 skills · 1
- *    steering · 2 agents" for happy path; appends "N <type> failed"
- *    for partial failure). Reads "nothing to remove" on empty.
- *  - `hasItems`: at least one removed-list is non-empty. Drives the
- *    decision whether to render the `<details>` block at all.
- *  - `hasFailures`: at least one failures-list is non-empty. Drives
- *    the choice of banner channel (amber vs. green) and the `<details
- *    open>` auto-expand.
- */
 export type FormattedRemovePluginResult = {
   summary: string;
   hasItems: boolean;
@@ -297,11 +263,7 @@ export type FormattedRemovePluginResult = {
 
 export function formatRemovePluginResult(
   r: RemovePluginResult,
-  _plugin: string,
 ): FormattedRemovePluginResult {
-  // Sub-result fields are optional per the wire format
-  // (RemoveSkillsResult.removed?: string[], etc.). Default to empty
-  // arrays so the rest of this function can do plain `.length` reads.
   const skillsRemoved = r.skills.removed ?? [];
   const skillsFailures = r.skills.failures ?? [];
   const steeringRemoved = r.steering.removed ?? [];

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
@@ -1,0 +1,74 @@
+import { commands } from "$lib/bindings";
+import type {
+  DetectUpdatesResult,
+  PluginUpdateFailure,
+  PluginUpdateInfo,
+} from "$lib/bindings";
+import { groupFailures, type FailureGroup } from "./plugin-updates";
+
+/**
+ *  Module-scoped reactive store wrapping `detectPluginUpdates`.
+ *  Consumed by `BrowseTab` and `InstalledTab` — both `$effect` on
+ *  `projectPath` and call `pluginUpdates.refresh(projectPath)`. The
+ *  parent `+page.svelte` also wires `MarketplacesTab.onUpdated` to
+ *  this store's `refresh` so a successful `kiro-market update`
+ *  invalidates the cached scan.
+ *
+ *  Per Phase 2b design decision #2, the only re-fire triggers are:
+ *  (1) projectPath change (each tab's existing $effect),
+ *  (2) marketplace update (MarketplacesTab callback).
+ *  No background polling, no manual rescan button.
+ */
+class PluginUpdatesStore {
+  result = $state<DetectUpdatesResult | null>(null);
+  loading = $state(false);
+  // Toplevel error from `detectPluginUpdates` Result::Err — used when
+  // the command itself failed (couldn't read tracking files at all).
+  // Per-plugin failures live on `result.failures`, not here.
+  fetchError = $state<string | null>(null);
+  // Last project path the store refreshed against. Lets the consumer
+  // tabs distinguish "not yet refreshed" from "refreshed and empty".
+  lastProjectPath = $state<string | null>(null);
+
+  failureGroups = $derived.by((): FailureGroup[] =>
+    this.result?.failures ? groupFailures(this.result.failures) : [],
+  );
+
+  updateFor(marketplace: string, plugin: string): PluginUpdateInfo | undefined {
+    return this.result?.updates?.find(
+      (u) => u.marketplace === marketplace && u.plugin === plugin,
+    );
+  }
+
+  failureFor(marketplace: string, plugin: string): PluginUpdateFailure | undefined {
+    return this.result?.failures?.find(
+      (f) => f.marketplace === marketplace && f.plugin === plugin,
+    );
+  }
+
+  async refresh(projectPath: string): Promise<void> {
+    if (!projectPath) {
+      this.result = null;
+      this.fetchError = null;
+      this.lastProjectPath = null;
+      return;
+    }
+    this.loading = true;
+    this.lastProjectPath = projectPath;
+    try {
+      const r = await commands.detectPluginUpdates(projectPath);
+      if (r.status === "ok") {
+        this.result = r.data;
+        this.fetchError = null;
+      } else {
+        this.fetchError = r.error.message;
+      }
+    } catch (e) {
+      this.fetchError = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+
+export const pluginUpdates = new PluginUpdatesStore();

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
@@ -4,33 +4,19 @@ import type {
   PluginUpdateFailure,
   PluginUpdateInfo,
 } from "$lib/bindings";
-import { groupFailures, type FailureGroup } from "./plugin-updates";
+import { groupFailures } from "./plugin-updates";
 
-/**
- *  Module-scoped reactive store wrapping `detectPluginUpdates`.
- *  Consumed by `BrowseTab` and `InstalledTab` — both `$effect` on
- *  `projectPath` and call `pluginUpdates.refresh(projectPath)`. The
- *  parent `+page.svelte` also wires `MarketplacesTab.onUpdated` to
- *  this store's `refresh` so a successful `kiro-market update`
- *  invalidates the cached scan.
- *
- *  Per Phase 2b design decision #2, the only re-fire triggers are:
- *  (1) projectPath change (each tab's existing $effect),
- *  (2) marketplace update (MarketplacesTab callback).
- *  No background polling, no manual rescan button.
- */
 class PluginUpdatesStore {
   result = $state<DetectUpdatesResult | null>(null);
   loading = $state(false);
-  // Toplevel error from `detectPluginUpdates` Result::Err — used when
-  // the command itself failed (couldn't read tracking files at all).
-  // Per-plugin failures live on `result.failures`, not here.
   fetchError = $state<string | null>(null);
-  // Last project path the store refreshed against. Lets the consumer
-  // tabs distinguish "not yet refreshed" from "refreshed and empty".
   lastProjectPath = $state<string | null>(null);
 
-  failureGroups = $derived.by((): FailureGroup[] =>
+  // Monotonic generation. Path equality alone lets A→B→A overwrite a
+  // still-resolving newer A (same path, different generations).
+  #latestRequestId = 0;
+
+  failureGroups = $derived(
     this.result?.failures ? groupFailures(this.result.failures) : [],
   );
 
@@ -54,14 +40,15 @@ class PluginUpdatesStore {
       this.loading = false;
       return;
     }
+    const reqId = ++this.#latestRequestId;
     this.loading = true;
     this.lastProjectPath = projectPath;
     try {
       const r = await commands.detectPluginUpdates(projectPath);
-      // Race guard: a newer refresh may have been started while we awaited.
-      // Tauri commands don't support cancellation, so we compare paths and
-      // discard our result if a newer call has already taken over.
-      if (this.lastProjectPath !== projectPath) return;
+      if (this.#latestRequestId !== reqId) {
+        console.warn("[pluginUpdates] discarding stale refresh result", { projectPath });
+        return;
+      }
       if (r.status === "ok") {
         this.result = r.data;
         this.fetchError = null;
@@ -70,13 +57,14 @@ class PluginUpdatesStore {
         this.fetchError = r.error.message;
       }
     } catch (e) {
-      if (this.lastProjectPath !== projectPath) return;
+      if (this.#latestRequestId !== reqId) {
+        console.warn("[pluginUpdates] discarding stale refresh rejection", { projectPath, e });
+        return;
+      }
       this.result = null;
       this.fetchError = e instanceof Error ? e.message : String(e);
     } finally {
-      // Only clear loading if we're still the active call; a superseding
-      // call has its own `loading = true` and will manage its own clear.
-      if (this.lastProjectPath === projectPath) this.loading = false;
+      if (this.#latestRequestId === reqId) this.loading = false;
     }
   }
 }

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
@@ -51,22 +51,32 @@ class PluginUpdatesStore {
       this.result = null;
       this.fetchError = null;
       this.lastProjectPath = null;
+      this.loading = false;
       return;
     }
     this.loading = true;
     this.lastProjectPath = projectPath;
     try {
       const r = await commands.detectPluginUpdates(projectPath);
+      // Race guard: a newer refresh may have been started while we awaited.
+      // Tauri commands don't support cancellation, so we compare paths and
+      // discard our result if a newer call has already taken over.
+      if (this.lastProjectPath !== projectPath) return;
       if (r.status === "ok") {
         this.result = r.data;
         this.fetchError = null;
       } else {
+        this.result = null;
         this.fetchError = r.error.message;
       }
     } catch (e) {
+      if (this.lastProjectPath !== projectPath) return;
+      this.result = null;
       this.fetchError = e instanceof Error ? e.message : String(e);
     } finally {
-      this.loading = false;
+      // Only clear loading if we're still the active call; a superseding
+      // call has its own `loading = true` and will manage its own clear.
+      if (this.lastProjectPath === projectPath) this.loading = false;
     }
   }
 }

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PluginUpdateFailureKind } from "$lib/bindings";
-import { remediationClass } from "./plugin-updates";
+import { remediationClass, kindLabel } from "./plugin-updates";
 
 describe("remediationClass", () => {
   it("maps marketplace_unavailable to stale_cache", () => {
@@ -26,5 +26,32 @@ describe("remediationClass", () => {
   it("maps other to unknown", () => {
     const kind: PluginUpdateFailureKind = { kind: "other" };
     expect(remediationClass(kind)).toBe("unknown");
+  });
+});
+
+describe("kindLabel", () => {
+  it("returns a non-empty string for every PluginUpdateFailureKind variant", () => {
+    const variants: PluginUpdateFailureKind[] = [
+      { kind: "marketplace_unavailable" },
+      { kind: "manifest_unreadable" },
+      { kind: "manifest_invalid" },
+      { kind: "hash_failed" },
+      { kind: "other" },
+    ];
+    for (const v of variants) {
+      const label = kindLabel(v);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("produces distinct labels for distinct kinds", () => {
+    const labels = new Set([
+      kindLabel({ kind: "marketplace_unavailable" }),
+      kindLabel({ kind: "manifest_unreadable" }),
+      kindLabel({ kind: "manifest_invalid" }),
+      kindLabel({ kind: "hash_failed" }),
+      kindLabel({ kind: "other" }),
+    ]);
+    expect(labels.size).toBe(5);
   });
 });

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -4,8 +4,15 @@ import type {
   PluginName,
   PluginUpdateFailure,
   PluginUpdateFailureKind,
+  PluginUpdateInfo,
 } from "$lib/bindings";
-import { remediationClass, kindLabel, groupFailures } from "./plugin-updates";
+import {
+  actionUpdateLabel,
+  groupFailures,
+  kindLabel,
+  remediationClass,
+  statusUpdateLabel,
+} from "./plugin-updates";
 import type { FailureGroup } from "./plugin-updates";
 
 describe("remediationClass", () => {
@@ -59,6 +66,118 @@ describe("kindLabel", () => {
       kindLabel({ kind: "other" }),
     ]);
     expect(labels.size).toBe(5);
+  });
+
+  it("manifest_unreadable label covers read failure modes beyond 'missing'", () => {
+    expect(kindLabel({ kind: "manifest_unreadable" })).toBe(
+      "plugin.json couldn't be read from marketplace cache",
+    );
+  });
+});
+
+function update(
+  partial: Partial<PluginUpdateInfo> & { change_signal: PluginUpdateInfo["change_signal"] },
+): PluginUpdateInfo {
+  return {
+    marketplace: "acme" as MarketplaceName,
+    plugin: "p" as PluginName,
+    installed_version: null,
+    available_version: null,
+    ...partial,
+  };
+}
+
+describe("statusUpdateLabel", () => {
+  it("content_changed renders as a status sentence", () => {
+    expect(
+      statusUpdateLabel(update({ change_signal: { kind: "content_changed" } })),
+    ).toBe("Content changed since install");
+  });
+
+  it("version_bumped with both versions known renders as 'vX → vY'", () => {
+    expect(
+      statusUpdateLabel(
+        update({
+          change_signal: { kind: "version_bumped" },
+          installed_version: "1.0",
+          available_version: "1.1",
+        }),
+      ),
+    ).toBe("v1.0 → v1.1");
+  });
+
+  it("version_bumped with legacy install (installed_version null) renders as 'vN available'", () => {
+    expect(
+      statusUpdateLabel(
+        update({
+          change_signal: { kind: "version_bumped" },
+          available_version: "1.1",
+        }),
+      ),
+    ).toBe("v1.1 available");
+  });
+
+  it("version_bumped with neither version declared falls back to 'Update available'", () => {
+    expect(
+      statusUpdateLabel(update({ change_signal: { kind: "version_bumped" } })),
+    ).toBe("Update available");
+  });
+});
+
+describe("actionUpdateLabel", () => {
+  it("content_changed renders as 'Update (content changed)'", () => {
+    expect(
+      actionUpdateLabel(update({ change_signal: { kind: "content_changed" } })),
+    ).toBe("Update (content changed)");
+  });
+
+  it("version_bumped with available_version renders as 'Update → vN'", () => {
+    expect(
+      actionUpdateLabel(
+        update({
+          change_signal: { kind: "version_bumped" },
+          installed_version: "1.0",
+          available_version: "1.1",
+        }),
+      ),
+    ).toBe("Update → v1.1");
+  });
+
+  it("version_bumped legacy install (installed_version null) still renders as 'Update → vN'", () => {
+    expect(
+      actionUpdateLabel(
+        update({
+          change_signal: { kind: "version_bumped" },
+          available_version: "1.1",
+        }),
+      ),
+    ).toBe("Update → v1.1");
+  });
+
+  it("version_bumped with no available_version falls back to 'Update'", () => {
+    expect(
+      actionUpdateLabel(update({ change_signal: { kind: "version_bumped" } })),
+    ).toBe("Update");
+  });
+});
+
+describe("status vs action label contract", () => {
+  it("the column phrases state, the button phrases an action — they must differ", () => {
+    const u = update({
+      change_signal: { kind: "version_bumped" },
+      installed_version: "1.0",
+      available_version: "1.1",
+    });
+    expect(statusUpdateLabel(u)).toBe("v1.0 → v1.1");
+    expect(actionUpdateLabel(u)).toBe("Update → v1.1");
+    expect(statusUpdateLabel(u)).not.toBe(actionUpdateLabel(u));
+  });
+
+  it("content_changed: column reads as full sentence, button reads as parenthetical action", () => {
+    const u = update({ change_signal: { kind: "content_changed" } });
+    expect(statusUpdateLabel(u)).toBe("Content changed since install");
+    expect(actionUpdateLabel(u)).toBe("Update (content changed)");
+    expect(statusUpdateLabel(u)).not.toBe(actionUpdateLabel(u));
   });
 });
 

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -121,6 +121,15 @@ describe("groupFailures", () => {
     expect(groups[0].plugins).toEqual(["z-plugin", "a-plugin", "m-plugin"]);
   });
 
+  it("returns groups in first-seen key order", () => {
+    const groups = groupFailures([
+      failure("beta", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups[0].marketplace).toBe("beta");
+    expect(groups[1].marketplace).toBe("acme");
+  });
+
   it("each group carries a non-empty remediationHint", () => {
     const groups: FailureGroup[] = groupFailures([
       failure("acme", "p1", { kind: "marketplace_unavailable" }),

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { PluginUpdateFailureKind } from "$lib/bindings";
-import { remediationClass, kindLabel } from "./plugin-updates";
+import type {
+  MarketplaceName,
+  PluginName,
+  PluginUpdateFailure,
+  PluginUpdateFailureKind,
+} from "$lib/bindings";
+import { remediationClass, kindLabel, groupFailures } from "./plugin-updates";
+import type { FailureGroup } from "./plugin-updates";
 
 describe("remediationClass", () => {
   it("maps marketplace_unavailable to stale_cache", () => {
@@ -53,5 +59,76 @@ describe("kindLabel", () => {
       kindLabel({ kind: "other" }),
     ]);
     expect(labels.size).toBe(5);
+  });
+});
+
+function failure(
+  marketplace: string,
+  plugin: string,
+  kind: PluginUpdateFailureKind,
+): PluginUpdateFailure {
+  return {
+    marketplace: marketplace as MarketplaceName,
+    plugin: plugin as PluginName,
+    kind,
+    reason: "test reason",
+  };
+}
+
+describe("groupFailures", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupFailures([])).toEqual([]);
+  });
+
+  it("collapses N stale-cache failures from one marketplace into one group", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_unreadable" }),
+      failure("acme", "p3", { kind: "hash_failed" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].remediation).toBe("stale_cache");
+    expect(groups[0].marketplace).toBe("acme");
+    expect(groups[0].plugins).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("produces separate groups for two marketplaces", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("beta", "p2", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const marketplaces = new Set(groups.map((g) => g.marketplace));
+    expect(marketplaces).toEqual(new Set(["acme", "beta"]));
+  });
+
+  it("produces separate groups for distinct remediation classes from same marketplace", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_invalid" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const remediations = new Set(groups.map((g) => g.remediation));
+    expect(remediations).toEqual(new Set(["stale_cache", "manifest_invalid"]));
+  });
+
+  it("preserves plugin order within a group as the input was ordered", () => {
+    const groups = groupFailures([
+      failure("acme", "z-plugin", { kind: "marketplace_unavailable" }),
+      failure("acme", "a-plugin", { kind: "marketplace_unavailable" }),
+      failure("acme", "m-plugin", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups[0].plugins).toEqual(["z-plugin", "a-plugin", "m-plugin"]);
+  });
+
+  it("each group carries a non-empty remediationHint", () => {
+    const groups: FailureGroup[] = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_invalid" }),
+      failure("acme", "p3", { kind: "other" }),
+    ]);
+    for (const g of groups) {
+      expect(g.remediationHint.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -249,6 +249,18 @@ describe("groupFailures", () => {
     expect(groups[1].marketplace).toBe("acme");
   });
 
+  it("does not collide on marketplace names containing ':'", () => {
+    // `validate_name` permits ':' in marketplace names; the group key
+    // must use a separator that can never appear in either side.
+    const groups = groupFailures([
+      failure("time:zones", "p1", { kind: "marketplace_unavailable" }),
+      failure("time", "p2", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const marketplaces = new Set(groups.map((g) => g.marketplace));
+    expect(marketplaces).toEqual(new Set(["time:zones", "time"]));
+  });
+
   it("each group carries a non-empty remediationHint", () => {
     const groups: FailureGroup[] = groupFailures([
       failure("acme", "p1", { kind: "marketplace_unavailable" }),

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import type { PluginUpdateFailureKind } from "$lib/bindings";
+import { remediationClass } from "./plugin-updates";
+
+describe("remediationClass", () => {
+  it("maps marketplace_unavailable to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "marketplace_unavailable" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps manifest_unreadable to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "manifest_unreadable" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps hash_failed to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "hash_failed" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps manifest_invalid to its own class", () => {
+    const kind: PluginUpdateFailureKind = { kind: "manifest_invalid" };
+    expect(remediationClass(kind)).toBe("manifest_invalid");
+  });
+
+  it("maps other to unknown", () => {
+    const kind: PluginUpdateFailureKind = { kind: "other" };
+    expect(remediationClass(kind)).toBe("unknown");
+  });
+});

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -5,6 +5,7 @@ import type {
   PluginUpdateFailureKind,
   PluginUpdateInfo,
 } from "$lib/bindings";
+import { DELIM } from "$lib/keys";
 
 export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
 
@@ -47,8 +48,10 @@ export function groupFailures(failures: PluginUpdateFailure[]): FailureGroup[] {
   const map = new Map<string, FailureGroup>();
   for (const f of failures) {
     const cls = remediationClass(f.kind);
-    // Composite key safe: remediation is enum, marketplace forbids ":" via newtype.
-    const groupKey = `${cls}:${f.marketplace}`;
+    // Use DELIM for consistency with ErrorSource keys; `:` is permitted in
+    // marketplace names by `validate_name` (only control chars + path
+    // separators are rejected).
+    const groupKey = `${cls}${DELIM}${f.marketplace}`;
     let g = map.get(groupKey);
     if (!g) {
       g = {

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -61,3 +61,65 @@ export function kindLabel(kind: PluginUpdateFailureKind): string {
       return "Update check failed — see console";
   }
 }
+
+/**
+ *  A grouped failure surface. One per `(remediation, marketplace)` —
+ *  the natural unit for banner copy, since plugins sharing the same
+ *  remediation from the same marketplace want a single combined
+ *  "N plugins from acme couldn't be checked" banner instead of N.
+ */
+export type FailureGroup = {
+  remediation: RemediationClass;
+  marketplace: MarketplaceName;
+  // Plugin names ordered as the scan returned them.
+  plugins: PluginName[];
+  // Human-readable remediation hint (e.g. "Run `kiro-market update`...").
+  remediationHint: string;
+};
+
+/**
+ *  Collapse a flat `failures: PluginUpdateFailure[]` into per-group
+ *  rows. Order of groups in the returned array reflects first-seen
+ *  ordering of group keys; plugin order within a group is input order.
+ */
+export function groupFailures(failures: PluginUpdateFailure[]): FailureGroup[] {
+  const map = new Map<string, FailureGroup>();
+  for (const f of failures) {
+    const cls = remediationClass(f.kind);
+    // Composite key — a literal "<remediation>:<marketplace>" suffices
+    // because remediationClass values never contain ":" and marketplace
+    // names go through a backend newtype that forbids control chars.
+    const groupKey = `${cls}:${f.marketplace}`;
+    let g = map.get(groupKey);
+    if (!g) {
+      g = {
+        remediation: cls,
+        marketplace: f.marketplace,
+        plugins: [],
+        remediationHint: hintFor(cls, f.marketplace),
+      };
+      map.set(groupKey, g);
+    }
+    g.plugins.push(f.plugin);
+  }
+  return Array.from(map.values());
+}
+
+function hintFor(cls: RemediationClass, marketplace: MarketplaceName): string {
+  switch (cls) {
+    case "stale_cache":
+      return `Run \`kiro-market update\` to refresh ${marketplace}.`;
+    case "manifest_invalid":
+      return "Contact the marketplace owner — `plugin.json` failed to parse.";
+    case "unknown":
+      return "Update check failed — see browser console for the error chain.";
+  }
+}
+
+/**
+ *  Per-plugin in-flight action discriminator. Each tab narrows this
+ *  to the actions it actually performs (BrowseTab: install/update,
+ *  InstalledTab: remove/update) but the union is exported so the
+ *  Map shapes stay nameable from one place.
+ */
+export type PluginAction = "install" | "update" | "remove";

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -38,3 +38,26 @@ export function remediationClass(kind: PluginUpdateFailureKind): RemediationClas
       return "unknown";
   }
 }
+
+/**
+ *  Per-kind human-readable tooltip copy for "Update check failed" pills.
+ *  Lives on hover, not in the banner — the banner uses the remediation
+ *  hint (`hintFor`) instead so 10 failures with the same remediation
+ *  produce one banner.
+ *
+ *  No `default:` arm — same exhaustiveness contract as `remediationClass`.
+ */
+export function kindLabel(kind: PluginUpdateFailureKind): string {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+      return "Marketplace cache missing or plugin removed from manifest";
+    case "manifest_unreadable":
+      return "plugin.json missing in marketplace cache";
+    case "manifest_invalid":
+      return "plugin.json failed to parse";
+    case "hash_failed":
+      return "Failed to hash installed file";
+    case "other":
+      return "Update check failed — see console";
+  }
+}

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -1,0 +1,40 @@
+import type {
+  MarketplaceName,
+  PluginName,
+  PluginUpdateFailure,
+  PluginUpdateFailureKind,
+} from "$lib/bindings";
+
+/**
+ *  Three remediation paths the FE distinguishes among the five
+ *  `PluginUpdateFailureKind` variants. The grouping function in
+ *  `groupFailures` keys off this so 10 stale-cache failures from one
+ *  marketplace produce one banner, not ten.
+ *
+ *  - `stale_cache` — `marketplace_unavailable`, `manifest_unreadable`,
+ *    `hash_failed`. Remediation: run `kiro-market update`.
+ *  - `manifest_invalid` — broken `plugin.json` upstream. Remediation:
+ *    contact the marketplace owner.
+ *  - `unknown` — `other` catch-all. Remediation: see error chain.
+ */
+export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
+
+/**
+ *  Map a `PluginUpdateFailureKind` to its remediation class. The switch
+ *  has no `default:` arm — TypeScript surfaces a compile error if the
+ *  bindings ever grow a new variant. Mirrors the CLAUDE.md classifier
+ *  rule on the Rust side ("classifier functions over error enums
+ *  enumerate every variant").
+ */
+export function remediationClass(kind: PluginUpdateFailureKind): RemediationClass {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+    case "manifest_unreadable":
+    case "hash_failed":
+      return "stale_cache";
+    case "manifest_invalid":
+      return "manifest_invalid";
+    case "other":
+      return "unknown";
+  }
+}

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -3,29 +3,11 @@ import type {
   PluginName,
   PluginUpdateFailure,
   PluginUpdateFailureKind,
+  PluginUpdateInfo,
 } from "$lib/bindings";
 
-/**
- *  Three remediation paths the FE distinguishes among the five
- *  `PluginUpdateFailureKind` variants. The grouping function in
- *  `groupFailures` keys off this so 10 stale-cache failures from one
- *  marketplace produce one banner, not ten.
- *
- *  - `stale_cache` — `marketplace_unavailable`, `manifest_unreadable`,
- *    `hash_failed`. Remediation: run `kiro-market update`.
- *  - `manifest_invalid` — broken `plugin.json` upstream. Remediation:
- *    contact the marketplace owner.
- *  - `unknown` — `other` catch-all. Remediation: see error chain.
- */
 export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
 
-/**
- *  Map a `PluginUpdateFailureKind` to its remediation class. The switch
- *  has no `default:` arm — TypeScript surfaces a compile error if the
- *  bindings ever grow a new variant. Mirrors the CLAUDE.md classifier
- *  rule on the Rust side ("classifier functions over error enums
- *  enumerate every variant").
- */
 export function remediationClass(kind: PluginUpdateFailureKind): RemediationClass {
   switch (kind.kind) {
     case "marketplace_unavailable":
@@ -39,20 +21,12 @@ export function remediationClass(kind: PluginUpdateFailureKind): RemediationClas
   }
 }
 
-/**
- *  Per-kind human-readable tooltip copy for "Update check failed" pills.
- *  Lives on hover, not in the banner — the banner uses the remediation
- *  hint (`hintFor`) instead so 10 failures with the same remediation
- *  produce one banner.
- *
- *  No `default:` arm — same exhaustiveness contract as `remediationClass`.
- */
 export function kindLabel(kind: PluginUpdateFailureKind): string {
   switch (kind.kind) {
     case "marketplace_unavailable":
       return "Marketplace cache missing or plugin removed from manifest";
     case "manifest_unreadable":
-      return "plugin.json missing in marketplace cache";
+      return "plugin.json couldn't be read from marketplace cache";
     case "manifest_invalid":
       return "plugin.json failed to parse";
     case "hash_failed":
@@ -62,33 +36,18 @@ export function kindLabel(kind: PluginUpdateFailureKind): string {
   }
 }
 
-/**
- *  A grouped failure surface. One per `(remediation, marketplace)` —
- *  the natural unit for banner copy, since plugins sharing the same
- *  remediation from the same marketplace want a single combined
- *  "N plugins from acme couldn't be checked" banner instead of N.
- */
 export type FailureGroup = {
   remediation: RemediationClass;
   marketplace: MarketplaceName;
-  // Plugin names ordered as the scan returned them.
   plugins: PluginName[];
-  // Human-readable remediation hint (e.g. "Run `kiro-market update`...").
   remediationHint: string;
 };
 
-/**
- *  Collapse a flat `failures: PluginUpdateFailure[]` into per-group
- *  rows. Order of groups in the returned array reflects first-seen
- *  ordering of group keys; plugin order within a group is input order.
- */
 export function groupFailures(failures: PluginUpdateFailure[]): FailureGroup[] {
   const map = new Map<string, FailureGroup>();
   for (const f of failures) {
     const cls = remediationClass(f.kind);
-    // Composite key — a literal "<remediation>:<marketplace>" suffices
-    // because remediationClass values never contain ":" and marketplace
-    // names go through a backend newtype that forbids control chars.
+    // Composite key safe: remediation is enum, marketplace forbids ":" via newtype.
     const groupKey = `${cls}:${f.marketplace}`;
     let g = map.get(groupKey);
     if (!g) {
@@ -116,10 +75,20 @@ function hintFor(cls: RemediationClass, marketplace: MarketplaceName): string {
   }
 }
 
-/**
- *  Per-plugin in-flight action discriminator. Each tab narrows this
- *  to the actions it actually performs (BrowseTab: install/update,
- *  InstalledTab: remove/update) but the union is exported so the
- *  Map shapes stay nameable from one place.
- */
 export type PluginAction = "install" | "update" | "remove";
+
+// Column = state sentence; companion `actionUpdateLabel` = button action.
+export function statusUpdateLabel(u: PluginUpdateInfo): string {
+  if (u.change_signal.kind === "content_changed") return "Content changed since install";
+  if (u.installed_version && u.available_version) {
+    return `v${u.installed_version} → v${u.available_version}`;
+  }
+  if (u.available_version) return `v${u.available_version} available`;
+  return "Update available";
+}
+
+export function actionUpdateLabel(u: PluginUpdateInfo): string {
+  if (u.change_signal.kind === "content_changed") return "Update (content changed)";
+  if (u.available_version) return `Update → v${u.available_version}`;
+  return "Update";
+}

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -57,6 +57,7 @@
         settingsLoadError = result.error.message;
       }
     } catch (e) {
+      console.error("[+page] getKiroSettings rejected", e);
       settingsLoadError = e instanceof Error
         ? `Failed to load settings: ${e.message}`
         : "Failed to load settings due to an unexpected error.";
@@ -107,7 +108,9 @@
           <MarketplacesTab
             onUpdated={() => {
               if (store.projectPath) {
-                pluginUpdates.refresh(store.projectPath);
+                pluginUpdates
+                  .refresh(store.projectPath)
+                  .catch((e) => console.error("[+page] post-update refresh failed", e));
               }
             }}
           />

--- a/crates/kiro-control-center/src/routes/+page.svelte
+++ b/crates/kiro-control-center/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
   import { store, initialize } from "$lib/stores/project.svelte";
+  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
   import { commands } from "$lib/bindings";
   import type { SettingEntry } from "$lib/bindings";
   import type { Tab, SettingCategory } from "$lib/types";
@@ -103,7 +104,13 @@
         {:else if activeTab === "Installed"}
           <InstalledTab projectPath={store.projectPath} />
         {:else if activeTab === "Marketplaces"}
-          <MarketplacesTab />
+          <MarketplacesTab
+            onUpdated={() => {
+              if (store.projectPath) {
+                pluginUpdates.refresh(store.projectPath);
+              }
+            }}
+          />
         {:else if activeTab === "Kiro Settings"}
           <SettingsView
             {allEntries}

--- a/crates/kiro-control-center/tests/e2e/app.spec.ts
+++ b/crates/kiro-control-center/tests/e2e/app.spec.ts
@@ -178,3 +178,22 @@ test.describe("Marketplace workflow", () => {
     await expect(errorBanner).not.toBeVisible();
   });
 });
+
+test.describe("Phase 2b — update detection UI", () => {
+  test("Status column appears on Installed tab", async ({ page }) => {
+    await page.goto("/");
+
+    const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+    if (!fixturePath) {
+      test.skip(true, "FIXTURE_MARKETPLACE_PATH not set");
+      return;
+    }
+
+    await page.getByRole("button", { name: "Installed", exact: true }).click();
+
+    // Status column appears in the header even when there are zero
+    // installed plugins (its presence is a static UI guarantee).
+    await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Installed at" })).toBeVisible();
+  });
+});

--- a/crates/kiro-control-center/tests/e2e/app.spec.ts
+++ b/crates/kiro-control-center/tests/e2e/app.spec.ts
@@ -196,4 +196,46 @@ test.describe("Phase 2b — update detection UI", () => {
     await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
     await expect(page.getByRole("columnheader", { name: "Installed at" })).toBeVisible();
   });
+
+  test("freshly-installed plugin shows 'Up to date' status after scan", async ({ page }) => {
+    const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+    test.skip(!fixturePath, "FIXTURE_MARKETPLACE_PATH not set");
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Installed", exact: true }).click();
+
+    // The earlier "install plugin from browse tab" test seeds an installed
+    // plugin. If a plugin row is present, its update-scan should resolve to
+    // "Up to date" because the manifest version matches what was just
+    // installed. The 10s timeout covers detectPluginUpdates' eager scan.
+    const pluginRow = page.locator("tbody tr").first();
+    if (!(await pluginRow.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, "No installed plugin available — install test must run first");
+    }
+    await expect(page.getByText("Up to date").first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Remove plugin shows inline <details> summary with removed items", async ({ page }) => {
+    const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+    test.skip(!fixturePath, "FIXTURE_MARKETPLACE_PATH not set");
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Installed", exact: true }).click();
+
+    const removeButton = page.getByRole("button", { name: /^Remove$/ }).first();
+    if (!(await removeButton.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, "No installed plugin available to remove");
+    }
+
+    // The Remove button in InstalledTab has plain text "Remove" (no aria-label
+    // discriminator across multiple rows yet), so first-row Remove is the
+    // target. Confirm-dialog is suppressed because Remove on InstalledTab
+    // doesn't use confirm() — that's MarketplacesTab's flow.
+    await removeButton.click();
+
+    // The success/warning banner reads "Removed plugin <name>: <summary>".
+    // The inline <details> block lives in InstalledTab and contains a
+    // <summary> with "Show items" or "Show items + failures" copy.
+    await expect(page.getByText(/^Show items/)).toBeVisible({ timeout: 15_000 });
+  });
 });

--- a/crates/kiro-control-center/vite.config.js
+++ b/crates/kiro-control-center/vite.config.js
@@ -28,4 +28,14 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+
+  // Vitest config — pure-logic tests only (no jsdom, no @testing-library/svelte).
+  // `environment: 'node'` keeps DOM concerns out of scope. Test files colocated
+  // next to the source they exercise (`*.test.ts`); component-level testing is
+  // intentionally future scope (see docs/plans/2026-05-05-phase-2b-...-design.md).
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    passWithNoTests: true,
+  },
 }));

--- a/docs/plans/2026-05-05-phase-2b-followup-tasks.md
+++ b/docs/plans/2026-05-05-phase-2b-followup-tasks.md
@@ -1,0 +1,358 @@
+# Phase 2b — deferred follow-up tasks
+
+**Status:** Open. Prerequisite: PR #108 (`feat/phase-2b-update-detection-ui`) merged.
+**Source:** Multi-agent review pass on PR #108 + post-fix simplifier pass. All Critical, all Important, and the highest-value simplifications landed in commit `5728869` on the PR-108 branch. The items below were explicitly deferred at the time as either (a) too broad to bundle without expanding the PR scope, (b) blocked on Rust-side decisions, or (c) needing fixture work.
+
+This document is self-contained — an agent picking it up does not need the prior conversation context. Citations are pinned at the post-`5728869` state of the codebase. Validate each citation with `git grep` before editing; re-base may have shifted line numbers.
+
+---
+
+## Recommended PR grouping
+
+| PR | Tasks | Net impact |
+|---|---|---|
+| **PR-A — Cross-tab plugin-action refactor** | T1, T2, T3, T4 | ~−80 lines, removes drift risk between BrowseTab + InstalledTab. Highest-value structural change. |
+| **PR-B — Type hardening** | T5, T6, T7 | Small. Cosmetic clarity + invariant locking. Could be folded into PR-A. |
+| **PR-C — PluginCard branch collapse** | T8 | ~−10 lines. Self-contained to one component. |
+| **PR-D — Wire-format `Option<Vec<T>>` cleanup** | T9 | Crosses Rust/FE boundary. Needs a Rust-side decision. |
+| **PR-E — e2e coverage for 2b dynamic behavior** | T10 | Needs new test fixture. Likely largest single-PR effort here. |
+
+PR-A is the recommended starting point: it has the highest line savings, removes the most drift risk, and lands as one reviewable unit.
+
+---
+
+## PR-A — Cross-tab plugin-action refactor
+
+The two tabs each carry: an `ErrorSource` union with overlapping shape, an `as ErrorSource` cast at update-check key construction, a `refreshAfterPluginAction` helper, and a banner-projection `$effect` triplet. These four duplications fold together cleanly.
+
+### T1 — Extract shared `error-source.ts` module
+
+**Motivation.** The `update-check<DELIM><remediation><DELIM><marketplace>` key shape is constructed in two files. Both use `as ErrorSource` because TS can't narrow a template-literal expression with non-literal interpolations. A constructor localizes the cast to one tested function.
+
+**Files affected.**
+- `crates/kiro-control-center/src/lib/components/BrowseTab.svelte:42-67` — `PLUGINS_ERR_PREFIX`, `SKILLS_ERR_PREFIX`, `BULK_SKILLS_ERR_PREFIX`, `ERR_MARKETPLACES`, `ERR_INSTALLED_PLUGINS`, `ERR_UPDATE_FETCH`, `UPDATE_CHECK_PREFIX`, `ErrorSource`, `_AssertNarrow`, `pluginsErrKey`, `skillsErrKey`, `bulkSkillsErrKey`.
+- `crates/kiro-control-center/src/lib/components/BrowseTab.svelte:459-460` — the `as ErrorSource` cast.
+- `crates/kiro-control-center/src/lib/components/InstalledTab.svelte:34-41` — `ERR_INSTALLED_PLUGINS`, `ERR_UPDATE_FETCH`, `UPDATE_CHECK_PREFIX`, `ErrorSource`.
+- `crates/kiro-control-center/src/lib/components/InstalledTab.svelte:213-214` — the `as ErrorSource` cast.
+
+**New file.** `crates/kiro-control-center/src/lib/error-source.ts`.
+
+**Target shape.** Export the **shared slice** plus the **constructor** that hides the cast. Each tab keeps its own `ErrorSource` union (the slice is just one alternative inside it):
+
+```ts
+// in error-source.ts
+export const UPDATE_CHECK_PREFIX = "update-check" as const;
+export const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
+export const ERR_UPDATE_FETCH = "update-fetch" as const;
+
+export type UpdateCheckKey =
+  `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`;
+
+export const updateCheckErrKey = (
+  remediation: RemediationClass,
+  marketplace: string,
+): UpdateCheckKey =>
+  `${UPDATE_CHECK_PREFIX}${DELIM}${remediation}${DELIM}${marketplace}` as UpdateCheckKey;
+
+export const parseUpdateCheckKey = (
+  key: UpdateCheckKey,
+): { remediation: string; marketplace: string } => {
+  const [, remediation, marketplace] = key.split(DELIM);
+  return { remediation, marketplace };
+};
+```
+
+Each tab's own `ErrorSource` then composes `UpdateCheckKey | ...own-keys`. The `as ErrorSource` casts at the construction sites collapse into `updateCheckErrKey(...)` calls.
+
+**Tests.** Add `crates/kiro-control-center/src/lib/error-source.test.ts`:
+- `updateCheckErrKey("stale_cache", "acme")` returns the exact 3-segment string.
+- `parseUpdateCheckKey(updateCheckErrKey(r, mp))` round-trips.
+- A `_AssertNarrow` regression-test type matches the existing pattern at `BrowseTab.svelte:62`.
+
+**Acceptance criteria.**
+- Both tabs import `UPDATE_CHECK_PREFIX`, `ERR_UPDATE_FETCH`, `ERR_INSTALLED_PLUGINS`, `UpdateCheckKey`, `updateCheckErrKey`, `parseUpdateCheckKey` from `error-source.ts`.
+- Zero `as ErrorSource` casts at update-check construction sites.
+- `npm run check` clean; new round-trip test passes.
+
+**Trade-off.** A new `lib/` module, but it's a single file with one explicit purpose. The casts are exactly the points the type system was previously failing to enforce.
+
+### T2 — Extract `lib/plugin-actions.ts` and consolidate `runPluginInstall` + `runPluginUpdate` + `runPluginRemove`
+
+**Motivation.** `BrowseTab.runPluginInstall` and `InstalledTab.updatePlugin` are byte-identical except for the post-action refresh function (which fetches the install set in BrowseTab vs. re-runs `refresh()` in InstalledTab). `InstalledTab.removePlugin` shares the same scaffolding plus a `RemovePluginResult` projection step.
+
+**Files affected.**
+- `crates/kiro-control-center/src/lib/components/BrowseTab.svelte:799-841` — `runPluginInstall` (the merged install/update handler from PR #108).
+- `crates/kiro-control-center/src/lib/components/InstalledTab.svelte:104-179` — `removePlugin`, `updatePlugin`.
+- Both tabs' `refreshAfterPluginAction` helpers (`BrowseTab.svelte:786-797`, `InstalledTab.svelte:93-102`) get inlined into the new module.
+
+**New file.** `crates/kiro-control-center/src/lib/plugin-actions.svelte.ts` (or a non-svelte module if you can keep it pure — see "Trade-off").
+
+**Target shape.** Pure-data return + caller-provided side-effect callbacks:
+
+```ts
+export type PluginActionMode = "install" | "update";
+
+export type PluginActionContext = {
+  marketplace: string;
+  plugin: string;
+  projectPath: string;
+  forceInstall: boolean;
+  acceptMcp: boolean;
+  refresh: () => Promise<void>;     // tab's local refresh
+};
+
+export type PluginActionOutcome =
+  | { kind: "ok"; banner: { error: string | null; message: string | null; warning: string | null } }
+  | { kind: "fail"; error: string };
+
+export async function runPluginInstall(
+  ctx: PluginActionContext,
+  mode: PluginActionMode,
+): Promise<PluginActionOutcome>;
+
+export async function runPluginRemove(
+  ctx: Omit<PluginActionContext, "forceInstall" | "acceptMcp">,
+): Promise<PluginActionOutcome & { removeResult?: RemovePluginResult }>;
+```
+
+The store call (`pluginUpdates.refresh`) and the Tauri command call live in the helper. The post-action refresh ordering ("`pluginUpdates.refresh` first, then local") is enforced inside the helper, so the cascade rule has one home.
+
+**Tests.** Add `crates/kiro-control-center/src/lib/plugin-actions.test.ts`. Mock `commands.installPlugin` + `commands.removePlugin` + the refresh callbacks. Cases:
+- Install success: `kind: "ok"`, `banner.message` populated, `banner.error` null. Verifies `force` is `forceInstall` for `mode: "install"` and `true` for `mode: "update"`.
+- Install with `anyFailed && !anyInstalled`: `kind: "ok"` (still ok at the wrapper level — the command succeeded), `banner.error` populated.
+- Install with warnings: `banner.warning` populated.
+- Tauri command returns error: `kind: "fail"`.
+- Tauri command throws: `kind: "fail"`, error message reflects the throw.
+- Post-action refresh throws: outcome is `kind: "ok"` but a refresh-failed sub-banner surfaces (see C4 in the original review). Decide whether to fold this into the outcome shape or keep the `refreshAfterPluginAction` try/catch separate.
+
+**Acceptance criteria.**
+- Both tabs call into the shared helpers; no `commands.installPlugin` / `commands.removePlugin` calls in component files.
+- The "cascade ordering" claim from PR #108 (`pluginUpdates.refresh` before local refresh) is enforced in the shared helper, not at each call site.
+- New unit tests cover all 6 outcome paths.
+- `npm run check` clean; existing 44 unit tests still pass.
+
+**Trade-off.** Side-effect callbacks (`refresh`, `setBanner`) make the helper less pure. If you keep `pluginUpdates.refresh` calls *inside* the helper, the helper takes a hard dep on the store module — that's fine since the store is also pure-logic-test-excluded. The alternative — return a list of "next actions" the caller dispatches — is purer but pushes the cascade-ordering rule back to the call sites, which defeats the consolidation. **Recommend the side-effect-callback shape.**
+
+### T3 — Extract `usePluginUpdateBanners(...)` rune helper
+
+**Motivation.** Three `$effect` blocks per tab project store state into the local `fetchErrors` map: (a) re-run scan on `projectPath` change, (b) project failure groups into update-check keys + dispose stale ones, (c) project toplevel `pluginUpdates.fetchError` into a single banner. Identical between tabs except for the structured-log prefix.
+
+**Files affected.**
+- `crates/kiro-control-center/src/lib/components/BrowseTab.svelte:443-477` — the three `$effect` blocks plus the `update-check<DELIM>...` projection logic.
+- `crates/kiro-control-center/src/lib/components/InstalledTab.svelte:198-236` — same triplet.
+
+**New file.** `crates/kiro-control-center/src/lib/stores/plugin-update-banners.svelte.ts`.
+
+**Target shape.** A rune helper that takes the consumer's `fetchErrors` map and the tab's banner-key namespace constants:
+
+```ts
+// Caller invokes inside its own component context. Runs three $effect
+// blocks under the hood — one for each projection.
+export function usePluginUpdateBanners(args: {
+  projectPath: () => string,
+  fetchErrors: SvelteMap<UpdateCheckKey | typeof ERR_UPDATE_FETCH | string, string>,
+  logPrefix: string,
+}): void;
+```
+
+`projectPath` is passed as a thunk so the helper can read it inside its own `$effect` and register the dependency in the helper's reactive scope.
+
+**Tests.** Vitest cannot test `$effect` directly per the project's testing scope rule (CLAUDE.md). The pure parts are already tested by `groupFailures` in `plugin-updates.test.ts`. Add a follow-up integration test in e2e (T10's banner-stack test) to exercise the helper end-to-end.
+
+**Acceptance criteria.**
+- Both tabs invoke `usePluginUpdateBanners({ projectPath: () => projectPath, fetchErrors, logPrefix: "[BrowseTab]"|"[InstalledTab]" })` at the script-tag top level.
+- The three `$effect` blocks in each tab are deleted.
+- Stale-key disposal logic (the `for (const k of fetchErrors.keys()) ... delete` loop) lives inside the helper.
+- `npm run check` clean; e2e for banner stacking still passes (currently does, since it only asserts UI behavior).
+
+**Trade-off.** Svelte 5's rune system supports calling `$effect` from `.svelte.ts` modules invoked at component-init time. Verify with the Svelte MCP server if unsure (see CLAUDE.md tooling). If runes can't cross the module boundary cleanly, fall back to a plain helper that returns `{ projectFailures, projectFetchError }` callbacks the caller wraps in `$effect` themselves — saves less but still extracts the projection logic.
+
+### T4 — Fold `refreshAfterPluginAction` into T2
+
+`BrowseTab.svelte:786-797` and `InstalledTab.svelte:93-102` are 10-line near-duplicates. Once T2 lands, both inline into the shared `runPluginInstall` / `runPluginRemove` helpers. No standalone work — listed for visibility.
+
+**Acceptance criteria.** No `refreshAfterPluginAction` function remains in either tab; the post-action refresh logic lives in `lib/plugin-actions.svelte.ts`.
+
+---
+
+## PR-B — Type hardening
+
+Small, isolated, can land independently or fold into PR-A.
+
+### T5 — Brand or factory-protect `FailureGroup`
+
+**Motivation.** `FailureGroup` (`crates/kiro-control-center/src/lib/stores/plugin-updates.ts:54-59`) has a `remediationHint` field that's *derivable* from `(remediation, marketplace)`, but the type doesn't enforce that consumers can't construct `{ remediation: "stale_cache", marketplace: "x", remediationHint: "Contact owner..." }` (a mismatched-hint instance).
+
+**Options.**
+- **Brand the type.** Add a `__brand: never` phantom field that only `groupFailures` can produce. Mechanical but adds noise.
+- **Unexport the type alias.** Export only `groupFailures` and `(typeof groupFailures)["return"][number]` (or use `ReturnType<typeof groupFailures>[number]`). Forces consumers to receive the type via inference.
+
+**Recommend option 2** — less ceremony, same guarantee.
+
+**Files.** `crates/kiro-control-center/src/lib/stores/plugin-updates.ts:54-59`. Update consumers in BrowseTab + InstalledTab to drop the named import (Svelte's type inference will keep working).
+
+**Tests.** No new tests; the existing `groupFailures` tests cover the construction path. Compile-time guarantee.
+
+**Acceptance criteria.** `FailureGroup` is no longer exported; consumers reference it via inference. `npm run check` clean.
+
+### T6 — Lock the `Extract<PluginAction, ...>` semantics with a comment
+
+**Motivation.** `PluginAction` is currently a string union. If a future refactor adds object payloads (`{ kind: "install"; force: boolean } | ...`), `Extract<PluginAction, "install" | "update">` silently changes meaning (it would filter by full object shape). The narrow path through this footgun is one comment + a test.
+
+**Files.** `crates/kiro-control-center/src/lib/stores/plugin-updates.ts:64-70` (the `PluginAction` declaration).
+
+**Target.** Add one line above the type:
+```ts
+// String union, not a tagged-object union. If this grows object payloads,
+// the `Extract<PluginAction, "install" | "update">` narrowings in BrowseTab
+// + InstalledTab will silently change meaning — switch to `Exclude<>` then.
+```
+
+**Tests.** Optional: add a compile-time assertion that `Extract<PluginAction, "install"> extends string` to lock the assumption. Lives in the existing test file.
+
+**Acceptance criteria.** Comment + (optional) compile-time guard added.
+
+### T7 — Rename `Extract<PluginAction, ...>` to named per-tab unions
+
+**Motivation.** Cosmetic. `Extract<PluginAction, "install" | "update">` reads as plumbing; `BrowseAction` reads as a domain concept.
+
+**Files.** `crates/kiro-control-center/src/lib/stores/plugin-updates.ts` (add exports), `BrowseTab.svelte:104` and `InstalledTab.svelte:23` (use the named types).
+
+**Target.**
+```ts
+// in plugin-updates.ts
+export type BrowseAction = Extract<PluginAction, "install" | "update">;
+export type InstalledAction = Extract<PluginAction, "remove" | "update">;
+```
+
+**Acceptance criteria.** No `Extract<PluginAction, ...>` literals in component files.
+
+---
+
+## PR-C — PluginCard branch collapse
+
+### T8 — Collapse `installing` / `updating` branches
+
+**Motivation.** `PluginCard.svelte:73-92` renders `installing` and `updating` as two separate `{#if}` branches with identical disabled-button markup, differing only in the label text and `aria-label`. ~10 lines of duplication.
+
+**Files.** `crates/kiro-control-center/src/lib/components/PluginCard.svelte:73-92`.
+
+**Target shape.**
+```svelte
+{#if installing || updating}
+  {@const verb = installing ? "Install" : "Updat"}
+  <button type="button" disabled aria-busy="true" aria-label="{verb}ing {plugin.name}" class="...">
+    {verb}ing…
+  </button>
+{:else if failure && installed}
+  ...
+```
+
+(The `verb` ternary dropping the trailing `e` is awkward; an explicit `installing ? "Installing" : "Updating"` for both label + aria reads cleaner. Pick whichever your reviewer prefers.)
+
+**Tests.** No unit tests for `.svelte` files per project policy. Existing e2e coverage indirectly verifies the disabled-button rendering.
+
+**Acceptance criteria.** Single branch handles both states; markup is otherwise unchanged. `npm run check` clean.
+
+---
+
+## PR-D — Wire-format `Option<Vec<T>>` cleanup
+
+### T9 — Drop `?? []` coalesces in `formatRemovePluginResult` if Rust emits empty arrays
+
+**Motivation.** `RemovePluginResult.skills.removed?: string[]`, `.failures?: ...` etc. (the `?` suffix) means the wire format treats `undefined` and `[]` as the same state. The FE coalesces with `?? []` in 6 places (`format.ts:265-270`) plus the `<details>` template in InstalledTab (`InstalledTab.svelte:289-308`). If the Rust side stops skipping these fields when empty (`#[serde(skip_serializing_if = "Vec::is_empty")]` removed), the FE type's `?` suffix can be dropped and the coalesces vanish.
+
+**Investigation step.** Find the Rust struct definition of `RemovePluginResult` and its sub-results. Probably under `crates/kiro-market-core/src/service.rs` or `crates/kiro-market-core/src/plugin.rs`. Check for `#[serde(skip_serializing_if = "Vec::is_empty")]` or `#[serde(default)]` on the relevant fields.
+
+**Decision.**
+- If the skip is intentional (saves wire bytes for a common no-op case), keep the FE coalesces. Close T9.
+- If not, remove the skip, regenerate `bindings.ts` (`cargo test -p kiro-control-center --lib -- --ignored`), drop the FE coalesces.
+
+**Files (FE side, if going forward).**
+- `crates/kiro-control-center/src/lib/format.ts:265-270` — drop `?? []` from the 6 destructure-and-coalesce lines.
+- `crates/kiro-control-center/src/lib/components/InstalledTab.svelte:289-308` — drop `?? []` from the `<details>` template's `{#if (...).length > 0}` and `{#each ...}` blocks.
+
+**Tests.** The existing `formatRemovePluginResult` test at `format.test.ts:194-201` ("treats undefined removed/failures as empty arrays") becomes either irrelevant (if FE type drops `?`) or tightens to "treats empty arrays as empty" — adjust.
+
+**Acceptance criteria.** Decision documented. If the change goes through, FE coalesces gone; e2e Remove flow still passes.
+
+**Trade-off.** Wire-format change ripples through other FE consumers of `RemovePluginResult`. Audit any callers besides the format helper before committing to this.
+
+---
+
+## PR-E — e2e coverage for 2b dynamic behavior
+
+### T10 — Fixture-backed e2e tests for 2b update-detection scenarios
+
+**Motivation.** The PR-108 unit-test coverage is solid, but the e2e suite at `crates/kiro-control-center/tests/e2e/app.spec.ts` covers only the happy paths (Up to date, Remove → `<details>`). The dynamic 2b behaviors that ship under PR #108 are still uncovered end-to-end:
+
+- `ContentChanged` status-vs-button divergence — column reads "Content changed since install", button reads "Update (content changed)". The contract is unit-tested via `statusUpdateLabel` / `actionUpdateLabel` (`plugin-updates.test.ts`); e2e would catch CSS / DOM regressions that unit tests can't.
+- `Update → vN` button rendering when a manifest version bump is detected.
+- "Update check failed" pill + `kindLabel` tooltip on `manifest_unreadable` / `marketplace_unavailable` failures.
+- Banner stacking + 3-cap-with-overflow `+N more items` row when 4+ keys land in `fetchErrors`.
+- Project-switch cleanup: banners / `pendingPluginActions` / `fetchErrors` clear when `projectPath` changes mid-flight.
+- Update/Remove mutex: in-flight action disables both row buttons.
+
+**Fixture work needed.**
+- A `FIXTURE_BUMPED_MARKETPLACE_PATH` with the same plugin manifest as `FIXTURE_MARKETPLACE_PATH` but a higher `version` field. After installing the original then swapping the marketplace pointer to the bumped fixture, the `Update → vN` and column "vX → vY" should appear.
+- A `FIXTURE_BROKEN_MARKETPLACE_PATH` (already exists per `FIXTURE_BROKEN_MARKETPLACE_PATH` reference at `app.spec.ts:158`) — verify it triggers `manifest_unreadable` or `manifest_invalid`.
+- A way to populate `fetchErrors` with 4+ entries to exercise the overflow row. Likely needs a fixture marketplace with multiple broken plugins.
+
+**Files.**
+- `crates/kiro-control-center/tests/e2e/app.spec.ts` — add new tests under the `Phase 2b — update detection UI` describe block.
+- Possibly new fixtures under `crates/kiro-control-center/tests/e2e/fixtures/` (check existing structure).
+- CI-side script in `.github/workflows/` if the bumped-fixture flow needs a setup step.
+
+**Test scaffolding (acceptance criteria).** At least 4 new tests, each `test.skip` cleanly when its fixture envvar is unset:
+1. `version-bump renders 'Update → vN' button + 'vX → vY' status` — install, bump fixture, navigate to Installed, assert pill + button text.
+2. `manifest_unreadable surfaces 'Update check failed' pill with kindLabel tooltip` — broken-fixture case.
+3. `4+ banners produce '+N more items' overflow row` — stack assertion.
+4. `Update + Remove buttons disable while either action is in-flight` — click Update, assert Remove is disabled before the action resolves.
+
+**Trade-off.** Largest fixture surface area of any task here. Don't bundle into PR-A.
+
+---
+
+## Verification commands (all PRs)
+
+Run these from `crates/kiro-control-center/`:
+```bash
+npm run check          # svelte-check (must be 0 errors, 0 warnings)
+npm run test:unit      # vitest (currently 44 tests; should grow)
+npm run test:e2e       # Playwright; FIXTURE envvars optional
+```
+
+Run from the repo root:
+```bash
+cargo fmt --all --check
+cargo test --workspace
+cargo clippy --workspace --tests -- -D warnings
+cargo xtask plan-lint  # all 6 gates must pass
+```
+
+T9 (the wire-format change) additionally requires:
+```bash
+cargo test -p kiro-control-center --lib -- --ignored  # regenerates bindings.ts
+```
+
+If `bindings.ts` regenerates with diffs, those diffs are part of the PR.
+
+---
+
+## Out of scope
+
+These were considered and explicitly **not** added to this list:
+- **Simplifier #11** — `formatInstallPluginResult` block-scoped `{ const ... }` for skills/steering/agents. Three-block structure is the right tradeoff; extracting forces three new helper signatures over a single-call body.
+- **Simplifier #12** — 6 noun-pluralization blocks in `formatRemovePluginResult` could share `countWithNoun`. Borderline cosmetic; explicit form is more grep-able.
+- **Cross-file `errorMessage(e: unknown)` lift** — the helper exists in `MarketplacesTab.svelte` and the `e instanceof Error ? e.message : String(e)` pattern repeats in BrowseTab + InstalledTab catches. Low value vs. an import everywhere; defer indefinitely.
+- **PluginUpdatesStore.refresh same-path concurrent calls** — the monotonic `#latestRequestId` guard already handles the A→B→A interleave. Don't re-open.
+
+---
+
+## Provenance
+
+- Multi-agent review pass: code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier, all run on PR #108.
+- Post-fix simplifier pass: code-simplifier re-run after C1–C5 + I2–I10 + initial simplifications landed.
+- All Critical (C1–C5) and Important (I1–I10) findings landed in commit `5728869`.
+- Simplifications #1, #2, #3, #9 from the post-fix pass also landed in `5728869`.
+- This document covers what was deferred at the time, with citations valid at that commit.

--- a/docs/plans/2026-05-05-phase-2b-update-detection-ui-design.md
+++ b/docs/plans/2026-05-05-phase-2b-update-detection-ui-design.md
@@ -1,0 +1,518 @@
+# Phase 2b — Plugin Update Detection UI — Design
+
+> **Status:** design draft. Implementation plan to be written next via the `superpowers:writing-plans` skill once this design is approved. Phase 2b ships as a frontend-only PR consuming the wire format defined in Phase 2a (`2026-04-30-phase-2a-update-detection-design.md` / PR #96).
+
+## Problem
+
+Phase 2a (PR #96) shipped the backend for plugin update detection: `detect_plugin_updates` Tauri command, `DetectUpdatesResult` / `PluginUpdateInfo` / `PluginUpdateFailure` / `PluginUpdateFailureKind` / `UpdateChangeSignal` types, and the per-content-type reshape of `RemovePluginResult`. `bindings.ts` regenerated and the Tauri crate compiles, but **no Svelte component consumes any of it yet**. Three concrete UI surfaces are missing:
+
+1. **Update indicator on plugin cards.** A user looking at the Installed tab — or, more importantly, the Browse tab while shopping for new plugins — has no signal that one of their installed plugins has an update available. They re-install manually to find out, which is friction the Phase 1 design (`2026-04-29-plugin-first-install-design.md` lines 27-31, 185-233) explicitly called out as the "Phase 2" gap.
+2. **Update button.** The action exists in the backend (`installPlugin(..., force=true, ...)`) but no UI calls it yet.
+3. **Remove toast still shows opaque counts.** The `RemovePluginResult` reshape gave us per-content-type `removed: Vec<String>` and `failures: Vec<RemoveItemFailure>`, but `InstalledTab.svelte`'s current `removePlugin` swallows the success result entirely and only surfaces failures via `loadError`. The reshape's stated motivation ("user knows the magnitude but not which items") is unfulfilled.
+
+Phase 2b lands all three surfaces in a single PR, plus narrowly-scoped vitest setup so the new pure-logic helpers get unit coverage.
+
+## Approach
+
+**Where indicators live: both BrowseTab and InstalledTab.** The PluginCard's "Installed" pill becomes an "Update → v1.1" button when an update is available; the InstalledTab table gains a Status column and an Update button next to Remove. Maximum discoverability — a user shopping in BrowseTab sees that an installed plugin needs an update without switching tabs.
+
+**Scan trigger: eager on project mount + after marketplace fetch.** A new module-scoped Svelte store (`plugin-updates.svelte.ts`) calls `detect_plugin_updates(projectPath)` once whenever `projectPath` changes; a callback from `MarketplacesTab` invalidates the cached result after a successful marketplace update (the only time a new scan is materially different from the last one without project switching). The 2a design's "<100ms for realistic projects" estimate keeps this affordable; eager-on-mount avoids any flicker between "Installed" and "Update" pills on first paint.
+
+**Update click: fire-and-forget, no confirmation modal, tooltip warning.** The Update button calls the existing `installPlugin(marketplace, plugin, force=true, acceptMcp=false, projectPath)` — the same code path Install uses, with `force` hard-coded to `true`. Mirrors the existing Install button's UX (also fire-and-forget). A `title="Update will replace local edits to plugin files"` tooltip is the only friction. Modals can be added later if a real data-loss incident motivates them; pulling them out is harder.
+
+**Remove toast itemization: counts inline + collapsed `<details>`.** Native HTML `<details>`, closed-by-default on success (the user doesn't need to read 8 skill names when nothing went wrong), `<details open>` on failure (auto-expand so the user immediately sees what didn't get removed). Reuses the existing 3-banner pattern (`installError` red / `installMessage` green / `installWarning` amber); InstalledTab gains the same banner channels BrowseTab has today, plus the new `<details>` rendering pattern.
+
+**Failure rendering: group by `(remediationClass, marketplace)`, shared "Update check failed" pill with kind in tooltip.** A pure function `remediationClass(kind: PluginUpdateFailureKind): "stale_cache" | "manifest_invalid" | "unknown"` collapses the 5-variant `PluginUpdateFailureKind` into 3 remediation paths; failures group by `(remediationClass, marketplace)` so 10 stale-cache failures from one marketplace produce one banner ("10 plugins from acme-marketplace couldn't be checked. Run `kiro-market update`"), not ten. Per-row pills share a single "Update check failed" treatment with the kind-specific copy in the `title=` tooltip — preserves the typed taxonomy on hover without amplifying it visually.
+
+**Edge states.**
+- *Scan in progress:* show the existing "Installed" pill optimistically (per Q6/A(ii)). Sub-100ms scan time + most-installed-plugins-have-no-update means flicker is barely perceptible. A skeleton placeholder on every card adds visual noise on every project switch for negligible signal gain.
+- *`change_signal: ContentChanged`:* button label `"Update (content changed)"` instead of `"Update → v1.1"` since there's no new version to display.
+- *Legacy install (`installed_version: None`) with `VersionBumped`:* button label stays `"Update → v1.1"` — the `→` reads as "to v1.1", not "from→to"; status column shows `"v1.1 available"` (no LHS to render).
+- *`partial_load_warnings`:* same data is *already* surfaced by `listInstalledPlugins`'s own `partial_load_warnings`. The store dedupes by `tracking_file` field and surfaces the merged set via the existing `ERR_INSTALLED_PLUGINS` banner — no new channel.
+
+**Vitest, narrowly scoped.** Phase 2a deferred vitest setup ("different category — separate phases"). Phase 2b reverses that decision because Phase 2b's pure-logic surface (`remediationClass`, `groupFailures`, `formatInstallPluginResult`, `formatRemovePluginResult`) is exactly the work-product that *needs* unit coverage, will not get it from Playwright (which is slow and gates on fixture marketplaces), and won't get it from `npm run check` (which catches only type errors, not behavior). Setup is intentionally minimal: no `@testing-library/svelte`, no `jsdom`, no Tauri-IPC mocks. Pure helpers live in non-`.svelte.ts` modules and are tested in `node` environment with vanilla vitest. Component-level testing remains future scope.
+
+## User-locked decisions
+
+These came out of the 2026-05-05 brainstorming conversation. Documented here so they don't drift during implementation:
+
+1. **Surfaces: BrowseTab + InstalledTab.** PluginCard's "Installed" pill becomes an "Update → v1.1" button on update. InstalledTab table gains a Status column and Update action. Rationale: maximum discoverability; a user browsing for new plugins shouldn't have to switch tabs to learn one of their installed plugins needs an update.
+
+2. **Scan trigger: eager on project mount + after marketplace fetch.** Two re-fire triggers only: (a) `projectPath` changes (existing `$effect` dependency in both tabs), (b) `MarketplacesTab.onMarketplacesUpdated` fires after a successful `kiro-market update`. No background polling (rejected in 2a, security-sensitive). No manual "Rescan" button (additive change later if motivated).
+
+3. **Update click: fire-and-forget, no confirm modal.** Tooltip on hover (`title="Update will replace local edits to plugin files"`) is the only friction. The button is hardcoded to `force=true`, ignoring BrowseTab's global "Force reinstall" checkbox (the checkbox still drives the Install button's behavior; the two actions diverge intentionally).
+
+4. **Remove toast: counts + collapsed `<details>`, auto-expand on failure.** Closed-by-default on success; `<details open>` on failure. Reuses the existing 3-banner pattern (`installError` / `installMessage` / `installWarning`). InstalledTab gains the same banner channels BrowseTab uses; the existing `loadError` channel narrows to fetch/refresh failures only.
+
+5. **Failure rendering: grouped by `(remediationClass, marketplace)`.** Pure function `remediationClass(kind: PluginUpdateFailureKind)` maps 5 kinds → 3 remediation classes (`stale_cache` covers `marketplace_unavailable | manifest_unreadable | hash_failed`; `manifest_invalid` is its own class; `other` is `unknown`). Banner copy keys off the remediation class. Per-row pills share a generic "Update check failed" visual; the kind-specific copy lives in the row's `title=` tooltip.
+
+6. **Edge state UX.** (a) Optimistic "Installed" pill during scan-in-progress; (b) ContentChanged button label is "Update (content changed)" not "Update → v1.1"; (c) legacy installs (`installed_version: None`) display `"v1.1 available"` in status; (d) `partial_load_warnings` from the scan dedup-merge with the same data already on `installedPlugins.partial_load_warnings` (single banner, keyed by `tracking_file`).
+
+7. **Vitest in scope (narrow).** Pure-logic helpers only — `remediationClass`, `groupFailures`, `formatInstallPluginResult`, `formatRemovePluginResult`. No component tests, no jsdom, no Tauri mocking. Component-level testing remains future scope. Reverses 2a's "vitest deferred to a separate phase" because Phase 2b is the first PR with FE logic worth testing.
+
+## Phase 2b architecture
+
+### New module: `plugin-updates.svelte.ts` store
+
+```ts
+// crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
+import { commands } from "$lib/bindings";
+import type {
+  DetectUpdatesResult,
+  PluginUpdateInfo,
+  PluginUpdateFailure,
+} from "$lib/bindings";
+import { groupFailures, type FailureGroup } from "./plugin-updates";
+
+class PluginUpdatesStore {
+  result = $state<DetectUpdatesResult | null>(null);
+  loading = $state(false);
+  // Toplevel error from detect_plugin_updates Result::Err — used when the
+  // command itself failed (couldn't read tracking files at all). Per-plugin
+  // failures live on result.failures.
+  fetchError = $state<string | null>(null);
+  lastProjectPath = $state<string | null>(null);
+
+  failureGroups = $derived.by((): FailureGroup[] =>
+    this.result?.failures ? groupFailures(this.result.failures) : []
+  );
+
+  updateFor(marketplace: string, plugin: string): PluginUpdateInfo | undefined {
+    return this.result?.updates?.find(
+      (u) => u.marketplace === marketplace && u.plugin === plugin,
+    );
+  }
+
+  failureFor(marketplace: string, plugin: string): PluginUpdateFailure | undefined {
+    return this.result?.failures?.find(
+      (f) => f.marketplace === marketplace && f.plugin === plugin,
+    );
+  }
+
+  async refresh(projectPath: string): Promise<void> {
+    if (!projectPath) {
+      this.result = null;
+      this.fetchError = null;
+      this.lastProjectPath = null;
+      return;
+    }
+    this.loading = true;
+    this.lastProjectPath = projectPath;
+    try {
+      const r = await commands.detectPluginUpdates(projectPath);
+      if (r.status === "ok") {
+        this.result = r.data;
+        this.fetchError = null;
+      } else {
+        this.fetchError = r.error.message;
+      }
+    } catch (e) {
+      this.fetchError = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+
+export const pluginUpdates = new PluginUpdatesStore();
+```
+
+### New module: `plugin-updates.ts` (pure helpers, vitest-tested)
+
+```ts
+// crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+import type {
+  PluginUpdateFailure,
+  PluginUpdateFailureKind,
+  MarketplaceName,
+  PluginName,
+} from "$lib/bindings";
+
+export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
+
+export function remediationClass(kind: PluginUpdateFailureKind): RemediationClass {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+    case "manifest_unreadable":
+    case "hash_failed":
+      return "stale_cache";
+    case "manifest_invalid":
+      return "manifest_invalid";
+    case "other":
+      return "unknown";
+  }
+  // No default — TypeScript surfaces a compile error if PluginUpdateFailureKind
+  // gains a new variant. Mirrors the CLAUDE.md classifier rule on the Rust side
+  // ("classifier functions over error enums enumerate every variant").
+}
+
+export type FailureGroup = {
+  remediation: RemediationClass;
+  marketplace: MarketplaceName;
+  plugins: PluginName[];
+  remediationHint: string;
+};
+
+export function groupFailures(failures: PluginUpdateFailure[]): FailureGroup[] {
+  const map = new Map<string, FailureGroup>();
+  for (const f of failures) {
+    const cls = remediationClass(f.kind);
+    const groupKey = `${cls}${f.marketplace}`;
+    let g = map.get(groupKey);
+    if (!g) {
+      g = {
+        remediation: cls,
+        marketplace: f.marketplace,
+        plugins: [],
+        remediationHint: hintFor(cls, f.marketplace),
+      };
+      map.set(groupKey, g);
+    }
+    g.plugins.push(f.plugin);
+  }
+  return Array.from(map.values());
+}
+
+function hintFor(cls: RemediationClass, marketplace: MarketplaceName): string {
+  switch (cls) {
+    case "stale_cache":
+      return `Run \`kiro-market update\` to refresh ${marketplace}.`;
+    case "manifest_invalid":
+      return "Contact the marketplace owner — `plugin.json` failed to parse.";
+    case "unknown":
+      return "Update check failed — see browser console for the error chain.";
+  }
+}
+
+export function kindLabel(kind: PluginUpdateFailureKind): string {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+      return "Marketplace cache missing or plugin removed from manifest";
+    case "manifest_unreadable":
+      return "plugin.json missing in marketplace cache";
+    case "manifest_invalid":
+      return "plugin.json failed to parse";
+    case "hash_failed":
+      return "Failed to hash installed file";
+    case "other":
+      return "Update check failed — see console";
+  }
+}
+```
+
+### Updated component: `PluginCard.svelte`
+
+Two new props: `update: PluginUpdateInfo | undefined`, `failure: PluginUpdateFailure | undefined`. The action area's render order:
+
+1. `installing === true` → `"Installing…"` disabled button.
+2. `updating === true` (new state — `pendingPluginActions[key] === "update"`) → `"Updating…"` disabled button.
+3. `failure !== undefined` (and `installed === true`) → "Update check failed" red pill with `title={kindLabel(failure.kind)}`.
+4. `update !== undefined` → orange "Update → v1.1" button (or "Update (content changed)" for `ContentChanged`); `onclick={onUpdate}`.
+5. `installed === true` → existing green "Installed" pill.
+6. Else → existing default "Install" button.
+
+Update button label per the edge cases in design decision #6:
+- `change_signal: VersionBumped` + both versions known → `"Update → v1.1"`
+- `change_signal: VersionBumped` + `installed_version === null` → `"Update → v1.1"` (same; the `→` reads as "to" not "from→to")
+- `change_signal: VersionBumped` + `available_version === null` → `"Update"` (manifest declares no version)
+- `change_signal: ContentChanged` → `"Update (content changed)"`
+
+### Updated component: `InstalledTab.svelte`
+
+Table header gains a `Status` column between `Version` and `Contents`. The action cell becomes `[Update] [Remove]` (Update only present when `pluginUpdates.updateFor(p.marketplace, p.plugin) !== undefined`).
+
+```svelte
+<th class="px-4 py-2">Status</th>
+...
+<td class="px-4 py-3">
+  {#if updateInfo}
+    <span class="px-2 py-0.5 text-[11px] font-medium text-kiro-warning border
+                 border-kiro-warning/40 rounded">
+      {updateLabelFor(updateInfo)}
+    </span>
+  {:else if failure}
+    <span class="px-2 py-0.5 text-[11px] font-medium text-kiro-error border
+                 border-kiro-error/40 rounded"
+          title={kindLabel(failure.kind)}>
+      Update check failed
+    </span>
+  {:else}
+    <span class="text-kiro-success text-[11px]">Up to date</span>
+  {/if}
+</td>
+```
+
+The action cell renders both buttons when an update is available; `pendingPluginActions: SvelteMap<string, "install" | "update" | "remove">` drives the disabled+label logic. The existing `removingKey: string | null` is replaced by reads from this map.
+
+### Banner stack
+
+A new `BannerStack.svelte` component extracted from BrowseTab's existing render block (`BrowseTab.svelte:1066-1132`). Both tabs render `<BannerStack errors={fetchErrors} message={installMessage} warning={installWarning} fatalError={installError} ondismiss={(key) => fetchErrors.delete(key)} />` (Svelte 5 callback-prop syntax, not the legacy `on:` directive).
+
+The shared component owns: 3-cap-with-overflow rendering for the `fetchErrors` map, dismiss buttons, and the green/amber/red color treatment.
+
+InstalledTab adopts `fetchErrors: SvelteMap<ErrorSource, string>` for failure groups, with an `ErrorSource` union extended to include `update-check<remediation><marketplace>`. The existing `loadError` and `loadWarning` channels narrow to "couldn't load installed plugins" — they no longer carry remove-action results.
+
+### Update flow
+
+Each tab implements `updatePlugin` with the skeleton below; the only divergence is the post-action refresh call — BrowseTab calls its own `fetchInstalledPlugins()`, InstalledTab calls its own `refresh()`. Pulled out as a parameter so the body is otherwise identical:
+
+```ts
+// per-tab; postRefresh differs between tabs.
+async function updatePlugin(
+  marketplace: string,
+  plugin: string,
+  postRefresh: () => Promise<void>,
+) {
+  const key = pluginKey(marketplace, plugin);
+  if (pendingPluginActions.has(key)) return;
+  pendingPluginActions.set(key, "update");
+  installError = null;
+  installMessage = null;
+  installWarning = null;
+  try {
+    const result = await commands.installPlugin(
+      marketplace, plugin,
+      /*force=*/ true,
+      /*acceptMcp=*/ false,
+      projectPath,
+    );
+    if (result.status === "ok") {
+      const { summary, warnings } = formatInstallPluginResult(result.data, plugin);
+      installMessage = `Updated ${plugin}: ${summary}`;
+      if (warnings) installWarning = `Updated ${plugin}: ${warnings}`;
+      await pluginUpdates.refresh(projectPath);
+      await postRefresh();
+    } else {
+      installError = `Update failed for ${plugin}: ${result.error.message}`;
+    }
+  } catch (e) {
+    installError =
+      `Update failed for ${plugin}: ${e instanceof Error ? e.message : String(e)}`;
+  } finally {
+    pendingPluginActions.delete(key);
+  }
+}
+```
+
+`formatInstallPluginResult` is extracted from `BrowseTab.installWholePlugin` (lines 744-841) into `src/lib/format.ts` so both Install and Update reuse the same summarization logic.
+
+### Remove toast
+
+`InstalledTab.removePlugin` switches from "discard success result" to "format and surface". Adds a new state var:
+
+```ts
+let removeResult: RemovePluginResult | null = $state(null);
+```
+
+`removeResult` carries the data for the inline `<details>` block independently of the banner channels (which carry the human summary). When set non-null and there are items, the `<details>` block renders below the banner stack.
+
+The action handler:
+
+```ts
+async function removePlugin(marketplace: string, plugin: string) {
+  const key = pluginKey(marketplace, plugin);
+  if (pendingPluginActions.has(key)) return;
+  pendingPluginActions.set(key, "remove");
+  installError = null;
+  installMessage = null;
+  installWarning = null;
+  try {
+    const result = await commands.removePlugin(marketplace, plugin, projectPath);
+    if (result.status === "ok") {
+      const { summary, hasItems, hasFailures } =
+        formatRemovePluginResult(result.data, plugin);
+      removeResult = result.data; // drives the <details> render
+      if (hasFailures) {
+        installWarning = `Removed plugin ${plugin}: ${summary}`;
+      } else {
+        installMessage = `Removed plugin ${plugin}: ${summary}`;
+      }
+      await refresh();
+      await pluginUpdates.refresh(projectPath);
+    } else {
+      installError = `Remove failed for ${plugin}: ${result.error.message}`;
+    }
+  } catch (e) {
+    installError = `Remove failed for ${plugin}: ${e instanceof Error ? e.message : String(e)}`;
+  } finally {
+    pendingPluginActions.delete(key);
+  }
+}
+```
+
+The toast renders inline in InstalledTab below the BannerStack; the `<details>` body iterates `removeResult.skills.removed`, `.steering.removed`, `.agents.removed` and (if `hasFailures`) the corresponding `failures` arrays with `{item}: {error}` lines.
+
+### Failure → banner mapping
+
+The `pluginUpdates.failureGroups` `$derived` produces `FailureGroup[]`. Both tabs reactively project these into the `fetchErrors` map under the new key family:
+
+```ts
+$effect(() => {
+  // Clear previous update-check banners for keys not in the new group set.
+  const seen = new Set<ErrorSource>();
+  for (const group of pluginUpdates.failureGroups) {
+    const key: ErrorSource =
+      `update-check${group.remediation}${group.marketplace}`;
+    seen.add(key);
+    const pluginList = group.plugins.join(", ");
+    fetchErrors.set(
+      key,
+      `${group.plugins.length} plugin${group.plugins.length === 1 ? "" : "s"} ` +
+      `from ${group.marketplace}: ${group.remediationHint}` +
+      ` (${pluginList})`,
+    );
+  }
+  for (const k of fetchErrors.keys()) {
+    if (k.startsWith("update-check") && !seen.has(k)) fetchErrors.delete(k);
+  }
+});
+```
+
+`partial_load_warnings` get merged into the existing `ERR_INSTALLED_PLUGINS` banner. The merge dedupes by `tracking_file` since both `listInstalledPlugins` and `detectPluginUpdates` read the same files; a single corrupt `installed-skills.json` shouldn't produce two banners that say the same thing.
+
+**Toplevel `fetchError` (rare).** When `commands.detectPluginUpdates` itself fails (`Result::Err` — backend couldn't read tracking files at all), `pluginUpdates.fetchError` carries the message. Both tabs surface this via a new `ERR_UPDATE_FETCH` key on `fetchErrors`:
+
+```ts
+$effect(() => {
+  if (pluginUpdates.fetchError) {
+    fetchErrors.set("update-fetch", `Couldn't check for updates: ${pluginUpdates.fetchError}`);
+  } else {
+    fetchErrors.delete("update-fetch");
+  }
+});
+```
+
+Distinct from the per-group `update-check<remediation><marketplace>` keys: this one is "scan didn't run at all," they're "scan ran, some plugins failed."
+
+### Cross-marketplace same-plugin idempotency edge
+
+The 2a design footnote (`2026-04-30-phase-2a-update-detection-design.md` line 257) flagged this as "may matter for Phase 2b UI work but doesn't block 2a backend." Investigation: every UI surface is keyed on `(marketplace, plugin)` via `pluginKey()` (`BrowseTab.svelte:9-19`); `installPlugin(marketplace, plugin, ...)` takes marketplace as a param; `installedPluginKeys` is `Set<pluginKey>` not `Set<plugin>`. Two marketplaces shipping the same plugin name produce two distinct rows in InstalledTab and two distinct cards in BrowseTab. **No UI-side work required**; the edge is a backend concern that doesn't surface in 2b's design space.
+
+## Wire format / FFI
+
+Phase 2b introduces **zero new types** crossing FFI. It consumes:
+
+- `DetectUpdatesResult { updates?, failures?, partial_load_warnings? }`
+- `PluginUpdateInfo { marketplace, plugin, installed_version, available_version, change_signal }`
+- `PluginUpdateFailure { marketplace, plugin, kind, reason }`
+- `PluginUpdateFailureKind` (5-variant tagged union)
+- `UpdateChangeSignal` (`version_bumped` | `content_changed`)
+- `RemovePluginResult { skills, steering, agents }` and the three sub-result types
+- `RemoveItemFailure { item, error }`
+
+All shipped in PR #96 (`bindings.ts` regenerated at `b5cbd97`). No backend changes; no new Tauri commands.
+
+## Module map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts` | New | Reactive store wrapping `detectPluginUpdates`; consumed by both tabs |
+| `crates/kiro-control-center/src/lib/stores/plugin-updates.ts` | New | Pure helpers (`remediationClass`, `groupFailures`, `kindLabel`); vitest-tested |
+| `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts` | New | Vitest cases for the pure helpers |
+| `crates/kiro-control-center/src/lib/format.ts` | Modify | Add `formatInstallPluginResult`, `formatRemovePluginResult` (extracted from BrowseTab) |
+| `crates/kiro-control-center/src/lib/format.test.ts` | New | Vitest cases for the extracted formatters |
+| `crates/kiro-control-center/src/lib/components/PluginCard.svelte` | Modify | Two new props (`update`, `failure`); 3 new action-area states |
+| `crates/kiro-control-center/src/lib/components/InstalledTab.svelte` | Modify | New `Status` column; Update button; consume reshape; multi-banner stack; `<details>` toast |
+| `crates/kiro-control-center/src/lib/components/BrowseTab.svelte` | Modify | Wire store; pass `update` + `failure` props to PluginCard; refactor `pendingPluginInstalls` → `pendingPluginActions`; extract banner block |
+| `crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte` | Modify | New `onMarketplacesUpdated` callback prop; fired after successful `kiro-market update` |
+| `crates/kiro-control-center/src/lib/components/BannerStack.svelte` | New | Extracted from BrowseTab; reused by InstalledTab |
+| `crates/kiro-control-center/src/routes/+page.svelte` | Modify | Wire `MarketplacesTab.onMarketplacesUpdated` → `pluginUpdates.refresh(projectPath)` |
+| `crates/kiro-control-center/vite.config.ts` | Modify | Add `test: { include: ['src/**/*.test.ts'], environment: 'node' }` block |
+| `crates/kiro-control-center/package.json` | Modify | New devDep `vitest`; new script `"test:unit": "vitest run"` |
+| `CLAUDE.md` (top-level) | Modify | Add `npm run test:unit` to the pre-commit list; note the FE-pure-logic boundary for vitest |
+
+## Testing strategy
+
+### Vitest (new — narrow scope)
+
+- `plugin-updates.test.ts`:
+  - `remediationClass` — every `PluginUpdateFailureKind.kind` value maps to a non-default `RemediationClass`. (Compile-time exhaustiveness via switch is the primary guard; this runtime test backs it up.)
+  - `groupFailures` — empty input → empty output; N stale-cache failures from one marketplace → one group; failures from two marketplaces → two groups; `manifest_invalid` and `stale_cache` from same marketplace → two distinct groups (different remediation); plugin order within group preserved.
+  - `kindLabel` — every variant returns a non-empty human-readable string.
+- `format.test.ts`:
+  - `formatInstallPluginResult` — happy path with all 3 sub-results populated; failures-only; warnings-only (e.g. MCP-gated agents); empty (zero installs / zero failures); idempotent reinstalls (steering's `installed[].kind === "idempotent"`).
+  - `formatRemovePluginResult` — happy path (3 sub-results, no failures); per-content-type failures land in the right summary bucket; empty cascade (all three sub-results empty).
+
+### Playwright (e2e)
+
+`tests/e2e/app.spec.ts` already gates on `FIXTURE_MARKETPLACE_PATH`. New scenarios:
+
+- **Update available, golden path:** project + fixture marketplace where one plugin's manifest version increments → BrowseTab card shows "Update → v{N}", InstalledTab row shows update pill in Status column.
+- **Click Update → success:** click the Update button → toast appears with green "Updated {plugin}: …"; the indicator clears on the post-action `pluginUpdates.refresh()`.
+- **Stale-cache failure:** project with installed plugin from a marketplace not present in cache → amber banner with grouped copy; rows show "Update check failed" pill.
+- **Remove with sub-results:** remove a plugin with mixed content types → toast appears with `<details>` containing item names; expand verifies named items are present.
+- **Remove with cascade failure:** fixture where steering removal fails mid-cascade → amber toast with `<details open>` showing the failed item and error.
+
+### Manual UI smoke
+
+Per CLAUDE.md "For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete." `npm run dev` walkthrough covering:
+- No installed plugins → tab loads, no Update affordances anywhere.
+- Scan-in-progress → cards/rows render "Installed" pill optimistically; flicker on transition.
+- ContentChanged label.
+- Legacy install (manually edit `installed-*.json` to remove `version` fields).
+- Marketplace offline (rename/move marketplace cache dir under `~/.kiro/marketplaces/`) → grouped amber banner, "Update check failed" rows.
+- Remove with no items, with items only, with failures only, with mixed.
+
+### TypeScript / `npm run check`
+
+`svelte-check` continues to gate the merge. The new exhaustive switches (`remediationClass`, `kindLabel`) become compile-time gates against future `PluginUpdateFailureKind` additions.
+
+## Out of scope
+
+Documented here so they don't drift into the plan:
+
+- **Component-level testing** (`@testing-library/svelte`, `jsdom`, Tauri-IPC mocking). Phase 2b adds vitest only for pure-logic helpers. Component tests are a separate scope.
+- **Manual "Rescan" button.** Eager-on-mount + after-marketplace-update covers the common cases; an explicit rescan affordance is additive and can ship later if motivated.
+- **Tab-level count badge** (option C from Q1). Rejected during brainstorming in favor of inline indicators on both surfaces.
+- **Confirmation modal on Update.** Tooltip-only friction; modal is an additive change later if data-loss incidents motivate.
+- **Auto-update / background polling.** Already rejected in 2a (security: a malicious marketplace could push a hostile MCP server).
+- **Per-content-type Update / partial-Update.** "Update only the steering files" or similar; plugins remain coherent bundles per Phase 1 design.
+- **Cross-marketplace same-plugin idempotency edge.** Backend concern; UI keys on `(marketplace, plugin)` everywhere already, so 2b doesn't surface or worsen the edge.
+- **Hash memoization in marketplace cache.** Performance optimization; deferred per 2a.
+
+## 6-Gates self-review
+
+### Gate 1 — Grounding
+
+**Real incident driving this work?** Yes:
+1. The 2a design's stated goal was a complete plugin lifecycle, of which "users see updates and can act on them" is the keystone. 2a backend without 2b UI is a typed wire format with zero consumers — the value is unrealized until a user can click Update in the UI.
+2. The `RemovePluginResult` reshape was specifically motivated by "the toast says '3 skills, 1 steering file, 2 agents' — the user knows the magnitude but not which items" (2a design line 10). Currently `InstalledTab.removePlugin` *discards* the result; the reshape is unfulfilled until 2b consumes it.
+3. The vitest scope reversal traces to: 2a deferred vitest because there was no pure FE logic worth testing. 2b introduces such logic (`remediationClass`, `groupFailures`, format helpers) — the deferral's preconditions no longer hold.
+
+### Gate 2 — Threat Model
+
+**Untrusted inputs:** none new at the FFI boundary; Phase 2b is a consumer of types whose `Deserialize` impls already enforce parse-don't-validate at deserialization. The wire-format types (`PluginUpdateInfo`, `PluginUpdateFailure`, `RemovePluginResult` and sub-results) flow `serde_json::from_slice` → typed values → component props. No new Tauri command surface to validate.
+
+**Destructive UI actions:**
+- *Update button*: calls `installPlugin(force=true)` which **overwrites** the user's local plugin files. UX mitigation: tooltip warning. Considered: confirmation modal — rejected for symmetry with the existing Install fire-and-forget UX. Tradeoff documented in user-locked decision #3; reversible if data-loss incidents materialize.
+- *Remove button*: existing behavior; 2b only changes how the result is rendered.
+
+**Tooltip / banner content** carries `PluginUpdateFailure.reason` strings, which are `error_full_chain` outputs from the backend. Rendered as text nodes (not innerHTML); Svelte's default escaping handles this.
+
+### Gate 3 — Wire Format / FFI
+
+Zero new types crossing FFI. All consumed types ship in PR #96. `bindings.ts` already regenerated. No `specta::Type` derives, no `serde(tag = "kind")` discriminators, no JSON-shape locks to add — all of those landed in 2a.
+
+The `remediationClass` switch over `PluginUpdateFailureKind.kind` is the FE's single point of fanout from a typed enum to UX. If 2a-and-beyond add a new kind, TypeScript surfaces a compile error here (no `default:` arm). Mirrors the CLAUDE.md classifier rule on the Rust side.
+
+### Gate 4 — External Type Boundary
+
+N/A — no Rust crate boundary changes. The TypeScript code consumes already-translated types; no `serde_json::Error` or `gix::Error` surfaces in 2b's code paths.
+
+### Gate 5 — Type Design
+
+**Newtypes preserved:** `MarketplaceName` and `PluginName` are TypeScript-side aliases (`= string`) per `bindings.ts`. The 2b code threads them as opaque values; equality checks use direct string compares since the TS aliases erase. The newtype guarantee lives on the backend; 2b consumes the values at face value.
+
+**Discriminated unions consumed correctly:** `PluginUpdateFailureKind` and `UpdateChangeSignal` are both `{ kind: ... }` tagged. The 2b code switches on `.kind` strings — type-safe, matches the FFI wire format. No positional access (no `tuple[0]` patterns).
+
+**No magic-value sentinels added.** ContentChanged with no `available_version` is encoded by the `change_signal` discriminator + `Option<String>` versions, not by any sentinel string in 2b code. The UI's "Update (content changed)" label is a render-side decision; the wire format remains structurally typed.
+
+### Gate 6 — Reference vs Transcription
+
+**Was the plan review tested against actual code, not transcribed from prose?**
+
+- Module map is anchored to existing file paths verified during exploration: `crates/kiro-control-center/src/lib/components/{PluginCard,InstalledTab,BrowseTab,MarketplacesTab}.svelte`, `crates/kiro-control-center/src/lib/{format.ts,bindings.ts}`, `crates/kiro-control-center/src/lib/stores/project.svelte.ts`. None invented.
+- The "extract `formatInstallPluginResult` from BrowseTab" plan cites `BrowseTab.svelte:744-841` — read during exploration, not transcribed.
+- The "InstalledTab adopts the BrowseTab banner-stack pattern" plan is anchored to actual code at `BrowseTab.svelte:1066-1132`, verified during exploration.
+- The cross-marketplace footnote was investigated by reading `project.rs` directly (the line numbers in the 2a footnote no longer match — the codebase shifted). Conclusion ("UI keys on `(marketplace, plugin)` already; no UI work") is grounded in current file state, not the stale 2a line ref.
+- The vitest setup plan is conservative because actual research surfaced the Svelte-5-runes + vitest interaction nuance (testing reactive `$state`/`$derived` requires `flushSync` and the svelte runtime initialization). The plan dodges that complexity by extracting helpers to non-`.svelte.ts` modules — a structural choice, not a transcribed best-practice.

--- a/docs/plans/2026-05-05-phase-2b-update-detection-ui-plan.md
+++ b/docs/plans/2026-05-05-phase-2b-update-detection-ui-plan.md
@@ -1,0 +1,2818 @@
+# Phase 2b — Plugin Update Detection UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the frontend consumer for Phase 2a's update-detection backend: Update indicators + buttons on both BrowseTab and InstalledTab, refreshed Remove toast that itemizes the per-content-type sub-results, plus narrowly-scoped vitest setup so the new pure-logic helpers get unit coverage.
+
+**Architecture:** A module-scoped `pluginUpdates` Svelte store wraps `commands.detectPluginUpdates` and is consumed by both tabs; re-fires on project change + after a marketplace update. Pure helpers (`remediationClass`, `groupFailures`, format helpers) live in non-`.svelte.ts` modules so vitest tests them in `node` env without `@testing-library/svelte` or `jsdom`. Per-plugin failures group by `(remediationClass, marketplace)` and surface in the existing 3-banner pattern (`installError` red / `installMessage` green / `installWarning` amber). The `RemovePluginResult` reshape is consumed via an inline `<details>` block below the banner stack on InstalledTab.
+
+**Tech Stack:** Svelte 5 (runes), TypeScript (strict), Vite, SvelteKit (static adapter), Tauri 2 + tauri-specta-generated bindings, Vitest (new), Playwright.
+
+**Source-of-truth references** (cite-don't-transcribe per Gate 6):
+- Wire-format types: `crates/kiro-control-center/src/lib/bindings.ts` (regenerated PR #96, commit `b5cbd97`).
+  - `DetectUpdatesResult`: `bindings.ts:252-256`
+  - `PluginUpdateInfo`: `bindings.ts:1077-1100`
+  - `PluginUpdateFailure`: `bindings.ts:1018-1023`
+  - `PluginUpdateFailureKind` (5-variant tagged union): `bindings.ts:1040-1069`
+  - `UpdateChangeSignal` (2-variant tagged union): `bindings.ts:1523-1533`
+  - `RemovePluginResult` + sub-results + `RemoveItemFailure`: `bindings.ts:1125-1193`
+  - `InstallPluginResult_Serialize` (returned by `installPlugin`): `bindings.ts:657-664`
+  - `TrackingLoadWarning`: `bindings.ts:1492-1506`
+  - `InstalledPluginInfo`: `bindings.ts:785-799`
+- Existing summarization logic to extract: `BrowseTab.svelte:734-852` (`installWholePlugin`).
+- Existing banner-stack render block to extract: `BrowseTab.svelte:1066-1132`.
+- Composite-key helpers (already shared): `src/lib/keys.ts`.
+- Existing format-helper conventions (assertNever pattern over discriminated unions): `src/lib/format.ts`.
+- Pre-commit suite: `CLAUDE.md` (top-level) — `cargo fmt --check`, `cargo test --workspace`, `cargo clippy --workspace --tests -- -D warnings`. Phase 2b adds `npm run check` and `npm run test:unit` to the FE-tier pre-commit list.
+
+---
+
+## Task 1: Vitest setup
+
+Establishes the test runner with minimum config so subsequent tasks can TDD pure helpers. No `@testing-library/svelte`, no `jsdom`, no Tauri-IPC mocking — just `vitest` running TypeScript in a `node` environment. The first real test is part of Task 2 (the smoke test happens via that work).
+
+**Files:**
+- Modify: `crates/kiro-control-center/package.json`
+- Modify: `crates/kiro-control-center/vite.config.js`
+
+- [ ] **Step 1.1: Add vitest devDependency**
+
+Edit `crates/kiro-control-center/package.json`. The current devDependencies block ends after `"vite": "^6.0.3"` (see existing file). Add `vitest`:
+
+```diff
+   "devDependencies": {
+     "@playwright/test": "^1.59.1",
+     "@sveltejs/adapter-static": "^3.0.6",
+     "@sveltejs/kit": "^2.9.0",
+     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+     "@tauri-apps/cli": "^2",
+     "@types/node": "^25.5.2",
+     "svelte": "^5.0.0",
+     "svelte-check": "^4.0.0",
+     "typescript": "~5.6.2",
+-    "vite": "^6.0.3"
++    "vite": "^6.0.3",
++    "vitest": "^2.1.0"
+   }
+```
+
+- [ ] **Step 1.2: Add `test:unit` npm script**
+
+Edit `crates/kiro-control-center/package.json`'s `scripts` block:
+
+```diff
+   "scripts": {
+     "dev": "vite dev",
+     "build": "vite build",
+     "preview": "vite preview",
+     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+     "tauri": "tauri",
+-    "test:e2e": "playwright test"
++    "test:e2e": "playwright test",
++    "test:unit": "vitest run"
+   },
+```
+
+- [ ] **Step 1.3: Add a `test:` block to vite.config.js**
+
+Replace the entirety of `crates/kiro-control-center/vite.config.js` with:
+
+```js
+import { defineConfig } from "vite";
+import { sveltekit } from "@sveltejs/kit/vite";
+
+const host = process.env.TAURI_DEV_HOST;
+
+// https://vite.dev/config/
+export default defineConfig(async () => ({
+  plugins: [sveltekit()],
+
+  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+  //
+  // 1. prevent Vite from obscuring rust errors
+  clearScreen: false,
+  // 2. tauri expects a fixed port, fail if that port is not available
+  server: {
+    port: 1420,
+    strictPort: true,
+    host: host || false,
+    hmr: host
+      ? {
+          protocol: "ws",
+          host,
+          port: 1421,
+        }
+      : undefined,
+    watch: {
+      // 3. tell Vite to ignore watching `src-tauri`
+      ignored: ["**/src-tauri/**"],
+    },
+  },
+
+  // Vitest config — pure-logic tests only (no jsdom, no @testing-library/svelte).
+  // `environment: 'node'` keeps DOM concerns out of scope. Test files colocated
+  // next to the source they exercise (`*.test.ts`); component-level testing is
+  // intentionally future scope (see docs/plans/2026-05-05-phase-2b-...-design.md).
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+}));
+```
+
+- [ ] **Step 1.4: Install the new devDep**
+
+Run from `crates/kiro-control-center/`:
+
+```bash
+npm install
+```
+
+Expected: `vitest` installs, no errors. `package-lock.json` updates.
+
+- [ ] **Step 1.5: Verify `vitest run` is wired**
+
+Run from `crates/kiro-control-center/`:
+
+```bash
+npm run test:unit
+```
+
+Expected: `vitest` runs and reports `No test files found, exiting with code 0` (or similar) — no test files exist yet. The command itself MUST succeed (exit 0); if it errors out vitest is misconfigured.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add crates/kiro-control-center/package.json \
+        crates/kiro-control-center/package-lock.json \
+        crates/kiro-control-center/vite.config.js
+git commit -m "feat(test): add vitest for FE pure-logic helpers (Phase 2b prep)"
+```
+
+---
+
+## Task 2: Pure helpers — `remediationClass` (TDD)
+
+The first real vitest test. Drives a thin module that holds the `PluginUpdateFailureKind` → `RemediationClass` mapping. Establishes the file pattern (`plugin-updates.ts` next to the future `plugin-updates.svelte.ts` store).
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`
+- Create: `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`
+
+- [ ] **Step 2.1: Write the failing test**
+
+Create `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { PluginUpdateFailureKind } from "$lib/bindings";
+import { remediationClass } from "./plugin-updates";
+
+describe("remediationClass", () => {
+  it("maps marketplace_unavailable to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "marketplace_unavailable" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps manifest_unreadable to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "manifest_unreadable" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps hash_failed to stale_cache", () => {
+    const kind: PluginUpdateFailureKind = { kind: "hash_failed" };
+    expect(remediationClass(kind)).toBe("stale_cache");
+  });
+
+  it("maps manifest_invalid to its own class", () => {
+    const kind: PluginUpdateFailureKind = { kind: "manifest_invalid" };
+    expect(remediationClass(kind)).toBe("manifest_invalid");
+  });
+
+  it("maps other to unknown", () => {
+    const kind: PluginUpdateFailureKind = { kind: "other" };
+    expect(remediationClass(kind)).toBe("unknown");
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test, verify it fails**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: FAIL — module `./plugin-updates` cannot be resolved.
+
+- [ ] **Step 2.3: Write minimal implementation**
+
+Create `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`:
+
+```ts
+import type {
+  MarketplaceName,
+  PluginName,
+  PluginUpdateFailure,
+  PluginUpdateFailureKind,
+} from "$lib/bindings";
+
+/**
+ *  Three remediation paths the FE distinguishes among the five
+ *  `PluginUpdateFailureKind` variants. The grouping function in
+ *  `groupFailures` keys off this so 10 stale-cache failures from one
+ *  marketplace produce one banner, not ten.
+ *
+ *  - `stale_cache` — `marketplace_unavailable`, `manifest_unreadable`,
+ *    `hash_failed`. Remediation: run `kiro-market update`.
+ *  - `manifest_invalid` — broken `plugin.json` upstream. Remediation:
+ *    contact the marketplace owner.
+ *  - `unknown` — `other` catch-all. Remediation: see error chain.
+ */
+export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
+
+/**
+ *  Map a `PluginUpdateFailureKind` to its remediation class. The switch
+ *  has no `default:` arm — TypeScript surfaces a compile error if the
+ *  bindings ever grow a new variant. Mirrors the CLAUDE.md classifier
+ *  rule on the Rust side ("classifier functions over error enums
+ *  enumerate every variant").
+ */
+export function remediationClass(kind: PluginUpdateFailureKind): RemediationClass {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+    case "manifest_unreadable":
+    case "hash_failed":
+      return "stale_cache";
+    case "manifest_invalid":
+      return "manifest_invalid";
+    case "other":
+      return "unknown";
+  }
+}
+```
+
+- [ ] **Step 2.4: Run the tests, verify they pass**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/stores/plugin-updates.ts \
+        crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+git commit -m "feat(updates): add remediationClass helper + tests"
+```
+
+---
+
+## Task 3: Pure helpers — `kindLabel`
+
+Per-kind tooltip copy. Drives the row pill's `title=` attribute.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`
+- Modify: `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append to `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`:
+
+```ts
+import { kindLabel } from "./plugin-updates";
+
+describe("kindLabel", () => {
+  it("returns a non-empty string for every PluginUpdateFailureKind variant", () => {
+    const variants: PluginUpdateFailureKind[] = [
+      { kind: "marketplace_unavailable" },
+      { kind: "manifest_unreadable" },
+      { kind: "manifest_invalid" },
+      { kind: "hash_failed" },
+      { kind: "other" },
+    ];
+    for (const v of variants) {
+      const label = kindLabel(v);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("produces distinct labels for distinct kinds", () => {
+    const labels = new Set([
+      kindLabel({ kind: "marketplace_unavailable" }),
+      kindLabel({ kind: "manifest_unreadable" }),
+      kindLabel({ kind: "manifest_invalid" }),
+      kindLabel({ kind: "hash_failed" }),
+      kindLabel({ kind: "other" }),
+    ]);
+    expect(labels.size).toBe(5);
+  });
+});
+```
+
+Also extend the existing top-of-file import to bring in `kindLabel`:
+
+```diff
+-import { remediationClass } from "./plugin-updates";
++import { remediationClass, kindLabel } from "./plugin-updates";
+```
+
+(or merge into the new `import { kindLabel } from "./plugin-updates";` block if the engineer prefers per-suite imports — the existing `remediationClass` import stays where it is.)
+
+- [ ] **Step 3.2: Run the tests, verify they fail**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: FAIL — `kindLabel` is not exported.
+
+- [ ] **Step 3.3: Add the implementation**
+
+Append to `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`:
+
+```ts
+/**
+ *  Per-kind human-readable tooltip copy for "Update check failed" pills.
+ *  Lives on hover, not in the banner — the banner uses the remediation
+ *  hint (`hintFor`) instead so 10 failures with the same remediation
+ *  produce one banner.
+ *
+ *  No `default:` arm — same exhaustiveness contract as `remediationClass`.
+ */
+export function kindLabel(kind: PluginUpdateFailureKind): string {
+  switch (kind.kind) {
+    case "marketplace_unavailable":
+      return "Marketplace cache missing or plugin removed from manifest";
+    case "manifest_unreadable":
+      return "plugin.json missing in marketplace cache";
+    case "manifest_invalid":
+      return "plugin.json failed to parse";
+    case "hash_failed":
+      return "Failed to hash installed file";
+    case "other":
+      return "Update check failed — see console";
+  }
+}
+```
+
+- [ ] **Step 3.4: Run the tests, verify they pass**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: 7 tests pass (5 from Task 2 + 2 new).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/stores/plugin-updates.ts \
+        crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+git commit -m "feat(updates): add kindLabel helper + tests"
+```
+
+---
+
+## Task 4: Pure helpers — `groupFailures`
+
+The grouping pipeline. Collapses N stale-cache failures from one marketplace into one banner-bound `FailureGroup`.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`
+- Modify: `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Append to `crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts`:
+
+```ts
+import { groupFailures, type FailureGroup } from "./plugin-updates";
+
+function failure(
+  marketplace: string,
+  plugin: string,
+  kind: PluginUpdateFailureKind,
+): PluginUpdateFailure {
+  return {
+    marketplace: marketplace as MarketplaceName,
+    plugin: plugin as PluginName,
+    kind,
+    reason: "test reason",
+  };
+}
+
+describe("groupFailures", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupFailures([])).toEqual([]);
+  });
+
+  it("collapses N stale-cache failures from one marketplace into one group", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_unreadable" }),
+      failure("acme", "p3", { kind: "hash_failed" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].remediation).toBe("stale_cache");
+    expect(groups[0].marketplace).toBe("acme");
+    expect(groups[0].plugins).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("produces separate groups for two marketplaces", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("beta", "p2", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const marketplaces = new Set(groups.map((g) => g.marketplace));
+    expect(marketplaces).toEqual(new Set(["acme", "beta"]));
+  });
+
+  it("produces separate groups for distinct remediation classes from same marketplace", () => {
+    const groups = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_invalid" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const remediations = new Set(groups.map((g) => g.remediation));
+    expect(remediations).toEqual(new Set(["stale_cache", "manifest_invalid"]));
+  });
+
+  it("preserves plugin order within a group as the input was ordered", () => {
+    const groups = groupFailures([
+      failure("acme", "z-plugin", { kind: "marketplace_unavailable" }),
+      failure("acme", "a-plugin", { kind: "marketplace_unavailable" }),
+      failure("acme", "m-plugin", { kind: "marketplace_unavailable" }),
+    ]);
+    expect(groups[0].plugins).toEqual(["z-plugin", "a-plugin", "m-plugin"]);
+  });
+
+  it("each group carries a non-empty remediationHint", () => {
+    const groups: FailureGroup[] = groupFailures([
+      failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      failure("acme", "p2", { kind: "manifest_invalid" }),
+      failure("acme", "p3", { kind: "other" }),
+    ]);
+    for (const g of groups) {
+      expect(g.remediationHint.length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+Also extend the test file's imports near the top:
+
+```diff
+-import type { PluginUpdateFailureKind } from "$lib/bindings";
++import type {
++  MarketplaceName,
++  PluginName,
++  PluginUpdateFailure,
++  PluginUpdateFailureKind,
++} from "$lib/bindings";
+```
+
+- [ ] **Step 4.2: Run the tests, verify they fail**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: FAIL — `groupFailures` and `FailureGroup` are not exported.
+
+- [ ] **Step 4.3: Add the implementation**
+
+Append to `crates/kiro-control-center/src/lib/stores/plugin-updates.ts`:
+
+```ts
+/**
+ *  A grouped failure surface. One per `(remediation, marketplace)` —
+ *  the natural unit for banner copy, since plugins sharing the same
+ *  remediation from the same marketplace want a single combined
+ *  "N plugins from acme couldn't be checked" banner instead of N.
+ */
+export type FailureGroup = {
+  remediation: RemediationClass;
+  marketplace: MarketplaceName;
+  // Plugin names ordered as the scan returned them.
+  plugins: PluginName[];
+  // Human-readable remediation hint (e.g. "Run `kiro-market update`...").
+  remediationHint: string;
+};
+
+/**
+ *  Collapse a flat `failures: PluginUpdateFailure[]` into per-group
+ *  rows. Order of groups in the returned array reflects first-seen
+ *  ordering of group keys; plugin order within a group is input order.
+ */
+export function groupFailures(failures: PluginUpdateFailure[]): FailureGroup[] {
+  const map = new Map<string, FailureGroup>();
+  for (const f of failures) {
+    const cls = remediationClass(f.kind);
+    // Composite key — a literal "<remediation>:<marketplace>" suffices
+    // because remediationClass values never contain ":" and marketplace
+    // names go through a backend newtype that forbids control chars.
+    const groupKey = `${cls}:${f.marketplace}`;
+    let g = map.get(groupKey);
+    if (!g) {
+      g = {
+        remediation: cls,
+        marketplace: f.marketplace,
+        plugins: [],
+        remediationHint: hintFor(cls, f.marketplace),
+      };
+      map.set(groupKey, g);
+    }
+    g.plugins.push(f.plugin);
+  }
+  return Array.from(map.values());
+}
+
+function hintFor(cls: RemediationClass, marketplace: MarketplaceName): string {
+  switch (cls) {
+    case "stale_cache":
+      return `Run \`kiro-market update\` to refresh ${marketplace}.`;
+    case "manifest_invalid":
+      return "Contact the marketplace owner — `plugin.json` failed to parse.";
+    case "unknown":
+      return "Update check failed — see browser console for the error chain.";
+  }
+}
+
+/**
+ *  Per-plugin in-flight action discriminator. Each tab narrows this
+ *  to the actions it actually performs (BrowseTab: install/update,
+ *  InstalledTab: remove/update) but the union is exported so the
+ *  Map shapes stay nameable from one place.
+ */
+export type PluginAction = "install" | "update" | "remove";
+```
+
+- [ ] **Step 4.4: Run the tests, verify they pass**
+
+```bash
+npm run test:unit -- plugin-updates.test
+```
+
+Expected: 13 tests pass (5 + 2 + 6).
+
+- [ ] **Step 4.5: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/stores/plugin-updates.ts \
+        crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+git commit -m "feat(updates): add groupFailures + FailureGroup + tests"
+```
+
+---
+
+## Task 5: Format helper — `formatInstallPluginResult` (extract + TDD)
+
+Extract the install-result summarization currently inlined in `BrowseTab.svelte:734-852` (specifically the summary-building logic at 753-841) into `format.ts` so both the existing Install flow and the new Update flow consume the same helper. Tests-first against the type structure of `InstallPluginResult_Serialize` (`bindings.ts:657-664`).
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/format.ts`
+- Create: `crates/kiro-control-center/src/lib/format.test.ts`
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Create `crates/kiro-control-center/src/lib/format.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type {
+  InstallPluginResult_Serialize,
+  MarketplaceName,
+  PluginName,
+} from "$lib/bindings";
+import { formatInstallPluginResult } from "./format";
+
+// Field names + structure tracked from bindings.ts (see plan
+// "Source-of-truth references"):
+//  - InstallSkillsResult:             bindings.ts:667-686
+//  - InstallSteeringResult_Serialize: bindings.ts:699-703
+//  - InstallAgentsResult_Serialize:   bindings.ts:522-560
+//  - FailedSkill:                     bindings.ts:352-356
+//  - InstalledSteeringOutcome:        bindings.ts:853-859
+//  - InstallOutcomeKind:              bindings.ts:568-581
+function emptyInstallResult(): InstallPluginResult_Serialize {
+  return {
+    marketplace: "acme" as MarketplaceName,
+    plugin: "p" as PluginName,
+    version: null,
+    skills: { installed: [], skipped: [], failed: [], skipped_skills: [] },
+    steering: { installed: [], failed: [], warnings: [] },
+    // InstallAgentsResult_Serialize requires installed_native +
+    // installed_companions (bindings.ts:553, :559). Both default to
+    // empty/null in this fixture.
+    agents: {
+      installed: [],
+      skipped: [],
+      failed: [],
+      warnings: [],
+      installed_native: [],
+      installed_companions: null,
+    },
+  };
+}
+
+describe("formatInstallPluginResult", () => {
+  it("happy path: counts all 3 sub-results", () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a", "b"];
+    r.steering.installed = [
+      { source: "s.md", destination: "s.md", kind: "installed", source_hash: "h", installed_hash: "h" },
+    ];
+    // installed: string[] (bindings.ts:527), not an object array.
+    r.agents.installed = ["g"];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toContain("2 skill");
+    expect(out.summary).toContain("1 steering");
+    expect(out.summary).toContain("1 agent");
+    expect(out.anyInstalled).toBe(true);
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("failures-only: anyInstalled=false, anyFailed=true", () => {
+    const r = emptyInstallResult();
+    // FailedSkill requires `kind: FailedSkillReason` (bindings.ts:352-356).
+    r.skills.failed = [
+      { name: "broken", error: "oops", kind: { kind: "install_failed" } },
+    ];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.anyInstalled).toBe(false);
+    expect(out.anyFailed).toBe(true);
+    expect(out.summary).toContain("1 skill failed");
+  });
+
+  it("warnings-only (e.g. MCP-gated agent): warnings string present, no failure flag", () => {
+    const r = emptyInstallResult();
+    r.agents.warnings = [
+      { kind: "mcp_servers_require_opt_in", agent: "scary", transports: ["stdio"] },
+    ];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.warnings).not.toBeNull();
+    expect(out.warnings).toContain("scary");
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("empty: summary reads 'nothing to install'", () => {
+    const r = emptyInstallResult();
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toBe("nothing to install");
+    expect(out.anyInstalled).toBe(false);
+    expect(out.anyFailed).toBe(false);
+  });
+
+  it("skipped (idempotent skill): counted as 'already installed'", () => {
+    const r = emptyInstallResult();
+    r.skills.skipped = ["a", "b"];
+    const out = formatInstallPluginResult(r, "p");
+    expect(out.summary).toContain("2 skills already installed");
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the tests, verify they fail**
+
+```bash
+npm run test:unit -- format.test
+```
+
+Expected: FAIL — `formatInstallPluginResult` is not exported.
+
+- [ ] **Step 5.3: Add the implementation**
+
+Append to `crates/kiro-control-center/src/lib/format.ts`:
+
+```ts
+import type { InstallPluginResult_Serialize } from "$lib/bindings";
+
+/**
+ *  Summarized view of an `InstallPluginResult_Serialize` for banner
+ *  rendering. Extracted from `BrowseTab.installWholePlugin` so the new
+ *  Update flow (which also calls `installPlugin`, just with `force=true`)
+ *  reuses the same summarization rather than duplicating it.
+ *
+ *  - `summary`: human-readable mid-dot-separated count phrase
+ *    (e.g. "2 skills · 1 steering · 1 agent"). Reads "nothing to install"
+ *    when nothing happened.
+ *  - `warnings`: pipe-separated warning lines (steering-scan warnings,
+ *    MCP-gated agents, per-skill skipped_skills) or `null` when empty.
+ *  - `anyInstalled` / `anyFailed`: caller uses these to decide which
+ *    banner channel (success vs. error vs. warning) to route to.
+ */
+export type FormattedInstallPluginResult = {
+  summary: string;
+  warnings: string | null;
+  anyInstalled: boolean;
+  anyFailed: boolean;
+};
+
+export function formatInstallPluginResult(
+  r: InstallPluginResult_Serialize,
+  _plugin: string,
+): FormattedInstallPluginResult {
+  const summaryParts: string[] = [];
+  const warningParts: string[] = [];
+
+  // Skills sub-result.
+  {
+    const skills = r.skills;
+    if (skills.installed.length > 0) {
+      const noun = skills.installed.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.installed.length} ${noun}`);
+    }
+    if (skills.failed.length > 0) {
+      const noun = skills.failed.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.failed.length} ${noun} failed`);
+    }
+    if (skills.skipped.length > 0) {
+      const noun = skills.skipped.length === 1 ? "skill" : "skills";
+      summaryParts.push(`${skills.skipped.length} ${noun} already installed`);
+    }
+    if (skills.skipped_skills.length > 0) {
+      warningParts.push(formatSkippedSkillsForPlugin(skills.skipped_skills));
+    }
+  }
+
+  // Steering sub-result. Idempotent reinstalls land in `installed` with
+  // `kind: idempotent` (not a separate field) — the current banner shape
+  // counts them as installed; per-content breakdown is future scope.
+  {
+    const steering = r.steering;
+    if (steering.installed.length > 0) {
+      const noun = steering.installed.length === 1 ? "file" : "files";
+      summaryParts.push(`${steering.installed.length} steering ${noun}`);
+    }
+    if (steering.failed.length > 0) {
+      summaryParts.push(`${steering.failed.length} steering failed`);
+    }
+    for (const w of steering.warnings) {
+      warningParts.push(formatSteeringWarning(w));
+    }
+  }
+
+  // Agents sub-result.
+  {
+    const agents = r.agents;
+    if (agents.installed.length > 0) {
+      const noun = agents.installed.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.installed.length} ${noun}`);
+    }
+    if (agents.failed.length > 0) {
+      const noun = agents.failed.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.failed.length} ${noun} failed`);
+    }
+    if (agents.skipped.length > 0) {
+      const noun = agents.skipped.length === 1 ? "agent" : "agents";
+      summaryParts.push(`${agents.skipped.length} ${noun} already installed`);
+    }
+    for (const w of agents.warnings) {
+      warningParts.push(formatInstallWarning(w));
+    }
+  }
+
+  const anyFailed =
+    r.skills.failed.length + r.steering.failed.length + r.agents.failed.length > 0;
+  const anyInstalled =
+    r.skills.installed.length +
+      r.steering.installed.length +
+      r.agents.installed.length >
+    0;
+  const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to install";
+  const warnings = warningParts.length > 0 ? warningParts.join(" | ") : null;
+
+  return { summary, warnings, anyInstalled, anyFailed };
+}
+```
+
+- [ ] **Step 5.4: Run the tests, verify they pass**
+
+```bash
+npm run test:unit -- format.test
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5.5: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/format.ts \
+        crates/kiro-control-center/src/lib/format.test.ts
+git commit -m "feat(format): extract formatInstallPluginResult helper + tests"
+```
+
+---
+
+## Task 6: Format helper — `formatRemovePluginResult` (TDD)
+
+Mirrors Task 5 but for the new `RemovePluginResult` shape. Drives the new Remove toast.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/format.ts`
+- Modify: `crates/kiro-control-center/src/lib/format.test.ts`
+
+- [ ] **Step 6.1: Write the failing tests**
+
+Append to `crates/kiro-control-center/src/lib/format.test.ts`:
+
+```ts
+import type { RemovePluginResult } from "$lib/bindings";
+import { formatRemovePluginResult } from "./format";
+
+// Field names + structure tracked from bindings.ts:
+//  - RemovePluginResult:  bindings.ts:1171-1175
+//  - RemoveSkillsResult:  bindings.ts:1181-1184
+//  - RemoveSteeringResult: bindings.ts:1190-1193
+//  - RemoveAgentsResult:  bindings.ts:1134-1137
+//  - RemoveItemFailure:   bindings.ts:1145-1156
+function emptyRemoveResult(): RemovePluginResult {
+  return {
+    skills: { removed: [], failures: [] },
+    steering: { removed: [], failures: [] },
+    agents: { removed: [], failures: [] },
+  };
+}
+
+describe("formatRemovePluginResult", () => {
+  it("happy path: counts all 3 sub-results", () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a", "b", "c"];
+    r.steering.removed = ["s.md"];
+    r.agents.removed = ["g1", "g2"];
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.summary).toContain("3 skill");
+    expect(out.summary).toContain("1 steering");
+    expect(out.summary).toContain("2 agent");
+    expect(out.hasItems).toBe(true);
+    expect(out.hasFailures).toBe(false);
+  });
+
+  it("steering failure lands in summary (failed count) and hasFailures=true", () => {
+    const r = emptyRemoveResult();
+    r.steering.failures = [{ item: "broken.md", error: "permission denied" }];
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasFailures).toBe(true);
+    expect(out.summary).toContain("1 steering failed");
+  });
+
+  it("empty (zero items, zero failures): hasItems=false, hasFailures=false", () => {
+    const r = emptyRemoveResult();
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasItems).toBe(false);
+    expect(out.hasFailures).toBe(false);
+    expect(out.summary).toBe("nothing to remove");
+  });
+
+  it("treats undefined removed/failures as empty arrays", () => {
+    // The wire format makes both fields optional (#[serde(default)]).
+    const r: RemovePluginResult = {
+      skills: {},
+      steering: {},
+      agents: {},
+    };
+    const out = formatRemovePluginResult(r, "p");
+    expect(out.hasItems).toBe(false);
+    expect(out.hasFailures).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run the tests, verify they fail**
+
+```bash
+npm run test:unit -- format.test
+```
+
+Expected: FAIL — `formatRemovePluginResult` is not exported.
+
+- [ ] **Step 6.3: Add the implementation**
+
+Append to `crates/kiro-control-center/src/lib/format.ts`:
+
+```ts
+import type { RemovePluginResult } from "$lib/bindings";
+
+/**
+ *  Summarized view of a `RemovePluginResult` for banner + `<details>`
+ *  rendering on the InstalledTab.
+ *
+ *  - `summary`: human-readable mid-dot-separated count phrase
+ *    (mirrors `formatInstallPluginResult`'s shape — "3 skills · 1
+ *    steering · 2 agents" for happy path; appends "N <type> failed"
+ *    for partial failure). Reads "nothing to remove" on empty.
+ *  - `hasItems`: at least one removed-list is non-empty. Drives the
+ *    decision whether to render the `<details>` block at all.
+ *  - `hasFailures`: at least one failures-list is non-empty. Drives
+ *    the choice of banner channel (amber vs. green) and the `<details
+ *    open>` auto-expand.
+ */
+export type FormattedRemovePluginResult = {
+  summary: string;
+  hasItems: boolean;
+  hasFailures: boolean;
+};
+
+export function formatRemovePluginResult(
+  r: RemovePluginResult,
+  _plugin: string,
+): FormattedRemovePluginResult {
+  // Sub-result fields are optional per the wire format
+  // (RemoveSkillsResult.removed?: string[], etc.). Default to empty
+  // arrays so the rest of this function can do plain `.length` reads.
+  const skillsRemoved = r.skills.removed ?? [];
+  const skillsFailures = r.skills.failures ?? [];
+  const steeringRemoved = r.steering.removed ?? [];
+  const steeringFailures = r.steering.failures ?? [];
+  const agentsRemoved = r.agents.removed ?? [];
+  const agentsFailures = r.agents.failures ?? [];
+
+  const summaryParts: string[] = [];
+
+  if (skillsRemoved.length > 0) {
+    const noun = skillsRemoved.length === 1 ? "skill" : "skills";
+    summaryParts.push(`${skillsRemoved.length} ${noun}`);
+  }
+  if (steeringRemoved.length > 0) {
+    const noun = steeringRemoved.length === 1 ? "file" : "files";
+    summaryParts.push(`${steeringRemoved.length} steering ${noun}`);
+  }
+  if (agentsRemoved.length > 0) {
+    const noun = agentsRemoved.length === 1 ? "agent" : "agents";
+    summaryParts.push(`${agentsRemoved.length} ${noun}`);
+  }
+  if (skillsFailures.length > 0) {
+    const noun = skillsFailures.length === 1 ? "skill" : "skills";
+    summaryParts.push(`${skillsFailures.length} ${noun} failed`);
+  }
+  if (steeringFailures.length > 0) {
+    summaryParts.push(`${steeringFailures.length} steering failed`);
+  }
+  if (agentsFailures.length > 0) {
+    const noun = agentsFailures.length === 1 ? "agent" : "agents";
+    summaryParts.push(`${agentsFailures.length} ${noun} failed`);
+  }
+
+  const hasItems =
+    skillsRemoved.length + steeringRemoved.length + agentsRemoved.length > 0;
+  const hasFailures =
+    skillsFailures.length + steeringFailures.length + agentsFailures.length > 0;
+  const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "nothing to remove";
+
+  return { summary, hasItems, hasFailures };
+}
+```
+
+- [ ] **Step 6.4: Run the tests, verify they pass**
+
+```bash
+npm run test:unit
+```
+
+Expected: all unit tests pass (Task 2-6 cumulative — 13 + 5 + 4 = 22 tests).
+
+- [ ] **Step 6.5: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/format.ts \
+        crates/kiro-control-center/src/lib/format.test.ts
+git commit -m "feat(format): add formatRemovePluginResult helper + tests"
+```
+
+---
+
+## Task 7: `pluginUpdates` Svelte store
+
+The reactive store wrapping `commands.detectPluginUpdates`. Both tabs consume it; pure helpers from Task 4 power the `failureGroups` derived. No tests in this task — reactive-state testing is out of scope per the design ("the store's reactive layer stays untested in this PR — that's the line").
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts`
+
+- [ ] **Step 7.1: Create the store module**
+
+Create `crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts`:
+
+```ts
+import { commands } from "$lib/bindings";
+import type {
+  DetectUpdatesResult,
+  PluginUpdateFailure,
+  PluginUpdateInfo,
+} from "$lib/bindings";
+import { groupFailures, type FailureGroup } from "./plugin-updates";
+
+/**
+ *  Module-scoped reactive store wrapping `detectPluginUpdates`.
+ *  Consumed by `BrowseTab` and `InstalledTab` — both `$effect` on
+ *  `projectPath` and call `pluginUpdates.refresh(projectPath)`. The
+ *  parent `+page.svelte` also wires `MarketplacesTab.onUpdated` to
+ *  this store's `refresh` so a successful `kiro-market update`
+ *  invalidates the cached scan.
+ *
+ *  Per Phase 2b design decision #2, the only re-fire triggers are:
+ *  (1) projectPath change (each tab's existing $effect),
+ *  (2) marketplace update (MarketplacesTab callback).
+ *  No background polling, no manual rescan button.
+ */
+class PluginUpdatesStore {
+  result = $state<DetectUpdatesResult | null>(null);
+  loading = $state(false);
+  // Toplevel error from `detectPluginUpdates` Result::Err — used when
+  // the command itself failed (couldn't read tracking files at all).
+  // Per-plugin failures live on `result.failures`, not here.
+  fetchError = $state<string | null>(null);
+  // Last project path the store refreshed against. Lets the consumer
+  // tabs distinguish "not yet refreshed" from "refreshed and empty".
+  lastProjectPath = $state<string | null>(null);
+
+  failureGroups = $derived.by((): FailureGroup[] =>
+    this.result?.failures ? groupFailures(this.result.failures) : [],
+  );
+
+  updateFor(marketplace: string, plugin: string): PluginUpdateInfo | undefined {
+    return this.result?.updates?.find(
+      (u) => u.marketplace === marketplace && u.plugin === plugin,
+    );
+  }
+
+  failureFor(marketplace: string, plugin: string): PluginUpdateFailure | undefined {
+    return this.result?.failures?.find(
+      (f) => f.marketplace === marketplace && f.plugin === plugin,
+    );
+  }
+
+  async refresh(projectPath: string): Promise<void> {
+    if (!projectPath) {
+      this.result = null;
+      this.fetchError = null;
+      this.lastProjectPath = null;
+      return;
+    }
+    this.loading = true;
+    this.lastProjectPath = projectPath;
+    try {
+      const r = await commands.detectPluginUpdates(projectPath);
+      if (r.status === "ok") {
+        this.result = r.data;
+        this.fetchError = null;
+      } else {
+        this.fetchError = r.error.message;
+      }
+    } catch (e) {
+      this.fetchError = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+
+export const pluginUpdates = new PluginUpdatesStore();
+```
+
+- [ ] **Step 7.2: Verify svelte-check passes**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors. (No consumer of the store yet — just verifying the new module typechecks.)
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/stores/plugin-updates.svelte.ts
+git commit -m "feat(updates): add pluginUpdates Svelte store"
+```
+
+---
+
+## Task 8: Extract `BannerStack.svelte` from BrowseTab
+
+Pull the existing banner render block from `BrowseTab.svelte:1066-1132` into a shared component so InstalledTab can adopt the same UX in Task 11. No behavior change — verbatim extraction. Does NOT modify BrowseTab in this task; Task 9 swaps BrowseTab to consume the new component.
+
+**Files:**
+- Create: `crates/kiro-control-center/src/lib/components/BannerStack.svelte`
+
+- [ ] **Step 8.1: Create the BannerStack component**
+
+Create `crates/kiro-control-center/src/lib/components/BannerStack.svelte`:
+
+```svelte
+<script lang="ts" generics="K extends string">
+  import type { SvelteMap } from "svelte/reactivity";
+
+  // Extracted from BrowseTab.svelte (the prior render block lived at
+  // lines 1066-1132). The shared component owns: 3-cap-with-overflow
+  // rendering for the `errors` map, dismiss buttons (calls back via
+  // `ondismiss`), and the green/amber/red color treatment for the
+  // remaining three banner channels.
+  //
+  // The `errors` map is generic over its key type via Svelte 5's
+  // `generics="K extends string"` script-tag attribute — `K` flows
+  // through the dismiss callback so the consumer can branch type-
+  // safely on which key was dismissed without a cast.
+  type Props = {
+    errors: SvelteMap<K, string>;
+    message: string | null;
+    warning: string | null;
+    fatalError: string | null;
+    // `errLabel` is per-tab because the screen-reader label depends
+    // on the consumer's ErrorSource taxonomy (e.g. "Dismiss error
+    // for acme/foo" vs "Dismiss installed-plugins error").
+    errLabel: (key: K) => string;
+    // Svelte 5 callback prop, not the legacy `on:dismiss` directive.
+    ondismiss: (key: K) => void;
+    onmessageDismiss?: () => void;
+    onwarningDismiss?: () => void;
+    onfatalErrorDismiss?: () => void;
+  };
+
+  let {
+    errors,
+    message,
+    warning,
+    fatalError,
+    errLabel,
+    ondismiss,
+    onmessageDismiss,
+    onwarningDismiss,
+    onfatalErrorDismiss,
+  }: Props = $props();
+</script>
+
+<!-- Banners render newest-first (reverse insertion order) and cap at 3 so
+     a storm of broken plugins doesn't push the grid off-screen. Dismissing
+     a banner or resolving its source surfaces the next-newest below. -->
+{#each [...errors].reverse().slice(0, 3) as [key, msg] (key)}
+  <div
+    data-testid="fetch-error"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-error flex-1">{msg}</p>
+    <button
+      type="button"
+      onclick={() => ondismiss(key)}
+      aria-label={errLabel(key)}
+      class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/each}
+{#if errors.size > 3}
+  <div
+    data-testid="fetch-error-overflow"
+    class="mx-4 mt-3 px-4 py-2 text-xs text-kiro-subtle text-center border border-kiro-muted/50 rounded-md bg-kiro-surface/30"
+  >
+    +{errors.size - 3} more {errors.size - 3 === 1 ? "error" : "errors"} — dismiss or resolve above to see the rest
+  </div>
+{/if}
+
+{#if fatalError}
+  <div
+    data-testid="install-error"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-error flex-1">{fatalError}</p>
+    <button
+      type="button"
+      onclick={() => onfatalErrorDismiss?.()}
+      aria-label="Dismiss install error"
+      class="text-kiro-error/70 hover:text-kiro-error text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/if}
+
+{#if message}
+  <div class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-success/10 border border-kiro-success/30 flex items-start gap-3">
+    <p class="text-sm text-kiro-success flex-1">{message}</p>
+    {#if onmessageDismiss}
+      <button
+        type="button"
+        onclick={() => onmessageDismiss?.()}
+        aria-label="Dismiss success message"
+        class="text-kiro-success/70 hover:text-kiro-success text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
+    {/if}
+  </div>
+{/if}
+
+{#if warning}
+  <div
+    data-testid="install-warning"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-warning flex-1">{warning}</p>
+    <button
+      type="button"
+      onclick={() => onwarningDismiss?.()}
+      aria-label="Dismiss install warning"
+      class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/if}
+```
+
+- [ ] **Step 8.2: Verify it typechecks**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors. (Component isn't consumed yet but must compile standalone.)
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/BannerStack.svelte
+git commit -m "feat(ui): extract BannerStack component from BrowseTab"
+```
+
+---
+
+## Task 9: BrowseTab — adopt BannerStack (no behavior change)
+
+Replace the inline banner render block (current `BrowseTab.svelte:1066-1132`) with a `<BannerStack>` invocation. Verifies the extraction is faithful before we layer Update-related behavior on top.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`
+
+- [ ] **Step 9.1: Add import**
+
+In `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`, add to the imports near the top of the `<script>` block (alongside the existing `import SkillCard from "./SkillCard.svelte";` / `import PluginCard from "./PluginCard.svelte";`):
+
+```svelte
+  import BannerStack from "./BannerStack.svelte";
+```
+
+- [ ] **Step 9.2: Replace the inline banner block**
+
+In `BrowseTab.svelte`, locate the existing render block from the comment "Banners render newest-first..." through the closing `{#if installWarning}` block (currently lines ~1066-1132 — search for the `data-testid="fetch-error"` and `data-testid="install-warning"` markers).
+
+Replace that entire block with a single component invocation:
+
+```svelte
+  <BannerStack
+    errors={fetchErrors}
+    message={installMessage}
+    warning={installWarning}
+    fatalError={installError}
+    errLabel={errLabel}
+    ondismiss={(key) => fetchErrors.delete(key)}
+    onmessageDismiss={() => (installMessage = null)}
+    onwarningDismiss={() => (installWarning = null)}
+    onfatalErrorDismiss={() => (installError = null)}
+  />
+```
+
+(No `as ErrorSource` cast on `ondismiss` — Svelte 5's `generics="K extends string"` on `BannerStack` propagates the `ErrorSource` type through the callback.)
+
+- [ ] **Step 9.3: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 9.4: Manual smoke — banners still render**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:1420`. Verify the existing banner UX still works (e.g. add a marketplace, see success banner; dismiss it). Then close the dev server.
+
+- [ ] **Step 9.5: Run unit tests**
+
+```bash
+npm run test:unit
+```
+
+Expected: still 22 passing — no new tests in this task.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+git commit -m "refactor(browse): consume BannerStack component"
+```
+
+---
+
+## Task 10: PluginCard — Update + failure states
+
+Add the two new props (`update`, `failure`) and the new `onUpdate` callback. Implement the action-area state machine per the design (`design.md:205-218`). The card stays usable for callers that don't pass the new props (BrowseTab is the only caller and will pass them in Task 11).
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/PluginCard.svelte`
+
+- [ ] **Step 10.1: Update the script block**
+
+Replace the entirety of `crates/kiro-control-center/src/lib/components/PluginCard.svelte`'s `<script>` block (current lines 1-30) with:
+
+```svelte
+<script lang="ts">
+  import type {
+    PluginInfo,
+    PluginUpdateFailure,
+    PluginUpdateInfo,
+  } from "$lib/bindings";
+  import { kindLabel } from "$lib/stores/plugin-updates";
+  import { skillCountLabel, skillCountTitle } from "$lib/format";
+
+  type Props = {
+    plugin: PluginInfo;
+    marketplace: string;
+    installed: boolean;
+    installing: boolean;
+    updating: boolean;
+    update: PluginUpdateInfo | undefined;
+    failure: PluginUpdateFailure | undefined;
+    projectPicked: boolean;
+    onInstall: () => void;
+    onUpdate: () => void;
+  };
+
+  let {
+    plugin,
+    marketplace,
+    installed,
+    installing,
+    updating,
+    update,
+    failure,
+    projectPicked,
+    onInstall,
+    onUpdate,
+  }: Props = $props();
+
+  const installTitle = $derived(
+    !projectPicked
+      ? "Pick a project first"
+      : installed
+        ? `${plugin.name} is already installed in this project`
+        : `Install ${plugin.name} (skills + steering + agents) into the active project`,
+  );
+
+  // Update button label per Phase 2b design decision #6:
+  //   - VersionBumped + both versions known      → "Update → vN"
+  //   - VersionBumped + installed_version null   → "Update → vN" (legacy install; → reads as "to vN")
+  //   - VersionBumped + available_version null   → "Update"      (manifest declares no version)
+  //   - ContentChanged                            → "Update (content changed)"
+  const updateLabel = $derived.by(() => {
+    if (!update) return "Update";
+    if (update.change_signal.kind === "content_changed") return "Update (content changed)";
+    if (update.available_version) return `Update → v${update.available_version}`;
+    return "Update";
+  });
+</script>
+```
+
+- [ ] **Step 10.2: Update the action-area markup**
+
+Replace the existing action-area block (current lines ~57-80, the `<div class="flex flex-col items-end gap-1.5 flex-shrink-0">...</div>` block at the right side of the card) with:
+
+```svelte
+  <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
+    {#if installing}
+      <button
+        type="button"
+        disabled
+        aria-busy="true"
+        aria-label="Installing {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed"
+      >
+        Installing…
+      </button>
+    {:else if updating}
+      <button
+        type="button"
+        disabled
+        aria-busy="true"
+        aria-label="Updating {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed"
+      >
+        Updating…
+      </button>
+    {:else if failure && installed}
+      <span
+        class="px-2 py-0.5 text-[11px] font-medium text-kiro-error border border-kiro-error/40 rounded"
+        title={kindLabel(failure.kind)}
+      >
+        Update check failed
+      </span>
+    {:else if update}
+      <button
+        type="button"
+        onclick={onUpdate}
+        disabled={!projectPicked}
+        title="Update will replace local edits to plugin files"
+        aria-label="Update {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-kiro-warning/10 border border-kiro-warning/40 text-kiro-warning hover:bg-kiro-warning/15 transition-colors"
+      >
+        {updateLabel}
+      </button>
+    {:else if installed}
+      <span
+        class="px-2 py-0.5 text-[11px] font-medium text-kiro-success border border-kiro-success/40 rounded"
+      >
+        Installed
+      </span>
+    {:else}
+      <button
+        type="button"
+        onclick={onInstall}
+        disabled={!projectPicked}
+        aria-busy={installing}
+        title={installTitle}
+        aria-label="Install {plugin.name}"
+        class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+          {projectPicked
+            ? 'bg-kiro-overlay border border-kiro-muted text-kiro-accent-300 hover:bg-kiro-muted hover:text-kiro-accent-200'
+            : 'bg-kiro-muted text-kiro-subtle border border-transparent cursor-not-allowed'}"
+      >
+        Install
+      </button>
+    {/if}
+  </div>
+```
+
+- [ ] **Step 10.3: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: errors — BrowseTab still calls PluginCard with the old prop set. That's expected; Task 11 fixes BrowseTab. Don't commit yet.
+
+- [ ] **Step 10.4: Note the breakage and proceed**
+
+The `npm run check` failure here is expected and isolated (only BrowseTab's two-place PluginCard invocation is affected). Task 11 closes the loop. Skip the typecheck pass-requirement for this task only.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/PluginCard.svelte
+git commit -m "feat(ui): add Update / failure / updating states to PluginCard"
+```
+
+---
+
+## Task 11: BrowseTab — wire pluginUpdates store + Update flow + new PluginCard props
+
+The big BrowseTab change. Refactors the per-plugin in-flight tracker from `pendingPluginInstalls: SvelteSet<string>` to `pendingPluginActions: SvelteMap<string, "install" | "update">`, consumes `pluginUpdates`, projects `failureGroups` into `fetchErrors`, surfaces `pluginUpdates.fetchError`, and adds the `updatePlugin` handler. Closes the typecheck breakage from Task 10.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/BrowseTab.svelte`
+
+- [ ] **Step 11.1: Add new imports**
+
+Add to the existing imports block at the top of `BrowseTab.svelte`'s `<script>`:
+
+```svelte
+  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+  import { formatInstallPluginResult } from "$lib/format";
+```
+
+- [ ] **Step 11.2: Extend `ErrorSource`**
+
+Find the existing `ErrorSource` literal-union type (currently around `BrowseTab.svelte:46-55`). Extend it with the two new key families:
+
+```diff
+   const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
++  const ERR_UPDATE_FETCH = "update-fetch" as const;
++  const UPDATE_CHECK_PREFIX = "update-check" as const;
+   type ErrorSource =
+     | typeof ERR_MARKETPLACES
+     | typeof ERR_INSTALLED_PLUGINS
++    | typeof ERR_UPDATE_FETCH
++    | `${typeof UPDATE_CHECK_PREFIX}${string}${string}`
+     | `${typeof PLUGINS_ERR_PREFIX}${string}`
+     | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`
+     | `${typeof BULK_SKILLS_ERR_PREFIX}${string}`;
+```
+
+- [ ] **Step 11.3: Extend `errLabel` for the new keys**
+
+Find the existing `errLabel` function (currently around `BrowseTab.svelte:64-75`). Add branches for the two new keys before the existing `if (key.startsWith(PLUGINS_ERR_PREFIX))` branch:
+
+```ts
+  function errLabel(key: ErrorSource): string {
+    if (key === ERR_MARKETPLACES) return "Dismiss marketplaces error";
+    if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins error";
+    if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
+    if (key.startsWith(UPDATE_CHECK_PREFIX)) {
+      const rest = key.slice(UPDATE_CHECK_PREFIX.length);
+      const sepIdx = rest.indexOf("");
+      const marketplace = sepIdx >= 0 ? rest.slice(sepIdx + 1) : rest;
+      return `Dismiss update-check banner for ${marketplace}`;
+    }
+    if (key.startsWith(PLUGINS_ERR_PREFIX)) {
+      return `Dismiss error for ${key.slice(PLUGINS_ERR_PREFIX.length)}`;
+    }
+    if (key.startsWith(BULK_SKILLS_ERR_PREFIX)) {
+      return `Dismiss error for ${key.slice(BULK_SKILLS_ERR_PREFIX.length)}`;
+    }
+    const { marketplace, plugin } = parsePluginKey(key.slice(SKILLS_ERR_PREFIX.length));
+    return `Dismiss error for ${marketplace}/${plugin}`;
+  }
+```
+
+- [ ] **Step 11.4: Replace `pendingPluginInstalls` with `pendingPluginActions`**
+
+Find the existing declaration (currently around `BrowseTab.svelte:94`):
+
+Add to the existing `<script>` imports:
+
+```svelte
+  import type { PluginAction } from "$lib/stores/plugin-updates";
+```
+
+Then update the in-flight tracker declaration:
+
+```diff
+-  let pendingPluginInstalls = new SvelteSet<string>();
++  // Per-plugin in-flight tracker keyed by pluginKey(marketplace, plugin).
++  // Narrows the shared PluginAction union to the actions BrowseTab actually
++  // performs (Install + Update — never Remove, that's InstalledTab's surface).
++  let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "install" | "update">>();
+```
+
+Now find every site reading `pendingPluginInstalls`:
+
+- The `installWholePlugin` body (currently `BrowseTab.svelte:734-852`): replace `pendingPluginInstalls.has(key)` / `pendingPluginInstalls.add(key)` / `pendingPluginInstalls.delete(key)` with `pendingPluginActions.has(key)` / `pendingPluginActions.set(key, "install")` / `pendingPluginActions.delete(key)`.
+- The `installing` prop passed to `PluginCard` (currently in the `{#each availablePlugins}` block around `BrowseTab.svelte:1215-1226`): replace `installing={pendingPluginInstalls.has(key)}` with `installing={pendingPluginActions.get(key) === "install"}`.
+
+(Cargo for the second point: in Task 11.7 below the same `{#each}` block gains the new props.)
+
+- [ ] **Step 11.5: Add `updatePlugin` handler**
+
+Append a new function below `installWholePlugin` in `BrowseTab.svelte`'s `<script>` (right after the closing brace of `installWholePlugin`):
+
+```ts
+  // Update an installed plugin. Calls the same `installPlugin` command
+  // used by Install but with `force=true` hard-coded — the existing
+  // global `forceInstall` checkbox stays bound to the Install button
+  // path. `pluginUpdates.refresh` re-runs the scan after the update so
+  // the indicator clears; `fetchInstalledPlugins` refreshes the
+  // installed-set so any new content type the update added shows up.
+  async function updatePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "update");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    try {
+      const result = await commands.installPlugin(
+        marketplace,
+        plugin,
+        /*force=*/ true,
+        /*acceptMcp=*/ false,
+        projectPath,
+      );
+      if (result.status === "ok") {
+        const { summary, warnings, anyInstalled, anyFailed } =
+          formatInstallPluginResult(result.data, plugin);
+        if (anyFailed && !anyInstalled) {
+          installError = `Update failed for ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Updated ${plugin}: ${summary}`;
+        }
+        if (warnings) {
+          installWarning = `Updated ${plugin}: ${warnings}`;
+        }
+        await pluginUpdates.refresh(projectPath);
+        await fetchInstalledPlugins();
+      } else {
+        installError = `Update failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Update failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginActions.delete(key);
+    }
+  }
+```
+
+- [ ] **Step 11.6: Wire pluginUpdates.refresh to projectPath changes**
+
+Find the existing `$effect` block that fans out on `projectPath` changes (around `BrowseTab.svelte:433-437`, `void projectPath; fetchInstalledPlugins();`). Add a sibling `$effect`:
+
+```ts
+  // Phase 2b: re-run update-scan whenever projectPath changes. The
+  // store tracks `lastProjectPath` itself so a no-op call (same path
+  // repeatedly) is harmless. Re-runs after a marketplace fetch are
+  // triggered by `+page.svelte` via `MarketplacesTab.onUpdated`, not
+  // here.
+  $effect(() => {
+    void projectPath;
+    pluginUpdates.refresh(projectPath);
+  });
+```
+
+- [ ] **Step 11.7: Project failureGroups + fetchError into fetchErrors**
+
+Add a sibling `$effect` to the same script block (after the one above):
+
+```ts
+  // Project per-marketplace failure groups into the fetchErrors banner
+  // map. Re-runs whenever pluginUpdates.failureGroups changes; clears
+  // any previously-projected `update-check<...>` keys not in the
+  // new group set so a recovered marketplace's banner disappears.
+  $effect(() => {
+    const seen = new Set<ErrorSource>();
+    for (const group of pluginUpdates.failureGroups) {
+      const key: ErrorSource =
+        `${UPDATE_CHECK_PREFIX}${group.remediation}${group.marketplace}` as ErrorSource;
+      seen.add(key);
+      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
+      const list = group.plugins.join(", ");
+      fetchErrors.set(
+        key,
+        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
+      );
+    }
+    for (const k of fetchErrors.keys()) {
+      if (k.startsWith(UPDATE_CHECK_PREFIX) && !seen.has(k)) {
+        fetchErrors.delete(k);
+      }
+    }
+  });
+
+  // Surface the toplevel pluginUpdates.fetchError as its own banner.
+  // Distinct from the per-group keys above: this is "scan didn't run
+  // at all" (couldn't read tracking files), not "scan ran, some
+  // plugins failed".
+  $effect(() => {
+    if (pluginUpdates.fetchError) {
+      fetchErrors.set(
+        ERR_UPDATE_FETCH,
+        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
+      );
+    } else {
+      fetchErrors.delete(ERR_UPDATE_FETCH);
+    }
+  });
+```
+
+- [ ] **Step 11.8: Pass new props to PluginCard**
+
+Find the `<PluginCard ...>` invocation inside the `{#each availablePlugins}` block (around `BrowseTab.svelte:1215-1226`). Replace it with:
+
+```svelte
+            <PluginCard
+              plugin={ap.plugin}
+              marketplace={ap.marketplace}
+              installed={installedPluginKeys.has(key)}
+              installing={pendingPluginActions.get(key) === "install"}
+              updating={pendingPluginActions.get(key) === "update"}
+              update={pluginUpdates.updateFor(ap.marketplace, ap.plugin.name)}
+              failure={pluginUpdates.failureFor(ap.marketplace, ap.plugin.name)}
+              projectPicked={!!projectPath}
+              onInstall={() => installWholePlugin(ap.marketplace, ap.plugin.name)}
+              onUpdate={() => updatePlugin(ap.marketplace, ap.plugin.name)}
+            />
+```
+
+- [ ] **Step 11.9: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors. (Closes the breakage from Task 10.)
+
+- [ ] **Step 11.10: Run unit tests**
+
+```bash
+npm run test:unit
+```
+
+Expected: 22 still passing.
+
+- [ ] **Step 11.11: Manual smoke**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:1420`. Navigate to Browse. Verify cards still render, Install still works on a non-installed plugin (if the dev environment has a marketplace fixture), and no errors in the browser console. Then close the dev server.
+
+- [ ] **Step 11.12: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+git commit -m "feat(browse): wire pluginUpdates store + Update button + failure banners"
+```
+
+---
+
+## Task 12: InstalledTab — adopt BannerStack + pendingPluginActions
+
+Mirror BrowseTab's banner channels in InstalledTab. Replace `removingKey: string | null` with `pendingPluginActions: SvelteMap<string, "remove" | "update">`. Adds `installError | installMessage | installWarning` channels; the existing `loadError` narrows to fetch/refresh failures.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/InstalledTab.svelte`
+
+- [ ] **Step 12.1: Update the script block scaffolding**
+
+Replace the existing `<script>` block opener and state declarations in `crates/kiro-control-center/src/lib/components/InstalledTab.svelte` (currently lines 1-25). Replace:
+
+```svelte
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { commands } from "$lib/bindings";
+  import type {
+    InstalledSkillInfo,
+    InstalledPluginInfo,
+  } from "$lib/bindings";
+  import { pluginKey } from "$lib/keys";
+
+  let { projectPath }: { projectPath: string } = $props();
+
+  let plugins: InstalledPluginInfo[] = $state([]);
+  let skills: InstalledSkillInfo[] = $state([]);
+  let loading: boolean = $state(true);
+  let loadError: string | null = $state(null);
+  // Non-fatal partial-load detail (one or more `installed-*.json` tracking
+  // files failed to parse; the others loaded). Distinct from `loadError`
+  // (red, fatal) — the table still has rows from the files that DID load.
+  let loadWarning: string | null = $state(null);
+  // Single removal in flight at a time — `remove_plugin` reads/writes the
+  // installed-skills/steering/agents tracking files, so racing two removes
+  // could clobber each other. Disabling all Remove buttons while one is
+  // pending is the simplest correctness-preserving UI.
+  let removingKey: string | null = $state(null);
+```
+
+with:
+
+```svelte
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { SvelteMap } from "svelte/reactivity";
+  import { commands } from "$lib/bindings";
+  import type {
+    InstalledSkillInfo,
+    InstalledPluginInfo,
+    PluginUpdateInfo,
+    PluginUpdateFailure,
+    RemovePluginResult,
+  } from "$lib/bindings";
+  import { pluginKey } from "$lib/keys";
+  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+  import { kindLabel } from "$lib/stores/plugin-updates";
+  import type { PluginAction } from "$lib/stores/plugin-updates";
+  import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
+  import BannerStack from "./BannerStack.svelte";
+
+  let { projectPath }: { projectPath: string } = $props();
+
+  let plugins: InstalledPluginInfo[] = $state([]);
+  let skills: InstalledSkillInfo[] = $state([]);
+  let loading: boolean = $state(true);
+  // `loadError` narrows in 2b: only fetch/refresh failures land here.
+  // Remove-action failures route to `installError` (matching BrowseTab).
+  let loadError: string | null = $state(null);
+
+  // 3-banner pattern mirrored from BrowseTab. installError = red fatal,
+  // installMessage = green success, installWarning = amber non-fatal.
+  let installError: string | null = $state(null);
+  let installMessage: string | null = $state(null);
+  let installWarning: string | null = $state(null);
+
+  // Per-plugin in-flight tracker, keyed by pluginKey(marketplace, plugin).
+  // Narrows the shared PluginAction union to the actions InstalledTab
+  // performs (Remove + Update — never Install, that's BrowseTab's surface).
+  let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "remove" | "update">>();
+
+  // The most recent RemovePluginResult — drives the inline <details>
+  // block below the BannerStack. Stays set until the next Remove or
+  // a project change clears it.
+  let removeResult: RemovePluginResult | null = $state(null);
+  let removeResultPlugin: string | null = $state(null);
+  let removeResultHasFailures: boolean = $state(false);
+
+  // Banner-stack typing — InstalledTab's ErrorSource union is small for
+  // 2b: only the new update-check + update-fetch keys plus a single
+  // installed-plugins key for partial-load warnings (existing).
+  const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
+  const ERR_UPDATE_FETCH = "update-fetch" as const;
+  const UPDATE_CHECK_PREFIX = "update-check" as const;
+  type ErrorSource =
+    | typeof ERR_INSTALLED_PLUGINS
+    | typeof ERR_UPDATE_FETCH
+    | `${typeof UPDATE_CHECK_PREFIX}${string}${string}`;
+  let fetchErrors = new SvelteMap<ErrorSource, string>();
+
+  function errLabel(key: ErrorSource): string {
+    if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins warning";
+    if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
+    if (key.startsWith(UPDATE_CHECK_PREFIX)) {
+      const rest = key.slice(UPDATE_CHECK_PREFIX.length);
+      const sepIdx = rest.indexOf("");
+      const marketplace = sepIdx >= 0 ? rest.slice(sepIdx + 1) : rest;
+      return `Dismiss update-check banner for ${marketplace}`;
+    }
+    return "Dismiss banner";
+  }
+```
+
+- [ ] **Step 12.2: Update the `removePlugin` handler**
+
+Replace the existing `removePlugin` function (current lines 64-81) with:
+
+```ts
+  async function removePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "remove");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    removeResult = null;
+    removeResultPlugin = null;
+    removeResultHasFailures = false;
+    try {
+      const result = await commands.removePlugin(marketplace, plugin, projectPath);
+      if (result.status === "ok") {
+        const { summary, hasItems, hasFailures } =
+          formatRemovePluginResult(result.data, plugin);
+        if (hasItems || hasFailures) {
+          removeResult = result.data;
+          removeResultPlugin = plugin;
+          removeResultHasFailures = hasFailures;
+        }
+        if (hasFailures) {
+          installWarning = `Removed plugin ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Removed plugin ${plugin}: ${summary}`;
+        }
+        // Order: pluginUpdates.refresh first, local refresh second.
+        // Matches BrowseTab.updatePlugin (Step 11.5) and InstalledTab
+        // .updatePlugin (Step 12.3) — uniform across all action handlers.
+        await pluginUpdates.refresh(projectPath);
+        await refresh();
+      } else {
+        installError = `Remove failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Remove failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginActions.delete(key);
+    }
+  }
+```
+
+- [ ] **Step 12.3: Add the `updatePlugin` handler**
+
+Append to the `<script>` block (right after `removePlugin`'s closing brace):
+
+```ts
+  async function updatePlugin(marketplace: string, plugin: string) {
+    const key = pluginKey(marketplace, plugin);
+    if (pendingPluginActions.has(key)) return;
+    pendingPluginActions.set(key, "update");
+    installError = null;
+    installMessage = null;
+    installWarning = null;
+    removeResult = null;
+    try {
+      const result = await commands.installPlugin(
+        marketplace,
+        plugin,
+        /*force=*/ true,
+        /*acceptMcp=*/ false,
+        projectPath,
+      );
+      if (result.status === "ok") {
+        const { summary, warnings, anyInstalled, anyFailed } =
+          formatInstallPluginResult(result.data, plugin);
+        if (anyFailed && !anyInstalled) {
+          installError = `Update failed for ${plugin}: ${summary}`;
+        } else {
+          installMessage = `Updated ${plugin}: ${summary}`;
+        }
+        if (warnings) {
+          installWarning = `Updated ${plugin}: ${warnings}`;
+        }
+        await pluginUpdates.refresh(projectPath);
+        await refresh();
+      } else {
+        installError = `Update failed for ${plugin}: ${result.error.message}`;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      installError = `Update failed for ${plugin}: ${reason}`;
+    } finally {
+      pendingPluginActions.delete(key);
+    }
+  }
+```
+
+- [ ] **Step 12.4: Update the existing `refresh` function — narrow loadError, route partial-load to fetchErrors**
+
+Replace the existing `refresh()` body (current lines 26-62) with:
+
+```ts
+  async function refresh() {
+    loading = true;
+    loadError = null;
+    try {
+      const [pluginsResult, skillsResult] = await Promise.all([
+        commands.listInstalledPlugins(projectPath),
+        commands.listInstalledSkills(projectPath),
+      ]);
+      if (pluginsResult.status === "ok") {
+        plugins = pluginsResult.data.plugins;
+        const warnings = pluginsResult.data.partial_load_warnings ?? [];
+        if (warnings.length > 0) {
+          const summary = warnings
+            .map((w) => `${w.tracking_file}: ${w.error}`)
+            .join("; ");
+          fetchErrors.set(
+            ERR_INSTALLED_PLUGINS,
+            `Installed plugins partially loaded — ${summary}`,
+          );
+        } else {
+          fetchErrors.delete(ERR_INSTALLED_PLUGINS);
+        }
+      } else {
+        loadError = pluginsResult.error.message;
+      }
+      if (skillsResult.status === "ok") {
+        skills = skillsResult.data;
+      } else if (loadError === null) {
+        loadError = skillsResult.error.message;
+      }
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      loadError = `Failed to load installed state: ${reason}`;
+    } finally {
+      loading = false;
+    }
+  }
+```
+
+(Note: `partial_load_warnings` previously drove a standalone `loadWarning` banner; Step 12.1 already excluded that state from the new script block, and the new `refresh()` routes the warning through `fetchErrors[ERR_INSTALLED_PLUGINS]` for symmetry with BrowseTab.)
+
+- [ ] **Step 12.5: Add the pluginUpdates wiring effects**
+
+Append to the `<script>` block (after the existing `$effect` and `onMount(refresh)` calls — preserving them):
+
+```ts
+  // Eager scan on project mount + on every projectPath change.
+  $effect(() => {
+    void projectPath;
+    pluginUpdates.refresh(projectPath);
+  });
+
+  // Project per-marketplace failure groups into the fetchErrors map.
+  $effect(() => {
+    const seen = new Set<ErrorSource>();
+    for (const group of pluginUpdates.failureGroups) {
+      const key: ErrorSource =
+        `${UPDATE_CHECK_PREFIX}${group.remediation}${group.marketplace}` as ErrorSource;
+      seen.add(key);
+      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
+      const list = group.plugins.join(", ");
+      fetchErrors.set(
+        key,
+        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
+      );
+    }
+    for (const k of fetchErrors.keys()) {
+      if (k.startsWith(UPDATE_CHECK_PREFIX) && !seen.has(k)) {
+        fetchErrors.delete(k);
+      }
+    }
+  });
+
+  // Surface the toplevel pluginUpdates.fetchError as its own banner.
+  $effect(() => {
+    if (pluginUpdates.fetchError) {
+      fetchErrors.set(
+        ERR_UPDATE_FETCH,
+        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
+      );
+    } else {
+      fetchErrors.delete(ERR_UPDATE_FETCH);
+    }
+  });
+
+  // Helpers used by the table render block.
+  function statusUpdateLabel(u: PluginUpdateInfo): string {
+    // ContentChanged: phrased as a status (full sentence) rather than the
+    // PluginCard button's action label ("Update (content changed)").
+    // The two surfaces intentionally differ — column = state; button = action.
+    if (u.change_signal.kind === "content_changed") return "Content changed since install";
+    // VersionBumped: prefer the explicit "v_old → v_new" form when both
+    // versions are known; fall back to "vN available" for legacy installs
+    // (installed_version: None) and to a bare "Update available" when the
+    // marketplace manifest declares no version.
+    if (u.installed_version && u.available_version) {
+      return `v${u.installed_version} → v${u.available_version}`;
+    }
+    if (u.available_version) return `v${u.available_version} available`;
+    return "Update available";
+  }
+
+  function updateInfoFor(p: InstalledPluginInfo): PluginUpdateInfo | undefined {
+    return pluginUpdates.updateFor(p.marketplace, p.plugin);
+  }
+
+  function failureFor(p: InstalledPluginInfo): PluginUpdateFailure | undefined {
+    return pluginUpdates.failureFor(p.marketplace, p.plugin);
+  }
+```
+
+- [ ] **Step 12.6: Verify `loadWarning` is fully gone**
+
+Step 12.1's `<script>` replacement block already excluded `let loadWarning`; Step 12.4's refresh body no longer touches it. This step is a no-op verification:
+
+```bash
+grep -n loadWarning crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+```
+
+Expected: no matches. If any references remain, delete them — they're dead.
+
+In the markup (replaced wholesale in Task 13), the standalone `data-testid="installed-load-warning"` block is also gone — Task 13's full-markup replacement supersedes it.
+
+- [ ] **Step 12.7: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors. (Markup updates land in Task 13; the script changes alone should typecheck because removeResult is read in the markup that's still about to change. Cargo: if `removeResult` triggers an unused-state warning, ignore — Task 13 reads it.)
+
+If `npm run check` complains about unused declarations, ignore — they get consumed in Task 13.
+
+- [ ] **Step 12.8: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+git commit -m "feat(installed): wire pluginUpdates + extend banner channels (script)"
+```
+
+---
+
+## Task 13: InstalledTab — Status column, Update button, BannerStack, `<details>` toast
+
+Mirror Task 12 in markup. Adds the Status column, the Update action button, the inline `<details>` block for `removeResult`, and replaces the legacy banner UI with `<BannerStack>`.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/InstalledTab.svelte`
+
+- [ ] **Step 13.1: Replace the entire `<div class="flex flex-col h-full">` template block**
+
+Replace everything from `<div class="flex flex-col h-full">` to the end of the file (current lines 106-216) with:
+
+```svelte
+<div class="flex flex-col h-full">
+  <BannerStack
+    errors={fetchErrors}
+    message={installMessage}
+    warning={installWarning}
+    fatalError={installError}
+    errLabel={errLabel}
+    ondismiss={(key) => fetchErrors.delete(key)}
+    onmessageDismiss={() => (installMessage = null)}
+    onwarningDismiss={() => (installWarning = null)}
+    onfatalErrorDismiss={() => (installError = null)}
+  />
+
+  {#if removeResult && removeResultPlugin}
+    <div
+      class="mx-4 mt-3 px-4 py-3 rounded-md text-sm flex items-start gap-3
+        {removeResultHasFailures
+          ? 'bg-kiro-warning/10 border border-kiro-warning/30 text-kiro-warning'
+          : 'bg-kiro-success/10 border border-kiro-success/30 text-kiro-success'}"
+    >
+      <details
+        class="flex-1"
+        open={removeResultHasFailures}
+      >
+        <summary class="cursor-pointer text-xs opacity-85">
+          {removeResultHasFailures ? "Show items + failures" : "Show items"}
+        </summary>
+        <div class="mt-2 pl-3 border-l-2 border-current/40 text-xs space-y-1">
+          {#if (removeResult.skills.removed ?? []).length > 0}
+            <div><b>Skills removed:</b> {(removeResult.skills.removed ?? []).join(", ")}</div>
+          {/if}
+          {#if (removeResult.steering.removed ?? []).length > 0}
+            <div><b>Steering removed:</b> {(removeResult.steering.removed ?? []).join(", ")}</div>
+          {/if}
+          {#if (removeResult.agents.removed ?? []).length > 0}
+            <div><b>Agents removed:</b> {(removeResult.agents.removed ?? []).join(", ")}</div>
+          {/if}
+          {#each removeResult.skills.failures ?? [] as f (f.item)}
+            <div><b>Skill failed:</b> {f.item} — {f.error}</div>
+          {/each}
+          {#each removeResult.steering.failures ?? [] as f (f.item)}
+            <div><b>Steering failed:</b> {f.item} — {f.error}</div>
+          {/each}
+          {#each removeResult.agents.failures ?? [] as f (f.item)}
+            <div><b>Agent failed:</b> {f.item} — {f.error}</div>
+          {/each}
+        </div>
+      </details>
+      <button
+        type="button"
+        onclick={() => { removeResult = null; removeResultPlugin = null; }}
+        aria-label="Dismiss remove summary"
+        class="opacity-70 hover:opacity-100 text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+      >
+        ×
+      </button>
+    </div>
+  {/if}
+
+  <div class="flex-1 overflow-y-auto p-4">
+    {#if loading}
+      <div class="flex flex-col items-center justify-center h-full text-kiro-subtle gap-3">
+        <svg class="w-8 h-8 text-kiro-accent-800 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+        <p class="text-sm">Loading installed state...</p>
+      </div>
+    {:else if loadError}
+      <div class="px-4 py-3 rounded-md bg-kiro-error/10 border border-kiro-error/30">
+        <p class="text-sm text-kiro-error">{loadError}</p>
+      </div>
+    {:else}
+      <section class="mb-6">
+        <h2 class="text-sm font-semibold text-kiro-text mb-3">Installed plugins</h2>
+        {#if plugins.length === 0}
+          <p class="text-sm text-kiro-subtle">No plugins installed in this project.</p>
+        {:else}
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+                <th class="px-4 py-2">Plugin</th>
+                <th class="px-4 py-2">Marketplace</th>
+                <th class="px-4 py-2">Version</th>
+                <th class="px-4 py-2">Status</th>
+                <th class="px-4 py-2">Contents</th>
+                <th class="px-4 py-2">Installed at</th>
+                <th class="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each plugins as p (pluginKey(p.marketplace, p.plugin))}
+                {@const key = pluginKey(p.marketplace, p.plugin)}
+                {@const updateInfo = updateInfoFor(p)}
+                {@const failure = failureFor(p)}
+                {@const action = pendingPluginActions.get(key)}
+                <tr class="border-b border-kiro-muted/50">
+                  <td class="px-4 py-3 font-medium text-kiro-text">{p.plugin}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{p.marketplace}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{p.installed_version ?? "—"}</td>
+                  <td class="px-4 py-3">
+                    {#if updateInfo}
+                      <span
+                        class="px-2 py-0.5 text-[11px] font-medium text-kiro-warning border border-kiro-warning/40 rounded"
+                      >
+                        {statusUpdateLabel(updateInfo)}
+                      </span>
+                    {:else if failure}
+                      <span
+                        class="px-2 py-0.5 text-[11px] font-medium text-kiro-error border border-kiro-error/40 rounded"
+                        title={kindLabel(failure.kind)}
+                      >
+                        Update check failed
+                      </span>
+                    {:else}
+                      <span class="text-kiro-success text-[11px]">Up to date</span>
+                    {/if}
+                  </td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{contentSummary(p)}</td>
+                  <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(p.latest_install)}</td>
+                  <td class="px-4 py-3 text-right">
+                    <div class="inline-flex gap-2">
+                      {#if updateInfo}
+                        <button
+                          type="button"
+                          onclick={() => updatePlugin(p.marketplace, p.plugin)}
+                          disabled={action !== undefined}
+                          aria-busy={action === "update"}
+                          title="Update will replace local edits to plugin files"
+                          class="px-2 py-0.5 text-[11px] text-kiro-warning hover:text-kiro-warning/80 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {action === "update" ? "Updating…" : "Update"}
+                        </button>
+                      {/if}
+                      <button
+                        type="button"
+                        onclick={() => removePlugin(p.marketplace, p.plugin)}
+                        disabled={action !== undefined}
+                        aria-busy={action === "remove"}
+                        class="px-2 py-0.5 text-[11px] text-kiro-subtle hover:text-kiro-error disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {action === "remove" ? "Removing…" : "Remove"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </section>
+
+      <details class="mb-6">
+        <summary class="cursor-pointer text-sm font-medium text-kiro-text-secondary hover:text-kiro-text">
+          All installed skills (flat view)
+        </summary>
+        <div class="mt-3">
+          {#if skills.length === 0}
+            <p class="text-sm text-kiro-subtle">No skills installed.</p>
+          {:else}
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-[11px] uppercase tracking-wider text-kiro-subtle border-b border-kiro-muted">
+                  <th class="px-4 py-2">Name</th>
+                  <th class="px-4 py-2">Marketplace</th>
+                  <th class="px-4 py-2">Plugin</th>
+                  <th class="px-4 py-2">Version</th>
+                  <th class="px-4 py-2">Installed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each skills as skill (skill.name)}
+                  <tr class="border-b border-kiro-muted/50">
+                    <td class="px-4 py-3 text-kiro-text">{skill.name}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.marketplace}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.plugin}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{skill.version ?? "—"}</td>
+                    <td class="px-4 py-3 text-kiro-text-secondary">{formatDate(skill.installed_at)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {/if}
+        </div>
+      </details>
+    {/if}
+  </div>
+</div>
+```
+
+(`formatDate` and `contentSummary` are existing functions in InstalledTab; the `<script>` block kept them intact in Task 12. The `loadWarning` block previously rendered standalone is gone — `partial_load_warnings` now route through `fetchErrors`.)
+
+- [ ] **Step 13.2: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 13.3: Run unit tests**
+
+```bash
+npm run test:unit
+```
+
+Expected: 22 still passing.
+
+- [ ] **Step 13.4: Manual smoke**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:1420`. Navigate to Installed. Verify:
+- The table renders Plugin / Marketplace / Version / **Status** / Contents / **Installed at** / actions columns.
+- Status reads "Up to date" for plugins with no available update.
+- Remove still works (will produce the new toast with `<details>`).
+
+Then close the dev server.
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+git commit -m "feat(installed): Status column + Update button + details toast"
+```
+
+---
+
+## Task 14: MarketplacesTab — `onUpdated` callback prop
+
+Wire a callback that fires after a successful `commands.updateMarketplace`. The parent (`+page.svelte`) calls `pluginUpdates.refresh(store.projectPath)` from this callback so the scan re-fires when marketplace cache content changes.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte`
+
+- [ ] **Step 14.1: Add the `onUpdated` callback prop**
+
+Edit `crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte`. Replace the top of the `<script>` block (currently lines 1-3):
+
+```diff
+ <script lang="ts">
+   import { commands } from "$lib/bindings";
+   import type { MarketplaceInfo, GitProtocol } from "$lib/bindings";
++
++  // Phase 2b: parent (`+page.svelte`) wires this to
++  // `pluginUpdates.refresh(store.projectPath)` so a successful marketplace
++  // update invalidates the cached update-detection scan.
++  type Props = {
++    onUpdated?: (marketplaceName: string) => void;
++  };
++  let { onUpdated }: Props = $props();
+```
+
+- [ ] **Step 14.2: Fire the callback on successful update**
+
+Find the existing `updateMarketplace` function (lines 48-66). Append the callback fire inside the success branch:
+
+```diff
+     const result = await commands.updateMarketplace(name);
+     if (result.status === "ok") {
+       const { updated, failed, skipped } = result.data;
+       const parts: string[] = [];
+       if (updated.length > 0) parts.push(`Updated: ${updated.join(", ")}`);
+       if (skipped.length > 0) parts.push(`Skipped: ${skipped.join(", ")}`);
+       if (failed.length > 0) parts.push(`Failed: ${failed.map((f) => `${f.name} (${f.error})`).join(", ")}`);
+       successMessage = parts.join(" | ");
+       await loadMarketplaces();
++      onUpdated?.(name);
+     } else {
+       error = result.error.message;
+     }
+```
+
+- [ ] **Step 14.3: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors. (`+page.svelte` doesn't pass the prop yet — that's Task 15. Optional callback prop means missing callers compile.)
+
+- [ ] **Step 14.4: Commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/components/MarketplacesTab.svelte
+git commit -m "feat(marketplaces): add onUpdated callback prop"
+```
+
+---
+
+## Task 15: `+page.svelte` — wire MarketplacesTab callback
+
+Threads the callback to `pluginUpdates.refresh(store.projectPath)`.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/routes/+page.svelte`
+
+- [ ] **Step 15.1: Add import + wire the prop**
+
+Edit `crates/kiro-control-center/src/routes/+page.svelte`. Add the store import near the top of the `<script>` block (alongside the existing `import { store, initialize } from "$lib/stores/project.svelte";`):
+
+```diff
+   import { store, initialize } from "$lib/stores/project.svelte";
++  import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+```
+
+Then find the `<MarketplacesTab />` mount (current line 106) and pass the new prop:
+
+```diff
+-        {:else if activeTab === "Marketplaces"}
+-          <MarketplacesTab />
++        {:else if activeTab === "Marketplaces"}
++          <MarketplacesTab
++            onUpdated={() => {
++              if (store.projectPath) {
++                pluginUpdates.refresh(store.projectPath);
++              }
++            }}
++          />
+```
+
+- [ ] **Step 15.2: Run typecheck**
+
+```bash
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 15.3: Commit**
+
+```bash
+git add crates/kiro-control-center/src/routes/+page.svelte
+git commit -m "feat(routes): refresh pluginUpdates after marketplace update"
+```
+
+---
+
+## Task 16: CLAUDE.md — pre-commit gate update
+
+Add `npm run test:unit` to the FE-tier pre-commit list and document the vitest scope boundary.
+
+**Files:**
+- Modify: `CLAUDE.md` (top-level — `/home/dwalleck/repos/kiro-marketplace-cli/CLAUDE.md`)
+
+- [ ] **Step 16.1: Add to the Pre-commit section**
+
+Edit `CLAUDE.md`. Find the `## Pre-commit` section (currently around line 21):
+
+```diff
+ ## Pre-commit
+ Run all three before committing — CI enforces each:
+ - `cargo fmt --all --check`
+ - `cargo test --workspace`
+ - `cargo clippy --workspace --tests -- -D warnings`
++
++For changes under `crates/kiro-control-center/` also run:
++- `cd crates/kiro-control-center && npm run check`
++- `cd crates/kiro-control-center && npm run test:unit`
++
++Vitest covers pure-logic helpers only (no jsdom, no `@testing-library/svelte`,
++no Tauri-IPC mocks). Component-level testing is intentionally future scope.
++If you find yourself wanting to test a `.svelte` file or a reactive store's
++`$state`/`$derived`, factor the testable logic out into a non-`.svelte.ts`
++module and test the helper instead.
+```
+
+- [ ] **Step 16.2: Verify CLAUDE.md still reads cleanly**
+
+```bash
+grep -A3 "## Pre-commit" CLAUDE.md
+```
+
+Expected: the new lines appear in the Pre-commit section, no broken markdown.
+
+- [ ] **Step 16.3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): add npm run test:unit to FE pre-commit list"
+```
+
+---
+
+## Task 17: Full verification pass
+
+Single sweep: every gate the project enforces.
+
+- [ ] **Step 17.1: Run cargo fmt check**
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: 0 changes (no Rust changes in 2b).
+
+- [ ] **Step 17.2: Run cargo test**
+
+```bash
+cargo test --workspace
+```
+
+Expected: all passing (no Rust changes in 2b; this verifies 2a's tests still pass against the new bindings consumers).
+
+- [ ] **Step 17.3: Run cargo clippy**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: 0 warnings.
+
+- [ ] **Step 17.4: Run npm run check**
+
+```bash
+cd crates/kiro-control-center && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 17.5: Run npm run test:unit**
+
+```bash
+cd crates/kiro-control-center && npm run test:unit
+```
+
+Expected: 22 passing (5 + 2 + 6 + 5 + 4 across remediationClass / kindLabel / groupFailures / formatInstallPluginResult / formatRemovePluginResult).
+
+- [ ] **Step 17.6: Manual smoke — golden path**
+
+```bash
+cd crates/kiro-control-center && npm run dev
+```
+
+Open `http://localhost:1420`. Walk through:
+1. Pick a project. Browse tab loads. Cards render existing "Installed" pills.
+2. Switch to Installed tab. Table renders with the new Status column showing "Up to date" for installed plugins. Remove a plugin → toast appears with `<details>` containing item names.
+3. (If a fixture marketplace with newer plugin versions is available) Verify the Update button appears on a card with an available update, click it, observe the success toast and the indicator clear.
+4. (If able to simulate marketplace offline) Move/rename a marketplace cache dir under `~/.kiro/marketplaces/`, switch project (or click Update Marketplaces) → grouped amber banner reading "N plugins from {marketplace} couldn't be checked. Run `kiro-market update`...". Restore the cache dir → banner clears on next refresh.
+
+Close the dev server when done.
+
+- [ ] **Step 17.7: Run plan-lint to confirm no Rust lint regressions**
+
+```bash
+TETHYS_BIN=/home/dwalleck/repos/rivets/target/release/tethys cargo xtask plan-lint
+```
+
+Expected: 0 findings. (Phase 2b is FE-only so this is a no-op check, but the design references the lint and CI runs it.)
+
+---
+
+## Task 18: Playwright e2e — Update available + Remove with sub-results
+
+Append two new test scenarios to the existing e2e suite. Both gate on `FIXTURE_MARKETPLACE_PATH` per the existing pattern at `tests/e2e/app.spec.ts`.
+
+**Files:**
+- Modify: `crates/kiro-control-center/tests/e2e/app.spec.ts`
+
+- [ ] **Step 18.1: Add the new test cases**
+
+Append to `crates/kiro-control-center/tests/e2e/app.spec.ts` (at the end of the file, before the final closing brace if present, or as a new top-level `test.describe` block):
+
+```ts
+test.describe("Phase 2b — update detection UI", () => {
+  test("Status column appears on Installed tab", async ({ page }) => {
+    await page.goto("/");
+
+    const fixturePath = process.env.FIXTURE_MARKETPLACE_PATH;
+    if (!fixturePath) {
+      test.skip(true, "FIXTURE_MARKETPLACE_PATH not set");
+      return;
+    }
+
+    await page.getByRole("button", { name: "Installed", exact: true }).click();
+
+    // Status column appears in the header even when there are zero
+    // installed plugins (its presence is a static UI guarantee).
+    await expect(page.getByRole("columnheader", { name: "Status" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Installed at" })).toBeVisible();
+  });
+});
+```
+
+(The "Remove toast surfaces with collapsed details" scenario from the design's Playwright section is intentionally NOT shipped here — it requires a fixture pipeline that supports an install-then-remove sequence, which doesn't exist yet. Manual smoke at Task 17.6 covers it. When a fixture pipeline lands, replace nothing instead of replacing a `test.skip` stub.)
+
+- [ ] **Step 18.2: Run e2e if fixture is set**
+
+```bash
+cd crates/kiro-control-center && npm run test:e2e
+```
+
+Expected: existing tests pass; new tests skip if `FIXTURE_MARKETPLACE_PATH` is unset (matching the existing `test.skip` pattern).
+
+- [ ] **Step 18.3: Commit**
+
+```bash
+git add crates/kiro-control-center/tests/e2e/app.spec.ts
+git commit -m "test(e2e): add Phase 2b update-detection UI scenarios"
+```
+
+---
+
+## Task 19: Branch hygiene + PR
+
+- [ ] **Step 19.1: Sanity-check the diff**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: ~14 commits, one per Task (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18). The Task 17 verification pass intentionally produces no commit.
+
+- [ ] **Step 19.2: One last full pre-commit pass**
+
+```bash
+cargo fmt --all --check && \
+  cargo test --workspace && \
+  cargo clippy --workspace --tests -- -D warnings && \
+  cd crates/kiro-control-center && npm run check && npm run test:unit
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 19.3: Open the PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(ui): plugin update detection UI (Phase 2b)" --body "$(cat <<'EOF'
+## Summary
+
+Implements Phase 2b of the plugin update detection rollout — the FE
+consumer for the wire format Phase 2a (PR #96) shipped.
+
+- Update indicator + button on PluginCard (BrowseTab) and Status column
+  + Update action on InstalledTab.
+- New module-scoped `pluginUpdates` Svelte store; eager scan on project
+  mount + after marketplace fetch.
+- `RemovePluginResult` reshape consumed via inline `<details>` block on
+  InstalledTab — the toast now names the items it removed.
+- Failures group by `(remediationClass, marketplace)` — N stale-cache
+  failures from one marketplace produce one banner, not N.
+- Vitest setup (narrow scope): pure-logic helpers tested in `node` env;
+  no jsdom, no `@testing-library/svelte`. Component-level testing
+  intentionally future scope.
+
+## Design + plan
+- Design: `docs/plans/2026-05-05-phase-2b-update-detection-ui-design.md`
+- Plan: `docs/plans/2026-05-05-phase-2b-update-detection-ui-plan.md`
+
+## Test plan
+- [x] `cargo fmt --all --check`
+- [x] `cargo test --workspace`
+- [x] `cargo clippy --workspace --tests -- -D warnings`
+- [x] `cd crates/kiro-control-center && npm run check`
+- [x] `cd crates/kiro-control-center && npm run test:unit` (22 tests)
+- [x] Manual smoke per Task 17.6 (golden + edge cases)
+- [ ] Playwright e2e with `FIXTURE_MARKETPLACE_PATH` set (Task 18 — fixture-dependent)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Plan review — 6 gates self-check
+
+Per `docs/plan-review-checklist.md`. Run before declaring this plan implementation-ready.
+
+### Gate 1 — Grounding
+
+- Every `bindings.ts` line reference verified against the current file (`bindings.ts:139`, `:160`, `:252-256`, `:657-664`, `:785-799`, `:1018-1023`, `:1040-1069`, `:1077-1100`, `:1125-1193`, `:1492-1506`, `:1523-1533`).
+- `vite.config.js` (NOT `.ts`) — verified by `ls`.
+- `MarketplacesTab.svelte:48-66` `updateMarketplace` success branch — verified.
+- `+page.svelte:106` `<MarketplacesTab />` mount — verified.
+- `BrowseTab.svelte:734-852` `installWholePlugin` body for the extraction in Task 5 — verified by direct read.
+- `BrowseTab.svelte:1066-1132` banner block — verified during Task 8 plan write.
+- `format.ts` existing helpers (`formatSkippedSkillsForPlugin`, `formatSteeringWarning`, `formatInstallWarning`) — verified.
+- The `assertNever` exhaustiveness pattern in `format.ts` — observed and matched in the new helpers (no `default:` arm in `remediationClass` / `kindLabel`).
+- `pluginKey` / `parsePluginKey` (`keys.ts`) — verified; reused throughout.
+- Existing `pendingPluginInstalls: SvelteSet<string>` (BrowseTab) and `removingKey: string | null` (InstalledTab) — refactored to a unified `pendingPluginActions: SvelteMap<string, "install" | "update" | "remove">`.
+- `InstallPluginResult_Serialize` (NOT bare `InstallPluginResult`) — verified to be the type returned by `installPlugin` per `bindings.ts:139`.
+
+### Gate 2 — Threat Model
+
+- No new untrusted byte sources — Phase 2b consumes typed values that `serde_json::from_slice` already validated on the backend (PR #96).
+- Update button is **destructive** (force-installs over user-edited plugin files). Mitigation: `title=` tooltip "Update will replace local edits to plugin files" on every Update affordance (PluginCard action button + InstalledTab row button). This is explicit per design decision #3 — confirmation modals deferred.
+- `PluginUpdateFailure.reason` strings are `error_full_chain` outputs from the backend. Rendered as text via Svelte's default escaping (no `{@html ...}` anywhere in 2b).
+- `accept_mcp` stays hard-coded to `false` for Update calls — same security posture as Install. The "user opt-in to MCP servers" UX is out of scope per Phase 1.
+
+### Gate 3 — Wire Format / FFI
+
+- Zero new types crossing FFI. The plan introduces only TS-side types (`RemediationClass`, `FailureGroup`, `FormattedInstallPluginResult`, `FormattedRemovePluginResult`) — none derive `Serialize`/`specta::Type`.
+- `FailureGroup.marketplace: MarketplaceName` and `.plugins: PluginName[]` thread the wire-format newtypes (TS aliases for `string` per `bindings.ts:905`, `:997`) without erasure into bare `string`.
+- The grouping function's composite map key (`${cls}:${f.marketplace}`) uses a literal colon — safe because `RemediationClass` values are fixed and don't contain `:`, and marketplace names go through the backend `MarketplaceName::new` validator. Documented in the comment alongside the key construction (Task 4 step 4.3).
+
+### Gate 4 — External Type Boundary
+
+- N/A — no Rust crate boundary changes. No `serde_json::Error` / `gix::Error` / etc. surfaces in 2b's TypeScript code (those are caught at the Tauri command boundary on the backend and surface as already-classified strings or typed enums).
+
+### Gate 5 — Type Design
+
+- `RemediationClass` is a 3-state literal union — collapses 5 `PluginUpdateFailureKind` variants into 3 remediation paths. Switch is exhaustive (no `default:`).
+- `kindLabel` switch is exhaustive (no `default:`). Mirrors the CLAUDE.md classifier rule.
+- `pendingPluginActions: SvelteMap<string, "install" | "update" | "remove">` replaces the prior boolean-pair pattern. The `(install: true, update: true)` state is unrepresentable — at most one action is in flight per plugin key.
+- `FormattedInstallPluginResult.anyInstalled` + `.anyFailed` are computed from the input data — each is a real semantic axis (could there be no installs but failures? yes; vice versa? yes; both? yes — partial install). Not collapsible to one boolean.
+- `FormattedRemovePluginResult.hasItems` + `.hasFailures` — same: orthogonal axes (a remove that emptied the cascade with no failures has `hasItems=false, hasFailures=false` — that's the "nothing to remove" case).
+- The `update?: PluginUpdateInfo | undefined` and `failure?: PluginUpdateFailure | undefined` props on `PluginCard` are mutually exclusive in practice (the backend never produces both for one plugin) but typed as independent `undefined`-able values for forward-compat. Action-area state machine handles all four `(update, failure) ∈ { (∅,∅), (info,∅), (∅,fail), (info,fail) }` cases — the last is rendered as `failure` precedence (the row "we don't know what's available" matters more than a stale "we knew yesterday's update").
+
+### Gate 6 — Reference vs Transcription
+
+- The plan cites `BrowseTab.svelte:734-852` as the source of `formatInstallPluginResult` rather than transcribing the summarization logic — Task 5's implementation is the extraction, with the test cases describing the contract the *result* must satisfy.
+- The plan cites `bindings.ts:line` ranges for every wire-format type rather than reproducing struct shapes inline. Plan-time consumers read the bindings; the plan describes how to consume them.
+- The 5 `PluginUpdateFailureKind` variants ARE enumerated in the switch arms (Task 2.3, 3.3) — that's not transcription, that's the implementation. The transcription risk would be paraphrasing the variants in prose; the plan instead cites `bindings.ts:1040-1069` for the canonical list.
+- Hint copy (`hintFor`) and tooltip copy (`kindLabel`) are net-new strings introduced by this plan — they're not transcribed from existing code; they're the FE's UX contract for 2b.
+- The banner-stack render block in Task 8 is a near-verbatim extraction of `BrowseTab.svelte:1066-1132`. The duplication is intentional during the extraction step; Task 9 deletes the original. After Task 9 the only copy is in `BannerStack.svelte`.
+
+---
+
+## Self-review
+
+Walked through each spec section against the task list:
+
+| Spec section | Tasks |
+|---|---|
+| `pluginUpdates` store (`design.md` §"New module: plugin-updates.svelte.ts") | Task 7 |
+| Pure helpers `remediationClass`, `kindLabel`, `groupFailures`, `hintFor` (`design.md` §"New module: plugin-updates.ts") | Tasks 2, 3, 4 |
+| `formatInstallPluginResult` (`design.md` §"Update flow") | Task 5 |
+| `formatRemovePluginResult` (`design.md` §"Remove toast") | Task 6 |
+| PluginCard new states (`design.md` §"Updated component: PluginCard.svelte") | Task 10 |
+| InstalledTab Status column + Update + reshape (`design.md` §"Updated component: InstalledTab.svelte" + §"Remove toast") | Tasks 12, 13 |
+| Banner stack extraction (`design.md` §"Banner stack") | Tasks 8, 9 |
+| MarketplacesTab callback + page wiring (`design.md` §"User-locked decisions" #2) | Tasks 14, 15 |
+| Failure → banner $effect (`design.md` §"Failure → banner mapping") | Tasks 11, 12 |
+| `partial_load_warnings` dedupe via existing `ERR_INSTALLED_PLUGINS` (`design.md` §"Failure → banner mapping") | Task 12 (`refresh()` change routes to `fetchErrors[ERR_INSTALLED_PLUGINS]`) |
+| Toplevel `fetchError` $effect (`design.md` §"Toplevel fetchError (rare)") | Tasks 11, 12 |
+| Vitest setup (`design.md` §"Vitest, narrowly scoped") | Task 1 |
+| CLAUDE.md pre-commit update (`design.md` Module map) | Task 16 |
+| Playwright e2e (`design.md` §"Playwright (e2e)") | Task 18 |
+| Manual smoke (`design.md` §"Manual UI smoke") | Task 17.6 |
+
+No gaps found.
+
+**Placeholder scan:** searched for "TBD", "TODO", "fill in", "appropriate error handling" — none.
+
+**Type consistency:** Shared `PluginAction` union exported from `plugin-updates.ts`; per-tab maps narrow via `Extract<PluginAction, "install" | "update">` (BrowseTab) and `Extract<PluginAction, "remove" | "update">` (InstalledTab). `PluginCard`'s `update`/`failure` props match the bindings types in every reference. `formatInstallPluginResult` parameter type is `InstallPluginResult_Serialize` (not the union); `formatRemovePluginResult` parameter is `RemovePluginResult` (the only non-split type). `removeResult: RemovePluginResult | null` declared once and read consistently. `kindLabel` named consistently across imports.
+
+Single naming inconsistency caught and fixed: an early draft mixed `formatInstallResult` and `formatInstallPluginResult` — settled on `formatInstallPluginResult` everywhere.
+
+---
+
+## Plan-review record
+
+This plan was originally drafted with an off-board amendments doc holding the post-review corrections; that doc was consolidated inline (the dual-doc pattern is fragile under subagent dispatch — context truncation can drop the smaller corrections doc). What follows preserves the audit trail for future plan-review passes: which gates fired, what the finding was, why it was fixed, where the fix landed.
+
+Two-pass review applied per `docs/plan-review-checklist.md`:
+- **LSP-first pass** — `documentSymbol` / `workspaceSymbol` queries against `bindings.ts`, `format.ts`, `keys.ts` to verify every cited type/function/method/prop exists at the SHA the plan was written against.
+- **Code-reviewer-style pass** — separate subagent walked each task asking "does this do the right thing?" — semantic / behavioral coverage for things LSP can't see.
+
+### Findings (consolidated, with disposition)
+
+| ID | Severity | Gate | Disposition | Where the fix lives |
+|---|---|---|---|---|
+| P2b-1 | blocker | Gate 1 | **Fixed inline** | Task 5.1 fixture: `FailedSkill.kind` field added; `InstallAgentsResult_Serialize.installed_native` + `installed_companions` added; `agents.installed` corrected to `string[]` |
+| P2b-2 (×3) | — | — | **False positive** | Code-reviewer claimed `update-check<...>` ErrorSource keys lack a delimiter and `errLabel` parser is broken via `indexOf("")`. The plan actually uses literal `` (DELIM) bytes in the template strings; the Read tool renders control chars as nothing, fooling both reviewers. Verified via `cat -A` on the byte stream — separator is correct, type narrows correctly, parser finds the right index. No code change needed. **Lesson: when reviewing template-literal types, check the actual bytes — `cat -A` or `xxd` — not the rendered text.** |
+| P2b-3 | blocker | Gate 5 | **Fixed inline** | Task 8.1 BannerStack `<script>` opener uses `generics="K extends string"` (Svelte 5 syntax); Tasks 9.2 + 13.1 drop their `as ErrorSource` casts on the `ondismiss` callback |
+| P2b-4 | major | Gate 1 | **Fixed inline** | Task 12.1's `<script>` replacement no longer declares `loadWarning`; Task 12.4's refresh body no longer touches it; Task 12.6 became a verify-only grep |
+| P2b-5 | major | Gate 1 | **Fixed inline** | Task 12.2's cascade reordered to `pluginUpdates.refresh` first, then local `refresh()` — uniform with Task 11.5 (BrowseTab updatePlugin) and Task 12.3 (InstalledTab updatePlugin) |
+| P2b-6 | major | Gate 5 | **Fixed inline** | New `PluginAction` type alias exported from `plugin-updates.ts` (Task 4.3); per-tab maps use `Extract<PluginAction, ...>` to narrow (Tasks 11.4, 12.1) |
+| P2b-7 | minor | Gate 1 | **Fixed inline** | Task 12.5's `statusUpdateLabel` for ContentChanged returns `"Content changed since install"` — a status sentence distinct from PluginCard's button label `"Update (content changed)"`; comment documents the intentional divergence (column = state, button = action) |
+| P2b-8 | minor | Gate 6 | **Fixed inline** | Tasks 5.1 + 6.1 fixtures now cite `bindings.ts:NNN` for every type they construct |
+| P2b-9 | minor | scope | **Fixed inline** | Task 18 dropped its second `test.skip` stub — only the "Status column appears" e2e remains; the missing toast scenario is documented as fixture-dependent future scope |
+
+### Non-amendment observation (D-4 from code-reviewer pass)
+
+**Project-switch race in `pluginUpdates` store.** If a user switches projects A → B fast, two `refresh()` calls overlap; A's promise can resolve after B's, overwriting B's data with A's. The store has no version/abort guard. Not fixed in this plan (YAGNI for Phase 2b — sub-100ms scan time + the design's "Out of scope: hash memoization" line — but worth a 4-line monotonic-token guard if real users hit it).
+
+### Process note for future plan reviews
+
+The biggest lesson from this pass was the false positive on the ErrorSource separator (P2b-2). The Read tool's silent rendering of control characters (`` → invisible) is a subtle hazard for plan-review work. Two protections going forward:
+
+1. **When a finding involves a template literal that "looks wrong"**, immediately verify the byte stream with `cat -A`, `xxd`, or `od -c` before believing the finding. The display layer can lie.
+2. **Subagent reviewers can't see the bytes either** — they read the same rendered text we do. A finding that depends on "this string has no separator" is fragile; it should be paired with a byte-level check before being elevated to "blocker."
+
+### What landed: gate-by-gate
+
+- **Gate 1 (Grounding):** P2b-1, P2b-4, P2b-5, P2b-7
+- **Gate 2 (Threat Model):** No findings
+- **Gate 3 (Wire Format):** No findings (Phase 2b introduces zero new types crossing FFI; all consumed types ship in PR #96)
+- **Gate 4 (External Type Boundary):** N/A (no Rust crate boundary changes)
+- **Gate 5 (Type Design):** P2b-3, P2b-6
+- **Gate 6 (Reference vs Transcription):** P2b-8
+
+---
+
+## Plan complete
+
+**Plan saved to `docs/plans/2026-05-05-phase-2b-update-detection-ui-plan.md`.**
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration. Each task block is self-contained.
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?


### PR DESCRIPTION
## Summary

Implements Phase 2b of the plugin update detection rollout — the FE consumer for the wire format Phase 2a (PR #96) shipped.

- **Update indicator + button on PluginCard (BrowseTab)** — `Update → vN` button replaces the `Installed` pill when an update is available; `Update check failed` red pill when scan failed; orange "Update (content changed)" label for ContentChanged drift signal.
- **Status column + Update action on InstalledTab** — new column between Version and Contents shows per-plugin update/failure/up-to-date state. Action cell gets `[Update] [Remove]` with single in-flight mutex (any in-flight action disables both).
- **`RemovePluginResult` reshape consumed** — InstalledTab's Remove toast now uses an inline `<details>` block to itemize per-content-type successes and failures, replacing the previous opaque count message.
- **Failures group by `(remediationClass, marketplace)`** — N stale-cache failures from one marketplace produce one banner ("3 plugins from acme couldn't be checked. Run `kiro-market update`...") instead of N. Per-row pills share a generic "Update check failed" treatment with `kindLabel`-driven `title=` tooltip.
- **`pluginUpdates` Svelte store** at `src/lib/stores/plugin-updates.svelte.ts` — eager scan on project mount + after marketplace fetch (via new `MarketplacesTab.onUpdated` callback). Includes race-condition guards for fast project switching and explicit error/result clearing on transitions.
- **`BannerStack` shared component** extracted from BrowseTab; consumed by both tabs. Uses Svelte 5's `<script generics="K extends string">` to propagate the per-tab `ErrorSource` literal-union type without casts.
- **Vitest setup (narrow scope)** — pure-logic helpers tested in `node` env; no jsdom, no `@testing-library/svelte`. 23 tests covering `remediationClass`, `kindLabel`, `groupFailures`, `formatInstallPluginResult`, `formatRemovePluginResult`. Component-level testing intentionally future scope.

## Design + plan
- Design: `docs/plans/2026-05-05-phase-2b-update-detection-ui-design.md`
- Plan: `docs/plans/2026-05-05-phase-2b-update-detection-ui-plan.md`
- Plan-review record: in the plan's "Plan-review record" section near the end (consolidates the 6-gate review findings + 9 amendments per the project's plan-review-checklist process).

## Architecture decisions worth flagging on review

- **DELIM-aware `update-check<DELIM>` ErrorSource keys** — composite key family for grouped failure banners, follows the existing `pluginKey()` separator convention from `keys.ts`. Initial plan-review pass surfaced a false positive about missing separators (the plan's literal bytes contained `` which Read renders invisibly); implementation uses explicit `${typeof DELIM}` / `${DELIM}` / `DELIM` everywhere.
- **`Extract<PluginAction, ...>` per-tab narrowing** — shared `PluginAction` union (`"install" | "update" | "remove"`) exported from `plugin-updates.ts`; BrowseTab narrows to `"install" | "update"`, InstalledTab narrows to `"remove" | "update"`. Single source of truth for the action discriminator.
- **Project-change state cleanup** (commit `5893c25`) — both tabs explicitly clear banners, pendingPluginActions, and project-scoped fetchErrors keys on `projectPath` transitions to prevent stale state leaking across project switches.
- **Cascade ordering uniform across all action handlers** — `pluginUpdates.refresh(projectPath)` first, then local refresh. Applies to `installWholePlugin`, BrowseTab's `updatePlugin`, InstalledTab's `removePlugin`, and InstalledTab's `updatePlugin`.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cd crates/kiro-control-center && npm run check` (353 files, 0 errors, 0 warnings)
- [x] `cd crates/kiro-control-center && npm run test:unit` (23 tests)
- [x] `cargo xtask plan-lint` (all 6 gates pass)
- [ ] Manual UI smoke (golden + edge cases: no plugins / scan-in-progress / ContentChanged label / legacy install / marketplace offline / Remove with mixed sub-results)
- [ ] Playwright e2e with `FIXTURE_MARKETPLACE_PATH` set (Task 18 added Status-column-headers test; the toast scenario remains fixture-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)