### PR TITLE
chore(settings): remove autoMode from checked-in settings.json (silently ignored)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,4 @@
 {
-  "autoMode": {
-    "environment": [
-      "$defaults",
-      "Source control: github.com/dwalleck and all projects in it",
-      "Local temp directories"
-    ],
-    "allow": [
-      "$defaults",
-      "Creation and deletion of temporary files and directories",
-      "commits and pushes to allowed repositories"
-    ],
-    "soft_deny": [
-      "$defaults"
-    ],
-    "hard_deny": [
-      "$defaults",
-      "Deleting files, repositories"
-    ]
-  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Removes the `autoMode` block from the checked-in `.claude/settings.json`. The block was never being read from there — per the official Claude Code docs ([auto-mode-config](https://code.claude.com/docs/en/auto-mode-config)):

> "The classifier does not read `autoMode` from shared project settings in `.claude/settings.json`, so a checked-in repo cannot inject its own allow rules."

This is a deliberate security boundary so an untrusted repo can't ship `allow` rules that bypass the classifier.

## Where `autoMode` IS read from

| Scope | File |
|---|---|
| Personal (developer-wide) | `~/.claude/settings.json` |
| Per-project, per-developer | `.claude/settings.local.json` (gitignored) |
| Organization-wide | Managed settings |
| Per-invocation | `--settings` flag / Agent SDK |

## What I did

1. Removed the `autoMode` block from `.claude/settings.json` (the only tracked change in this PR).
2. Added the same block to `.claude/settings.local.json` locally — that file was gitignored in PR #114, so this isn't tracked. Each developer keeps their own personal copy there.
3. Verified with `claude auto-mode config`: the custom rules now appear in the effective config with `\$defaults` expanded:

```
allow:     [...defaults,
            \"Creation and deletion of temporary files and directories\",
            \"commits and pushes to allowed repositories\"]
hard_deny: [...defaults, \"Deleting files, repositories\"]
soft_deny: [...defaults]
```

The `hooks` block stays in the checked-in `.claude/settings.json` — hooks ARE intended to be team-shared (and Claude Code does read them from there).

## Plan-availability note

> \"Auto mode is available on Max, Team, Enterprise, and API plans through the Anthropic API. It is not available on Pro or on Bedrock, Vertex, or Foundry.\"

The migration is harmless on plans without autoMode support — Claude Code silently ignores unknown config in that case.

## Test plan

- [x] `.claude/settings.json` still parses as valid JSON
- [x] `.claude/settings.local.json` still parses as valid JSON (locally, gitignored)
- [x] `claude auto-mode config` confirms the rules are loaded with `\$defaults` expanded
- [ ] CI green (single one-block deletion in a tracked file; no other surfaces touched)

## See also

- Stacking note: PR #116 (`chore/init-rivets-issue-tracker`) is also open. Both PRs touch `.claude/`-adjacent or repo-root config files but their diffs don't conflict — #116 narrows `.gitignore` for the rivets/tethys collision; this PR drops a JSON block in a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)