### PR TITLE
refactor(service): make FailedAgent a tagged enum

### DIFF
--- a/crates/kiro-control-center/src-tauri/src/commands/agents.rs
+++ b/crates/kiro-control-center/src-tauri/src/commands/agents.rs
@@ -416,15 +416,16 @@ mod tests {
             "expected one failure with ContentChangedRequiresForce, got: {:?}",
             result.failed
         );
-        assert!(
-            matches!(
-                &result.failed[0].error,
-                kiro_market_core::error::AgentError::ContentChangedRequiresForce { name }
-                    if name == "reviewer"
+        match &result.failed[0] {
+            kiro_market_core::service::FailedAgent::Agent {
+                error: kiro_market_core::error::AgentError::ContentChangedRequiresForce { name },
+                ..
+            } if name == "reviewer" => {}
+            other => panic!(
+                "expected FailedAgent::Agent {{ error: ContentChangedRequiresForce {{ name: \"reviewer\" }}, .. }}, \
+                 got {other:?}"
             ),
-            "wrong error variant: {:?}",
-            result.failed[0].error
-        );
+        }
 
         let json = serde_json::to_value(&result).expect("InstallAgentsResult serializes");
         let failed_error = json

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -192,6 +192,30 @@ export const commands = {
 
 /* Types */
 /**
+ *  A string that has been validated as a safe agent / skill / plugin name.
+ * 
+ *  Construction goes through [`AgentName::new`], which applies
+ *  [`validate_name`] — so holding an `AgentName` is a static guarantee
+ *  that the inner string passed name validation (non-empty, no path
+ *  separators, no `..`, no NUL, no Windows reserved names, etc.).
+ * 
+ *  The newtype replaces a plain `String` for the validated `name` field
+ *  of [`crate::agent::parse_native::NativeAgentBundle`] so downstream
+ *  install code never needs to re-validate. `Deserialize` calls `new`
+ *  internally, so any future serializable type that embeds an
+ *  `AgentName` rejects bad names at parse time.
+ * 
+ *  The native-agent projection (`NativeAgentProjection`) deliberately
+ *  keeps a raw `Option<String>` for the wire-format `name` field so the
+ *  post-parse conversion can route into distinct
+ *  [`crate::agent::parse_native::NativeParseFailure`] variants
+ *  (`MissingName` vs `InvalidName(reason)` vs `InvalidJson`) — this
+ *  granularity is part of the contract surfaced via
+ *  `service::native_parse_failure_to_agent_error`.
+ */
+export type AgentName = string;
+
+/**
  *  Canonical content hash for installed artifacts.
  * 
  *  Stored on disk as the string `"blake3:" + 64 ASCII hex chars`. The
@@ -292,6 +316,12 @@ export type ErrorType = "not_found" | "already_exists" | "validation" | "git_err
  *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
  * 
  *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
+ * 
+ *  `#[non_exhaustive]` matches the workspace convention for FFI-crossing
+ *  enums (`InstallWarning`, `PluginUpdateFailureKind`, `SkippedReason`).
+ *  Adding a fourth variant later is then a non-breaking change for
+ *  out-of-tree consumers; in-tree CLI / Tauri / test matches add `_ =>`
+ *  fallback arms.
  */
 export type FailedAgent = FailedAgent_Serialize | FailedAgent_Deserialize;
 
@@ -309,15 +339,22 @@ export type FailedAgent = FailedAgent_Serialize | FailedAgent_Deserialize;
  *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
  * 
  *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
+ * 
+ *  `#[non_exhaustive]` matches the workspace convention for FFI-crossing
+ *  enums (`InstallWarning`, `PluginUpdateFailureKind`, `SkippedReason`).
+ *  Adding a fourth variant later is then a non-breaking change for
+ *  out-of-tree consumers; in-tree CLI / Tauri / test matches add `_ =>`
+ *  fallback arms.
  */
 export type FailedAgent_Deserialize = 
 /**
  *  A native or translated agent failed during install. Name is
- *  known because parsing succeeded — callers had a parsed
- *  `AgentDefinition` or `NativeAgentBundle` in scope when the
- *  failure occurred.
+ *  the validated [`crate::validation::AgentName`] — parsing succeeded
+ *  (callers had a parsed `AgentDefinition` or `NativeAgentBundle` in
+ *  scope), so the wire format carries a guaranteed-valid identifier
+ *  rather than a raw string.
  */
-{ kind: "agent"; name: string; source_path: string; error: string } | 
+{ kind: "agent"; name: AgentName; source_path: string; error: string } | 
 /**
  *  An agent file failed before parse, so no name is available.
  *  `source_path` is the only identifier the FE can show. The
@@ -351,15 +388,22 @@ export type FailedAgent_Deserialize =
  *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
  * 
  *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
+ * 
+ *  `#[non_exhaustive]` matches the workspace convention for FFI-crossing
+ *  enums (`InstallWarning`, `PluginUpdateFailureKind`, `SkippedReason`).
+ *  Adding a fourth variant later is then a non-breaking change for
+ *  out-of-tree consumers; in-tree CLI / Tauri / test matches add `_ =>`
+ *  fallback arms.
  */
 export type FailedAgent_Serialize = 
 /**
  *  A native or translated agent failed during install. Name is
- *  known because parsing succeeded — callers had a parsed
- *  `AgentDefinition` or `NativeAgentBundle` in scope when the
- *  failure occurred.
+ *  the validated [`crate::validation::AgentName`] — parsing succeeded
+ *  (callers had a parsed `AgentDefinition` or `NativeAgentBundle` in
+ *  scope), so the wire format carries a guaranteed-valid identifier
+ *  rather than a raw string.
  */
-{ kind: "agent"; name: string; source_path: string; error: string } | 
+{ kind: "agent"; name: AgentName; source_path: string; error: string } | 
 /**
  *  An agent file failed before parse, so no name is available.
  *  `source_path` is the only identifier the FE can show. The

--- a/crates/kiro-control-center/src/lib/bindings.ts
+++ b/crates/kiro-control-center/src/lib/bindings.ts
@@ -279,55 +279,105 @@ export type DiscoveredProject = {
 export type ErrorType = "not_found" | "already_exists" | "validation" | "git_error" | "io_error" | "parse_error" | "internal" | "unknown";
 
 /**
- *  An agent that failed to install, with the typed error.
+ *  A failure entry for one element of an agent install batch.
  * 
- *  `name` is `Some` once parsing has identified the agent; pre-parse
- *  failures use `source_path` as the fallback identifier. `error` is the
- *  typed [`AgentError`] so frontends can branch on cause without
- *  substring-matching the rendered message; a custom `Serialize` impl
- *  projects it to the chain string for the wire format.
+ *  Three-variant tagged enum so the wire format distinguishes per-agent
+ *  failures (where `name` is known after parse), pre-parse failures
+ *  (where `source_path` is the only identifier), and bundle-level
+ *  failures (companion bundles are plugin-scoped, not agent-scoped).
+ * 
+ *  JSON shape via `#[serde(tag = "kind", rename_all = "snake_case")]`:
+ *  - `{"kind": "agent", "name": "...", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "unparseable_agent", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
+ * 
+ *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
  */
 export type FailedAgent = FailedAgent_Serialize | FailedAgent_Deserialize;
 
 /**
- *  An agent that failed to install, with the typed error.
+ *  A failure entry for one element of an agent install batch.
  * 
- *  `name` is `Some` once parsing has identified the agent; pre-parse
- *  failures use `source_path` as the fallback identifier. `error` is the
- *  typed [`AgentError`] so frontends can branch on cause without
- *  substring-matching the rendered message; a custom `Serialize` impl
- *  projects it to the chain string for the wire format.
+ *  Three-variant tagged enum so the wire format distinguishes per-agent
+ *  failures (where `name` is known after parse), pre-parse failures
+ *  (where `source_path` is the only identifier), and bundle-level
+ *  failures (companion bundles are plugin-scoped, not agent-scoped).
+ * 
+ *  JSON shape via `#[serde(tag = "kind", rename_all = "snake_case")]`:
+ *  - `{"kind": "agent", "name": "...", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "unparseable_agent", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
+ * 
+ *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
  */
-export type FailedAgent_Deserialize = {
-	name: string | null,
-	source_path: string,
-	/**
-	 *  Typed error. `Serialize` renders it as a string via
-	 *  [`crate::error::error_full_chain`] so the wire shape stays string;
-	 *  in-process consumers can match on the typed variants directly.
-	 */
-	error: string,
-};
+export type FailedAgent_Deserialize = 
+/**
+ *  A native or translated agent failed during install. Name is
+ *  known because parsing succeeded — callers had a parsed
+ *  `AgentDefinition` or `NativeAgentBundle` in scope when the
+ *  failure occurred.
+ */
+{ kind: "agent"; name: string; source_path: string; error: string } | 
+/**
+ *  An agent file failed before parse, so no name is available.
+ *  `source_path` is the only identifier the FE can show. The
+ *  error variant inside carries the structured parse failure.
+ */
+{ kind: "unparseable_agent"; source_path: string; error: string } | 
+/**
+ *  A plugin's companion-file bundle (e.g. `agents/prompts/*.md`)
+ *  failed atomically. The bundle is plugin-scoped, not agent-scoped,
+ *  so neither `name` nor `source_path` (a per-agent concept) applies.
+ * 
+ *  `conflicts` enumerates destination paths that conflicted. Today
+ *  the engine bails on first conflict, so length is 0 (rejection
+ *  before per-file enumeration, e.g. `MultipleScanRootsNotSupported`)
+ *  or 1 (orphan / cross-plugin). Forward-compatible with future
+ *  "collect all conflicts" engine work without another wire migration.
+ */
+{ kind: "companion_bundle"; plugin: PluginName; conflicts: string[]; error: string };
 
 /**
- *  An agent that failed to install, with the typed error.
+ *  A failure entry for one element of an agent install batch.
  * 
- *  `name` is `Some` once parsing has identified the agent; pre-parse
- *  failures use `source_path` as the fallback identifier. `error` is the
- *  typed [`AgentError`] so frontends can branch on cause without
- *  substring-matching the rendered message; a custom `Serialize` impl
- *  projects it to the chain string for the wire format.
+ *  Three-variant tagged enum so the wire format distinguishes per-agent
+ *  failures (where `name` is known after parse), pre-parse failures
+ *  (where `source_path` is the only identifier), and bundle-level
+ *  failures (companion bundles are plugin-scoped, not agent-scoped).
+ * 
+ *  JSON shape via `#[serde(tag = "kind", rename_all = "snake_case")]`:
+ *  - `{"kind": "agent", "name": "...", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "unparseable_agent", "source_path": "...", "error": "..."}`
+ *  - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
+ * 
+ *  Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
  */
-export type FailedAgent_Serialize = {
-	name: string | null,
-	source_path: string,
-	/**
-	 *  Typed error. `Serialize` renders it as a string via
-	 *  [`crate::error::error_full_chain`] so the wire shape stays string;
-	 *  in-process consumers can match on the typed variants directly.
-	 */
-	error: string,
-};
+export type FailedAgent_Serialize = 
+/**
+ *  A native or translated agent failed during install. Name is
+ *  known because parsing succeeded — callers had a parsed
+ *  `AgentDefinition` or `NativeAgentBundle` in scope when the
+ *  failure occurred.
+ */
+{ kind: "agent"; name: string; source_path: string; error: string } | 
+/**
+ *  An agent file failed before parse, so no name is available.
+ *  `source_path` is the only identifier the FE can show. The
+ *  error variant inside carries the structured parse failure.
+ */
+{ kind: "unparseable_agent"; source_path: string; error: string } | 
+/**
+ *  A plugin's companion-file bundle (e.g. `agents/prompts/*.md`)
+ *  failed atomically. The bundle is plugin-scoped, not agent-scoped,
+ *  so neither `name` nor `source_path` (a per-agent concept) applies.
+ * 
+ *  `conflicts` enumerates destination paths that conflicted. Today
+ *  the engine bails on first conflict, so length is 0 (rejection
+ *  before per-file enumeration, e.g. `MultipleScanRootsNotSupported`)
+ *  or 1 (orphan / cross-plugin). Forward-compatible with future
+ *  "collect all conflicts" engine work without another wire migration.
+ */
+{ kind: "companion_bundle"; plugin: PluginName; conflicts: string[]; error: string };
 
 /**
  *  A skill that failed to install, with the reason.

--- a/crates/kiro-control-center/src/lib/plugin-actions.ts
+++ b/crates/kiro-control-center/src/lib/plugin-actions.ts
@@ -136,6 +136,19 @@ export async function runPluginInstall(
       } else {
         primary = { kind: "message", text: `${successPrefix}: ${summary}` };
       }
+      // Per design 2026-05-09-failed-agent-discriminator-design.md (F3):
+      // when the inline-failure UI ships, render `result.data.agents.failed`
+      // by switching on the discriminator with an exhaustiveness guard:
+      //
+      //   switch (entry.kind) {
+      //     case "agent": return renderAgent(entry.name, entry.source_path, entry.error);
+      //     case "unparseable_agent": return renderUnparseable(entry.source_path, entry.error);
+      //     case "companion_bundle": return renderBundle(entry.plugin, entry.conflicts, entry.error);
+      //     default: { const _exhaustive: never = entry; throw new Error(`unhandled ${JSON.stringify(_exhaustive)}`); }
+      //   }
+      //
+      // Pair the runtime switch with a value-position assert per CLAUDE.md
+      // discriminator-pushdown discipline (see _PLUGIN_ACTION_VALUES + _AssertPluginActionExhaustive).
       if (warnings) {
         warning = `${successPrefix}: ${warnings}`;
       }

--- a/crates/kiro-market-core/src/agent/emit.rs
+++ b/crates/kiro-market-core/src/agent/emit.rs
@@ -36,7 +36,7 @@ pub fn build_kiro_json(
     mapped_tools: &[MappedTool],
 ) -> serde_json::Result<Value> {
     let mut obj = Map::new();
-    obj.insert("name".into(), Value::String(def.name.clone()));
+    obj.insert("name".into(), Value::String(def.name.as_str().to_owned()));
     if let Some(desc) = &def.description {
         obj.insert("description".into(), Value::String(desc.clone()));
     }
@@ -44,7 +44,7 @@ pub fn build_kiro_json(
         "prompt".into(),
         Value::String(format!(
             "file://./prompts/{}.md",
-            percent_encode_path_segment(&def.name)
+            percent_encode_path_segment(def.name.as_str())
         )),
     );
     if let Some(model) = &def.model {
@@ -114,7 +114,7 @@ mod tests {
 
     fn sample_claude_def() -> AgentDefinition {
         AgentDefinition {
-            name: "reviewer".into(),
+            name: crate::validation::AgentName::new("reviewer").expect("valid test name"),
             description: Some("Reviews code".into()),
             prompt_body: "You are a reviewer.\n".into(),
             model: Some("opus".into()),
@@ -137,7 +137,7 @@ mod tests {
         // The JSON `name` field keeps the space; the file:// URI must
         // percent-encode it per RFC 3986.
         let mut def = sample_claude_def();
-        def.name = "Terraform Agent".into();
+        def.name = crate::validation::AgentName::new("Terraform Agent").expect("valid test name");
         let out = build_kiro_json(&def, &[]).unwrap();
         assert_eq!(out["name"], "Terraform Agent");
         assert_eq!(out["prompt"], "file://./prompts/Terraform%20Agent.md");
@@ -146,7 +146,8 @@ mod tests {
     #[test]
     fn emit_preserves_unreserved_chars_in_prompt_uri() {
         let mut def = sample_claude_def();
-        def.name = "pr-review_toolkit.v2~beta".into();
+        def.name = crate::validation::AgentName::new("pr-review_toolkit.v2~beta")
+            .expect("valid test name");
         let out = build_kiro_json(&def, &[]).unwrap();
         // Unreserved chars per RFC 3986: alphanumeric and -_.~ — no encoding.
         assert_eq!(

--- a/crates/kiro-market-core/src/agent/mod.rs
+++ b/crates/kiro-market-core/src/agent/mod.rs
@@ -29,7 +29,7 @@ mod tests {
     #[test]
     fn agent_definition_constructs_with_minimum_fields() {
         let def = AgentDefinition {
-            name: "reviewer".into(),
+            name: crate::validation::AgentName::new("reviewer").expect("valid test name"),
             description: None,
             prompt_body: "You are a reviewer.".into(),
             model: None,

--- a/crates/kiro-market-core/src/agent/parse_claude.rs
+++ b/crates/kiro-market-core/src/agent/parse_claude.rs
@@ -34,16 +34,14 @@ pub fn parse_claude_agent(content: &str) -> Result<AgentDefinition, ParseFailure
             reason: e.to_string(),
         })?;
 
-    let name = fm.name.ok_or(ParseFailure::MissingName)?;
-    // Validate the name at parse time so downstream fs operations (and the
-    // file:// URI in the emitted JSON) can trust it without re-checking.
-    crate::validation::validate_name(&name).map_err(|e| match e {
-        // Both ValidationError variants project to ParseFailure::InvalidName
-        // because validate_name only emits InvalidName in practice; the
-        // InvalidRelativePath arm is defensive against a future change to
-        // validate_name's contract. Listed explicitly (rather than via `_ =>`)
-        // so a new ValidationError variant forces a compile-time decision per
-        // CLAUDE.md "Classifier functions enumerate every variant".
+    let raw_name = fm.name.ok_or(ParseFailure::MissingName)?;
+    // Construct the validated AgentName at parse time so downstream fs
+    // operations (and the file:// URI in the emitted JSON) can trust it
+    // without re-checking. The two-arm match enumerates every
+    // ValidationError variant per CLAUDE.md "Classifier functions
+    // enumerate every variant" — a new variant forces a compile-time
+    // decision rather than silently routing via `_ =>`.
+    let name = crate::validation::AgentName::new(raw_name).map_err(|e| match e {
         crate::error::ValidationError::InvalidName { reason, .. }
         | crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
             ParseFailure::InvalidName { reason }

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -157,6 +157,35 @@ Body text.
         assert!(parse_copilot_agent(src).is_err());
     }
 
+    /// Mirrors `parse_claude::tests::parse_rejects_path_traversal_in_name`.
+    /// Both parsers route through `AgentName::new`, but the integration
+    /// path through Copilot frontmatter needs its own behavioral test —
+    /// a future refactor that skipped `AgentName::new` on this branch
+    /// (e.g. introducing a Copilot-specific naming convention) would
+    /// silently regress against the Claude-only test alone.
+    #[test]
+    fn parse_rejects_path_traversal_in_name() {
+        let src = "---\nname: ../escape\ntools: []\n---\nbody\n";
+        let err = parse_copilot_agent(src).unwrap_err();
+        assert!(
+            matches!(err, ParseFailure::InvalidName { .. }),
+            "expected InvalidName for traversal, got {err:?}"
+        );
+    }
+
+    /// Mirrors `parse_claude::tests::parse_rejects_empty_name`. Locks
+    /// the empty-string rejection path through Copilot frontmatter
+    /// independently of Claude.
+    #[test]
+    fn parse_rejects_empty_name() {
+        let src = "---\nname: \"\"\ntools: []\n---\nbody\n";
+        let err = parse_copilot_agent(src).unwrap_err();
+        assert!(
+            matches!(err, ParseFailure::InvalidName { .. }),
+            "expected InvalidName for empty name, got {err:?}"
+        );
+    }
+
     #[test]
     fn parse_dialect_set_to_copilot() {
         let def = parse_copilot_agent(TERRAFORM).expect("parse");

--- a/crates/kiro-market-core/src/agent/parse_copilot.rs
+++ b/crates/kiro-market-core/src/agent/parse_copilot.rs
@@ -56,12 +56,13 @@ pub fn parse_copilot_agent(content: &str) -> Result<AgentDefinition, ParseFailur
             reason: e.to_string(),
         })?;
 
-    let name = fm.name.ok_or(ParseFailure::MissingName)?;
-    // Validate the name at parse time so downstream fs operations (and the
-    // file:// URI in the emitted JSON) can trust it without re-checking.
-    crate::validation::validate_name(&name).map_err(|e| match e {
-        // See parse_claude.rs for rationale on the explicit two-arm form
-        // — same CLAUDE.md classifier-exhaustiveness discipline.
+    let raw_name = fm.name.ok_or(ParseFailure::MissingName)?;
+    // Construct the validated AgentName at parse time so downstream fs
+    // operations (and the file:// URI in the emitted JSON) can trust it
+    // without re-checking. See parse_claude.rs for rationale on the
+    // explicit two-arm form — same CLAUDE.md classifier-exhaustiveness
+    // discipline.
+    let name = crate::validation::AgentName::new(raw_name).map_err(|e| match e {
         crate::error::ValidationError::InvalidName { reason, .. }
         | crate::error::ValidationError::InvalidRelativePath { reason, .. } => {
             ParseFailure::InvalidName { reason }

--- a/crates/kiro-market-core/src/agent/types.rs
+++ b/crates/kiro-market-core/src/agent/types.rs
@@ -108,15 +108,15 @@ mod tests {
 
 /// Agent definition normalized across Claude and Copilot source formats.
 ///
-/// Constructed only by the parsers in this module. Fields are `pub` for
-/// emitter and install-layer access, but callers should not mutate `name`
-/// after construction without re-running name validation — the parsers
-/// enforce path-safe naming up front so downstream fs operations can rely
-/// on it.
+/// Constructed only by the parsers in this module. The `name` field is a
+/// validated [`crate::validation::AgentName`] — the parsers route through
+/// `AgentName::new` so downstream fs operations can rely on path-safe
+/// naming without re-validation.
 #[derive(Debug, Clone)]
 pub struct AgentDefinition {
     /// Short identifier used as the filename stem and Kiro agent `name` key.
-    pub name: String,
+    /// Validated at parse time; see [`crate::validation::AgentName`].
+    pub name: crate::validation::AgentName,
     /// Optional human-readable blurb. Not shown to the model.
     pub description: Option<String>,
     /// Markdown body (everything after the closing YAML fence).

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -379,7 +379,9 @@ pub enum AgentError {
     /// single scan root only — companion ownership tracking would otherwise
     /// have to disambiguate which scan root each companion belongs to,
     /// expanding the tracking schema. Out of scope for v1.
-    #[error("native plugin spans multiple agent scan roots; v1 supports a single scan root only")]
+    #[error(
+        "native plugin spans multiple agent scan roots ({roots:?}); v1 supports a single scan root only"
+    )]
     MultipleScanRootsNotSupported { roots: Vec<PathBuf> },
 
     /// A native companion source file is a hardlink (Unix `nlink > 1`).

--- a/crates/kiro-market-core/src/error.rs
+++ b/crates/kiro-market-core/src/error.rs
@@ -288,6 +288,20 @@ pub enum SkillError {
 // Agent errors
 // ---------------------------------------------------------------------------
 
+/// Render a list of paths in OS-native form, comma-separated. Used by
+/// [`AgentError::MultipleScanRootsNotSupported`]'s Display so the rendered
+/// message reads naturally on Windows (`{:?}` would escape backslashes,
+/// producing `["C:\\Users\\me\\agents"]` which looks like a path-mangling
+/// bug to the user). Comma-joined `Path::display()` matches how every
+/// other error message in this file renders single paths.
+fn format_path_list(roots: &[PathBuf]) -> String {
+    roots
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Errors related to agent operations.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -380,7 +394,8 @@ pub enum AgentError {
     /// have to disambiguate which scan root each companion belongs to,
     /// expanding the tracking schema. Out of scope for v1.
     #[error(
-        "native plugin spans multiple agent scan roots ({roots:?}); v1 supports a single scan root only"
+        "native plugin spans multiple agent scan roots ({}); v1 supports a single scan root only",
+        format_path_list(roots)
     )]
     MultipleScanRootsNotSupported { roots: Vec<PathBuf> },
 
@@ -1020,7 +1035,17 @@ mod tests {
         let err = AgentError::MultipleScanRootsNotSupported {
             roots: vec![PathBuf::from("./agents/"), PathBuf::from("./extra/")],
         };
-        assert!(err.to_string().contains("multiple agent scan roots"));
+        let s = err.to_string();
+        assert!(s.contains("multiple agent scan roots"), "got: {s}");
+        // Lock the actionable payload — every root must appear in the
+        // rendered message. The whole reason this variant interpolates
+        // `format_path_list(roots)` is to surface scan roots to the user;
+        // a future "simplification" that drops the projection would pass
+        // the prefix-only assertion above. Each root path stays in the
+        // message via OS-native `Path::display()` rendering, not Debug
+        // (which on Windows escapes backslashes and dilutes signal).
+        assert!(s.contains("agents"), "scan root must render: {s}");
+        assert!(s.contains("extra"), "scan root must render: {s}");
     }
 
     #[test]

--- a/crates/kiro-market-core/src/project.rs
+++ b/crates/kiro-market-core/src/project.rs
@@ -2208,7 +2208,9 @@ impl KiroProject {
         force: bool,
         source_path: Option<&Path>,
     ) -> crate::error::Result<()> {
-        validation::validate_name(&def.name)?;
+        // No re-validation: `def.name: AgentName` is a parse-time guarantee.
+        // Bind once so downstream uses don't repeat `def.name.as_str()`.
+        let name_str = def.name.as_str();
 
         // CPU-bound work outside the lock to keep the critical section short.
         let json = crate::agent::emit::build_kiro_json(def, mapped_tools)?;
@@ -2222,22 +2224,22 @@ impl KiroProject {
             &self.agent_tracking_path(),
             || -> crate::error::Result<()> {
                 let mut installed = self.load_installed_agents()?;
-                if !force && installed.agents.contains_key(&def.name) {
+                if !force && installed.agents.contains_key(name_str) {
                     return Err(AgentError::AlreadyInstalled {
-                        name: def.name.clone(),
+                        name: name_str.to_owned(),
                     }
                     .into());
                 }
 
                 let (staging, json_rel, prompt_rel, installed_hash) =
-                    self.stage_agent_files(&def.name, &json_bytes, def.prompt_body.as_bytes())?;
+                    self.stage_agent_files(name_str, &json_bytes, def.prompt_body.as_bytes())?;
 
                 let PromotedAgent {
                     json_target,
                     prompt_target,
                     backups,
                 } = self.promote_staged_agent(
-                    &def.name,
+                    name_str,
                     staging.path(),
                     &json_rel,
                     &prompt_rel,
@@ -2268,7 +2270,7 @@ impl KiroProject {
                     .and_then(|(parent, _)| crate::validation::RelativePath::new(parent).ok())
                     .unwrap_or_else(crate::validation::RelativePath::agents_root);
 
-                installed.agents.insert(def.name.clone(), meta);
+                installed.agents.insert(name_str.to_owned(), meta);
 
                 // Cross-plugin force-transfer: if a prior owner of the
                 // same prompt path is some OTHER plugin, scrub the prompt
@@ -4961,33 +4963,12 @@ mod tests {
         assert!(prompt.contains("fresh body"), "got: {prompt}");
     }
 
-    #[test]
-    fn install_agent_force_still_rejects_unsafe_name() {
-        // --force is not a bypass for name validation. The parser rejects
-        // unsafe names at frontmatter time, so construct the definition
-        // directly to exercise the validate_name guard inside install_agent_inner.
-        let (_dir, project) = temp_project();
-        let def = AgentDefinition {
-            name: "../escape".to_string(),
-            description: None,
-            prompt_body: "body".to_string(),
-            model: None,
-            source_tools: Vec::new(),
-            mcp_servers: std::collections::BTreeMap::new(),
-            dialect: AgentDialect::Claude,
-        };
-
-        let err = project
-            .install_agent_force(&def, &[], sample_agent_meta(), None)
-            .expect_err("unsafe name must be rejected under force");
-        assert!(
-            matches!(
-                err,
-                crate::error::Error::Validation(crate::error::ValidationError::InvalidName { .. })
-            ),
-            "expected InvalidName, got: {err:?}"
-        );
-    }
+    // `install_agent_force_still_rejects_unsafe_name` was removed alongside
+    // `install_agent_rejects_unsafe_name`. Both tested the install-layer
+    // `validate_name` re-check that `AgentDefinition.name: AgentName`
+    // makes structurally unreachable. Parse-time rejection is covered by
+    // `parse_claude::tests::parse_rejects_path_traversal_in_name` and
+    // the `validation::tests` for `AgentName::new`.
 
     #[test]
     fn install_agent_updates_tracking() {
@@ -5007,18 +4988,14 @@ mod tests {
         assert_eq!(tracking.agents["a"].dialect, AgentDialect::Claude);
     }
 
-    #[test]
-    fn install_agent_rejects_unsafe_name() {
-        let (_dir, project) = temp_project();
-        let src_tmp = tempfile::tempdir().unwrap();
-        let src = write_agent(src_tmp.path(), "x", "---\nname: x\n---\nbody\n");
-        let (mut def, mapped) = parse_and_map(&src);
-        def.name = "../escape".into();
-        let err = project
-            .install_agent(&def, &mapped, sample_agent_meta(), None)
-            .unwrap_err();
-        assert!(matches!(err, crate::error::Error::Validation(_)));
-    }
+    // `install_agent_rejects_unsafe_name` was removed when
+    // `AgentDefinition.name` was promoted to `AgentName` — the type system
+    // now precludes constructing a `def` with an unsafe name, so the
+    // install-layer defensive `validate_name` check became unreachable
+    // (and was deleted with it). Parse-time rejection is covered by
+    // `parse_claude::tests::parse_rejects_path_traversal_in_name` and
+    // `parse_rejects_empty_name`, plus `validation::tests` for the
+    // `AgentName::new` constructor.
 
     #[test]
     fn install_agent_emits_tools_and_allowed_tools_from_mapping() {
@@ -7264,7 +7241,7 @@ mod tests {
 
         let source_md = write_agent(tmp.path(), "rev", "You are a reviewer.");
         let def = crate::agent::AgentDefinition {
-            name: "rev".into(),
+            name: crate::validation::AgentName::new("rev").expect("valid test name"),
             description: None,
             prompt_body: "You are a reviewer.".into(),
             model: None,
@@ -7330,7 +7307,7 @@ mod tests {
         for name in ["alpha", "beta"] {
             let source_md = write_agent(tmp.path(), name, "body");
             let def = crate::agent::AgentDefinition {
-                name: name.into(),
+                name: crate::validation::AgentName::new(name).expect("valid test name"),
                 description: None,
                 prompt_body: "body".into(),
                 model: None,
@@ -7383,7 +7360,7 @@ mod tests {
         // First install: source under `agents/`.
         let alpha_md = write_agent(tmp.path(), "alpha", "body");
         let alpha_def = crate::agent::AgentDefinition {
-            name: "alpha".into(),
+            name: crate::validation::AgentName::new("alpha").expect("valid test name"),
             description: None,
             prompt_body: "body".into(),
             model: None,
@@ -7417,7 +7394,7 @@ mod tests {
         // source_scan_root must follow.
         let beta_md = write_agent(tmp.path(), "beta", "body2");
         let beta_def = crate::agent::AgentDefinition {
-            name: "beta".into(),
+            name: crate::validation::AgentName::new("beta").expect("valid test name"),
             description: None,
             prompt_body: "body2".into(),
             model: None,

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -641,24 +641,97 @@ pub enum UpdateChangeSignal {
     ContentChanged,
 }
 
-/// An agent that failed to install, with the typed error.
+/// A failure entry for one element of an agent install batch.
 ///
-/// `name` is `Some` once parsing has identified the agent; pre-parse
-/// failures use `source_path` as the fallback identifier. `error` is the
-/// typed [`AgentError`] so frontends can branch on cause without
-/// substring-matching the rendered message; a custom `Serialize` impl
-/// projects it to the chain string for the wire format.
+/// Three-variant tagged enum so the wire format distinguishes per-agent
+/// failures (where `name` is known after parse), pre-parse failures
+/// (where `source_path` is the only identifier), and bundle-level
+/// failures (companion bundles are plugin-scoped, not agent-scoped).
+///
+/// JSON shape via `#[serde(tag = "kind", rename_all = "snake_case")]`:
+/// - `{"kind": "agent", "name": "...", "source_path": "...", "error": "..."}`
+/// - `{"kind": "unparseable_agent", "source_path": "...", "error": "..."}`
+/// - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
+///
+/// Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
-pub struct FailedAgent {
-    pub name: Option<String>,
-    pub source_path: std::path::PathBuf,
-    /// Typed error. `Serialize` renders it as a string via
-    /// [`crate::error::error_full_chain`] so the wire shape stays string;
-    /// in-process consumers can match on the typed variants directly.
-    #[serde(serialize_with = "serialize_agent_error")]
-    #[cfg_attr(feature = "specta", specta(type = String))]
-    pub error: crate::error::AgentError,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FailedAgent {
+    /// A native or translated agent failed during install. Name is
+    /// known because parsing succeeded — callers had a parsed
+    /// `AgentDefinition` or `NativeAgentBundle` in scope when the
+    /// failure occurred.
+    Agent {
+        name: String,
+        source_path: std::path::PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+    /// An agent file failed before parse, so no name is available.
+    /// `source_path` is the only identifier the FE can show. The
+    /// error variant inside carries the structured parse failure.
+    UnparseableAgent {
+        source_path: std::path::PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+    /// A plugin's companion-file bundle (e.g. `agents/prompts/*.md`)
+    /// failed atomically. The bundle is plugin-scoped, not agent-scoped,
+    /// so neither `name` nor `source_path` (a per-agent concept) applies.
+    ///
+    /// `conflicts` enumerates destination paths that conflicted. Today
+    /// the engine bails on first conflict, so length is 0 (rejection
+    /// before per-file enumeration, e.g. `MultipleScanRootsNotSupported`)
+    /// or 1 (orphan / cross-plugin). Forward-compatible with future
+    /// "collect all conflicts" engine work without another wire migration.
+    CompanionBundle {
+        plugin: crate::validation::PluginName,
+        conflicts: Vec<std::path::PathBuf>,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+}
+
+/// Project an `AgentError` returned by `KiroProject::install_native_companions`
+/// into the `conflicts` list on `FailedAgent::CompanionBundle`.
+///
+/// Two variants carry destination paths that ARE conflicts:
+/// `OrphanFileAtDestination` (orphan file with no tracking) and
+/// `PathOwnedByOtherPlugin` (cross-plugin conflict). All other variants
+/// either carry source paths (which don't belong in `conflicts`) or
+/// describe non-conflict failures.
+///
+/// Exhaustive per CLAUDE.md's "Classifier functions over error enums
+/// enumerate every variant" rule. A new `AgentError` variant should
+/// force a compile error here, not silently default to empty.
+fn companion_conflicts_from_error(err: &crate::error::AgentError) -> Vec<std::path::PathBuf> {
+    use crate::error::AgentError;
+    match err {
+        // Two destination-conflict variants share the same projection
+        // (the `path` field is the conflicting destination). Merged
+        // per `clippy::match_same_arms`; the union-pattern still
+        // counts as exhaustive over `AgentError` — adding a new
+        // variant breaks compilation here, satisfying the CLAUDE.md
+        // classifier rule.
+        AgentError::OrphanFileAtDestination { path }
+        | AgentError::PathOwnedByOtherPlugin { path, .. } => vec![path.clone()],
+        AgentError::AlreadyInstalled { .. }
+        | AgentError::NotInstalled { .. }
+        | AgentError::ParseFailed { .. }
+        | AgentError::NativeManifestParseFailed { .. }
+        | AgentError::NativeManifestMissingName { .. }
+        | AgentError::NativeManifestInvalidName { .. }
+        | AgentError::ManifestReadFailed { .. }
+        | AgentError::NameClashWithOtherPlugin { .. }
+        | AgentError::ContentChangedRequiresForce { .. }
+        | AgentError::MultipleScanRootsNotSupported { .. }
+        | AgentError::SourceHardlinked { .. }
+        | AgentError::InstallFailed { .. } => Vec::new(),
+    }
 }
 
 /// If the discovered `companion_files` span more than one scan root,
@@ -1645,8 +1718,8 @@ impl MarketplaceService {
                     // Install-layer variants (AlreadyInstalled/NotInstalled)
                     // shouldn't come from parse_agent_file, but we collect
                     // them as failures rather than crashing the batch.
-                    result.failed.push(FailedAgent {
-                        name: None,
+                    // Pre-parse failure → `UnparseableAgent` (no name yet).
+                    result.failed.push(FailedAgent::UnparseableAgent {
                         source_path: path.clone(),
                         error: e,
                     });
@@ -1724,8 +1797,9 @@ impl MarketplaceService {
                             source: Box::new(other),
                         },
                     };
-                    result.failed.push(FailedAgent {
-                        name: Some(def.name),
+                    // Parse succeeded earlier → name is known.
+                    result.failed.push(FailedAgent::Agent {
+                        name: def.name,
                         source_path: path.clone(),
                         error: agent_err,
                     });
@@ -1769,9 +1843,12 @@ impl MarketplaceService {
         // whole install — leaving the user with a partial install they
         // didn't ask for.
         if let Some(roots) = multiple_companion_scan_roots(&companion_files) {
-            result.failed.push(FailedAgent {
-                name: None,
-                source_path: plugin_dir.to_path_buf(),
+            // Bundle-level rejection BEFORE per-file enumeration —
+            // `conflicts` is empty because we never got to the
+            // collision-classification step.
+            result.failed.push(FailedAgent::CompanionBundle {
+                plugin: ctx.plugin.clone(),
+                conflicts: Vec::new(),
                 error: crate::error::AgentError::MultipleScanRootsNotSupported { roots },
             });
             return result;
@@ -1809,8 +1886,8 @@ impl MarketplaceService {
         {
             Ok(b) => b,
             Err(parse_err) => {
-                result.failed.push(FailedAgent {
-                    name: None,
+                // Parse failed → no `bundle.name` yet; route as UnparseableAgent.
+                result.failed.push(FailedAgent::UnparseableAgent {
                     source_path: file.source.clone(),
                     error: native_parse_failure_to_agent_error(&file.source, parse_err),
                 });
@@ -1838,8 +1915,8 @@ impl MarketplaceService {
         }
 
         let Some(filename) = file.source.file_name().map(std::path::PathBuf::from) else {
-            result.failed.push(FailedAgent {
-                name: Some(bundle.name.to_string()),
+            result.failed.push(FailedAgent::Agent {
+                name: bundle.name.to_string(),
                 source_path: file.source.clone(),
                 error: crate::error::AgentError::NativeManifestInvalidName {
                     path: file.source.clone(),
@@ -1851,8 +1928,8 @@ impl MarketplaceService {
         let source_hash = match crate::hash::hash_artifact(&file.scan_root, &[filename]) {
             Ok(h) => h,
             Err(e) => {
-                result.failed.push(FailedAgent {
-                    name: Some(bundle.name.to_string()),
+                result.failed.push(FailedAgent::Agent {
+                    name: bundle.name.to_string(),
                     source_path: file.source.clone(),
                     error: crate::error::AgentError::InstallFailed {
                         path: file.source.clone(),
@@ -1892,8 +1969,8 @@ impl MarketplaceService {
                 }
                 result.installed_native.push(outcome);
             }
-            Err(err) => result.failed.push(FailedAgent {
-                name: Some(bundle.name.to_string()),
+            Err(err) => result.failed.push(FailedAgent::Agent {
+                name: bundle.name.to_string(),
                 source_path: file.source.clone(),
                 error: err,
             }),
@@ -1918,9 +1995,10 @@ impl MarketplaceService {
             // Discovery guarantees `f.source` is under `f.scan_root` —
             // strip_prefix should never fail. Defensive fallback.
             let Ok(rel) = f.source.strip_prefix(&f.scan_root) else {
-                result.failed.push(FailedAgent {
-                    name: None,
-                    source_path: f.source.clone(),
+                // Discovery contract violation (not a destination conflict).
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts: Vec::new(),
                     error: crate::error::AgentError::InstallFailed {
                         path: f.source.clone(),
                         source: Box::new(crate::error::Error::Io(std::io::Error::other(
@@ -1936,9 +2014,11 @@ impl MarketplaceService {
         let source_hash = match crate::hash::hash_artifact(&scan_root, &rel_paths) {
             Ok(h) => h,
             Err(e) => {
-                result.failed.push(FailedAgent {
-                    name: None,
-                    source_path: scan_root,
+                // Bundle-level pre-promotion failure — no destination
+                // conflicts because we never reached collision classification.
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts: Vec::new(),
                     error: crate::error::AgentError::InstallFailed {
                         path: plugin_dir.to_path_buf(),
                         source: Box::new(e.into()),
@@ -1959,11 +2039,17 @@ impl MarketplaceService {
             plugin_dir,
         }) {
             Ok(outcome) => result.installed_companions = Some(outcome),
-            Err(err) => result.failed.push(FailedAgent {
-                name: None,
-                source_path: scan_root,
-                error: err,
-            }),
+            Err(err) => {
+                // The classifier extracts conflict paths from the typed
+                // error (Orphan / PathOwnedByOtherPlugin carry destination
+                // paths). All other variants → empty `conflicts`.
+                let conflicts = companion_conflicts_from_error(&err);
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts,
+                    error: err,
+                });
+            }
         }
     }
 
@@ -2775,8 +2861,8 @@ fn required_source_path(
 ) -> Result<crate::validation::RelativePath, FailedAgent> {
     crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| {
         let path_buf = path.to_path_buf();
-        FailedAgent {
-            name: Some(agent_name),
+        FailedAgent::Agent {
+            name: agent_name,
             source_path: path_buf.clone(),
             error: crate::error::AgentError::InstallFailed {
                 path: path_buf,
@@ -2982,6 +3068,233 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Wire-format lock for `FailedAgent`. Pins the three-variant
+    // tagged-enum shape that crosses the FFI boundary via specta.
+    // `#[serde(tag = "kind", rename_all = "snake_case")]` produces
+    // `kind: "agent" | "unparseable_agent" | "companion_bundle"`
+    // in JSON. If a future change accidentally drops the tag,
+    // renames a variant, or adds/removes a field, these tests fire
+    // before bindings.ts drift reaches the frontend.
+    //
+    // Each variant has its own test (split for `clippy::too_many_lines`);
+    // CompanionBundle has two scenarios (orphan = length-1 conflicts;
+    // pre-enumeration rejection = empty conflicts) so the empty-vs-absent
+    // serde rendering for `Vec::new()` is locked.
+    //
+    // Asserts exact key-set per variant — the substitute for a
+    // round-trip test (we can't `from_value` because the typed
+    // `AgentError` doesn't `Deserialize`; a one-way `serialize_with`
+    // projects it to a string). Exact-key-set assertions catch the
+    // same drift a round-trip would: any added/removed/renamed field
+    // breaks the test.
+    // -----------------------------------------------------------------------
+
+    /// Helper: collect a JSON object's keys into a `BTreeSet` for
+    /// order-independent comparison.
+    fn failed_agent_key_set(value: &serde_json::Value) -> std::collections::BTreeSet<String> {
+        value
+            .as_object()
+            .expect("variant serializes to a JSON object")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn failed_agent_agent_variant_serializes_with_full_key_set() {
+        use crate::error::AgentError;
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+
+        let agent = FailedAgent::Agent {
+            name: "reviewer".to_owned(),
+            source_path: PathBuf::from("/src/reviewer.json"),
+            error: AgentError::ContentChangedRequiresForce {
+                name: "reviewer".to_owned(),
+            },
+        };
+        let agent_json = serde_json::to_value(&agent).expect("serialize Agent");
+        assert_eq!(agent_json["kind"], "agent");
+        assert_eq!(agent_json["name"], "reviewer");
+        assert_eq!(agent_json["source_path"], "/src/reviewer.json");
+        assert!(
+            agent_json["error"].is_string(),
+            "error must serialize as string per FFI contract"
+        );
+        assert_eq!(
+            failed_agent_key_set(&agent_json),
+            BTreeSet::from([
+                "error".to_owned(),
+                "kind".to_owned(),
+                "name".to_owned(),
+                "source_path".to_owned()
+            ]),
+            "Agent variant key set drifted"
+        );
+    }
+
+    #[test]
+    fn failed_agent_unparseable_variant_serializes_without_name() {
+        use crate::error::AgentError;
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+
+        let unparseable = FailedAgent::UnparseableAgent {
+            source_path: PathBuf::from("/src/broken.json"),
+            error: AgentError::NativeManifestParseFailed {
+                path: PathBuf::from("/src/broken.json"),
+                reason: "expected `,` or `}`".to_owned(),
+            },
+        };
+        let unparseable_json =
+            serde_json::to_value(&unparseable).expect("serialize UnparseableAgent");
+        assert_eq!(unparseable_json["kind"], "unparseable_agent");
+        assert_eq!(unparseable_json["source_path"], "/src/broken.json");
+        assert!(unparseable_json["error"].is_string());
+        assert_eq!(
+            failed_agent_key_set(&unparseable_json),
+            BTreeSet::from([
+                "error".to_owned(),
+                "kind".to_owned(),
+                "source_path".to_owned()
+            ]),
+            "UnparseableAgent variant key set drifted"
+        );
+    }
+
+    #[test]
+    fn failed_agent_companion_bundle_orphan_serializes_with_length_one_conflicts() {
+        use crate::error::AgentError;
+        use crate::validation::PluginName;
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+
+        let bundle_orphan = FailedAgent::CompanionBundle {
+            plugin: PluginName::new("myplugin").expect("valid plugin name"),
+            conflicts: vec![PathBuf::from("prompts/code-reviewer.md")],
+            error: AgentError::OrphanFileAtDestination {
+                path: PathBuf::from("/dest/prompts/code-reviewer.md"),
+            },
+        };
+        let bundle_orphan_json =
+            serde_json::to_value(&bundle_orphan).expect("serialize CompanionBundle (orphan)");
+        assert_eq!(bundle_orphan_json["kind"], "companion_bundle");
+        assert_eq!(bundle_orphan_json["plugin"], "myplugin");
+        let conflicts = bundle_orphan_json["conflicts"]
+            .as_array()
+            .expect("conflicts is array");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0], "prompts/code-reviewer.md");
+        assert!(bundle_orphan_json["error"].is_string());
+        assert_eq!(
+            failed_agent_key_set(&bundle_orphan_json),
+            BTreeSet::from([
+                "conflicts".to_owned(),
+                "error".to_owned(),
+                "kind".to_owned(),
+                "plugin".to_owned()
+            ]),
+            "CompanionBundle variant key set drifted"
+        );
+    }
+
+    /// Multi-scan-root rejection fires BEFORE per-file collision
+    /// classification — `conflicts` is correctly empty, NOT absent.
+    /// Locking this guarantees serde renders `Vec::new()` as `[]`,
+    /// not as the field being omitted.
+    #[test]
+    fn failed_agent_companion_bundle_empty_conflicts_serializes_as_empty_array() {
+        use crate::error::AgentError;
+        use crate::validation::PluginName;
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+
+        let bundle_empty = FailedAgent::CompanionBundle {
+            plugin: PluginName::new("myplugin").expect("valid plugin name"),
+            conflicts: Vec::new(),
+            error: AgentError::MultipleScanRootsNotSupported {
+                roots: vec![PathBuf::from("agents"), PathBuf::from("other-agents")],
+            },
+        };
+        let bundle_empty_json =
+            serde_json::to_value(&bundle_empty).expect("serialize CompanionBundle (empty)");
+        assert_eq!(bundle_empty_json["kind"], "companion_bundle");
+        assert_eq!(bundle_empty_json["plugin"], "myplugin");
+        assert_eq!(
+            bundle_empty_json["conflicts"],
+            serde_json::json!([]),
+            "empty conflicts must serialize as `[]`, not be omitted"
+        );
+        assert!(bundle_empty_json["error"].is_string());
+        assert_eq!(
+            failed_agent_key_set(&bundle_empty_json),
+            BTreeSet::from([
+                "conflicts".to_owned(),
+                "error".to_owned(),
+                "kind".to_owned(),
+                "plugin".to_owned()
+            ]),
+            "CompanionBundle (empty conflicts) variant key set drifted"
+        );
+    }
+
+    /// Classifier routing test: orphan errors produce a length-1
+    /// `conflicts` entry containing the destination path.
+    #[test]
+    fn companion_conflicts_from_error_orphan_returns_destination_path() {
+        use crate::error::AgentError;
+        use std::path::PathBuf;
+
+        let err = AgentError::OrphanFileAtDestination {
+            path: PathBuf::from("/dest/prompts/code-reviewer.md"),
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert_eq!(
+            conflicts,
+            vec![PathBuf::from("/dest/prompts/code-reviewer.md")]
+        );
+    }
+
+    /// Classifier routing test: cross-plugin path conflicts also
+    /// produce a length-1 `conflicts` entry. The `owner` field is
+    /// not consumed by the classifier — it survives in the typed
+    /// error inside `FailedAgent::CompanionBundle.error`.
+    #[test]
+    fn companion_conflicts_from_error_path_owned_by_other_plugin_returns_destination_path() {
+        use crate::error::AgentError;
+        use std::path::PathBuf;
+
+        let err = AgentError::PathOwnedByOtherPlugin {
+            path: PathBuf::from("/dest/prompts/shared.md"),
+            owner: "otherplugin".to_owned(),
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert_eq!(conflicts, vec![PathBuf::from("/dest/prompts/shared.md")]);
+    }
+
+    /// Classifier routing test: errors that fire BEFORE per-file
+    /// enumeration produce an empty conflicts list. `MultipleScanRootsNotSupported`
+    /// is the canonical pre-enumeration case (rejection at discovery).
+    /// This test pins the empty-conflicts branch so that a future
+    /// "default to empty" wildcard regression (which CLAUDE.md
+    /// prohibits) is also caught behaviorally.
+    #[test]
+    fn companion_conflicts_from_error_multi_scan_root_returns_empty() {
+        use crate::error::AgentError;
+        use std::path::PathBuf;
+
+        let err = AgentError::MultipleScanRootsNotSupported {
+            roots: vec![PathBuf::from("agents"), PathBuf::from("other-agents")],
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert!(
+            conflicts.is_empty(),
+            "MultipleScanRootsNotSupported is a bundle-level rejection that fires \
+             BEFORE per-file enumeration; conflicts must be empty, got: {conflicts:?}"
+        );
+    }
+
     #[test]
     fn install_plugin_agents_emits_json_and_warnings_per_file() {
         use crate::agent::tools::UnmappedReason;
@@ -3154,7 +3467,10 @@ mod tests {
         // surfaces despite B's failure.
         assert_eq!(result.installed, vec!["aaa".to_string()]);
         assert_eq!(result.failed.len(), 1);
-        assert_eq!(result.failed[0].name.as_deref(), Some("bbb"));
+        match &result.failed[0] {
+            FailedAgent::Agent { name, .. } => assert_eq!(name, "bbb"),
+            other => panic!("expected FailedAgent::Agent, got {other:?}"),
+        }
         let has_unmapped = result.warnings.iter().any(|w| {
             matches!(
                 w,
@@ -3814,10 +4130,16 @@ mod tests {
 
         // The bundle is rejected wholesale.
         assert_eq!(result.failed.len(), 1);
-        assert!(matches!(
-            &result.failed[0].error,
-            crate::error::AgentError::MultipleScanRootsNotSupported { .. }
-        ));
+        match &result.failed[0] {
+            FailedAgent::CompanionBundle {
+                error: crate::error::AgentError::MultipleScanRootsNotSupported { .. },
+                ..
+            } => {}
+            other => panic!(
+                "expected FailedAgent::CompanionBundle {{ error: MultipleScanRootsNotSupported, .. }}, \
+                 got {other:?}"
+            ),
+        }
 
         // No agents commit, no companions commit.
         assert!(

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -654,16 +654,24 @@ pub enum UpdateChangeSignal {
 /// - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
 ///
 /// Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
+///
+/// `#[non_exhaustive]` matches the workspace convention for FFI-crossing
+/// enums (`InstallWarning`, `PluginUpdateFailureKind`, `SkippedReason`).
+/// Adding a fourth variant later is then a non-breaking change for
+/// out-of-tree consumers; in-tree CLI / Tauri / test matches add `_ =>`
+/// fallback arms.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum FailedAgent {
     /// A native or translated agent failed during install. Name is
-    /// known because parsing succeeded — callers had a parsed
-    /// `AgentDefinition` or `NativeAgentBundle` in scope when the
-    /// failure occurred.
+    /// the validated [`crate::validation::AgentName`] — parsing succeeded
+    /// (callers had a parsed `AgentDefinition` or `NativeAgentBundle` in
+    /// scope), so the wire format carries a guaranteed-valid identifier
+    /// rather than a raw string.
     Agent {
-        name: String,
+        name: crate::validation::AgentName,
         source_path: std::path::PathBuf,
         #[serde(serialize_with = "serialize_agent_error")]
         #[cfg_attr(feature = "specta", specta(type = String))]
@@ -1747,7 +1755,7 @@ impl MarketplaceService {
             };
             for u in unmapped {
                 result.warnings.push(InstallWarning::UnmappedTool {
-                    agent: def.name.clone(),
+                    agent: def.name.as_str().to_owned(),
                     tool: u.source,
                     reason: u.reason,
                 });
@@ -1785,7 +1793,7 @@ impl MarketplaceService {
                 project.install_agent(&def, &mapped, meta, Some(&path))
             };
             match install_result {
-                Ok(()) => result.installed.push(def.name),
+                Ok(()) => result.installed.push(def.name.into_inner()),
                 Err(Error::Agent(crate::error::AgentError::AlreadyInstalled { name })) => {
                     result.skipped.push(name);
                 }
@@ -1916,7 +1924,7 @@ impl MarketplaceService {
 
         let Some(filename) = file.source.file_name().map(std::path::PathBuf::from) else {
             result.failed.push(FailedAgent::Agent {
-                name: bundle.name.to_string(),
+                name: bundle.name.clone(),
                 source_path: file.source.clone(),
                 error: crate::error::AgentError::NativeManifestInvalidName {
                     path: file.source.clone(),
@@ -1929,7 +1937,7 @@ impl MarketplaceService {
             Ok(h) => h,
             Err(e) => {
                 result.failed.push(FailedAgent::Agent {
-                    name: bundle.name.to_string(),
+                    name: bundle.name.clone(),
                     source_path: file.source.clone(),
                     error: crate::error::AgentError::InstallFailed {
                         path: file.source.clone(),
@@ -1943,7 +1951,7 @@ impl MarketplaceService {
         let source_path = match required_source_path(
             &bundle.agent_json_source,
             plugin_dir,
-            bundle.name.to_string(),
+            bundle.name.clone(),
         ) {
             Ok(rp) => rp,
             Err(failed) => {
@@ -1970,7 +1978,7 @@ impl MarketplaceService {
                 result.installed_native.push(outcome);
             }
             Err(err) => result.failed.push(FailedAgent::Agent {
-                name: bundle.name.to_string(),
+                name: bundle.name.clone(),
                 source_path: file.source.clone(),
                 error: err,
             }),
@@ -2726,7 +2734,7 @@ fn translated_agent_blocked_by_mcp_gate(
         result
             .warnings
             .push(InstallWarning::McpServersRequireOptIn {
-                agent: def.name.clone(),
+                agent: def.name.as_str().to_owned(),
                 transports,
             });
         return true;
@@ -2857,7 +2865,7 @@ fn required_skill_scan_root(
 fn required_source_path(
     path: &Path,
     plugin_dir: &Path,
-    agent_name: String,
+    agent_name: crate::validation::AgentName,
 ) -> Result<crate::validation::RelativePath, FailedAgent> {
     crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| {
         let path_buf = path.to_path_buf();
@@ -3108,7 +3116,7 @@ mod tests {
         use std::path::PathBuf;
 
         let agent = FailedAgent::Agent {
-            name: "reviewer".to_owned(),
+            name: crate::validation::AgentName::new("reviewer").expect("valid test name"),
             source_path: PathBuf::from("/src/reviewer.json"),
             error: AgentError::ContentChangedRequiresForce {
                 name: "reviewer".to_owned(),

--- a/crates/kiro-market-core/src/service/mod.rs
+++ b/crates/kiro-market-core/src/service/mod.rs
@@ -704,6 +704,26 @@ pub enum FailedAgent {
     },
 }
 
+impl FailedAgent {
+    /// Borrow the typed `AgentError` that every variant carries.
+    ///
+    /// Common-payload accessor so a `#[non_exhaustive]` consumer fallback
+    /// (`other => …`) can render the chain-preserved error string instead
+    /// of dropping it. The match is exhaustive over the variant set —
+    /// adding a future variant without an `error: AgentError` field is
+    /// then a compile error here, which is the right forcing function:
+    /// the wire-format contract is "every failure record carries a typed
+    /// error", and we want the type system to enforce that.
+    #[must_use]
+    pub fn error(&self) -> &crate::error::AgentError {
+        match self {
+            FailedAgent::Agent { error, .. }
+            | FailedAgent::UnparseableAgent { error, .. }
+            | FailedAgent::CompanionBundle { error, .. } => error,
+        }
+    }
+}
+
 /// Project an `AgentError` returned by `KiroProject::install_native_companions`
 /// into the `conflicts` list on `FailedAgent::CompanionBundle`.
 ///

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -406,10 +406,14 @@ fn print_agent_outcome(result: &InstallAgentsResult) {
                 }
             }
             // `FailedAgent` is `#[non_exhaustive]`. A future variant
-            // shouldn't be a panic — render a generic line so the user
-            // still sees that something failed; the chain-preserved
-            // error string is the actionable payload.
-            _ => eprintln!("  {prefix} Agent install failed (unknown variant)"),
+            // shouldn't panic — render the chain-preserved error string
+            // via the common `error()` accessor so the user gets the
+            // actionable payload even when this CLI hasn't yet learned
+            // to render the new variant's per-variant context.
+            other => eprintln!(
+                "  {prefix} Agent install failed: {}",
+                kiro_market_core::error::error_full_chain(other.error()),
+            ),
         }
     }
     for w in &result.warnings {

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -361,23 +361,56 @@ fn print_agent_outcome(result: &InstallAgentsResult) {
         );
     }
     for failed in &result.failed {
-        let (label, error) = match failed {
-            kiro_market_core::service::FailedAgent::Agent { name, error, .. } => {
-                (name.clone(), error)
+        // Per-variant rendering — the wire format distinguishes per-agent,
+        // pre-parse, and bundle-level failures so the CLI surface should
+        // too. A flat "Failed to install agent '<label>'" lie on a
+        // bundle failure was the original misdiagnosis class this PR
+        // (FailedAgent tagged enum) set out to prevent.
+        let prefix = "✗".red().bold();
+        match failed {
+            kiro_market_core::service::FailedAgent::Agent {
+                name,
+                source_path,
+                error,
+            } => {
+                eprintln!(
+                    "  {prefix} Failed to install agent '{name}' (from {}): {}",
+                    source_path.display(),
+                    kiro_market_core::error::error_full_chain(error),
+                );
             }
             kiro_market_core::service::FailedAgent::UnparseableAgent { source_path, error } => {
-                (source_path.display().to_string(), error)
+                eprintln!(
+                    "  {prefix} Failed to parse agent file {}: {}",
+                    source_path.display(),
+                    kiro_market_core::error::error_full_chain(error),
+                );
             }
-            kiro_market_core::service::FailedAgent::CompanionBundle { plugin, error, .. } => {
-                (plugin.as_str().to_owned(), error)
+            kiro_market_core::service::FailedAgent::CompanionBundle {
+                plugin,
+                conflicts,
+                error,
+            } => {
+                eprintln!(
+                    "  {prefix} Companion bundle for plugin '{plugin}' failed: {}",
+                    kiro_market_core::error::error_full_chain(error),
+                );
+                // Surface the destination paths the classifier projected
+                // (orphan / cross-plugin) so the user can see exactly
+                // which file conflicted. Empty for pre-enumeration
+                // rejections (e.g. MultipleScanRootsNotSupported); in
+                // that case the rendered error string carries the
+                // actionable payload (the scan roots).
+                for conflict in conflicts {
+                    eprintln!("      conflict: {}", conflict.display());
+                }
             }
-        };
-        let rendered = kiro_market_core::error::error_full_chain(error);
-        eprintln!(
-            "  {} Failed to install agent '{}': {rendered}",
-            "✗".red().bold(),
-            label
-        );
+            // `FailedAgent` is `#[non_exhaustive]`. A future variant
+            // shouldn't be a panic — render a generic line so the user
+            // still sees that something failed; the chain-preserved
+            // error string is the actionable payload.
+            _ => eprintln!("  {prefix} Agent install failed (unknown variant)"),
+        }
     }
     for w in &result.warnings {
         eprintln!("  {} {w}", "!".yellow().bold());

--- a/crates/kiro-market/src/commands/install.rs
+++ b/crates/kiro-market/src/commands/install.rs
@@ -361,11 +361,18 @@ fn print_agent_outcome(result: &InstallAgentsResult) {
         );
     }
     for failed in &result.failed {
-        let label = failed
-            .name
-            .as_deref()
-            .map_or_else(|| failed.source_path.display().to_string(), str::to_owned);
-        let rendered = kiro_market_core::error::error_full_chain(&failed.error);
+        let (label, error) = match failed {
+            kiro_market_core::service::FailedAgent::Agent { name, error, .. } => {
+                (name.clone(), error)
+            }
+            kiro_market_core::service::FailedAgent::UnparseableAgent { source_path, error } => {
+                (source_path.display().to_string(), error)
+            }
+            kiro_market_core::service::FailedAgent::CompanionBundle { plugin, error, .. } => {
+                (plugin.as_str().to_owned(), error)
+            }
+        };
+        let rendered = kiro_market_core::error::error_full_chain(error);
         eprintln!(
             "  {} Failed to install agent '{}': {rendered}",
             "✗".red().bold(),

--- a/docs/plans/2026-05-09-failed-agent-discriminator-design.md
+++ b/docs/plans/2026-05-09-failed-agent-discriminator-design.md
@@ -1,0 +1,206 @@
+# `FailedAgent` → tagged-enum wire format — design 2026-05-09
+
+## Problem
+
+The companion-bundle install path in `crates/kiro-market-core/src/service/mod.rs:1962-1966` reports failures using `FailedAgent { name: None, source_path: scan_root, ... }`, where `scan_root` is the `agents/` directory in the marketplace cache. The wire shape is structurally indistinguishable from a per-agent failure; the user sees `name: null` plus a path that ends in a slash. In the field this misled a debug session into diagnosing a discovery bug ("a directory is being detected as a file") when the actual cause was orphan-file conflict on a project (`kiro-control-center` itself) where `.kiro/agents/*.json` are committed to git for CI use.
+
+The shape is structurally ambiguous:
+
+- `name: Option<String>` overloads "agent name" and "no name available."
+- `source_path: PathBuf` overloads "the agent file we tried to install" and "the bundle scan-root we couldn't install."
+- The error variant inside `AgentError` carries the *real* path of the conflicting destination, but the FE has no type-level signal to look there.
+
+## Design
+
+Convert `FailedAgent` from a struct to a `#[serde(tag = "kind")]` enum with three variants. Precedent: `UpdateChangeSignal` (`crates/kiro-market-core/src/service/mod.rs:632`) already uses this pattern at the FFI boundary, so no new toolchain risk.
+
+```rust
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FailedAgent {
+    /// A native or translated agent failed during install.
+    /// Name is known because parsing succeeded.
+    Agent {
+        name: String,
+        source_path: PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: AgentError,
+    },
+    /// Failed before parse, so no name is available.
+    /// `source_path` is the only identifier.
+    UnparseableAgent {
+        source_path: PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: AgentError,
+    },
+    /// A plugin's companion-file bundle (e.g. `agents/prompts/*.md`)
+    /// failed atomically. Plugin-scoped, not agent-scoped.
+    CompanionBundle {
+        plugin: PluginName,
+        /// Destination paths under `.kiro/agents/` that conflicted.
+        /// Today: length-1 (engine bails on first conflict). Empty
+        /// when the rejection fires before per-file enumeration
+        /// (e.g. `MultipleScanRootsNotSupported`). Shape-compatible
+        /// with future "collect all conflicts" engine work without
+        /// another wire migration.
+        conflicts: Vec<PathBuf>,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: AgentError,
+    },
+}
+```
+
+Key decisions:
+
+- **Keep the type name `FailedAgent`.** `Vec<FailedAgent>` field stays; only per-element shape changes. Renaming would cosmetic-churn `result.failed` accesses with no semantic gain.
+- **Three variants, not two.** Folding `UnparseableAgent` into `Agent` (with `name: Option<String>`) reintroduces the nullable-name problem this PR is trying to remove.
+- **`conflicts: Vec<PathBuf>`** even though the engine produces length-1 today. Forward-compatible; locks the wire shape now. Empty for `MultipleScanRootsNotSupported` (rejection fires before any file enumeration).
+- **`plugin: PluginName`** (validated newtype). Specta-friendly per `crates/kiro-market-core/src/validation.rs:428-431` (`PluginName` already has `#[cfg_attr(feature = "specta", derive(specta::Type))]`).
+
+## Wire format (TS)
+
+Before:
+
+```ts
+type FailedAgent = {
+  name: string | null;
+  source_path: string;
+  error: string;
+};
+```
+
+After:
+
+```ts
+type FailedAgent =
+  | { kind: "agent";
+      name: string;
+      source_path: string;
+      error: string }
+  | { kind: "unparseable_agent";
+      source_path: string;
+      error: string }
+  | { kind: "companion_bundle";
+      plugin: string;
+      conflicts: string[];
+      error: string };
+```
+
+## Consumer impact
+
+LSP `findReferences` was unavailable during scoping (rust-analyzer was still building its cross-crate index on first start). Sites below were enumerated by grep; the post-change compiler errors will be the authoritative list.
+
+### Rust construction sites — 11 total
+
+All in `crates/kiro-market-core/src/service/mod.rs` except the helper at line 2778, which is in the same file.
+
+| Line | Today | New variant | Notes |
+|------|-------|-------------|-------|
+| 1648 | parse-failure on translated agent | `UnparseableAgent` | name unknown at this point |
+| 1727 | per-translated-agent install failure | `Agent` | name known via `def.name` |
+| 1772 | multi-scan-root rejection | `CompanionBundle` | `conflicts: vec![]` (rejection pre-enumeration) |
+| 1812 | parse-failure on native agent | `UnparseableAgent` | name unknown |
+| 1841 | native-manifest-invalid-name | `Agent` | name from `bundle.name` |
+| 1854 | hash failure on native agent | `Agent` | name from `bundle.name` |
+| 1895 | per-native-agent install failure | `Agent` | name from `bundle.name` |
+| 1921 | strip-prefix failure during companion | `CompanionBundle` | discovery-contract violation |
+| 1939 | hash failure during companion bundle | `CompanionBundle` | bundle-level |
+| 1962 | companion bundle install failure | `CompanionBundle` | the original misdiagnosed site |
+| 2778 | `required_source_path` helper for translated agents | `Agent` | name passed in by caller |
+
+### Rust test surface
+
+Grep found 1 explicit pattern-match (`crates/kiro-control-center/src-tauri/src/commands/agents.rs:421-426`). Other `result.failed[N].name`-style accesses across the test module will surface as compile errors after the type change — that's the authoritative count, not grep's. Each becomes a variant-aware match:
+
+```rust
+match &result.failed[0] {
+    FailedAgent::Agent { name, .. } => assert_eq!(name, "..."),
+    other => panic!("expected Agent variant, got {other:?}"),
+}
+```
+
+### TypeScript consumers
+
+| File | Line | Today | After |
+|------|------|-------|-------|
+| `crates/kiro-control-center/src/lib/format.ts` | 232-234, 246 | `agents.failed.length` | unchanged — variant-independent |
+| `crates/kiro-control-center/src/lib/plugin-actions.ts` | 146 | `result.data.agents.failed` (passed as `console.error` payload) | unchanged — diagnostic logger dumps the array, doesn't read fields |
+
+**Net FE consumer impact today: zero changes required.** The existing FE only reads `.length`. The wire-format upgrade pre-positions for the future inline-failure UI envisaged in the `plugin-actions.ts:130-138` comment without coupling that work to this PR.
+
+### bindings.ts
+
+Three current type definitions at lines 290-330 (`FailedAgent`, `FailedAgent_Serialize`, `FailedAgent_Deserialize`) are auto-generated by specta. Regenerate via `cargo test -p kiro-control-center --lib -- --ignored`. The `_Serialize` / `_Deserialize` split is a specta round-trip artifact; both collapse to the same discriminated union after regen.
+
+## Migration plan
+
+1. **Rust enum rewrite** — `crates/kiro-market-core/src/service/mod.rs:644-662` (struct → enum). `serialize_agent_error` field-level attribute migrates with each variant; no separate update needed.
+2. **Update 11 construction sites** per the table above. Pattern-replace pass with explicit re-read per site (no skimming).
+3. **`required_source_path` return type** stays `Result<RelativePath, FailedAgent>`; just constructs `FailedAgent::Agent { ... }` internally.
+4. **Tests** — `cargo test --workspace`, fix every compile error with the variant-aware match pattern shown above.
+5. **Bindings regen** — `cargo test -p kiro-control-center --lib -- --ignored`.
+6. **TS** — `npm run check`. Existing FE compiles unchanged. Add a comment near `plugin-actions.ts:130` documenting the discriminator-pushdown pattern future inline-failure UI should use (`switch (entry.kind) { ... default: const _: never = entry; ... }` plus `_ASSERT_EXHAUSTIVE` per CLAUDE.md's "discriminator-pushdown discipline" rule).
+7. **Verify clean** — `cargo fmt --all --check`, `cargo clippy --workspace --tests -- -D warnings`, `npm run check`, `npm run test:unit`, `cargo test --workspace`.
+
+## Follow-on work (intentionally not in this PR)
+
+Each item below is shaped so a future PR can pick it up independently. Numbered for cross-reference.
+
+### F1. Engine-level "collect all conflicts in a bundle"
+
+`classify_companion_collision` (`crates/kiro-market-core/src/project.rs:3104`) returns the first orphan-or-cross-plugin conflict and bails. The new `conflicts: Vec<PathBuf>` field is shaped to hold many; ships length-1 here. Extension would walk every `rel` in `input.rel_paths` collecting all conflicts, then return them as a single `Err(... { conflicts: Vec<...> })`. The wire format does not need to change for this work.
+
+**Why deferred:** larger test surface (matrix of orphan / cross-plugin / multi-conflict combinations) and an engine-side error-shape change (`AgentError::OrphanFileAtDestination { path: PathBuf }` → `AgentError::OrphanFilesAtDestination { paths: Vec<PathBuf> }` or similar). Out of scope for a wire-format-only PR.
+
+### F2. `FailedSteeringFile` parallel restructure
+
+Steering has its own `FailedSteeringFile` wire shape with parallel ambiguity potential (a future steering-bundle concept would face the same nullable-name problem). When steering grows a bundle-level concept it should adopt the same enum pattern as this PR.
+
+**Why deferred:** steering doesn't have a bundle-level construct today. Restructuring before there's a use case is YAGNI.
+
+### F3. Inline per-failure UI
+
+`crates/kiro-control-center/src/lib/plugin-actions.ts:130-138` documents this explicitly:
+
+> Temporary diagnostic: the current banner only carries the count-level summary ("1 steering failed · 8 agents failed"), so the per-item reasons that the Rust backend already sends (FailedSkill.error, FailedSteeringFile.error, FailedAgent.error — each carrying the full error chain) are otherwise invisible to the user. Log them to the DevTools console so they can be inspected without a backend-side console (release builds run under the `windows` subsystem, which detaches from the launching terminal). Follow-up work will surface these failures inline in the UI; see runPluginRemove's per-failure `<details>` panel in InstalledTab.svelte for the target shape.
+
+The new discriminated `FailedAgent` is what that UI should consume. Pair the `switch (entry.kind)` rendering with the `_ASSERT_EXHAUSTIVE` value-position guard (CLAUDE.md "discriminator-pushdown discipline").
+
+**Why deferred:** UI work is a separate concern from the wire-format change. Bundling them would force this PR to also touch InstalledTab.svelte and component testing.
+
+### F4. "Remove it manually" remediation message UX
+
+The orphan-file error message (`crates/kiro-market-core/src/error.rs:363-364`):
+
+```
+file exists at `{path}` but has no tracking entry; remove it manually or pass --force
+```
+
+is poor advice when the orphan is git-tracked (the kiro-control-center case that triggered this PR). A nicer message would acknowledge that orphans may be intentional repo content and suggest force-install or a different target.
+
+**Why deferred:** UX-text change in `AgentError` Display impl. Doesn't depend on or affect the wire-format change.
+
+### F5. Detect "destination is a git-tracked file" at install time
+
+A higher-leverage fix than F4: at install time, when an orphan is detected, check `git ls-files --error-unmatch <path>`. If git claims the file, the remediation message can be specific ("this file is git-tracked in your repo; force-install will produce a diff in your working tree").
+
+**Why deferred:** introduces a `git` subprocess dependency to `kiro-market-core`, which violates the "domain core stays free of external runtimes" rule from CLAUDE.md. The check belongs in the Tauri command layer or CLI, not core. Designable; not designed.
+
+## Risks
+
+- **specta + tagged enums**: validated by `UpdateChangeSignal` precedent. Low risk; verify regenerated `bindings.ts` shape matches design before merge.
+- **`PluginName` in wire format**: confirmed `#[cfg_attr(feature = "specta", derive(specta::Type))]` at `crates/kiro-market-core/src/validation.rs:429`. Low risk.
+- **Pattern-replace fatigue across 11 construction sites**: mitigation = re-read each site, don't skim. The compiler will catch logic errors but won't catch wrong-variant choice (e.g. accidentally using `UnparseableAgent` where `Agent` is correct because the name is in scope).
+
+## Verification gates (CLAUDE.md plan-review checklist)
+
+- **Gate 1 — Grounding**: each migration step cites a specific file:line. ✓
+- **Gate 2 — Threat Model**: no new attack surface (wire shape only).  ✓
+- **Gate 3 — Wire Format**: before/after TS shapes specified above.  ✓
+- **Gate 4 — External Type Boundary**: `AgentError` already projected via `serialize_agent_error`; no external error types newly exposed. ✓
+- **Gate 5 — Type Design**: three-variant decomposition rationale in "Key decisions" above.  ✓
+- **Gate 6 — Reference vs Transcription**: design cites the `UpdateChangeSignal` mechanism (the codebase precedent), not just the output shape it produces. ✓

--- a/docs/plans/2026-05-09-failed-agent-discriminator-design.md
+++ b/docs/plans/2026-05-09-failed-agent-discriminator-design.md
@@ -130,7 +130,7 @@ match &result.failed[0] {
 | `crates/kiro-control-center/src/lib/format.ts` | 232-234, 246 | `agents.failed.length` | unchanged — variant-independent |
 | `crates/kiro-control-center/src/lib/plugin-actions.ts` | 146 | `result.data.agents.failed` (passed as `console.error` payload) | unchanged — diagnostic logger dumps the array, doesn't read fields |
 
-**Net FE consumer impact today: zero changes required.** The existing FE only reads `.length`. The wire-format upgrade pre-positions for the future inline-failure UI envisaged in the `plugin-actions.ts:130-138` comment without coupling that work to this PR.
+**Net FE consumer impact today: zero changes required.** The existing FE only reads `.length`. The wire-format upgrade pre-positions for the future inline-failure UI (F3 below) without coupling that work to this PR.
 
 ### bindings.ts
 
@@ -143,7 +143,7 @@ Three current type definitions at lines 290-330 (`FailedAgent`, `FailedAgent_Ser
 3. **`required_source_path` return type** stays `Result<RelativePath, FailedAgent>`; just constructs `FailedAgent::Agent { ... }` internally.
 4. **Tests** — `cargo test --workspace`, fix every compile error with the variant-aware match pattern shown above.
 5. **Bindings regen** — `cargo test -p kiro-control-center --lib -- --ignored`.
-6. **TS** — `npm run check`. Existing FE compiles unchanged. Add a comment near `plugin-actions.ts:130` documenting the discriminator-pushdown pattern future inline-failure UI should use (`switch (entry.kind) { ... default: const _: never = entry; ... }` plus `_ASSERT_EXHAUSTIVE` per CLAUDE.md's "discriminator-pushdown discipline" rule).
+6. **TS** — `npm run check`. Existing FE compiles unchanged. Add a comment near the `agents.failed` consumer in `plugin-actions.ts` documenting the discriminator-pushdown pattern future inline-failure UI should use (`switch (entry.kind) { ... default: const _exhaustive: never = entry; ... }` plus a value-position `_AssertExhaustive` per CLAUDE.md's "discriminator-pushdown discipline" rule).
 7. **Verify clean** — `cargo fmt --all --check`, `cargo clippy --workspace --tests -- -D warnings`, `npm run check`, `npm run test:unit`, `cargo test --workspace`.
 
 ## Follow-on work (intentionally not in this PR)
@@ -164,11 +164,33 @@ Steering has its own `FailedSteeringFile` wire shape with parallel ambiguity pot
 
 ### F3. Inline per-failure UI
 
-`crates/kiro-control-center/src/lib/plugin-actions.ts:130-138` documents this explicitly:
+The current FE consumes `result.data.agents.failed` only at the count level
+(`format.ts` reads `.length` for the banner; `plugin-actions.ts` passes the
+array through to `console.error` as an opaque diagnostic payload). Per-item
+reasons that the Rust backend already sends — `FailedSkill.error`,
+`FailedSteeringFile.error`, `FailedAgent.error` (each carrying the full
+chain via `error_full_chain`) — are not surfaced inline in the UI today.
 
-> Temporary diagnostic: the current banner only carries the count-level summary ("1 steering failed · 8 agents failed"), so the per-item reasons that the Rust backend already sends (FailedSkill.error, FailedSteeringFile.error, FailedAgent.error — each carrying the full error chain) are otherwise invisible to the user. Log them to the DevTools console so they can be inspected without a backend-side console (release builds run under the `windows` subsystem, which detaches from the launching terminal). Follow-up work will surface these failures inline in the UI; see runPluginRemove's per-failure `<details>` panel in InstalledTab.svelte for the target shape.
+The new discriminated `FailedAgent` is what the inline-UI work should
+consume. The forward-looking comment block added in
+`crates/kiro-control-center/src/lib/plugin-actions.ts` near the
+`agents.failed` consumer documents the target switch shape:
 
-The new discriminated `FailedAgent` is what that UI should consume. Pair the `switch (entry.kind)` rendering with the `_ASSERT_EXHAUSTIVE` value-position guard (CLAUDE.md "discriminator-pushdown discipline").
+```ts
+switch (entry.kind) {
+  case "agent":             return renderAgent(entry.name, entry.source_path, entry.error);
+  case "unparseable_agent": return renderUnparseable(entry.source_path, entry.error);
+  case "companion_bundle":  return renderBundle(entry.plugin, entry.conflicts, entry.error);
+  default: { const _exhaustive: never = entry; throw new Error(`unhandled ${JSON.stringify(_exhaustive)}`); }
+}
+```
+
+Pair the runtime switch with a value-position assert per CLAUDE.md
+"discriminator-pushdown discipline" (see `_PLUGIN_ACTION_VALUES` +
+`_AssertPluginActionExhaustive` in `stores/plugin-updates.ts` for the
+canonical precedent). For the target shape of the inline `<details>`
+panel, see `runPluginRemove`'s per-failure rendering in
+`InstalledTab.svelte`.
 
 **Why deferred:** UI work is a separate concern from the wire-format change. Bundling them would force this PR to also touch InstalledTab.svelte and component testing.
 

--- a/docs/plans/2026-05-09-failed-agent-discriminator-plan.md
+++ b/docs/plans/2026-05-09-failed-agent-discriminator-plan.md
@@ -1,0 +1,1216 @@
+# `FailedAgent` Tagged-Enum Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `kiro_market_core::service::FailedAgent` from a struct with nullable name + dual-purpose `source_path` into a `#[serde(tag = "kind")]` discriminated enum with three variants (`agent` / `unparseable_agent` / `companion_bundle`). Eliminates the wire-format ambiguity that caused the kiro-control-center misdiagnosis where a directory-shaped `source_path` looked like a discovery bug.
+
+**Architecture:** The new enum follows the `UpdateChangeSignal` precedent (`crates/kiro-market-core/src/service/mod.rs:632-642`) — a Rust enum with `#[serde(tag = "kind", rename_all = "snake_case")]` that specta projects to a discriminated TS union via `bindings.ts`. Construction sites pattern-match on context (does the name exist? is this a per-agent or bundle-level failure?) to choose the correct variant. One small classifier helper extracts conflict paths from typed `AgentError` returns at site 1962, enumerating every variant per CLAUDE.md's classifier rule.
+
+**Tech Stack:** Rust 2024 (edition 1.85.0), `serde` + `serde_json`, `specta` (feature-gated), `thiserror`. TypeScript on the FE consuming `bindings.ts` (auto-generated).
+
+**Spec:** `docs/plans/2026-05-09-failed-agent-discriminator-design.md`
+
+**Behavior change (intentional):** This PR changes the wire-format JSON envelope for items in `result.failed`. Anything observing the raw JSON — log scrapers, browser devtools sessions, external CLI consumers reading `result.failed[i].name` — will see a structural change:
+
+- Before: `{"name": null | string, "source_path": "<path>", "error": "<chain>"}`
+- After: tagged enum with three variants discriminated by `kind`. Bundle failures no longer pretend to be agent failures with a directory-shaped `source_path`.
+
+Existing FE only reads `agents.failed.length` (variant-independent), so the in-app UI is unchanged today. The wire-shape change is the *point* of the PR — preserving the old shape would defeat the purpose. Note this in the merge commit message so anyone bisecting wire-format expectations finds the change immediately.
+
+---
+
+## File Structure
+
+| File | Role | Operation |
+|------|------|-----------|
+| `crates/kiro-market-core/src/service/mod.rs` | Enum definition, classifier helper, all 11 construction sites, wire-format test | Modify |
+| `crates/kiro-control-center/src-tauri/src/commands/agents.rs` | One existing pattern-match on `result.failed[0].error` | Modify |
+| `crates/kiro-control-center/src/lib/bindings.ts` | Auto-generated type definitions | Regenerate (machine-written) |
+| `crates/kiro-control-center/src/lib/plugin-actions.ts` | Add forward-looking comment about discriminator-pushdown for inline-failure UI | Modify |
+
+No new files. The enum, classifier helper, and tests all live in `service/mod.rs` next to the existing wire types per the project's "wire types co-located with service module" convention.
+
+---
+
+## Task 1: Write the failing wire-format test (RED)
+
+This test pins the JSON shape for all three variants. It will fail to compile because the variants don't exist yet — that's the failing-test step.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` (append to existing `mod tests` at line ~2864)
+
+- [ ] **Step 1.1: Add the test at the bottom of the existing `mod tests` block**
+
+Locate the `mod tests` module in `crates/kiro-market-core/src/service/mod.rs` (starts around line 2864). Add this test inside it, near the existing `install_warning_*` tests for symmetry:
+
+```rust
+    /// Wire-format lock for `FailedAgent`. Pins the three-variant
+    /// tagged-enum shape that crosses the FFI boundary via specta.
+    /// `#[serde(tag = "kind", rename_all = "snake_case")]` produces
+    /// `kind: "agent" | "unparseable_agent" | "companion_bundle"`
+    /// in JSON. If a future change accidentally drops the tag,
+    /// renames a variant, or adds/removes a field, this test fires
+    /// before bindings.ts drift reaches the frontend.
+    ///
+    /// Asserts exact key-set per variant — the substitute for a
+    /// round-trip test (we can't `from_value` because the typed
+    /// `AgentError` doesn't `Deserialize`; a one-way `serialize_with`
+    /// projects it to a string). Exact-key-set assertions catch the
+    /// same drift a round-trip would: any added/removed/renamed field
+    /// breaks the test.
+    #[test]
+    fn failed_agent_serializes_as_three_variant_tagged_enum() {
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+        use crate::error::AgentError;
+        use crate::validation::PluginName;
+
+        fn key_set(value: &serde_json::Value) -> BTreeSet<String> {
+            value
+                .as_object()
+                .expect("variant serializes to a JSON object")
+                .keys()
+                .cloned()
+                .collect()
+        }
+
+        // ---- Agent variant ------------------------------------------------
+        let agent = FailedAgent::Agent {
+            name: "reviewer".to_owned(),
+            source_path: PathBuf::from("/src/reviewer.json"),
+            error: AgentError::ContentChangedRequiresForce {
+                name: "reviewer".to_owned(),
+            },
+        };
+        let agent_json = serde_json::to_value(&agent).expect("serialize Agent");
+        assert_eq!(agent_json["kind"], "agent");
+        assert_eq!(agent_json["name"], "reviewer");
+        assert_eq!(agent_json["source_path"], "/src/reviewer.json");
+        assert!(agent_json["error"].is_string(), "error must serialize as string per FFI contract");
+        assert_eq!(
+            key_set(&agent_json),
+            BTreeSet::from(["error".to_owned(), "kind".to_owned(), "name".to_owned(), "source_path".to_owned()]),
+            "Agent variant key set drifted"
+        );
+
+        // ---- UnparseableAgent variant -------------------------------------
+        let unparseable = FailedAgent::UnparseableAgent {
+            source_path: PathBuf::from("/src/broken.json"),
+            error: AgentError::NativeManifestParseFailed {
+                path: PathBuf::from("/src/broken.json"),
+                reason: "expected `,` or `}`".to_owned(),
+            },
+        };
+        let unparseable_json = serde_json::to_value(&unparseable).expect("serialize UnparseableAgent");
+        assert_eq!(unparseable_json["kind"], "unparseable_agent");
+        assert_eq!(unparseable_json["source_path"], "/src/broken.json");
+        assert!(unparseable_json["error"].is_string());
+        assert_eq!(
+            key_set(&unparseable_json),
+            BTreeSet::from(["error".to_owned(), "kind".to_owned(), "source_path".to_owned()]),
+            "UnparseableAgent variant key set drifted"
+        );
+
+        // ---- CompanionBundle variant: orphan case (length-1 conflicts) ----
+        let bundle_orphan = FailedAgent::CompanionBundle {
+            plugin: PluginName::new("myplugin").expect("valid plugin name"),
+            conflicts: vec![PathBuf::from("prompts/code-reviewer.md")],
+            error: AgentError::OrphanFileAtDestination {
+                path: PathBuf::from("/dest/prompts/code-reviewer.md"),
+            },
+        };
+        let bundle_orphan_json = serde_json::to_value(&bundle_orphan).expect("serialize CompanionBundle (orphan)");
+        assert_eq!(bundle_orphan_json["kind"], "companion_bundle");
+        assert_eq!(bundle_orphan_json["plugin"], "myplugin");
+        let conflicts = bundle_orphan_json["conflicts"].as_array().expect("conflicts is array");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0], "prompts/code-reviewer.md");
+        assert!(bundle_orphan_json["error"].is_string());
+        assert_eq!(
+            key_set(&bundle_orphan_json),
+            BTreeSet::from(["conflicts".to_owned(), "error".to_owned(), "kind".to_owned(), "plugin".to_owned()]),
+            "CompanionBundle variant key set drifted"
+        );
+
+        // ---- CompanionBundle variant: pre-enumeration rejection (empty) ---
+        // Multi-scan-root rejection fires BEFORE per-file collision
+        // classification — `conflicts` is correctly empty, NOT absent.
+        // Locking this guarantees serde renders `Vec::new()` as `[]`,
+        // not as the field being omitted.
+        let bundle_empty = FailedAgent::CompanionBundle {
+            plugin: PluginName::new("myplugin").expect("valid plugin name"),
+            conflicts: Vec::new(),
+            error: AgentError::MultipleScanRootsNotSupported {
+                roots: vec![PathBuf::from("agents"), PathBuf::from("other-agents")],
+            },
+        };
+        let bundle_empty_json = serde_json::to_value(&bundle_empty).expect("serialize CompanionBundle (empty)");
+        assert_eq!(bundle_empty_json["kind"], "companion_bundle");
+        assert_eq!(bundle_empty_json["plugin"], "myplugin");
+        assert_eq!(
+            bundle_empty_json["conflicts"],
+            serde_json::json!([]),
+            "empty conflicts must serialize as `[]`, not be omitted"
+        );
+        assert!(bundle_empty_json["error"].is_string());
+        assert_eq!(
+            key_set(&bundle_empty_json),
+            BTreeSet::from(["conflicts".to_owned(), "error".to_owned(), "kind".to_owned(), "plugin".to_owned()]),
+            "CompanionBundle (empty conflicts) variant key set drifted"
+        );
+    }
+```
+
+- [ ] **Step 1.2: Run the test and confirm compile failure**
+
+Run:
+```
+cargo test -p kiro-market-core --lib service::tests::failed_agent_serializes_as_three_variant_tagged_enum
+```
+
+Expected output: compilation errors mentioning `FailedAgent::Agent`, `FailedAgent::UnparseableAgent`, `FailedAgent::CompanionBundle` — each "no variant named X found for enum/struct `FailedAgent`". This is the failing-test signal; do NOT proceed to make it pass yet.
+
+- [ ] **Step 1.3: Do NOT commit yet**
+
+The crate doesn't compile. Tasks 2-5 will make it compile again. Commit only after the entire build is green.
+
+---
+
+## Task 2: Replace `FailedAgent` struct with the tagged enum
+
+This is the type-definition change. After this step the crate has even more compile errors (every construction site breaks). Tasks 3-5 fix them.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs:644-662`
+
+- [ ] **Step 2.1: Replace the struct with the enum**
+
+Find this block at lines 644-662:
+
+```rust
+/// An agent that failed to install, with the typed error.
+///
+/// `name` is `Some` once parsing has identified the agent; pre-parse
+/// failures use `source_path` as the fallback identifier. `error` is the
+/// typed [`AgentError`] so frontends can branch on cause without
+/// substring-matching the rendered message; a custom `Serialize` impl
+/// projects it to the chain string for the wire format.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct FailedAgent {
+    pub name: Option<String>,
+    pub source_path: std::path::PathBuf,
+    /// Typed error. `Serialize` renders it as a string via
+    /// [`crate::error::error_full_chain`] so the wire shape stays string;
+    /// in-process consumers can match on the typed variants directly.
+    #[serde(serialize_with = "serialize_agent_error")]
+    #[cfg_attr(feature = "specta", specta(type = String))]
+    pub error: crate::error::AgentError,
+}
+```
+
+Replace with:
+
+```rust
+/// A failure entry for one element of an agent install batch.
+///
+/// Three-variant tagged enum so the wire format distinguishes per-agent
+/// failures (where `name` is known after parse), pre-parse failures
+/// (where `source_path` is the only identifier), and bundle-level
+/// failures (companion bundles are plugin-scoped, not agent-scoped).
+///
+/// JSON shape via `#[serde(tag = "kind", rename_all = "snake_case")]`:
+/// - `{"kind": "agent", "name": "...", "source_path": "...", "error": "..."}`
+/// - `{"kind": "unparseable_agent", "source_path": "...", "error": "..."}`
+/// - `{"kind": "companion_bundle", "plugin": "...", "conflicts": [...], "error": "..."}`
+///
+/// Precedent: `UpdateChangeSignal` (this file) uses the same pattern.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FailedAgent {
+    /// A native or translated agent failed during install. Name is
+    /// known because parsing succeeded — callers had a parsed
+    /// `AgentDefinition` or `NativeAgentBundle` in scope when the
+    /// failure occurred.
+    Agent {
+        name: String,
+        source_path: std::path::PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+    /// An agent file failed before parse, so no name is available.
+    /// `source_path` is the only identifier the FE can show. The
+    /// error variant inside carries the structured parse failure.
+    UnparseableAgent {
+        source_path: std::path::PathBuf,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+    /// A plugin's companion-file bundle (e.g. `agents/prompts/*.md`)
+    /// failed atomically. The bundle is plugin-scoped, not agent-scoped,
+    /// so neither `name` nor `source_path` (a per-agent concept) applies.
+    ///
+    /// `conflicts` enumerates destination paths that conflicted. Today
+    /// the engine bails on first conflict, so length is 0 (rejection
+    /// before per-file enumeration, e.g. `MultipleScanRootsNotSupported`)
+    /// or 1 (orphan / cross-plugin). Forward-compatible with future
+    /// "collect all conflicts" engine work without another wire migration.
+    CompanionBundle {
+        plugin: crate::validation::PluginName,
+        conflicts: Vec<std::path::PathBuf>,
+        #[serde(serialize_with = "serialize_agent_error")]
+        #[cfg_attr(feature = "specta", specta(type = String))]
+        error: crate::error::AgentError,
+    },
+}
+```
+
+- [ ] **Step 2.2: Add the classifier helper for site 1962**
+
+Immediately after the enum definition (so it's findable next to the type it serves), add this helper. It must be exhaustive over `AgentError` per CLAUDE.md's classifier rule.
+
+```rust
+/// Project an `AgentError` returned by `KiroProject::install_native_companions`
+/// into the `conflicts` list on `FailedAgent::CompanionBundle`.
+///
+/// Two variants carry destination paths that ARE conflicts:
+/// `OrphanFileAtDestination` (orphan file with no tracking) and
+/// `PathOwnedByOtherPlugin` (cross-plugin conflict). All other variants
+/// either carry source paths (which don't belong in `conflicts`) or
+/// describe non-conflict failures.
+///
+/// Exhaustive per CLAUDE.md's "Classifier functions over error enums
+/// enumerate every variant" rule. A new `AgentError` variant should
+/// force a compile error here, not silently default to empty.
+fn companion_conflicts_from_error(err: &crate::error::AgentError) -> Vec<std::path::PathBuf> {
+    use crate::error::AgentError;
+    match err {
+        AgentError::OrphanFileAtDestination { path } => vec![path.clone()],
+        AgentError::PathOwnedByOtherPlugin { path, .. } => vec![path.clone()],
+        AgentError::AlreadyInstalled { .. }
+        | AgentError::NotInstalled { .. }
+        | AgentError::ParseFailed { .. }
+        | AgentError::NativeManifestParseFailed { .. }
+        | AgentError::NativeManifestMissingName { .. }
+        | AgentError::NativeManifestInvalidName { .. }
+        | AgentError::ManifestReadFailed { .. }
+        | AgentError::NameClashWithOtherPlugin { .. }
+        | AgentError::ContentChangedRequiresForce { .. }
+        | AgentError::MultipleScanRootsNotSupported { .. }
+        | AgentError::SourceHardlinked { .. }
+        | AgentError::InstallFailed { .. } => Vec::new(),
+    }
+}
+```
+
+- [ ] **Step 2.3: Add classifier unit tests**
+
+The classifier `companion_conflicts_from_error` has 14 match arms (2 produce paths, 12 return empty). The compile-time exhaustiveness gate catches *missing* arms when `AgentError` grows a variant; behavioral tests catch *wrong routing* (e.g. someone moves `OrphanFileAtDestination` into the empty branch by accident). Three tests lock the routing contract.
+
+Append to the existing `mod tests` block in `crates/kiro-market-core/src/service/mod.rs` (near the wire-format test from Task 1.1):
+
+```rust
+    /// Classifier routing test: orphan errors produce a length-1
+    /// `conflicts` entry containing the destination path.
+    #[test]
+    fn companion_conflicts_from_error_orphan_returns_destination_path() {
+        use std::path::PathBuf;
+        use crate::error::AgentError;
+
+        let err = AgentError::OrphanFileAtDestination {
+            path: PathBuf::from("/dest/prompts/code-reviewer.md"),
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert_eq!(conflicts, vec![PathBuf::from("/dest/prompts/code-reviewer.md")]);
+    }
+
+    /// Classifier routing test: cross-plugin path conflicts also
+    /// produce a length-1 `conflicts` entry. The `owner` field is
+    /// not consumed by the classifier — it survives in the typed
+    /// error inside `FailedAgent::CompanionBundle.error`.
+    #[test]
+    fn companion_conflicts_from_error_path_owned_by_other_plugin_returns_destination_path() {
+        use std::path::PathBuf;
+        use crate::error::AgentError;
+
+        let err = AgentError::PathOwnedByOtherPlugin {
+            path: PathBuf::from("/dest/prompts/shared.md"),
+            owner: "otherplugin".to_owned(),
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert_eq!(conflicts, vec![PathBuf::from("/dest/prompts/shared.md")]);
+    }
+
+    /// Classifier routing test: errors that fire BEFORE per-file
+    /// enumeration produce an empty conflicts list. `MultipleScanRootsNotSupported`
+    /// is the canonical pre-enumeration case (rejection at discovery).
+    /// This test pins the empty-conflicts branch so that a future
+    /// "default to empty" wildcard regression (which CLAUDE.md
+    /// prohibits) is also caught behaviorally.
+    #[test]
+    fn companion_conflicts_from_error_multi_scan_root_returns_empty() {
+        use std::path::PathBuf;
+        use crate::error::AgentError;
+
+        let err = AgentError::MultipleScanRootsNotSupported {
+            roots: vec![PathBuf::from("agents"), PathBuf::from("other-agents")],
+        };
+        let conflicts = companion_conflicts_from_error(&err);
+        assert!(
+            conflicts.is_empty(),
+            "MultipleScanRootsNotSupported is a bundle-level rejection that fires \
+             BEFORE per-file enumeration; conflicts must be empty, got: {conflicts:?}"
+        );
+    }
+```
+
+These tests will not run yet — the crate doesn't compile (construction sites still broken). They run in Task 6 along with the wire-format test.
+
+- [ ] **Step 2.4: Run cargo check to confirm new compile errors at construction sites**
+
+Run:
+```
+cargo check -p kiro-market-core
+```
+
+Expected: ~11 errors, each saying "expected struct `FailedAgent`, found enum variant" or "no field named `name` on enum `FailedAgent`" at the construction sites. This is normal — Tasks 3-5 fix them. The classifier function and its three new tests should NOT appear in the error list (they only depend on the new enum and `AgentError`, both of which exist).
+
+---
+
+## Task 3: Update construction sites in the translated-agent path
+
+These sites construct `FailedAgent` from the translated (markdown) agent install path.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` lines 1648, 1727, 2778
+
+- [ ] **Step 3.1: Site 1648 — translated parse failure → `UnparseableAgent`**
+
+Locate the block around line 1648 (inside `install_translated_agents_inner`). The current code:
+
+```rust
+                Err(e) => {
+                    // Install-layer variants (AlreadyInstalled/NotInstalled)
+                    // shouldn't come from parse_agent_file, but we collect
+                    // them as failures rather than crashing the batch.
+                    result.failed.push(FailedAgent {
+                        name: None,
+                        source_path: path.clone(),
+                        error: e,
+                    });
+                    continue;
+                }
+```
+
+Replace with:
+
+```rust
+                Err(e) => {
+                    // Install-layer variants (AlreadyInstalled/NotInstalled)
+                    // shouldn't come from parse_agent_file, but we collect
+                    // them as failures rather than crashing the batch.
+                    // Pre-parse failure → `UnparseableAgent` (no name yet).
+                    result.failed.push(FailedAgent::UnparseableAgent {
+                        source_path: path.clone(),
+                        error: e,
+                    });
+                    continue;
+                }
+```
+
+- [ ] **Step 3.2: Site 1727 — per-translated-agent install failure → `Agent`**
+
+Locate the block around line 1727. The current code:
+
+```rust
+                Err(e) => {
+                    let agent_err = match e {
+                        Error::Agent(agent_err) => agent_err,
+                        other => crate::error::AgentError::InstallFailed {
+                            path: path.clone(),
+                            source: Box::new(other),
+                        },
+                    };
+                    result.failed.push(FailedAgent {
+                        name: Some(def.name),
+                        source_path: path.clone(),
+                        error: agent_err,
+                    });
+                }
+```
+
+Replace the `result.failed.push(...)` portion with:
+
+```rust
+                Err(e) => {
+                    let agent_err = match e {
+                        Error::Agent(agent_err) => agent_err,
+                        other => crate::error::AgentError::InstallFailed {
+                            path: path.clone(),
+                            source: Box::new(other),
+                        },
+                    };
+                    // Parse succeeded earlier → name is known.
+                    result.failed.push(FailedAgent::Agent {
+                        name: def.name,
+                        source_path: path.clone(),
+                        error: agent_err,
+                    });
+                }
+```
+
+(`def.name` was wrapped in `Some(...)` for the old `Option<String>` field; now it's the inner `String` directly.)
+
+- [ ] **Step 3.3: Site 2778 — `required_source_path` helper → `Agent`**
+
+Locate `required_source_path` (around line 2765). The current code:
+
+```rust
+fn required_source_path(
+    path: &Path,
+    plugin_dir: &Path,
+    agent_name: String,
+) -> Result<crate::validation::RelativePath, FailedAgent> {
+    crate::validation::RelativePath::from_path_under(path, plugin_dir).map_err(|e| {
+        let path_buf = path.to_path_buf();
+        FailedAgent {
+            name: Some(agent_name),
+            source_path: path_buf.clone(),
+            error: crate::error::AgentError::InstallFailed {
+                path: path_buf,
+                source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
+                    "discovered agent path",
+                    path,
+                    plugin_dir,
+                ))),
+            },
+        }
+    })
+}
+```
+
+Replace the `FailedAgent { ... }` literal with:
+
+```rust
+        FailedAgent::Agent {
+            name: agent_name,
+            source_path: path_buf.clone(),
+            error: crate::error::AgentError::InstallFailed {
+                path: path_buf,
+                source: Box::new(crate::error::Error::Io(scan_root_invalid_io_err(
+                    "discovered agent path",
+                    path,
+                    plugin_dir,
+                ))),
+            },
+        }
+```
+
+(`Some(agent_name)` → `agent_name`. Same `name` parameter, just unwrapped.)
+
+- [ ] **Step 3.4: Verify intermediate compile state**
+
+Run:
+```
+cargo check -p kiro-market-core
+```
+
+Expected: errors at lines 1812, 1841, 1854, 1895, 1772, 1921, 1939, 1962 only. Translated-path sites no longer error.
+
+---
+
+## Task 4: Update construction sites in the native per-agent path
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` lines 1812, 1841, 1854, 1895
+
+- [ ] **Step 4.1: Site 1812 — native parse failure → `UnparseableAgent`**
+
+Locate the block around line 1812 (inside `install_one_native_agent`). Current:
+
+```rust
+        let bundle = match crate::agent::parse_native_kiro_agent_file(&file.source, &file.scan_root)
+        {
+            Ok(b) => b,
+            Err(parse_err) => {
+                result.failed.push(FailedAgent {
+                    name: None,
+                    source_path: file.source.clone(),
+                    error: native_parse_failure_to_agent_error(&file.source, parse_err),
+                });
+                return;
+            }
+        };
+```
+
+Replace with:
+
+```rust
+        let bundle = match crate::agent::parse_native_kiro_agent_file(&file.source, &file.scan_root)
+        {
+            Ok(b) => b,
+            Err(parse_err) => {
+                // Parse failed → no `bundle.name` yet; route as UnparseableAgent.
+                result.failed.push(FailedAgent::UnparseableAgent {
+                    source_path: file.source.clone(),
+                    error: native_parse_failure_to_agent_error(&file.source, parse_err),
+                });
+                return;
+            }
+        };
+```
+
+- [ ] **Step 4.2: Site 1841 — native-manifest-invalid-name → `Agent`**
+
+Locate the block around line 1841. Current:
+
+```rust
+        let Some(filename) = file.source.file_name().map(std::path::PathBuf::from) else {
+            result.failed.push(FailedAgent {
+                name: Some(bundle.name.to_string()),
+                source_path: file.source.clone(),
+                error: crate::error::AgentError::NativeManifestInvalidName {
+                    path: file.source.clone(),
+                    reason: "discovered file has no file-name component".to_owned(),
+                },
+            });
+            return;
+        };
+```
+
+Replace with:
+
+```rust
+        let Some(filename) = file.source.file_name().map(std::path::PathBuf::from) else {
+            result.failed.push(FailedAgent::Agent {
+                name: bundle.name.to_string(),
+                source_path: file.source.clone(),
+                error: crate::error::AgentError::NativeManifestInvalidName {
+                    path: file.source.clone(),
+                    reason: "discovered file has no file-name component".to_owned(),
+                },
+            });
+            return;
+        };
+```
+
+- [ ] **Step 4.3: Site 1854 — native hash failure → `Agent`**
+
+Locate the block around line 1854. Current:
+
+```rust
+        let source_hash = match crate::hash::hash_artifact(&file.scan_root, &[filename]) {
+            Ok(h) => h,
+            Err(e) => {
+                result.failed.push(FailedAgent {
+                    name: Some(bundle.name.to_string()),
+                    source_path: file.source.clone(),
+                    error: crate::error::AgentError::InstallFailed {
+                        path: file.source.clone(),
+                        source: Box::new(e.into()),
+                    },
+                });
+                return;
+            }
+```
+
+Replace with:
+
+```rust
+        let source_hash = match crate::hash::hash_artifact(&file.scan_root, &[filename]) {
+            Ok(h) => h,
+            Err(e) => {
+                result.failed.push(FailedAgent::Agent {
+                    name: bundle.name.to_string(),
+                    source_path: file.source.clone(),
+                    error: crate::error::AgentError::InstallFailed {
+                        path: file.source.clone(),
+                        source: Box::new(e.into()),
+                    },
+                });
+                return;
+            }
+```
+
+- [ ] **Step 4.4: Site 1895 — per-native-agent install failure → `Agent`**
+
+Locate the block around line 1895 (the `match project.install_native_agent(...)` arm). Current:
+
+```rust
+            Err(err) => result.failed.push(FailedAgent {
+                name: Some(bundle.name.to_string()),
+                source_path: file.source.clone(),
+                error: err,
+            }),
+```
+
+Replace with:
+
+```rust
+            Err(err) => result.failed.push(FailedAgent::Agent {
+                name: bundle.name.to_string(),
+                source_path: file.source.clone(),
+                error: err,
+            }),
+```
+
+- [ ] **Step 4.5: Verify intermediate compile state**
+
+Run:
+```
+cargo check -p kiro-market-core
+```
+
+Expected: errors only at lines 1772, 1921, 1939, 1962 (the four bundle-level sites left for Task 5).
+
+---
+
+## Task 5: Update construction sites in the companion-bundle path
+
+These four sites all become `FailedAgent::CompanionBundle`. Site 1962 is the only one that uses the classifier helper from Task 2.2.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` lines 1772, 1921, 1939, 1962
+
+- [ ] **Step 5.1: Site 1772 — multi-scan-root rejection → `CompanionBundle`**
+
+Locate the block around line 1772 (inside `install_native_kiro_cli_agents_inner`). Current:
+
+```rust
+        if let Some(roots) = multiple_companion_scan_roots(&companion_files) {
+            result.failed.push(FailedAgent {
+                name: None,
+                source_path: plugin_dir.to_path_buf(),
+                error: crate::error::AgentError::MultipleScanRootsNotSupported { roots },
+            });
+            return result;
+        }
+```
+
+Replace with:
+
+```rust
+        if let Some(roots) = multiple_companion_scan_roots(&companion_files) {
+            // Bundle-level rejection BEFORE per-file enumeration —
+            // `conflicts` is empty because we never got to the
+            // collision-classification step.
+            result.failed.push(FailedAgent::CompanionBundle {
+                plugin: ctx.plugin.clone(),
+                conflicts: Vec::new(),
+                error: crate::error::AgentError::MultipleScanRootsNotSupported { roots },
+            });
+            return result;
+        }
+```
+
+(`ctx.plugin` is `&PluginName`; clone to get an owned `PluginName`.)
+
+- [ ] **Step 5.2: Site 1921 — strip-prefix discovery violation → `CompanionBundle`**
+
+Locate the block around line 1921 (inside `install_native_companions_for_plugin`). Current:
+
+```rust
+            let Ok(rel) = f.source.strip_prefix(&f.scan_root) else {
+                result.failed.push(FailedAgent {
+                    name: None,
+                    source_path: f.source.clone(),
+                    error: crate::error::AgentError::InstallFailed {
+                        path: f.source.clone(),
+                        source: Box::new(crate::error::Error::Io(std::io::Error::other(
+                            "discovered companion not under its declared scan_root",
+                        ))),
+                    },
+                });
+                return;
+            };
+```
+
+Replace with:
+
+```rust
+            let Ok(rel) = f.source.strip_prefix(&f.scan_root) else {
+                // Discovery contract violation (not a destination conflict).
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts: Vec::new(),
+                    error: crate::error::AgentError::InstallFailed {
+                        path: f.source.clone(),
+                        source: Box::new(crate::error::Error::Io(std::io::Error::other(
+                            "discovered companion not under its declared scan_root",
+                        ))),
+                    },
+                });
+                return;
+            };
+```
+
+- [ ] **Step 5.3: Site 1939 — companion bundle hash failure → `CompanionBundle`**
+
+Locate the block around line 1939. Current:
+
+```rust
+        let source_hash = match crate::hash::hash_artifact(&scan_root, &rel_paths) {
+            Ok(h) => h,
+            Err(e) => {
+                result.failed.push(FailedAgent {
+                    name: None,
+                    source_path: scan_root,
+                    error: crate::error::AgentError::InstallFailed {
+                        path: plugin_dir.to_path_buf(),
+                        source: Box::new(e.into()),
+                    },
+                });
+                return;
+            }
+        };
+```
+
+Replace with:
+
+```rust
+        let source_hash = match crate::hash::hash_artifact(&scan_root, &rel_paths) {
+            Ok(h) => h,
+            Err(e) => {
+                // Bundle-level pre-promotion failure — no destination
+                // conflicts because we never reached collision classification.
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts: Vec::new(),
+                    error: crate::error::AgentError::InstallFailed {
+                        path: plugin_dir.to_path_buf(),
+                        source: Box::new(e.into()),
+                    },
+                });
+                return;
+            }
+        };
+```
+
+- [ ] **Step 5.4: Site 1962 — companion bundle install failure → `CompanionBundle` (uses classifier)**
+
+Locate the block around line 1962. Current:
+
+```rust
+        }) {
+            Ok(outcome) => result.installed_companions = Some(outcome),
+            Err(err) => result.failed.push(FailedAgent {
+                name: None,
+                source_path: scan_root,
+                error: err,
+            }),
+        }
+```
+
+Replace with:
+
+```rust
+        }) {
+            Ok(outcome) => result.installed_companions = Some(outcome),
+            Err(err) => {
+                // The classifier extracts conflict paths from the typed
+                // error (Orphan / PathOwnedByOtherPlugin carry destination
+                // paths). All other variants → empty `conflicts`.
+                let conflicts = companion_conflicts_from_error(&err);
+                result.failed.push(FailedAgent::CompanionBundle {
+                    plugin: ctx.plugin.clone(),
+                    conflicts,
+                    error: err,
+                });
+            }
+        }
+```
+
+- [ ] **Step 5.5: Verify the full crate compiles**
+
+Run:
+```
+cargo check -p kiro-market-core
+```
+
+Expected: 0 errors. The crate compiles. The wire-format test from Task 1 may now pass — check next.
+
+---
+
+## Task 6: Run the wire-format test (GREEN)
+
+- [ ] **Step 6.1: Run the wire-format test and the three classifier tests**
+
+The four new tests added by this plan are filterable by substring: the wire-format test is one match (`failed_agent_serializes_as_three_variant_tagged_enum`) and the three classifier tests share a prefix (`companion_conflicts_from_error_*`). Both filters in one cargo invocation:
+
+```
+cargo test -p kiro-market-core --lib failed_agent_serializes_as_three_variant_tagged_enum companion_conflicts_from_error
+```
+
+Expected: 4 passed. If the wire-format test fails, the assertion message indicates which JSON shape or key set drifted — re-read Task 2.1 carefully. If a classifier test fails, the routing in Task 2.2's helper is wrong — re-read which `AgentError` variants populate `conflicts` (only `OrphanFileAtDestination` and `PathOwnedByOtherPlugin`).
+
+- [ ] **Step 6.2: Run the full kiro-market-core test suite**
+
+Run:
+```
+cargo test -p kiro-market-core
+```
+
+Expected: most tests pass; some existing tests asserting old `FailedAgent { name, source_path, error }` shape will fail to compile or fail at runtime. Task 7 fixes them.
+
+---
+
+## Task 7: Fix existing test pattern-matches surfaced by the compiler
+
+Compile errors in the test module will be of two kinds:
+1. Construction patterns: `FailedAgent { name: Some(...), source_path: ..., error: ... }` — replace with `FailedAgent::Agent { name: ..., source_path: ..., error: ... }`.
+2. Field access patterns: `result.failed[0].name` / `result.failed[0].source_path` / `result.failed[0].error` — replace with a `match` that destructures the variant.
+
+**Files:**
+- Modify: `crates/kiro-market-core/src/service/mod.rs` (test module)
+- Modify: `crates/kiro-control-center/src-tauri/src/commands/agents.rs:421-427`
+
+- [ ] **Step 7.1: Run the workspace tests to surface every broken test**
+
+Run:
+```
+cargo test --workspace --no-run 2>&1 | head -200
+```
+
+Expected: a list of compile errors in test files. Each one points at the specific access pattern that needs updating.
+
+- [ ] **Step 7.2: Apply the variant-aware match pattern to each broken test**
+
+For every error like:
+
+```rust
+assert_eq!(result.failed[0].name, Some("reviewer".to_owned()));
+```
+
+Replace with:
+
+```rust
+match &result.failed[0] {
+    FailedAgent::Agent { name, .. } => assert_eq!(name, "reviewer"),
+    other => panic!("expected Agent variant, got {other:?}"),
+}
+```
+
+For an error-only assertion like:
+
+```rust
+assert!(matches!(
+    &result.failed[0].error,
+    AgentError::ContentChangedRequiresForce { name } if name == "reviewer"
+));
+```
+
+Replace with:
+
+```rust
+match &result.failed[0] {
+    FailedAgent::Agent { error: AgentError::ContentChangedRequiresForce { name }, .. } if name == "reviewer" => {}
+    other => panic!("expected Agent { error: ContentChangedRequiresForce, .. }, got {other:?}"),
+}
+```
+
+- [ ] **Step 7.3: Specifically fix `commands/agents.rs:421-427`**
+
+Locate `crates/kiro-control-center/src-tauri/src/commands/agents.rs:421-427`. Current:
+
+```rust
+        assert!(
+            matches!(
+                &result.failed[0].error,
+                kiro_market_core::error::AgentError::ContentChangedRequiresForce { name }
+                    if name == "reviewer"
+            ),
+            "wrong error variant: {:?}",
+            result.failed[0].error
+        );
+```
+
+Replace with:
+
+```rust
+        match &result.failed[0] {
+            kiro_market_core::service::FailedAgent::Agent {
+                error: kiro_market_core::error::AgentError::ContentChangedRequiresForce { name },
+                ..
+            } if name == "reviewer" => {}
+            other => panic!(
+                "expected FailedAgent::Agent {{ error: ContentChangedRequiresForce {{ name: \"reviewer\" }}, .. }}, \
+                 got {other:?}"
+            ),
+        }
+```
+
+The downstream JSON-shape assertion at lines 429-444 still works as-is — `serde_json::to_value(&result)` produces a value whose `/failed/0/error` pointer resolves to a string (per the new Agent variant's `error` field having the same `serialize_with` attribute).
+
+However, that test's assertion on `/failed/0/error` only finds the field if the JSON shape includes it at that path. Since the new tagged enum places `error` at `result.failed[0].error` regardless of variant, the existing JSON pointer continues to work. Confirm by re-running the test after the variant-aware match update.
+
+- [ ] **Step 7.4: Iterate until `cargo test --workspace --no-run` is clean**
+
+Run:
+```
+cargo test --workspace --no-run
+```
+
+If errors remain, repeat Step 7.2 for each. The compiler tells you exactly which file:line needs the variant match.
+
+- [ ] **Step 7.5: Run the full test suite**
+
+Run:
+```
+cargo test --workspace
+```
+
+Expected: all tests pass. If a runtime assertion fails (rare — usually caught by the compile errors in 7.1), inspect the panic message and update the test.
+
+---
+
+## Task 8: Lint, format, commit Rust changes
+
+- [ ] **Step 8.1: Format**
+
+Run:
+```
+cargo fmt --all
+```
+
+- [ ] **Step 8.2: Clippy**
+
+Run:
+```
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: 0 warnings. If clippy flags the new code, fix it (likely candidates: unnecessary `clone()`, `Vec::new()` vs `vec![]` style — match the surrounding code).
+
+- [ ] **Step 8.3: Confirm format check passes**
+
+Run:
+```
+cargo fmt --all --check
+```
+
+Expected: 0 output (silent success).
+
+- [ ] **Step 8.4: Stage and commit**
+
+```bash
+git add crates/kiro-market-core/src/service/mod.rs \
+        crates/kiro-control-center/src-tauri/src/commands/agents.rs
+git commit -m "$(cat <<'EOF'
+refactor(service): make FailedAgent a tagged enum
+
+Convert FailedAgent from a struct with nullable name + dual-purpose
+source_path into a #[serde(tag = "kind")] enum with three variants:
+agent, unparseable_agent, companion_bundle. Eliminates the wire-format
+ambiguity that surfaced as a "directory mis-installed as a file"
+misdiagnosis when companion-bundle failures used scan_root as
+source_path.
+
+Adds companion_conflicts_from_error classifier (exhaustive over
+AgentError per CLAUDE.md classifier rule) to project orphan and
+cross-plugin path conflicts into the new conflicts: Vec<PathBuf>
+field. Other AgentError variants → empty conflicts.
+
+11 construction sites updated; one downstream test pattern-match in
+commands/agents.rs adjusted for the new shape. FE consumers only read
+.length and need no changes today; bindings.ts regenerates in the
+follow-up commit.
+
+See docs/plans/2026-05-09-failed-agent-discriminator-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Regenerate bindings.ts
+
+- [ ] **Step 9.1: Run the bindings regen test**
+
+Run:
+```
+cargo test -p kiro-control-center --lib -- --ignored
+```
+
+This is the recipe documented in CLAUDE.md. It writes the new `bindings.ts` based on the updated specta-derived types.
+
+- [ ] **Step 9.2: Inspect the diff to confirm the new shape**
+
+Run:
+```
+git diff crates/kiro-control-center/src/lib/bindings.ts
+```
+
+Expected pattern in the diff for `FailedAgent`:
+
+```diff
+-export type FailedAgent_Deserialize = {
+-	name: string | null,
+-	source_path: string,
+-	error: string,
+-};
++export type FailedAgent_Deserialize =
++	| { kind: "agent"; name: string; source_path: string; error: string }
++	| { kind: "unparseable_agent"; source_path: string; error: string }
++	| { kind: "companion_bundle"; plugin: string; conflicts: string[]; error: string };
+```
+
+(Specta may format the union slightly differently — multi-line, trailing commas, or comments preserved. The key check: each of the three `kind` discriminator strings appears, and the field sets per variant match the design doc.)
+
+If the diff doesn't match (e.g. the discriminator is missing, or the shape is still a flat struct), the most likely cause is the `#[serde(tag = "kind", rename_all = "snake_case")]` attribute being dropped during the Task 2.1 edit — re-read the enum block in `service/mod.rs` and confirm the attribute is present.
+
+- [ ] **Step 9.3: Run TypeScript checks**
+
+Run from `crates/kiro-control-center/`:
+```
+npm run check
+```
+
+Expected: 0 errors. The existing FE consumers only read `.length` (`format.ts:232,234,246`, `plugin-actions.ts:146`), which is variant-independent. If TS errors appear, they indicate a consumer the grep missed — handle each by adding a discriminator-aware switch (see Task 10 for the pattern).
+
+---
+
+## Task 10: Add forward-looking comment to plugin-actions.ts
+
+The existing `console.error` diagnostic logger at `plugin-actions.ts:130-148` documents that inline-failure UI is follow-on work (F3 in the spec). The new wire shape is what that UI should consume. Add a comment near it that pre-positions the discriminator-pushdown pattern for whoever picks F3 up.
+
+**Files:**
+- Modify: `crates/kiro-control-center/src/lib/plugin-actions.ts` near line 148 (after the `console.error` block closes)
+
+- [ ] **Step 10.1: Read the existing comment block to preserve its tone**
+
+Run:
+```
+cat crates/kiro-control-center/src/lib/plugin-actions.ts | sed -n '125,150p'
+```
+
+- [ ] **Step 10.2: Insert the forward-looking comment**
+
+After the closing `}` of the `if (anyFailed) { console.error(...) }` block (around line 149), add:
+
+```typescript
+      // Per design 2026-05-09-failed-agent-discriminator-design.md (F3):
+      // when the inline-failure UI ships, render `result.data.agents.failed`
+      // by switching on the discriminator with an exhaustiveness guard:
+      //
+      //   switch (entry.kind) {
+      //     case "agent": return renderAgent(entry.name, entry.source_path, entry.error);
+      //     case "unparseable_agent": return renderUnparseable(entry.source_path, entry.error);
+      //     case "companion_bundle": return renderBundle(entry.plugin, entry.conflicts, entry.error);
+      //     default: { const _exhaustive: never = entry; throw new Error(`unhandled ${JSON.stringify(_exhaustive)}`); }
+      //   }
+      //
+      // Pair the runtime switch with a value-position assert per CLAUDE.md
+      // discriminator-pushdown discipline (see _PLUGIN_ACTION_VALUES + _AssertPluginActionExhaustive).
+```
+
+- [ ] **Step 10.3: Run TypeScript checks again**
+
+Run from `crates/kiro-control-center/`:
+```
+npm run check
+```
+
+Expected: 0 errors. (The comment doesn't change runtime behavior.)
+
+---
+
+## Task 11: Final verification gates
+
+Per CLAUDE.md "Pre-commit": run all four CI-enforced gates plus the FE checks before committing.
+
+- [ ] **Step 11.1: Format check**
+
+```
+cargo fmt --all --check
+```
+
+Expected: 0 output.
+
+- [ ] **Step 11.2: Workspace tests**
+
+```
+cargo test --workspace
+```
+
+Expected: all green.
+
+- [ ] **Step 11.3: Clippy**
+
+```
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: 0 warnings.
+
+- [ ] **Step 11.4: TypeScript check**
+
+From `crates/kiro-control-center/`:
+```
+npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 11.5: Vitest**
+
+From `crates/kiro-control-center/`:
+```
+npm run test:unit
+```
+
+Expected: all green.
+
+---
+
+## Task 12: Commit FE + bindings changes
+
+- [ ] **Step 12.1: Stage and commit**
+
+```bash
+git add crates/kiro-control-center/src/lib/bindings.ts \
+        crates/kiro-control-center/src/lib/plugin-actions.ts
+git commit -m "$(cat <<'EOF'
+chore(bindings): regenerate FailedAgent for tagged-enum wire shape
+
+Regenerates bindings.ts after the kiro-market-core enum conversion.
+The TS type for FailedAgent goes from a flat struct with nullable
+name to a discriminated union of three variants. Existing FE
+consumers only read .length and need no changes today.
+
+Also adds a forward-looking comment in plugin-actions.ts pointing
+at F3 (inline-failure UI) that documents the discriminator-pushdown
+switch shape future consumers should adopt, per CLAUDE.md.
+
+See docs/plans/2026-05-09-failed-agent-discriminator-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 12.2: Final status check**
+
+```
+git status --short
+```
+
+Expected: only your pre-existing in-progress modifications appear (the ones unrelated to this PR). The `FailedAgent` work is fully committed.
+
+---
+
+## Done
+
+The wire-format change is complete. Verify with one round-trip sanity check:
+
+```
+cargo run -p kiro-market -- list-marketplaces
+```
+
+(or any other command that exercises the install path) — if the CLI runs without panicking, the binary build is healthy. The actual install-with-orphan scenario is covered by the test from Task 1.
+
+Spec follow-on items (F1-F5) are documented in `docs/plans/2026-05-09-failed-agent-discriminator-design.md` for future PRs.

--- a/docs/plans/2026-05-09-failed-agent-discriminator-plan.md
+++ b/docs/plans/2026-05-09-failed-agent-discriminator-plan.md
@@ -24,6 +24,7 @@ Existing FE only reads `agents.failed.length` (variant-independent), so the in-a
 | File | Role | Operation |
 |------|------|-----------|
 | `crates/kiro-market-core/src/service/mod.rs` | Enum definition, classifier helper, all 11 construction sites, wire-format test | Modify |
+| `crates/kiro-market/src/commands/install.rs` | CLI install summary printer (`print_agent_outcome`); replace `.name`/`.source_path`/`.error` access with variant-aware match | Modify |
 | `crates/kiro-control-center/src-tauri/src/commands/agents.rs` | One existing pattern-match on `result.failed[0].error` | Modify |
 | `crates/kiro-control-center/src/lib/bindings.ts` | Auto-generated type definitions | Regenerate (machine-written) |
 | `crates/kiro-control-center/src/lib/plugin-actions.ts` | Add forward-looking comment about discriminator-pushdown for inline-failure UI | Modify |


### PR DESCRIPTION
## Summary

- Converts `kiro_market_core::service::FailedAgent` from a struct with nullable `name` + dual-purpose `source_path` into a `#[serde(tag = "kind")]` enum with three variants: `Agent { name, source_path, error }`, `UnparseableAgent { source_path, error }`, `CompanionBundle { plugin, conflicts, error }`.
- Eliminates the wire-format ambiguity that caused a debug session to misdiagnose a companion-bundle failure as a discovery bug (the bundle's `source_path` pointed at a directory because the old shape overloaded the field for both per-agent and bundle-level failures).
- 11 construction sites updated; one production CLI consumer (`kiro-market/src/commands/install.rs::print_agent_outcome`) was compile-forced into a variant-aware match. FE consumers only read `.length` and need no changes today.
- Adds `companion_conflicts_from_error` classifier (exhaustive over `AgentError`'s 14 variants per CLAUDE.md's classifier rule) so `OrphanFileAtDestination` and `PathOwnedByOtherPlugin` populate the new `conflicts: Vec<PathBuf>` field; all other variants → empty.

## Commits in this PR

1. `docs(plans): design FailedAgent tagged-enum wire format` — design doc with three-variant decomposition rationale, six plan-review gates, and follow-on items F1-F5.
2. `docs(plans): plan FailedAgent tagged-enum implementation` — 12-task plan with TDD-shaped steps, classifier unit tests, and exact-key-set wire-format assertions (substitute for round-trip since `AgentError` doesn't `Deserialize`).
3. `refactor(service): make FailedAgent a tagged enum` — Rust enum migration end-to-end including the classifier helper and 7 new tests (4 wire-format + 3 classifier).
4. `chore(bindings): regenerate FailedAgent for tagged-enum wire shape` — auto-regenerated `bindings.ts` plus a forward-looking comment in `plugin-actions.ts:139-151` documenting the discriminator-pushdown pattern future inline-failure UI should adopt (per CLAUDE.md's discriminator-pushdown discipline).

## Test plan

- [ ] `cargo fmt --all --check` — silent
- [ ] `cargo test --workspace` — all green (~1004 unit tests + doctests)
- [ ] `cargo clippy --workspace --tests -- -D warnings` — 0 warnings
- [ ] From `crates/kiro-control-center/`: `npm run check` — 0 errors
- [ ] From `crates/kiro-control-center/`: `npm run test:unit` — all vitest green
- [ ] Sanity-check the `bindings.ts` diff: `FailedAgent_Serialize` and `FailedAgent_Deserialize` are three-variant discriminated unions keyed by `kind`, with the field set in the design doc's "after" block.
- [ ] (Optional) Try installing a plugin into a fresh Kiro project and observe the `console.error` payload on a failure path: it now carries the `kind` discriminator instead of the old nullable-name + directory-shaped `source_path`.

## Behavior change (intentional)

This PR changes the wire-format JSON envelope for items in `result.failed`. Anything observing the raw JSON — log scrapers, browser devtools sessions, external CLI consumers reading `result.failed[i].name` — sees a structural change:

- Before: `{"name": null | string, "source_path": "<path>", "error": "<chain>"}`
- After: discriminated union by `kind` with three variants. Bundle failures no longer pretend to be agent failures with a directory-shaped `source_path`.

Existing FE consumers only read `agents.failed.length` (variant-independent), so the in-app UI is unchanged today. The wire-shape change is the *point* of the PR.

## Out of scope (carved out as follow-on PRs)

Five items are documented in the design doc with rationale for why they're deferred:

- **F1.** Engine-level "collect all conflicts in a bundle" — `classify_companion_collision` returns the first conflict and bails today; `conflicts: Vec<PathBuf>` is shape-compatible with multi-conflict but ships length-1.
- **F2.** `FailedSteeringFile` parallel restructure — apply the same enum pattern when steering grows a bundle-level concept.
- **F3.** Inline per-failure UI — the `plugin-actions.ts:139-151` comment pre-positions this work; the new wire shape is what that UI should consume.
- **F4.** "Remove it manually" remediation message UX — better advice when the orphan is git-tracked.
- **F5.** Detect "destination is a git-tracked file" at install time — would surface a remediation hint specific to the case that triggered this PR (the `kiro-control-center` repo dogfoods its own committed `.kiro/agents/*.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)