### PR TITLE
feat(ui): cross-tab pluginUpdates integration (Phase 2b)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,26 @@ These MUST be maintained in all changes:
      Add repo-specific conventions, gotchas, and workflow rules here.
      This section is preserved exactly as-is when re-running codebase-summary. -->
 
+You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation. Here's how to use the available tools effectively:
+
+## Available Svelte MCP Tools:
+
+### 1. list-sections
+
+Use this FIRST to discover all available documentation sections. Returns a structured list with titles, use_cases, and paths.
+When asked about Svelte or SvelteKit topics, ALWAYS use this tool at the start of the chat to find relevant sections.
+
+### 2. get-documentation
+
+Retrieves full documentation content for specific sections. Accepts single or multiple sections.
+After calling the list-sections tool, you MUST analyze the returned documentation sections (especially the use_cases field) and then use the get-documentation tool to fetch ALL documentation sections that are relevant for the user's task.
+
+### 3. svelte-autofixer
+
+Analyzes Svelte code and returns issues and suggestions.
+You MUST use this tool whenever writing Svelte code before sending it to the user. Keep calling it until no issues or suggestions are returned.
+
+### 4. playground-link
+
+Generates a Svelte Playground link with the provided code.
+After completing the code, ask the user if they want a playground link. Only call this tool after user confirmation and NEVER if code was written to files in their project.

--- a/crates/kiro-control-center/src/lib/components/BannerStack.svelte
+++ b/crates/kiro-control-center/src/lib/components/BannerStack.svelte
@@ -5,11 +5,13 @@
     errors: SvelteMap<K, string>;
     message: string | null;
     warning: string | null;
+    staleRefresh: string | null;
     fatalError: string | null;
     errLabel: (key: K) => string;
     ondismiss: (key: K) => void;
     onmessageDismiss?: () => void;
     onwarningDismiss?: () => void;
+    onstaleRefreshDismiss?: () => void;
     onfatalErrorDismiss?: () => void;
   };
 
@@ -17,11 +19,13 @@
     errors,
     message,
     warning,
+    staleRefresh,
     fatalError,
     errLabel,
     ondismiss,
     onmessageDismiss,
     onwarningDismiss,
+    onstaleRefreshDismiss,
     onfatalErrorDismiss,
   }: Props = $props();
 </script>
@@ -95,6 +99,26 @@
       type="button"
       onclick={() => onwarningDismiss?.()}
       aria-label="Dismiss install warning"
+      class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
+    >
+      ×
+    </button>
+  </div>
+{/if}
+
+<!-- Distinct from `warning`: post-action refresh failures are infrastructure
+     state, not domain warnings — separate slot so dismissing one doesn't
+     dismiss the other. -->
+{#if staleRefresh}
+  <div
+    data-testid="stale-refresh"
+    class="mx-4 mt-3 px-4 py-3 rounded-md bg-kiro-warning/10 border border-kiro-warning/30 flex items-start gap-3"
+  >
+    <p class="text-sm text-kiro-warning flex-1">{staleRefresh}</p>
+    <button
+      type="button"
+      onclick={() => onstaleRefreshDismiss?.()}
+      aria-label="Dismiss stale-refresh notice"
       class="text-kiro-warning/70 hover:text-kiro-warning text-lg leading-none flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-kiro-accent-500 rounded"
     >
       ×

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -3,7 +3,6 @@
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { commands } from "$lib/bindings";
   import {
-    formatInstallPluginResult,
     formatSkippedSkill,
     formatSkippedSkillsForPlugin,
     formatSteeringWarning,
@@ -19,6 +18,15 @@
   } from "$lib/keys";
   import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
   import type { PluginAction } from "$lib/stores/plugin-updates";
+  import {
+    ERR_INSTALLED_PLUGINS,
+    ERR_UPDATE_FETCH,
+    UPDATE_CHECK_PREFIX,
+    parseUpdateCheckKey,
+  } from "$lib/error-source";
+  import type { UpdateCheckKey } from "$lib/error-source";
+  import { runPluginInstall as doPluginInstall } from "$lib/plugin-actions";
+  import { usePluginUpdateBanners } from "$lib/stores/plugin-update-banners.svelte";
   import type {
     InstalledPluginInfo,
     MarketplaceInfo,
@@ -42,24 +50,19 @@
   const SKILLS_ERR_PREFIX = `skills${DELIM}` as const;
   const BULK_SKILLS_ERR_PREFIX = `bulk-skills${DELIM}` as const;
   const ERR_MARKETPLACES = "marketplaces" as const;
-  // Standalone (non-prefixed) keys for top-level fetches that have no
-  // (marketplace, plugin) tuple. Adding more standalone keys later means
-  // extending the union in `ErrorSource` and the dispatch in `errLabel`.
-  const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
-  const ERR_UPDATE_FETCH = "update-fetch" as const;
-  const UPDATE_CHECK_PREFIX = "update-check" as const;
   type ErrorSource =
     | typeof ERR_MARKETPLACES
     | typeof ERR_INSTALLED_PLUGINS
     | typeof ERR_UPDATE_FETCH
-    | `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`
+    | UpdateCheckKey
     | `${typeof PLUGINS_ERR_PREFIX}${string}`
     | `${typeof SKILLS_ERR_PREFIX}${string}${typeof DELIM}${string}`
     | `${typeof BULK_SKILLS_ERR_PREFIX}${string}`;
   // Compile-time guard: fails if any `as const` above is removed and the
   // union silently widens back to `string` (which would defeat typo
   // protection on `fetchErrors.get/set/delete` with zero compile errors).
-  type _AssertNarrow = string extends ErrorSource ? never : ErrorSource;
+  const _ = null as unknown as (string extends ErrorSource ? never : 0);
+  void _;
   const pluginsErrKey = (mp: string): ErrorSource => `${PLUGINS_ERR_PREFIX}${mp}`;
   const skillsErrKey = (mp: string, plugin: string): ErrorSource =>
     `${SKILLS_ERR_PREFIX}${mp}${DELIM}${plugin}`;
@@ -73,8 +76,7 @@
     if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins error";
     if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
     if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
-      // Type-literal guarantees ["update-check", "<remediation>", "<marketplace>"].
-      const [, , marketplace] = key.split(DELIM);
+      const { marketplace } = parseUpdateCheckKey(key);
       return `Dismiss update-check banner for ${marketplace}`;
     }
     if (key.startsWith(PLUGINS_ERR_PREFIX)) {
@@ -122,12 +124,8 @@
   let fetchErrors = new SvelteMap<ErrorSource, string>();
   let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
-  // Non-fatal install detail (skipped idempotent items, MCP-gated agents,
-  // unmapped tools, per-skill read failures, steering scan-path warnings).
-  // Distinct from `installError` (red, fatal) and `installMessage` (green,
-  // success summary) so the user sees BOTH "installed N items" AND "agent
-  // X requires --accept-mcp" simultaneously.
   let installWarning: string | null = $state(null);
+  let installStaleRefresh: string | null = $state(null);
 
   let availablePlugins = $derived.by(() => {
     const out: { marketplace: string; plugin: PluginInfo }[] = [];
@@ -446,42 +444,10 @@
     fetchInstalledPlugins();
   });
 
-  $effect(() => {
-    void projectPath;
-    pluginUpdates
-      .refresh(projectPath)
-      .catch((e) => console.error("[BrowseTab] pluginUpdates.refresh threw", e));
-  });
-
-  $effect(() => {
-    const seen = new Set<ErrorSource>();
-    for (const group of pluginUpdates.failureGroups) {
-      const key: ErrorSource =
-        `${UPDATE_CHECK_PREFIX}${DELIM}${group.remediation}${DELIM}${group.marketplace}` as ErrorSource;
-      seen.add(key);
-      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
-      const list = group.plugins.join(", ");
-      fetchErrors.set(
-        key,
-        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
-      );
-    }
-    for (const k of fetchErrors.keys()) {
-      if (k.startsWith(UPDATE_CHECK_PREFIX + DELIM) && !seen.has(k)) {
-        fetchErrors.delete(k);
-      }
-    }
-  });
-
-  $effect(() => {
-    if (pluginUpdates.fetchError) {
-      fetchErrors.set(
-        ERR_UPDATE_FETCH,
-        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
-      );
-    } else {
-      fetchErrors.delete(ERR_UPDATE_FETCH);
-    }
+  usePluginUpdateBanners({
+    projectPath: () => projectPath,
+    fetchErrors,
+    logPrefix: "BrowseTab",
   });
 
   $effect(() => {
@@ -521,6 +487,7 @@
       installError = null;
       installMessage = null;
       installWarning = null;
+      installStaleRefresh = null;
       pendingPluginActions.clear();
       // Snapshot first — deleting during keys() iteration re-triggers the effect.
       const stale: ErrorSource[] = [];
@@ -599,6 +566,7 @@
     installError = null;
     installMessage = null;
     installWarning = null;
+    installStaleRefresh = null;
 
     type Group = { marketplace: string; plugin: string; names: string[] };
     const groups = new Map<string, Group>();
@@ -714,6 +682,7 @@
     installError = null;
     installMessage = null;
     installWarning = null;
+    installStaleRefresh = null;
 
     try {
       const result = await commands.installPluginSteering(
@@ -769,36 +738,8 @@
     }
   }
 
-  // Whole-plugin install — runs every install path the plugin declares
-  // (skills + steering + agents) in one coordinated call. Surfaces the
-  // aggregated outcome across THREE banner states:
-  //   - `installMessage` (green): success summary including idempotent skips
-  //   - `installError`   (red):   fatal — at least one failure and zero installs
-  //   - `installWarning` (amber): non-fatal detail (skipped_skills, steering
-  //                               scan warnings, MCP-gated agents, unmapped
-  //                               tools). Mirrors `installSelected`'s
-  //                               accumulation pattern.
-  //
-  // The MCP-gated path is the security-critical one: with `accept_mcp = false`
-  // an agent declaring `mcp_servers` produces `InstallWarning::McpServersRequireOptIn`
-  // and never lands in `installed` or `failed`. Previously the count would
-  // silently disappear ("1 of 2 agents installed" with no explanation); the
-  // new warning banner names the agent and lists its transports so the user
-  // can re-run with the opt-in if they want it.
-  async function refreshAfterPluginAction(verbForBanner: string, plugin: string) {
-    try {
-      await pluginUpdates.refresh(projectPath);
-      await fetchInstalledPlugins();
-    } catch (e) {
-      console.error(`[BrowseTab] post-${verbForBanner} refresh threw`, e);
-      const reason = e instanceof Error ? e.message : String(e);
-      installError = `${plugin} ${verbForBanner} succeeded but refresh failed: ${reason}`;
-    }
-  }
-
-  // 4th arg of installPlugin is `acceptMcp` — Phase 1 hardcodes false. Phase 2
-  // will wire a UI toggle so a user can opt into installing agents that declare
-  // MCP servers (subprocesses / network connections).
+  // Plugin install/update delegated to lib/plugin-actions.ts — see PluginActionContext
+  // doc-comment for the banner contract and MCP-gating rationale.
   async function runPluginInstall(
     marketplace: string,
     plugin: string,
@@ -810,32 +751,30 @@
     installError = null;
     installMessage = null;
     installWarning = null;
-
-    const force = mode === "update" ? true : forceInstall;
-    const failPrefix =
-      mode === "update" ? `Update failed for ${plugin}` : `Plugin install failed for ${plugin}`;
-    const successPrefix = mode === "update" ? `Updated ${plugin}` : `Plugin ${plugin}`;
+    installStaleRefresh = null;
 
     try {
-      const result = await commands.installPlugin(marketplace, plugin, force, false, projectPath);
-      if (result.status === "ok") {
-        const { summary, warnings, anyInstalled, anyFailed } =
-          formatInstallPluginResult(result.data);
-        if (anyFailed && !anyInstalled) {
-          installError = `${failPrefix}: ${summary}`;
-        } else {
-          installMessage = `${successPrefix}: ${summary}`;
-        }
-        if (warnings) {
-          installWarning = `${successPrefix}: ${warnings}`;
-        }
-        await refreshAfterPluginAction(mode, plugin);
+      const outcome = await doPluginInstall(
+        {
+          marketplace,
+          plugin,
+          projectPath,
+          forceInstall,
+          acceptMcp: false,
+          refresh: () => fetchInstalledPlugins(),
+        },
+        mode,
+      );
+
+      if (outcome.kind === "ok") {
+        const p = outcome.banner.primary;
+        installError = p?.kind === "error" ? p.text : null;
+        installMessage = p?.kind === "message" ? p.text : null;
+        installWarning = outcome.banner.warning;
+        installStaleRefresh = outcome.banner.staleRefresh;
       } else {
-        installError = `${failPrefix}: ${result.error.message}`;
+        installError = outcome.error;
       }
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      installError = `${failPrefix}: ${reason}`;
     } finally {
       pendingPluginActions.delete(key);
     }
@@ -1057,11 +996,13 @@
     errors={fetchErrors}
     message={installMessage}
     warning={installWarning}
+    staleRefresh={installStaleRefresh}
     fatalError={installError}
     errLabel={errLabel}
     ondismiss={(key) => fetchErrors.delete(key)}
     onmessageDismiss={() => (installMessage = null)}
     onwarningDismiss={() => (installWarning = null)}
+    onstaleRefreshDismiss={() => (installStaleRefresh = null)}
     onfatalErrorDismiss={() => (installError = null)}
   />
 

--- a/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/BrowseTab.svelte
@@ -762,6 +762,8 @@
           forceInstall,
           acceptMcp: false,
           refresh: () => fetchInstalledPlugins(),
+          installPlugin: commands.installPlugin,
+          storeRefresh: (p) => pluginUpdates.refresh(p),
         },
         mode,
       );

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -11,7 +11,15 @@
   import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
   import { kindLabel, statusUpdateLabel } from "$lib/stores/plugin-updates";
   import type { PluginAction } from "$lib/stores/plugin-updates";
-  import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
+  import {
+    ERR_INSTALLED_PLUGINS,
+    ERR_UPDATE_FETCH,
+    UPDATE_CHECK_PREFIX,
+    parseUpdateCheckKey,
+  } from "$lib/error-source";
+  import type { UpdateCheckKey } from "$lib/error-source";
+  import { runPluginInstall, runPluginRemove } from "$lib/plugin-actions";
+  import { usePluginUpdateBanners } from "$lib/stores/plugin-update-banners.svelte";
   import BannerStack from "./BannerStack.svelte";
 
   let { projectPath }: { projectPath: string } = $props();
@@ -24,27 +32,35 @@
   let installError: string | null = $state(null);
   let installMessage: string | null = $state(null);
   let installWarning: string | null = $state(null);
+  let installStaleRefresh: string | null = $state(null);
 
   let pendingPluginActions = new SvelteMap<string, Extract<PluginAction, "remove" | "update">>();
 
   let removeResult: RemovePluginResult | null = $state(null);
   let removeResultPlugin: string | null = $state(null);
-  let removeResultHasFailures: boolean = $state(false);
+  let removeResultHasFailures = $derived.by(() => {
+    if (removeResult === null) return false;
+    return (
+      (removeResult.skills.failures ?? []).length +
+        (removeResult.steering.failures ?? []).length +
+        (removeResult.agents.failures ?? []).length >
+      0
+    );
+  });
 
-  const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
-  const ERR_UPDATE_FETCH = "update-fetch" as const;
-  const UPDATE_CHECK_PREFIX = "update-check" as const;
   type ErrorSource =
     | typeof ERR_INSTALLED_PLUGINS
     | typeof ERR_UPDATE_FETCH
-    | `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`;
+    | UpdateCheckKey;
+  const _ = null as unknown as (string extends ErrorSource ? never : 0);
+  void _;
   let fetchErrors = new SvelteMap<ErrorSource, string>();
 
   function errLabel(key: ErrorSource): string {
     if (key === ERR_INSTALLED_PLUGINS) return "Dismiss installed-plugins warning";
     if (key === ERR_UPDATE_FETCH) return "Dismiss update-check error";
     if (key.startsWith(UPDATE_CHECK_PREFIX + DELIM)) {
-      const [, , marketplace] = key.split(DELIM);
+      const { marketplace } = parseUpdateCheckKey(key);
       return `Dismiss update-check banner for ${marketplace}`;
     }
     return "Dismiss banner";
@@ -90,17 +106,6 @@
     }
   }
 
-  async function refreshAfterPluginAction(verbForBanner: string, plugin: string) {
-    try {
-      await pluginUpdates.refresh(projectPath);
-      await refresh();
-    } catch (e) {
-      console.error(`[InstalledTab] post-${verbForBanner} refresh threw`, e);
-      const reason = e instanceof Error ? e.message : String(e);
-      installError = `${plugin} ${verbForBanner} succeeded but refresh failed: ${reason}`;
-    }
-  }
-
   async function removePlugin(marketplace: string, plugin: string) {
     const key = pluginKey(marketplace, plugin);
     if (pendingPluginActions.has(key)) return;
@@ -108,31 +113,31 @@
     installError = null;
     installMessage = null;
     installWarning = null;
+    installStaleRefresh = null;
     removeResult = null;
     removeResultPlugin = null;
-    removeResultHasFailures = false;
+
     try {
-      const result = await commands.removePlugin(marketplace, plugin, projectPath);
-      if (result.status === "ok") {
-        const { summary, hasItems, hasFailures } =
-          formatRemovePluginResult(result.data);
-        if (hasItems || hasFailures) {
-          removeResult = result.data;
+      const outcome = await runPluginRemove({
+        marketplace,
+        plugin,
+        projectPath,
+        refresh: () => refresh(),
+      });
+
+      if (outcome.kind === "ok-removed" || outcome.kind === "ok-noop") {
+        const p = outcome.banner.primary;
+        installError = p?.kind === "error" ? p.text : null;
+        installMessage = p?.kind === "message" ? p.text : null;
+        installWarning = outcome.banner.warning;
+        installStaleRefresh = outcome.banner.staleRefresh;
+        if (outcome.kind === "ok-removed") {
+          removeResult = outcome.removeResult;
           removeResultPlugin = plugin;
-          removeResultHasFailures = hasFailures;
         }
-        if (hasFailures) {
-          installWarning = `Removed plugin ${plugin}: ${summary}`;
-        } else {
-          installMessage = `Removed plugin ${plugin}: ${summary}`;
-        }
-        await refreshAfterPluginAction("remove", plugin);
       } else {
-        installError = `Remove failed for ${plugin}: ${result.error.message}`;
+        installError = outcome.error;
       }
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      installError = `Remove failed for ${plugin}: ${reason}`;
     } finally {
       pendingPluginActions.delete(key);
     }
@@ -145,34 +150,32 @@
     installError = null;
     installMessage = null;
     installWarning = null;
+    installStaleRefresh = null;
     removeResult = null;
     removeResultPlugin = null;
+
     try {
-      const result = await commands.installPlugin(
-        marketplace,
-        plugin,
-        /*force=*/ true,
-        /*acceptMcp=*/ false,
-        projectPath,
+      const outcome = await runPluginInstall(
+        {
+          marketplace,
+          plugin,
+          projectPath,
+          forceInstall: false,
+          acceptMcp: false,
+          refresh: () => refresh(),
+        },
+        "update",
       );
-      if (result.status === "ok") {
-        const { summary, warnings, anyInstalled, anyFailed } =
-          formatInstallPluginResult(result.data);
-        if (anyFailed && !anyInstalled) {
-          installError = `Update failed for ${plugin}: ${summary}`;
-        } else {
-          installMessage = `Updated ${plugin}: ${summary}`;
-        }
-        if (warnings) {
-          installWarning = `Updated ${plugin}: ${warnings}`;
-        }
-        await refreshAfterPluginAction("update", plugin);
+
+      if (outcome.kind === "ok") {
+        const p = outcome.banner.primary;
+        installError = p?.kind === "error" ? p.text : null;
+        installMessage = p?.kind === "message" ? p.text : null;
+        installWarning = outcome.banner.warning;
+        installStaleRefresh = outcome.banner.staleRefresh;
       } else {
-        installError = `Update failed for ${plugin}: ${result.error.message}`;
+        installError = outcome.error;
       }
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      installError = `Update failed for ${plugin}: ${reason}`;
     } finally {
       pendingPluginActions.delete(key);
     }
@@ -200,42 +203,10 @@
     refresh();
   });
 
-  $effect(() => {
-    void projectPath;
-    pluginUpdates
-      .refresh(projectPath)
-      .catch((e) => console.error("[InstalledTab] pluginUpdates.refresh threw", e));
-  });
-
-  $effect(() => {
-    const seen = new Set<ErrorSource>();
-    for (const group of pluginUpdates.failureGroups) {
-      const key: ErrorSource =
-        `${UPDATE_CHECK_PREFIX}${DELIM}${group.remediation}${DELIM}${group.marketplace}` as ErrorSource;
-      seen.add(key);
-      const noun = group.plugins.length === 1 ? "plugin" : "plugins";
-      const list = group.plugins.join(", ");
-      fetchErrors.set(
-        key,
-        `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
-      );
-    }
-    for (const k of fetchErrors.keys()) {
-      if (k.startsWith(UPDATE_CHECK_PREFIX + DELIM) && !seen.has(k)) {
-        fetchErrors.delete(k);
-      }
-    }
-  });
-
-  $effect(() => {
-    if (pluginUpdates.fetchError) {
-      fetchErrors.set(
-        ERR_UPDATE_FETCH,
-        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
-      );
-    } else {
-      fetchErrors.delete(ERR_UPDATE_FETCH);
-    }
+  usePluginUpdateBanners({
+    projectPath: () => projectPath,
+    fetchErrors,
+    logPrefix: "InstalledTab",
   });
 
   let priorProjectPath: string | null = null;
@@ -243,10 +214,10 @@
     if (priorProjectPath !== null && priorProjectPath !== projectPath) {
       removeResult = null;
       removeResultPlugin = null;
-      removeResultHasFailures = false;
       installError = null;
       installMessage = null;
       installWarning = null;
+      installStaleRefresh = null;
       pendingPluginActions.clear();
       fetchErrors.clear();
     }
@@ -260,11 +231,13 @@
     errors={fetchErrors}
     message={installMessage}
     warning={installWarning}
+    staleRefresh={installStaleRefresh}
     fatalError={installError}
     errLabel={errLabel}
     ondismiss={(key) => fetchErrors.delete(key)}
     onmessageDismiss={() => (installMessage = null)}
     onwarningDismiss={() => (installWarning = null)}
+    onstaleRefreshDismiss={() => (installStaleRefresh = null)}
     onfatalErrorDismiss={() => (installError = null)}
   />
 

--- a/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
+++ b/crates/kiro-control-center/src/lib/components/InstalledTab.svelte
@@ -123,6 +123,8 @@
         plugin,
         projectPath,
         refresh: () => refresh(),
+        removePlugin: commands.removePlugin,
+        storeRefresh: (p) => pluginUpdates.refresh(p),
       });
 
       if (outcome.kind === "ok-removed" || outcome.kind === "ok-noop") {
@@ -163,6 +165,8 @@
           forceInstall: false,
           acceptMcp: false,
           refresh: () => refresh(),
+          installPlugin: commands.installPlugin,
+          storeRefresh: (p) => pluginUpdates.refresh(p),
         },
         "update",
       );

--- a/crates/kiro-control-center/src/lib/error-source.test.ts
+++ b/crates/kiro-control-center/src/lib/error-source.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  UPDATE_CHECK_PREFIX,
+  ERR_INSTALLED_PLUGINS,
+  ERR_UPDATE_FETCH,
+  updateCheckErrKey,
+  parseUpdateCheckKey,
+  isUpdateCheckKey,
+} from "./error-source";
+
+describe("updateCheckErrKey", () => {
+  it("returns the exact 3-segment string", () => {
+    expect(updateCheckErrKey("stale_cache", "acme")).toBe(
+      `${UPDATE_CHECK_PREFIX}\u001fstale_cache\u001facme`,
+    );
+    expect(updateCheckErrKey("manifest_invalid", "acme")).toBe(
+      `${UPDATE_CHECK_PREFIX}\u001fmanifest_invalid\u001facme`,
+    );
+  });
+});
+
+describe("parseUpdateCheckKey", () => {
+  it("round-trips through updateCheckErrKey", () => {
+    for (const [r, mp] of [
+      ["stale_cache", "acme"],
+      ["manifest_invalid", "acme"],
+      ["unknown", "other-mp"],
+    ] as const) {
+      const key = updateCheckErrKey(r, mp);
+      const parsed = parseUpdateCheckKey(key);
+      expect(parsed).toEqual({ remediation: r, marketplace: mp });
+    }
+  });
+
+  it("throws on malformed key (fewer than 3 segments)", () => {
+    expect(() => parseUpdateCheckKey("update-check")).toThrow(
+      "parseUpdateCheckKey: malformed key",
+    );
+  });
+
+  it("throws on malformed key (empty segments)", () => {
+    expect(() =>
+      parseUpdateCheckKey(`update-check\u001f\u001facme`),
+    ).toThrow("parseUpdateCheckKey: malformed key");
+  });
+
+  it("throws on wrong prefix (3 segments but not 'update-check')", () => {
+    expect(() =>
+      parseUpdateCheckKey(`foo\u001fbar\u001fbaz`),
+    ).toThrow("parseUpdateCheckKey: malformed key");
+  });
+});
+
+describe("isUpdateCheckKey", () => {
+  it("returns true for keys produced by updateCheckErrKey", () => {
+    expect(isUpdateCheckKey(updateCheckErrKey("stale_cache", "acme"))).toBe(true);
+    expect(isUpdateCheckKey(updateCheckErrKey("manifest_invalid", "beta"))).toBe(true);
+  });
+
+  it("returns false for fewer than 3 segments", () => {
+    expect(isUpdateCheckKey("update-check")).toBe(false);
+    expect(isUpdateCheckKey(`update-checkstale_cache`)).toBe(false);
+  });
+
+  it("returns false for empty segments", () => {
+    expect(isUpdateCheckKey(`update-checkacme`)).toBe(false);
+  });
+
+  it("returns false for wrong prefix", () => {
+    expect(isUpdateCheckKey(`foobarbaz`)).toBe(false);
+  });
+
+  it("returns false for unrelated namespace keys", () => {
+    expect(isUpdateCheckKey("installed-plugins")).toBe(false);
+    expect(isUpdateCheckKey("update-fetch")).toBe(false);
+    expect(isUpdateCheckKey(`pluginsacme`)).toBe(false);
+  });
+});
+
+describe("shared constants", () => {
+  it("ERR_INSTALLED_PLUGINS and ERR_UPDATE_FETCH hold their string values", () => {
+    expect(ERR_INSTALLED_PLUGINS).toBe("installed-plugins");
+    expect(ERR_UPDATE_FETCH).toBe("update-fetch");
+  });
+
+  it("UPDATE_CHECK_PREFIX is 'update-check'", () => {
+    expect(UPDATE_CHECK_PREFIX).toBe("update-check");
+  });
+});
+
+// Compile-time guard: mirrors the _AssertNarrow pattern in error-source.ts.
+// If either constant widens to string, this line fails type-check.
+type _AssertNarrow = string extends typeof UPDATE_CHECK_PREFIX ? never : typeof UPDATE_CHECK_PREFIX;

--- a/crates/kiro-control-center/src/lib/error-source.ts
+++ b/crates/kiro-control-center/src/lib/error-source.ts
@@ -1,0 +1,49 @@
+import { DELIM } from "$lib/keys";
+
+export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
+
+export const UPDATE_CHECK_PREFIX = "update-check" as const;
+export const ERR_INSTALLED_PLUGINS = "installed-plugins" as const;
+export const ERR_UPDATE_FETCH = "update-fetch" as const;
+
+export type UpdateCheckKey =
+  `${typeof UPDATE_CHECK_PREFIX}${typeof DELIM}${string}${typeof DELIM}${string}`;
+
+// Compile-time guard: fails if UPDATE_CHECK_PREFIX loses `as const` and
+// UpdateCheckKey silently widens to `string` (defeating typo protection
+// on `fetchErrors.get/set/delete` with zero compile errors).
+type _AssertNarrow = string extends UpdateCheckKey ? never : UpdateCheckKey;
+
+export const updateCheckErrKey = (
+  remediation: RemediationClass,
+  marketplace: string,
+): UpdateCheckKey =>
+  `${UPDATE_CHECK_PREFIX}${DELIM}${remediation}${DELIM}${marketplace}` as UpdateCheckKey;
+
+// Type guard: narrows `s` to `UpdateCheckKey` when shape, emptiness, and
+// prefix all check out. Use at trust boundaries (e.g. iterating SvelteMap
+// keys typed as `string`) to recover the brand without an `as` cast.
+export const isUpdateCheckKey = (s: string): s is UpdateCheckKey => {
+  const parts = s.split(DELIM);
+  return (
+    parts.length === 3 &&
+    parts.every((p) => p !== "") &&
+    parts[0] === UPDATE_CHECK_PREFIX
+  );
+};
+
+// Throw on malformed input rather than returning `{ remediation: undefined }`
+// dressed up as `{ remediation: string }`. Every call site round-trips through
+// `updateCheckErrKey`, so a malformed key is a programmer bug — throwing makes
+// the bug loud instead of silent.
+export const parseUpdateCheckKey = (
+  key: string,
+): { remediation: string; marketplace: string } => {
+  if (!isUpdateCheckKey(key)) {
+    throw new Error(
+      `parseUpdateCheckKey: malformed key (expected UPDATE_CHECK_PREFIX + DELIM + remediation + DELIM + marketplace): ${JSON.stringify(key)}`,
+    );
+  }
+  const parts = key.split(DELIM);
+  return { remediation: parts[1], marketplace: parts[2] };
+};

--- a/crates/kiro-control-center/src/lib/plugin-actions.test.ts
+++ b/crates/kiro-control-center/src/lib/plugin-actions.test.ts
@@ -1,0 +1,602 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  InstallPluginResult_Serialize,
+  MarketplaceName,
+  PluginName,
+  RemovePluginResult,
+  ErrorType,
+} from "$lib/bindings";
+
+const { mockRefresh, mockInstallPlugin, mockRemovePlugin } = vi.hoisted(() => ({
+  mockRefresh: vi.fn<(projectPath: string) => Promise<void>>().mockResolvedValue(
+    undefined,
+  ),
+  mockInstallPlugin: vi.fn(),
+  mockRemovePlugin: vi.fn(),
+}));
+
+vi.mock("$lib/stores/plugin-updates.svelte", () => ({
+  pluginUpdates: {
+    refresh: mockRefresh,
+  },
+}));
+
+vi.mock("$lib/bindings", () => ({
+  commands: {
+    installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
+    removePlugin: (...args: unknown[]) => mockRemovePlugin(...args),
+  },
+}));
+
+import { runPluginInstall, runPluginRemove } from "./plugin-actions";
+
+function emptyInstallResult(): InstallPluginResult_Serialize {
+  return {
+    marketplace: "acme" as MarketplaceName,
+    plugin: "p" as PluginName,
+    version: null,
+    skills: { installed: [], skipped: [], failed: [], skipped_skills: [] },
+    steering: { installed: [], failed: [], warnings: [] },
+    agents: {
+      installed: [],
+      skipped: [],
+      failed: [],
+      warnings: [],
+      installed_native: [],
+      installed_companions: null,
+    },
+  };
+}
+
+function emptyRemoveResult(): RemovePluginResult {
+  return {
+    skills: { removed: [], failures: [] },
+    steering: { removed: [], failures: [] },
+    agents: { removed: [], failures: [] },
+  };
+}
+
+const defaultCtx = {
+  marketplace: "acme",
+  plugin: "demo-plugin",
+  projectPath: "/test/project",
+  forceInstall: false,
+  acceptMcp: false,
+  refresh: () => Promise.resolve(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRefresh.mockResolvedValue(undefined);
+});
+
+describe("runPluginInstall", () => {
+  it("install success: kind=ok, banner.message populated, no errors, force=forceInstall", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a", "b"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Plugin demo-plugin: 2 skills",
+      });
+      expect(outcome.banner.warning).toBeNull();
+      expect(outcome.banner.staleRefresh).toBeNull();
+    }
+    expect(mockInstallPlugin).toHaveBeenCalledWith(
+      "acme",
+      "demo-plugin",
+      false,
+      false,
+      "/test/project",
+    );
+    expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("update mode: force=true regardless of forceInstall setting", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const ctx = { ...defaultCtx, forceInstall: false };
+    await runPluginInstall(ctx, "update");
+
+    expect(mockInstallPlugin).toHaveBeenCalledWith(
+      "acme",
+      "demo-plugin",
+      true,
+      false,
+      "/test/project",
+    );
+  });
+
+  it("anyFailed && !anyInstalled: banner.error populated", async () => {
+    const r = emptyInstallResult();
+    r.skills.failed = [
+      { name: "broken", error: "oops", kind: { kind: "install_failed" } },
+    ];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "error",
+        text: "Plugin install failed for demo-plugin: 1 skill failed",
+      });
+      expect(outcome.banner.warning).toBeNull();
+    }
+  });
+
+  it("partial success: some installed + some failed → banner.message, banner.error null", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    r.skills.failed = [
+      { name: "broken", error: "oops", kind: { kind: "install_failed" } },
+    ];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Plugin demo-plugin: 1 skill · 1 skill failed",
+      });
+      expect(outcome.banner.warning).toBeNull();
+    }
+  });
+
+  it("warnings: banner.warning populated alongside success message", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    r.agents.warnings = [
+      {
+        kind: "mcp_servers_require_opt_in",
+        agent: "scary",
+        transports: ["stdio"],
+      },
+    ];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Plugin demo-plugin: 1 skill",
+      });
+      expect(outcome.banner.warning).toBe(
+        "Plugin demo-plugin: agent 'scary' declares MCP servers [stdio] — re-run with --accept-mcp to install",
+      );
+    }
+  });
+
+  it("Tauri command returns error: kind=fail", async () => {
+    mockInstallPlugin.mockResolvedValue({
+      status: "error",
+      error: { message: "network unreachable", error_type: "internal" as ErrorType },
+    });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe(
+        "Plugin install failed for demo-plugin: network unreachable",
+      );
+    }
+  });
+
+  it("Tauri command returns undefined message: falls back to 'Unknown error'", async () => {
+    mockInstallPlugin.mockResolvedValue({
+      status: "error",
+      error: { message: undefined, error_type: "internal" as ErrorType },
+    });
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe(
+        "Plugin install failed for demo-plugin: Unknown error",
+      );
+    }
+  });
+
+  it("Tauri command throws: kind=fail with error message from throw", async () => {
+    mockInstallPlugin.mockRejectedValue(new Error("connection reset"));
+
+    const outcome = await runPluginInstall(defaultCtx, "install");
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe(
+        "Plugin install failed for demo-plugin: connection reset",
+      );
+    }
+  });
+
+  it("update mode fail prefix uses 'Update failed'", async () => {
+    mockInstallPlugin.mockResolvedValue({
+      status: "error",
+      error: { message: "disk full", error_type: "io_error" as ErrorType },
+    });
+
+    const outcome = await runPluginInstall(defaultCtx, "update");
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe("Update failed for demo-plugin: disk full");
+    }
+  });
+
+  it("update mode throw uses 'Update failed' prefix", async () => {
+    mockInstallPlugin.mockRejectedValue(new Error("crash"));
+
+    const outcome = await runPluginInstall(defaultCtx, "update");
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe("Update failed for demo-plugin: crash");
+    }
+  });
+
+  it("post-action store refresh throws: staleRefresh names store subsystem, tab refresh still runs", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    let tabRan = false;
+    mockRefresh.mockRejectedValue(new Error("store boom"));
+    const ctx = {
+      ...defaultCtx,
+      refresh: async () => {
+        tabRan = true;
+      },
+    };
+
+    const outcome = await runPluginInstall(ctx, "install");
+
+    expect(tabRan).toBe(true);
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Plugin demo-plugin: 1 skill",
+      });
+      expect(outcome.banner.staleRefresh).toBe(
+        "Plugin-update state is stale after install: store boom",
+      );
+    }
+  });
+
+  it("post-action tab refresh throws: staleRefresh names list subsystem, message preserved", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    mockRefresh.mockResolvedValue(undefined);
+    const ctx = {
+      ...defaultCtx,
+      refresh: async () => {
+        throw new Error("tab boom");
+      },
+    };
+
+    const outcome = await runPluginInstall(ctx, "install");
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Plugin demo-plugin: 1 skill",
+      });
+      expect(outcome.banner.staleRefresh).toBe(
+        "Installed-plugins list is stale after install: tab boom",
+      );
+    }
+  });
+
+  it("cascade ordering: pluginUpdates.refresh called before ctx.refresh", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const calls: string[] = [];
+    mockRefresh.mockImplementation(async () => {
+      calls.push("store-refresh");
+    });
+    const ctx = {
+      ...defaultCtx,
+      refresh: async () => {
+        calls.push("tab-refresh");
+      },
+    };
+
+    await runPluginInstall(ctx, "install");
+
+    expect(calls).toEqual(["store-refresh", "tab-refresh"]);
+  });
+
+  it("Tauri error: refresh is NOT called (store + tab)", async () => {
+    mockInstallPlugin.mockResolvedValue({
+      status: "error",
+      error: { message: "network unreachable", error_type: "internal" as ErrorType },
+    });
+
+    await runPluginInstall(defaultCtx, "install");
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("Tauri throw: refresh is NOT called (store + tab)", async () => {
+    mockInstallPlugin.mockRejectedValue(new Error("connection reset"));
+
+    await runPluginInstall(defaultCtx, "install");
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("acceptMcp: true propagates to Tauri command", async () => {
+    const r = emptyInstallResult();
+    r.skills.installed = ["a"];
+    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+
+    await runPluginInstall({ ...defaultCtx, acceptMcp: true }, "install");
+
+    expect(mockInstallPlugin).toHaveBeenCalledWith(
+      "acme",
+      "demo-plugin",
+      false,
+      true,
+      "/test/project",
+    );
+  });
+});
+
+describe("runPluginRemove", () => {
+  it("remove success: kind=ok-removed, banner.message, removeResult present", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a", "b"];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Removed plugin demo-plugin: 2 skills",
+      });
+      expect(outcome.removeResult).toBe(r);
+    }
+  });
+
+  it("remove with failures: kind=ok-removed, banner.warning", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    r.steering.failures = [
+      { item: "broken.md", error: "permission denied" },
+    ];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.primary).toBeNull();
+      expect(outcome.banner.warning).toBe(
+        "Removed plugin demo-plugin: 1 skill · 1 steering failed",
+      );
+    }
+  });
+
+  it("empty remove: kind=ok-noop, banner shows 'nothing to remove'", async () => {
+    const r = emptyRemoveResult();
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(outcome.kind).toBe("ok-noop");
+    if (outcome.kind === "ok-noop") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Removed plugin demo-plugin: nothing to remove",
+      });
+    }
+  });
+
+  it("Tauri command returns error: kind=fail", async () => {
+    mockRemovePlugin.mockResolvedValue({
+      status: "error",
+      error: { message: "project not found", error_type: "not_found" as ErrorType },
+    });
+
+    const outcome = await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe(
+        "Remove failed for demo-plugin: project not found",
+      );
+    }
+  });
+
+  it("Tauri command throws: kind=fail with error message", async () => {
+    mockRemovePlugin.mockRejectedValue(new Error("disk full"));
+
+    const outcome = await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(outcome.kind).toBe("fail");
+    if (outcome.kind === "fail") {
+      expect(outcome.error).toBe("Remove failed for demo-plugin: disk full");
+    }
+  });
+
+  it("post-action refresh throws: staleRefresh joins both subsystem messages, removeResult still correct", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    mockRefresh.mockRejectedValue(new Error("store boom"));
+    const ctx = {
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: async () => {
+        throw new Error("tab boom");
+      },
+    };
+
+    const outcome = await runPluginRemove(ctx);
+
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "message",
+        text: "Removed plugin demo-plugin: 1 skill",
+      });
+      expect(outcome.banner.staleRefresh).toBe(
+        "Plugin-update state is stale after remove: store boom — Installed-plugins list is stale after remove: tab boom",
+      );
+      expect(outcome.removeResult).toBe(r);
+    }
+  });
+
+  it("post-action store refresh throws: staleRefresh names store subsystem, tab refresh still runs", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    let tabRan = false;
+    mockRefresh.mockRejectedValue(new Error("store boom"));
+    const ctx = {
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: async () => {
+        tabRan = true;
+      },
+    };
+
+    const outcome = await runPluginRemove(ctx);
+
+    expect(tabRan).toBe(true);
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.staleRefresh).toBe(
+        "Plugin-update state is stale after remove: store boom",
+      );
+    }
+  });
+
+  it("post-action tab refresh throws: staleRefresh names list subsystem", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    mockRefresh.mockResolvedValue(undefined);
+    const ctx = {
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: async () => {
+        throw new Error("tab boom");
+      },
+    };
+
+    const outcome = await runPluginRemove(ctx);
+
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.staleRefresh).toBe(
+        "Installed-plugins list is stale after remove: tab boom",
+      );
+    }
+  });
+
+  it("cascade ordering: pluginUpdates.refresh called before ctx.refresh", async () => {
+    const r = emptyRemoveResult();
+    r.skills.removed = ["a"];
+    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+
+    const calls: string[] = [];
+    mockRefresh.mockImplementation(async () => {
+      calls.push("store-refresh");
+    });
+    const ctx = {
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: async () => {
+        calls.push("tab-refresh");
+      },
+    };
+
+    await runPluginRemove(ctx);
+
+    expect(calls).toEqual(["store-refresh", "tab-refresh"]);
+  });
+
+  it("Tauri error: refresh is NOT called (store + tab)", async () => {
+    mockRemovePlugin.mockResolvedValue({
+      status: "error",
+      error: { message: "project not found", error_type: "not_found" as ErrorType },
+    });
+
+    await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("Tauri throw: refresh is NOT called (store + tab)", async () => {
+    mockRemovePlugin.mockRejectedValue(new Error("disk full"));
+
+    await runPluginRemove({
+      marketplace: "acme",
+      plugin: "demo-plugin",
+      projectPath: "/test/project",
+      refresh: () => Promise.resolve(),
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/crates/kiro-control-center/src/lib/plugin-actions.test.ts
+++ b/crates/kiro-control-center/src/lib/plugin-actions.test.ts
@@ -1,34 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  ErrorType,
   InstallPluginResult_Serialize,
   MarketplaceName,
   PluginName,
   RemovePluginResult,
-  ErrorType,
 } from "$lib/bindings";
 
-const { mockRefresh, mockInstallPlugin, mockRemovePlugin } = vi.hoisted(() => ({
-  mockRefresh: vi.fn<(projectPath: string) => Promise<void>>().mockResolvedValue(
-    undefined,
-  ),
-  mockInstallPlugin: vi.fn(),
-  mockRemovePlugin: vi.fn(),
-}));
-
-vi.mock("$lib/stores/plugin-updates.svelte", () => ({
-  pluginUpdates: {
-    refresh: mockRefresh,
-  },
-}));
-
-vi.mock("$lib/bindings", () => ({
-  commands: {
-    installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
-    removePlugin: (...args: unknown[]) => mockRemovePlugin(...args),
-  },
-}));
-
-import { runPluginInstall, runPluginRemove } from "./plugin-actions";
+import {
+  runPluginInstall,
+  runPluginRemove,
+  type PluginActionContext,
+  type PluginRemoveContext,
+} from "./plugin-actions";
 
 function emptyInstallResult(): InstallPluginResult_Serialize {
   return {
@@ -56,27 +40,53 @@ function emptyRemoveResult(): RemovePluginResult {
   };
 }
 
-const defaultCtx = {
-  marketplace: "acme",
-  plugin: "demo-plugin",
-  projectPath: "/test/project",
-  forceInstall: false,
-  acceptMcp: false,
-  refresh: () => Promise.resolve(),
-};
+function makeInstallCtx(
+  overrides: Partial<PluginActionContext> = {},
+): PluginActionContext {
+  return {
+    marketplace: "acme",
+    plugin: "demo-plugin",
+    projectPath: "/test/project",
+    forceInstall: false,
+    acceptMcp: false,
+    refresh: () => Promise.resolve(),
+    storeRefresh: () => Promise.resolve(),
+    installPlugin: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRemoveCtx(
+  overrides: Partial<PluginRemoveContext> = {},
+): PluginRemoveContext {
+  return {
+    marketplace: "acme",
+    plugin: "demo-plugin",
+    projectPath: "/test/project",
+    refresh: () => Promise.resolve(),
+    storeRefresh: () => Promise.resolve(),
+    removePlugin: vi.fn(),
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockRefresh.mockResolvedValue(undefined);
 });
 
 describe("runPluginInstall", () => {
   it("install success: kind=ok, banner.message populated, no errors, force=forceInstall", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a", "b"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
+    const storeRefresh = vi.fn().mockResolvedValue(undefined);
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin, storeRefresh }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("ok");
     if (outcome.kind === "ok") {
@@ -87,25 +97,29 @@ describe("runPluginInstall", () => {
       expect(outcome.banner.warning).toBeNull();
       expect(outcome.banner.staleRefresh).toBeNull();
     }
-    expect(mockInstallPlugin).toHaveBeenCalledWith(
+    expect(installPlugin).toHaveBeenCalledWith(
       "acme",
       "demo-plugin",
       false,
       false,
       "/test/project",
     );
-    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(storeRefresh).toHaveBeenCalledOnce();
   });
 
   it("update mode: force=true regardless of forceInstall setting", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const ctx = { ...defaultCtx, forceInstall: false };
-    await runPluginInstall(ctx, "update");
+    await runPluginInstall(
+      makeInstallCtx({ installPlugin, forceInstall: false }),
+      "update",
+    );
 
-    expect(mockInstallPlugin).toHaveBeenCalledWith(
+    expect(installPlugin).toHaveBeenCalledWith(
       "acme",
       "demo-plugin",
       true,
@@ -119,9 +133,14 @@ describe("runPluginInstall", () => {
     r.skills.failed = [
       { name: "broken", error: "oops", kind: { kind: "install_failed" } },
     ];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("ok");
     if (outcome.kind === "ok") {
@@ -139,9 +158,14 @@ describe("runPluginInstall", () => {
     r.skills.failed = [
       { name: "broken", error: "oops", kind: { kind: "install_failed" } },
     ];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("ok");
     if (outcome.kind === "ok") {
@@ -163,9 +187,14 @@ describe("runPluginInstall", () => {
         transports: ["stdio"],
       },
     ];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("ok");
     if (outcome.kind === "ok") {
@@ -180,12 +209,17 @@ describe("runPluginInstall", () => {
   });
 
   it("Tauri command returns error: kind=fail", async () => {
-    mockInstallPlugin.mockResolvedValue({
-      status: "error",
-      error: { message: "network unreachable", error_type: "internal" as ErrorType },
-    });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: "network unreachable", error_type: "internal" as ErrorType },
+      });
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -196,12 +230,17 @@ describe("runPluginInstall", () => {
   });
 
   it("Tauri command returns undefined message: falls back to 'Unknown error'", async () => {
-    mockInstallPlugin.mockResolvedValue({
-      status: "error",
-      error: { message: undefined, error_type: "internal" as ErrorType },
-    });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: undefined, error_type: "internal" as ErrorType },
+      });
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -212,9 +251,14 @@ describe("runPluginInstall", () => {
   });
 
   it("Tauri command throws: kind=fail with error message from throw", async () => {
-    mockInstallPlugin.mockRejectedValue(new Error("connection reset"));
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockRejectedValue(new Error("connection reset"));
 
-    const outcome = await runPluginInstall(defaultCtx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -225,12 +269,17 @@ describe("runPluginInstall", () => {
   });
 
   it("update mode fail prefix uses 'Update failed'", async () => {
-    mockInstallPlugin.mockResolvedValue({
-      status: "error",
-      error: { message: "disk full", error_type: "io_error" as ErrorType },
-    });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: "disk full", error_type: "io_error" as ErrorType },
+      });
 
-    const outcome = await runPluginInstall(defaultCtx, "update");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "update",
+    );
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -239,9 +288,14 @@ describe("runPluginInstall", () => {
   });
 
   it("update mode throw uses 'Update failed' prefix", async () => {
-    mockInstallPlugin.mockRejectedValue(new Error("crash"));
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockRejectedValue(new Error("crash"));
 
-    const outcome = await runPluginInstall(defaultCtx, "update");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({ installPlugin }),
+      "update",
+    );
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -252,18 +306,22 @@ describe("runPluginInstall", () => {
   it("post-action store refresh throws: staleRefresh names store subsystem, tab refresh still runs", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
+    const storeRefresh = vi.fn().mockRejectedValue(new Error("store boom"));
 
     let tabRan = false;
-    mockRefresh.mockRejectedValue(new Error("store boom"));
-    const ctx = {
-      ...defaultCtx,
-      refresh: async () => {
-        tabRan = true;
-      },
-    };
-
-    const outcome = await runPluginInstall(ctx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({
+        installPlugin,
+        storeRefresh,
+        refresh: async () => {
+          tabRan = true;
+        },
+      }),
+      "install",
+    );
 
     expect(tabRan).toBe(true);
     expect(outcome.kind).toBe("ok");
@@ -281,17 +339,19 @@ describe("runPluginInstall", () => {
   it("post-action tab refresh throws: staleRefresh names list subsystem, message preserved", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    mockRefresh.mockResolvedValue(undefined);
-    const ctx = {
-      ...defaultCtx,
-      refresh: async () => {
-        throw new Error("tab boom");
-      },
-    };
-
-    const outcome = await runPluginInstall(ctx, "install");
+    const outcome = await runPluginInstall(
+      makeInstallCtx({
+        installPlugin,
+        refresh: async () => {
+          throw new Error("tab boom");
+        },
+      }),
+      "install",
+    );
 
     expect(outcome.kind).toBe("ok");
     if (outcome.kind === "ok") {
@@ -305,54 +365,76 @@ describe("runPluginInstall", () => {
     }
   });
 
-  it("cascade ordering: pluginUpdates.refresh called before ctx.refresh", async () => {
+  it("cascade ordering: storeRefresh called before ctx.refresh", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
     const calls: string[] = [];
-    mockRefresh.mockImplementation(async () => {
+    const storeRefresh = vi.fn().mockImplementation(async () => {
       calls.push("store-refresh");
     });
-    const ctx = {
-      ...defaultCtx,
-      refresh: async () => {
-        calls.push("tab-refresh");
-      },
-    };
 
-    await runPluginInstall(ctx, "install");
+    await runPluginInstall(
+      makeInstallCtx({
+        installPlugin,
+        storeRefresh,
+        refresh: async () => {
+          calls.push("tab-refresh");
+        },
+      }),
+      "install",
+    );
 
     expect(calls).toEqual(["store-refresh", "tab-refresh"]);
   });
 
   it("Tauri error: refresh is NOT called (store + tab)", async () => {
-    mockInstallPlugin.mockResolvedValue({
-      status: "error",
-      error: { message: "network unreachable", error_type: "internal" as ErrorType },
-    });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: "network unreachable", error_type: "internal" as ErrorType },
+      });
+    const storeRefresh = vi.fn().mockResolvedValue(undefined);
 
-    await runPluginInstall(defaultCtx, "install");
+    await runPluginInstall(
+      makeInstallCtx({ installPlugin, storeRefresh }),
+      "install",
+    );
 
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(storeRefresh).not.toHaveBeenCalled();
   });
 
   it("Tauri throw: refresh is NOT called (store + tab)", async () => {
-    mockInstallPlugin.mockRejectedValue(new Error("connection reset"));
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockRejectedValue(new Error("connection reset"));
+    const storeRefresh = vi.fn().mockResolvedValue(undefined);
 
-    await runPluginInstall(defaultCtx, "install");
+    await runPluginInstall(
+      makeInstallCtx({ installPlugin, storeRefresh }),
+      "install",
+    );
 
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(storeRefresh).not.toHaveBeenCalled();
   });
 
   it("acceptMcp: true propagates to Tauri command", async () => {
     const r = emptyInstallResult();
     r.skills.installed = ["a"];
-    mockInstallPlugin.mockResolvedValue({ status: "ok", data: r });
+    const installPlugin: PluginActionContext["installPlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    await runPluginInstall({ ...defaultCtx, acceptMcp: true }, "install");
+    await runPluginInstall(
+      makeInstallCtx({ installPlugin, acceptMcp: true }),
+      "install",
+    );
 
-    expect(mockInstallPlugin).toHaveBeenCalledWith(
+    expect(installPlugin).toHaveBeenCalledWith(
       "acme",
       "demo-plugin",
       false,
@@ -366,14 +448,11 @@ describe("runPluginRemove", () => {
   it("remove success: kind=ok-removed, banner.message, removeResult present", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a", "b"];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
 
     expect(outcome.kind).toBe("ok-removed");
     if (outcome.kind === "ok-removed") {
@@ -385,20 +464,17 @@ describe("runPluginRemove", () => {
     }
   });
 
-  it("remove with failures: kind=ok-removed, banner.warning", async () => {
+  it("remove with partial failures: kind=ok-removed, banner.warning", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a"];
     r.steering.failures = [
       { item: "broken.md", error: "permission denied" },
     ];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
 
     expect(outcome.kind).toBe("ok-removed");
     if (outcome.kind === "ok-removed") {
@@ -409,16 +485,41 @@ describe("runPluginRemove", () => {
     }
   });
 
+  it("hasFailures && !hasItems: primary error 'Remove failed', no misleading 'Removed plugin' prefix, removeResult populated", async () => {
+    // Total-fail: every removal attempt failed, nothing was actually removed.
+    // Banner must be a red error ("Remove failed for X: ...") not an amber
+    // "Removed plugin X: ..." (which would lie). removeResult stays populated
+    // so the per-failure details panel can render — useful context for the
+    // user about which items failed and why.
+    const r = emptyRemoveResult();
+    r.skills.failures = [
+      { item: "a", error: "permission denied" },
+      { item: "b", error: "locked file" },
+    ];
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
+
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
+
+    expect(outcome.kind).toBe("ok-removed");
+    if (outcome.kind === "ok-removed") {
+      expect(outcome.banner.primary).toEqual({
+        kind: "error",
+        text: "Remove failed for demo-plugin: 2 skills failed",
+      });
+      expect(outcome.banner.warning).toBeNull();
+      expect(outcome.removeResult).toBe(r);
+    }
+  });
+
   it("empty remove: kind=ok-noop, banner shows 'nothing to remove'", async () => {
     const r = emptyRemoveResult();
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    const outcome = await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
 
     expect(outcome.kind).toBe("ok-noop");
     if (outcome.kind === "ok-noop") {
@@ -430,17 +531,14 @@ describe("runPluginRemove", () => {
   });
 
   it("Tauri command returns error: kind=fail", async () => {
-    mockRemovePlugin.mockResolvedValue({
-      status: "error",
-      error: { message: "project not found", error_type: "not_found" as ErrorType },
-    });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: "project not found", error_type: "not_found" as ErrorType },
+      });
 
-    const outcome = await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -451,14 +549,11 @@ describe("runPluginRemove", () => {
   });
 
   it("Tauri command throws: kind=fail with error message", async () => {
-    mockRemovePlugin.mockRejectedValue(new Error("disk full"));
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockRejectedValue(new Error("disk full"));
 
-    const outcome = await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    const outcome = await runPluginRemove(makeRemoveCtx({ removePlugin }));
 
     expect(outcome.kind).toBe("fail");
     if (outcome.kind === "fail") {
@@ -469,19 +564,20 @@ describe("runPluginRemove", () => {
   it("post-action refresh throws: staleRefresh joins both subsystem messages, removeResult still correct", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a"];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
+    const storeRefresh = vi.fn().mockRejectedValue(new Error("store boom"));
 
-    mockRefresh.mockRejectedValue(new Error("store boom"));
-    const ctx = {
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: async () => {
-        throw new Error("tab boom");
-      },
-    };
-
-    const outcome = await runPluginRemove(ctx);
+    const outcome = await runPluginRemove(
+      makeRemoveCtx({
+        removePlugin,
+        storeRefresh,
+        refresh: async () => {
+          throw new Error("tab boom");
+        },
+      }),
+    );
 
     expect(outcome.kind).toBe("ok-removed");
     if (outcome.kind === "ok-removed") {
@@ -499,20 +595,21 @@ describe("runPluginRemove", () => {
   it("post-action store refresh throws: staleRefresh names store subsystem, tab refresh still runs", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a"];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
+    const storeRefresh = vi.fn().mockRejectedValue(new Error("store boom"));
 
     let tabRan = false;
-    mockRefresh.mockRejectedValue(new Error("store boom"));
-    const ctx = {
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: async () => {
-        tabRan = true;
-      },
-    };
-
-    const outcome = await runPluginRemove(ctx);
+    const outcome = await runPluginRemove(
+      makeRemoveCtx({
+        removePlugin,
+        storeRefresh,
+        refresh: async () => {
+          tabRan = true;
+        },
+      }),
+    );
 
     expect(tabRan).toBe(true);
     expect(outcome.kind).toBe("ok-removed");
@@ -526,19 +623,18 @@ describe("runPluginRemove", () => {
   it("post-action tab refresh throws: staleRefresh names list subsystem", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a"];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
-    mockRefresh.mockResolvedValue(undefined);
-    const ctx = {
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: async () => {
-        throw new Error("tab boom");
-      },
-    };
-
-    const outcome = await runPluginRemove(ctx);
+    const outcome = await runPluginRemove(
+      makeRemoveCtx({
+        removePlugin,
+        refresh: async () => {
+          throw new Error("tab boom");
+        },
+      }),
+    );
 
     expect(outcome.kind).toBe("ok-removed");
     if (outcome.kind === "ok-removed") {
@@ -548,55 +644,53 @@ describe("runPluginRemove", () => {
     }
   });
 
-  it("cascade ordering: pluginUpdates.refresh called before ctx.refresh", async () => {
+  it("cascade ordering: storeRefresh called before ctx.refresh", async () => {
     const r = emptyRemoveResult();
     r.skills.removed = ["a"];
-    mockRemovePlugin.mockResolvedValue({ status: "ok", data: r });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: r });
 
     const calls: string[] = [];
-    mockRefresh.mockImplementation(async () => {
+    const storeRefresh = vi.fn().mockImplementation(async () => {
       calls.push("store-refresh");
     });
-    const ctx = {
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: async () => {
-        calls.push("tab-refresh");
-      },
-    };
 
-    await runPluginRemove(ctx);
+    await runPluginRemove(
+      makeRemoveCtx({
+        removePlugin,
+        storeRefresh,
+        refresh: async () => {
+          calls.push("tab-refresh");
+        },
+      }),
+    );
 
     expect(calls).toEqual(["store-refresh", "tab-refresh"]);
   });
 
   it("Tauri error: refresh is NOT called (store + tab)", async () => {
-    mockRemovePlugin.mockResolvedValue({
-      status: "error",
-      error: { message: "project not found", error_type: "not_found" as ErrorType },
-    });
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockResolvedValue({
+        status: "error",
+        error: { message: "project not found", error_type: "not_found" as ErrorType },
+      });
+    const storeRefresh = vi.fn().mockResolvedValue(undefined);
 
-    await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    await runPluginRemove(makeRemoveCtx({ removePlugin, storeRefresh }));
 
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(storeRefresh).not.toHaveBeenCalled();
   });
 
   it("Tauri throw: refresh is NOT called (store + tab)", async () => {
-    mockRemovePlugin.mockRejectedValue(new Error("disk full"));
+    const removePlugin: PluginRemoveContext["removePlugin"] = vi
+      .fn()
+      .mockRejectedValue(new Error("disk full"));
+    const storeRefresh = vi.fn().mockResolvedValue(undefined);
 
-    await runPluginRemove({
-      marketplace: "acme",
-      plugin: "demo-plugin",
-      projectPath: "/test/project",
-      refresh: () => Promise.resolve(),
-    });
+    await runPluginRemove(makeRemoveCtx({ removePlugin, storeRefresh }));
 
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(storeRefresh).not.toHaveBeenCalled();
   });
 });

--- a/crates/kiro-control-center/src/lib/plugin-actions.ts
+++ b/crates/kiro-control-center/src/lib/plugin-actions.ts
@@ -1,0 +1,201 @@
+import { commands } from "$lib/bindings";
+import type { RemovePluginResult } from "$lib/bindings";
+import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
+import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+
+export type PluginActionMode = "install" | "update";
+
+export type PluginActionContext = {
+  marketplace: string;
+  plugin: string;
+  projectPath: string;
+  forceInstall: boolean;
+  // Security-critical: agents declaring mcp_servers are refused unless
+  // acceptMcp is true. With acceptMcp = false the agent produces
+  // InstallWarning::McpServersRequireOptIn and never lands in installed or
+  // failed — the warning names the agent and its transports so the user
+  // can re-run with the opt-in.
+  acceptMcp: boolean;
+  refresh: () => Promise<void>;
+};
+
+export type PluginRemoveContext = {
+  marketplace: string;
+  plugin: string;
+  projectPath: string;
+  refresh: () => Promise<void>;
+};
+
+export type PluginBanner = {
+  primary: { kind: "error"; text: string } | { kind: "message"; text: string } | null;
+  warning: string | null;
+  // Joined post-action refresh failures. The message text distinguishes
+  // which subsystem is stale (store vs. installed-list); independent
+  // dismiss per-subsystem isn't a UX requirement, so a single channel.
+  staleRefresh: string | null;
+};
+
+export type PluginActionOutcome =
+  | { kind: "ok"; banner: PluginBanner }
+  | { kind: "fail"; error: string };
+
+export type PluginRemoveOutcome =
+  | { kind: "ok-removed"; banner: PluginBanner; removeResult: RemovePluginResult }
+  | { kind: "ok-noop"; banner: PluginBanner }
+  | { kind: "fail"; error: string };
+
+export async function runPluginInstall(
+  ctx: PluginActionContext,
+  mode: PluginActionMode,
+): Promise<PluginActionOutcome> {
+  const force = mode === "update" ? true : ctx.forceInstall;
+  const failPrefix =
+    mode === "update"
+      ? `Update failed for ${ctx.plugin}`
+      : `Plugin install failed for ${ctx.plugin}`;
+  const successPrefix =
+    mode === "update" ? `Updated ${ctx.plugin}` : `Plugin ${ctx.plugin}`;
+
+  try {
+    const result = await commands.installPlugin(
+      ctx.marketplace,
+      ctx.plugin,
+      force,
+      ctx.acceptMcp,
+      ctx.projectPath,
+    );
+    if (result.status === "ok") {
+      const { summary, warnings, anyInstalled, anyFailed } =
+        formatInstallPluginResult(result.data);
+
+      let primary: PluginBanner["primary"] = null;
+      let warning: string | null = null;
+      const staleParts: string[] = [];
+
+      if (anyFailed && !anyInstalled) {
+        primary = { kind: "error", text: `${failPrefix}: ${summary}` };
+      } else {
+        primary = { kind: "message", text: `${successPrefix}: ${summary}` };
+      }
+      if (warnings) {
+        warning = `${successPrefix}: ${warnings}`;
+      }
+
+      // Plugin-updates store must refresh BEFORE the caller's local refresh
+      // so updateFor / failureFor are based on fresh state when the caller
+      // re-reads the project's installed list. If `ctx.refresh()` ran first,
+      // the template would pair stale (pre-refresh) store data with the new
+      // installed-plugins list, briefly showing "update available" badges
+      // for plugins that were just installed.
+      try {
+        await pluginUpdates.refresh(ctx.projectPath);
+      } catch (e) {
+        console.error(
+          `[plugin-actions] pluginUpdates.refresh threw after ${mode}`,
+          e,
+        );
+        const reason = e instanceof Error ? e.message : String(e);
+        staleParts.push(`Plugin-update state is stale after ${mode}: ${reason}`);
+      }
+
+      try {
+        await ctx.refresh();
+      } catch (e) {
+        console.error(
+          `[plugin-actions] tab refresh threw after ${mode}`,
+          e,
+        );
+        const reason = e instanceof Error ? e.message : String(e);
+        staleParts.push(`Installed-plugins list is stale after ${mode}: ${reason}`);
+      }
+
+      const staleRefresh = staleParts.length > 0 ? staleParts.join(" — ") : null;
+      return {
+        kind: "ok",
+        banner: { primary, warning, staleRefresh },
+      };
+    }
+    return {
+      kind: "fail",
+      error: `${failPrefix}: ${result.error.message ?? "Unknown error"}`,
+    };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    return { kind: "fail", error: `${failPrefix}: ${reason}` };
+  }
+}
+
+export async function runPluginRemove(
+  ctx: PluginRemoveContext,
+): Promise<PluginRemoveOutcome> {
+  try {
+    const result = await commands.removePlugin(
+      ctx.marketplace,
+      ctx.plugin,
+      ctx.projectPath,
+    );
+    if (result.status === "ok") {
+      const { summary, hasItems, hasFailures } =
+        formatRemovePluginResult(result.data);
+
+      let primary: PluginBanner["primary"] = null;
+      let warning: string | null = null;
+      const staleParts: string[] = [];
+
+      // Always emit a banner — even "nothing to remove" gives the user
+      // feedback that the action completed instead of feeling inert.
+      if (hasFailures) {
+        warning = `Removed plugin ${ctx.plugin}: ${summary}`;
+      } else {
+        primary = { kind: "message", text: `Removed plugin ${ctx.plugin}: ${summary}` };
+      }
+
+      try {
+        await pluginUpdates.refresh(ctx.projectPath);
+      } catch (e) {
+        console.error(
+          "[plugin-actions] pluginUpdates.refresh threw after remove",
+          e,
+        );
+        const reason = e instanceof Error ? e.message : String(e);
+        staleParts.push(`Plugin-update state is stale after remove: ${reason}`);
+      }
+
+      try {
+        await ctx.refresh();
+      } catch (e) {
+        console.error(
+          "[plugin-actions] tab refresh threw after remove",
+          e,
+        );
+        const reason = e instanceof Error ? e.message : String(e);
+        staleParts.push(`Installed-plugins list is stale after remove: ${reason}`);
+      }
+
+      const banner: PluginBanner = {
+        primary,
+        warning,
+        staleRefresh: staleParts.length > 0 ? staleParts.join(" — ") : null,
+      };
+
+      if (hasItems || hasFailures) {
+        return {
+          kind: "ok-removed",
+          banner,
+          removeResult: result.data,
+        };
+      }
+      return { kind: "ok-noop", banner };
+    }
+    return {
+      kind: "fail",
+      error: `Remove failed for ${ctx.plugin}: ${result.error.message ?? "Unknown error"}`,
+    };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    return {
+      kind: "fail",
+      error: `Remove failed for ${ctx.plugin}: ${reason}`,
+    };
+  }
+}

--- a/crates/kiro-control-center/src/lib/plugin-actions.ts
+++ b/crates/kiro-control-center/src/lib/plugin-actions.ts
@@ -1,7 +1,32 @@
-import { commands } from "$lib/bindings";
-import type { RemovePluginResult } from "$lib/bindings";
+import type {
+  CommandError,
+  InstallPluginResult_Serialize,
+  RemovePluginResult,
+} from "$lib/bindings";
 import { formatInstallPluginResult, formatRemovePluginResult } from "$lib/format";
-import { pluginUpdates } from "$lib/stores/plugin-updates.svelte";
+
+// Mirrors the shape produced by `typedError<T, CommandError>` in bindings.ts.
+// Re-declared here so this module stays pure-logic — no runtime import of
+// `commands` or any Tauri IPC machinery; callers inject the IPC functions
+// via context (CLAUDE.md "no Tauri-IPC mocks" — tests construct fakes
+// directly without `vi.mock`).
+type IpcResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "error"; error: CommandError };
+
+export type InstallPluginFn = (
+  marketplace: string,
+  plugin: string,
+  force: boolean,
+  acceptMcp: boolean,
+  projectPath: string,
+) => Promise<IpcResult<InstallPluginResult_Serialize>>;
+
+export type RemovePluginFn = (
+  marketplace: string,
+  plugin: string,
+  projectPath: string,
+) => Promise<IpcResult<RemovePluginResult>>;
 
 export type PluginActionMode = "install" | "update";
 
@@ -17,6 +42,9 @@ export type PluginActionContext = {
   // can re-run with the opt-in.
   acceptMcp: boolean;
   refresh: () => Promise<void>;
+  // Injected dependencies — see IpcResult comment above.
+  installPlugin: InstallPluginFn;
+  storeRefresh: (projectPath: string) => Promise<void>;
 };
 
 export type PluginRemoveContext = {
@@ -24,6 +52,9 @@ export type PluginRemoveContext = {
   plugin: string;
   projectPath: string;
   refresh: () => Promise<void>;
+  // Injected dependencies — see IpcResult comment above.
+  removePlugin: RemovePluginFn;
+  storeRefresh: (projectPath: string) => Promise<void>;
 };
 
 export type PluginBanner = {
@@ -57,7 +88,7 @@ export async function runPluginInstall(
     mode === "update" ? `Updated ${ctx.plugin}` : `Plugin ${ctx.plugin}`;
 
   try {
-    const result = await commands.installPlugin(
+    const result = await ctx.installPlugin(
       ctx.marketplace,
       ctx.plugin,
       force,
@@ -88,7 +119,7 @@ export async function runPluginInstall(
       // installed-plugins list, briefly showing "update available" badges
       // for plugins that were just installed.
       try {
-        await pluginUpdates.refresh(ctx.projectPath);
+        await ctx.storeRefresh(ctx.projectPath);
       } catch (e) {
         console.error(
           `[plugin-actions] pluginUpdates.refresh threw after ${mode}`,
@@ -129,7 +160,7 @@ export async function runPluginRemove(
   ctx: PluginRemoveContext,
 ): Promise<PluginRemoveOutcome> {
   try {
-    const result = await commands.removePlugin(
+    const result = await ctx.removePlugin(
       ctx.marketplace,
       ctx.plugin,
       ctx.projectPath,
@@ -144,14 +175,25 @@ export async function runPluginRemove(
 
       // Always emit a banner — even "nothing to remove" gives the user
       // feedback that the action completed instead of feeling inert.
-      if (hasFailures) {
+      // Three cases: total-fail (everything failed, nothing removed) →
+      // red error banner because "Removed plugin X" would lie. Partial-fail
+      // (some items removed, some failed) → amber warning. Clean success →
+      // green message. The total-fail branch keeps `kind: "ok-removed"` so
+      // the per-failure details panel still renders, giving the user
+      // actionable context about which items failed and why.
+      if (hasFailures && !hasItems) {
+        primary = {
+          kind: "error",
+          text: `Remove failed for ${ctx.plugin}: ${summary}`,
+        };
+      } else if (hasFailures) {
         warning = `Removed plugin ${ctx.plugin}: ${summary}`;
       } else {
         primary = { kind: "message", text: `Removed plugin ${ctx.plugin}: ${summary}` };
       }
 
       try {
-        await pluginUpdates.refresh(ctx.projectPath);
+        await ctx.storeRefresh(ctx.projectPath);
       } catch (e) {
         console.error(
           "[plugin-actions] pluginUpdates.refresh threw after remove",

--- a/crates/kiro-control-center/src/lib/stores/plugin-update-banners.svelte.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-update-banners.svelte.ts
@@ -1,8 +1,5 @@
-import {
-  ERR_UPDATE_FETCH,
-  UPDATE_CHECK_PREFIX,
-  updateCheckErrKey,
-} from "$lib/error-source";
+import { untrack } from "svelte";
+import { ERR_UPDATE_FETCH } from "$lib/error-source";
 import type { UpdateCheckKey } from "$lib/error-source";
 import { pluginUpdates } from "./plugin-updates.svelte";
 import { projectUpdateCheckBanners } from "./plugin-updates";
@@ -46,9 +43,16 @@ export function usePluginUpdateBanners(args: {
   });
 
   $effect(() => {
+    // Snapshot keys via `untrack` so this effect doesn't re-fire on its own
+    // writes. `SvelteMap.keys()` is reactive in Svelte 5; without untrack,
+    // the set/delete calls below would mutate the keyset the effect just
+    // depended on, triggering re-runs that rely on Svelte's idempotent-write
+    // optimization to terminate. The real signal that should drive banner
+    // updates is `pluginUpdates.failureGroups` (read above).
+    const existingKeys = untrack(() => Array.from(args.fetchErrors.keys()));
     const { upserts, staleKeys } = projectUpdateCheckBanners(
       pluginUpdates.failureGroups,
-      args.fetchErrors.keys(),
+      existingKeys,
     );
     for (const [key, msg] of upserts) {
       args.fetchErrors.set(key, msg);

--- a/crates/kiro-control-center/src/lib/stores/plugin-update-banners.svelte.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-update-banners.svelte.ts
@@ -1,0 +1,71 @@
+import {
+  ERR_UPDATE_FETCH,
+  UPDATE_CHECK_PREFIX,
+  updateCheckErrKey,
+} from "$lib/error-source";
+import type { UpdateCheckKey } from "$lib/error-source";
+import { pluginUpdates } from "./plugin-updates.svelte";
+import { projectUpdateCheckBanners } from "./plugin-updates";
+
+/**
+ * Reactive helper that projects plugin-update store state into a caller-owned
+ * `fetchErrors` SvelteMap. Must be called once at component-init time (inside
+ * the component's reactive scope) — it registers three `$effect` blocks under
+ * the hood.
+ *
+ * The helper only ever writes two families of keys:
+ *   - `UpdateCheckKey` (failure-group banners)
+ *   - `typeof ERR_UPDATE_FETCH` (toplevel fetch error)
+ * and removes stale `UpdateCheckKey` entries on each re-computation.
+ *
+ * The `fetchErrors` map may have a wider key type than what this helper writes,
+ * but its `set`/`delete` methods must accept at least `UpdateCheckKey |
+ * typeof ERR_UPDATE_FETCH` — structural typing (method-parameter
+ * contravariance) means `SvelteMap<ErrorSource, string>` satisfies this
+ * interface even when `ErrorSource` is a wider union.
+ */
+export function usePluginUpdateBanners(args: {
+  projectPath: () => string;
+  fetchErrors: {
+    set(key: UpdateCheckKey | typeof ERR_UPDATE_FETCH, value: string): void;
+    delete(key: UpdateCheckKey | typeof ERR_UPDATE_FETCH): void;
+    keys(): Iterable<string>;
+  };
+  logPrefix: string;
+}): void {
+  $effect(() => {
+    const p = args.projectPath();
+    pluginUpdates
+      .refresh(p)
+      .catch((e) =>
+        console.error(
+          `[${args.logPrefix}] pluginUpdates.refresh threw`,
+          e,
+        ),
+      );
+  });
+
+  $effect(() => {
+    const { upserts, staleKeys } = projectUpdateCheckBanners(
+      pluginUpdates.failureGroups,
+      args.fetchErrors.keys(),
+    );
+    for (const [key, msg] of upserts) {
+      args.fetchErrors.set(key, msg);
+    }
+    for (const k of staleKeys) {
+      args.fetchErrors.delete(k);
+    }
+  });
+
+  $effect(() => {
+    if (pluginUpdates.fetchError) {
+      args.fetchErrors.set(
+        ERR_UPDATE_FETCH,
+        `Couldn't check for updates: ${pluginUpdates.fetchError}`,
+      );
+    } else {
+      args.fetchErrors.delete(ERR_UPDATE_FETCH);
+    }
+  });
+}

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.test.ts
@@ -10,9 +10,11 @@ import {
   actionUpdateLabel,
   groupFailures,
   kindLabel,
+  projectUpdateCheckBanners,
   remediationClass,
   statusUpdateLabel,
 } from "./plugin-updates";
+import { updateCheckErrKey } from "../error-source";
 import type { FailureGroup } from "./plugin-updates";
 
 describe("remediationClass", () => {
@@ -270,5 +272,80 @@ describe("groupFailures", () => {
     for (const g of groups) {
       expect(g.remediationHint.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("projectUpdateCheckBanners", () => {
+  it("returns empty upserts and no staleKeys for empty groups", () => {
+    const { upserts, staleKeys } = projectUpdateCheckBanners([], []);
+    expect(upserts.size).toBe(0);
+    expect(staleKeys).toEqual([]);
+  });
+
+  it("produces one upsert per failure group", () => {
+    const { upserts, staleKeys } = projectUpdateCheckBanners(
+      groupFailures([
+        failure("acme", "p1", { kind: "marketplace_unavailable" }),
+        failure("acme", "p2", { kind: "manifest_unreadable" }),
+      ]),
+      [],
+    );
+    expect(upserts.size).toBe(1);
+    expect(staleKeys).toEqual([]);
+    expect([...upserts.keys()][0]).toBe(updateCheckErrKey("stale_cache", "acme"));
+  });
+
+  it("returns staleKeys for existing update-check keys not in the groups", () => {
+    const { staleKeys } = projectUpdateCheckBanners(
+      [],
+      [updateCheckErrKey("stale_cache", "acme"), updateCheckErrKey("manifest_invalid", "beta")],
+    );
+    expect(staleKeys).toEqual([
+      updateCheckErrKey("stale_cache", "acme"),
+      updateCheckErrKey("manifest_invalid", "beta"),
+    ]);
+  });
+
+  it("does NOT flag non-update-check keys as stale", () => {
+    const { staleKeys } = projectUpdateCheckBanners([], ["some-other-key", "installed-plugins"]);
+    expect(staleKeys).toEqual([]);
+  });
+
+  it("excludes keys that match a live group", () => {
+    const existing = [
+      updateCheckErrKey("stale_cache", "acme"),
+      updateCheckErrKey("stale_cache", "beta"),
+    ];
+    const { staleKeys } = projectUpdateCheckBanners(
+      groupFailures([failure("acme", "p1", { kind: "marketplace_unavailable" })]),
+      existing,
+    );
+    expect(staleKeys).toEqual([updateCheckErrKey("stale_cache", "beta")]);
+  });
+
+  it("upsert messages include plugin count and list", () => {
+    const { upserts } = projectUpdateCheckBanners(
+      groupFailures([
+        failure("acme", "p1", { kind: "marketplace_unavailable" }),
+        failure("acme", "p2", { kind: "marketplace_unavailable" }),
+      ]),
+      [],
+    );
+    const msg = [...upserts.values()][0];
+    expect(msg).toContain("2 plugins");
+    expect(msg).toContain("(p1, p2)");
+  });
+
+  it("singular noun: 1 plugin reads '1 plugin' not '1 plugins'", () => {
+    const { upserts } = projectUpdateCheckBanners(
+      groupFailures([
+        failure("acme", "p1", { kind: "marketplace_unavailable" }),
+      ]),
+      [],
+    );
+    const msg = [...upserts.values()][0];
+    expect(msg).toContain("1 plugin");
+    expect(msg).not.toContain("1 plugins");
+    expect(msg).toContain("(p1)");
   });
 });

--- a/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
+++ b/crates/kiro-control-center/src/lib/stores/plugin-updates.ts
@@ -6,8 +6,14 @@ import type {
   PluginUpdateInfo,
 } from "$lib/bindings";
 import { DELIM } from "$lib/keys";
-
-export type RemediationClass = "stale_cache" | "manifest_invalid" | "unknown";
+import {
+  isUpdateCheckKey,
+  updateCheckErrKey,
+} from "$lib/error-source";
+import type {
+  RemediationClass,
+  UpdateCheckKey,
+} from "$lib/error-source";
 
 export function remediationClass(kind: PluginUpdateFailureKind): RemediationClass {
   switch (kind.kind) {
@@ -94,4 +100,34 @@ export function actionUpdateLabel(u: PluginUpdateInfo): string {
   if (u.change_signal.kind === "content_changed") return "Update (content changed)";
   if (u.available_version) return `Update → v${u.available_version}`;
   return "Update";
+}
+
+/**
+ * Pure projection of failureGroups into an upsert+stale-delete pair.
+ * Keys are branded as UpdateCheckKey so consumers know the namespace
+ * they operate in.
+ */
+export function projectUpdateCheckBanners(
+  groups: FailureGroup[],
+  existingKeys: Iterable<string>,
+): { upserts: Map<UpdateCheckKey, string>; staleKeys: UpdateCheckKey[] } {
+  const upserts = new Map<UpdateCheckKey, string>();
+  const seen = new Set<UpdateCheckKey>();
+  for (const group of groups) {
+    const key = updateCheckErrKey(group.remediation, group.marketplace);
+    seen.add(key);
+    const noun = group.plugins.length === 1 ? "plugin" : "plugins";
+    const list = group.plugins.join(", ");
+    upserts.set(
+      key,
+      `${group.plugins.length} ${noun} from ${group.marketplace}: ${group.remediationHint} (${list})`,
+    );
+  }
+  const staleKeys: UpdateCheckKey[] = [];
+  for (const k of existingKeys) {
+    if (isUpdateCheckKey(k) && !seen.has(k)) {
+      staleKeys.push(k);
+    }
+  }
+  return { upserts, staleKeys };
 }

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@sveltejs/opencode"],
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Wire the `pluginUpdates` store + Update button + failure-group banners into both Browse and Installed tabs (single source of truth, no per-tab duplication of update-detection state)
- Extract plugin install/update/remove orchestration into shared TS helpers (`plugin-actions`, `error-source`, `plugin-update-banners`) so both tabs consume identical handlers and the previously-untestable logic gains Vitest coverage
- Branded `UpdateCheckKey` namespace with `isUpdateCheckKey` type guard, `parseUpdateCheckKey` validation; new `BannerStack.staleRefresh` slot surfaces post-action refresh failures distinct from domain warnings

## Test plan
- [ ] `cd crates/kiro-control-center && npm run check` — svelte-check, 0 errors
- [ ] `cd crates/kiro-control-center && npm run test:unit` — 91 unit tests pass
- [ ] `cd crates/kiro-control-center && npm run test:e2e` with `FIXTURE_MARKETPLACE_PATH` set — Phase 2b update-detection scenarios pass
- [ ] Manual: install a plugin via BrowseTab → success banner shows; if `pluginUpdates.refresh` throws post-action, `staleRefresh` banner surfaces with subsystem-naming text
- [ ] Manual: remove a plugin via InstalledTab → "Removed plugin X: …" banner always emits (including the no-op "nothing to remove" path); details panel only appears when items were actually removed
- [ ] Manual: switch project A → B → all banner state (including `installStaleRefresh`) clears in both tabs
- [ ] Manual: confirm Update button + failure-group banners surface in both tabs after a marketplace refresh, and dismissing one doesn't affect the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)